### PR TITLE
Use correct module name for consent script

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/js/bundles/cookie.js
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/js/bundles/cookie.js
@@ -7,6 +7,6 @@
  * All rights reserved
  */
 
-import { dpConsent } from 'dp-consent/dist/dp-consent.es.min'
+import { dpConsent } from '@demos-europe/dp-consent/dist/dp-consent.es.min'
 
 window.DpConsent = dpConsent


### PR DESCRIPTION
As the consent script is now published using npm, its name has changed, which must be reflected when including it.