### PR TITLE
fix(refs T29193): adjust variables name

### DIFF
--- a/templates/bundles/DemosPlanAdminBundle/DemosPlanAdmin/statistics.html.twig
+++ b/templates/bundles/DemosPlanAdminBundle/DemosPlanAdmin/statistics.html.twig
@@ -141,7 +141,7 @@
             },
             {
                 key: 'invitable_institutions'|trans,
-                value: statementStats.totalAmountOfToebStatements|default(0)
+                value: statementStats.totalAmountOfInstitutionStatements|default(0)
             }
         ] %}
 
@@ -158,7 +158,7 @@
             },
             {
                 key: 'invitable_institutions'|trans,
-                value: statementStats.averageAmountOfToebStatementsPerProcedure|default(0)
+                value: statementStats.averageAmountOfInstitutionStatementsPerProcedure|default(0)
             }
         ] %}
 


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T29193

Description: The variables are renamed in the BE, that's why we have to rename them here too.

How to review/test

- Log in with a support role user
- go to Statisitk in Plattformtools

Delete the checkbox if it doesn't apply/isn't necessary.

[X} Link all relevant tickets
[X] Move the tickets on the board accordingly