### PR TITLE
refactor (refs T28977): update EDT to 0.12.13

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1234,28 +1234,28 @@
         },
         {
             "name": "demos-europe/edt-access-definitions",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-access-definitions.git",
-                "reference": "f0775860ccbd4ec9f54506e19cedd34348b77841"
+                "reference": "22c33164ac28c84d2556dc0d047ecf9cb9e8a8cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-access-definitions/zipball/f0775860ccbd4ec9f54506e19cedd34348b77841",
-                "reference": "f0775860ccbd4ec9f54506e19cedd34348b77841",
+                "url": "https://api.github.com/repos/demos-europe/edt-access-definitions/zipball/22c33164ac28c84d2556dc0d047ecf9cb9e8a8cd",
+                "reference": "22c33164ac28c84d2556dc0d047ecf9cb9e8a8cd",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-queries": "^0.12.10",
+                "demos-europe/edt-queries": "^0.12.13",
                 "php": ">=7.3,<8",
                 "thecodingmachine/safe": "^1.3.3"
             },
             "conflict": {
-                "demos-europe/edt-dql": "<0.12.10",
-                "demos-europe/edt-extra": "<0.12.10",
-                "demos-europe/edt-jsonapi": "<0.12.10",
-                "demos-europe/edt-paths": "<0.12.10"
+                "demos-europe/edt-dql": "<0.12.13",
+                "demos-europe/edt-extra": "<0.12.13",
+                "demos-europe/edt-jsonapi": "<0.12.13",
+                "demos-europe/edt-paths": "<0.12.13"
             },
             "type": "library",
             "autoload": {
@@ -1276,34 +1276,34 @@
             ],
             "description": "Tools to regulate access to entities and their properties.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-access-definitions/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-access-definitions/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:50+00:00"
+            "time": "2022-09-20T14:14:03+00:00"
         },
         {
             "name": "demos-europe/edt-dql",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-dql.git",
-                "reference": "1cabe3025cce8184f04da2cab36285cb00262582"
+                "reference": "09be4f40c8e1e8fcb60c6d8d880c59a2cfc7e647"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-dql/zipball/1cabe3025cce8184f04da2cab36285cb00262582",
-                "reference": "1cabe3025cce8184f04da2cab36285cb00262582",
+                "url": "https://api.github.com/repos/demos-europe/edt-dql/zipball/09be4f40c8e1e8fcb60c6d8d880c59a2cfc7e647",
+                "reference": "09be4f40c8e1e8fcb60c6d8d880c59a2cfc7e647",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-queries": "^0.12.10",
+                "demos-europe/edt-queries": "^0.12.13",
                 "doctrine/orm": "^2.5",
                 "php": ">=7.3,<8"
             },
             "conflict": {
-                "demos-europe/edt-access-definitions": "<0.12.10",
-                "demos-europe/edt-extra": "<0.12.10",
-                "demos-europe/edt-jsonapi": "<0.12.10",
-                "demos-europe/edt-paths": "<0.12.10"
+                "demos-europe/edt-access-definitions": "<0.12.13",
+                "demos-europe/edt-extra": "<0.12.13",
+                "demos-europe/edt-jsonapi": "<0.12.13",
+                "demos-europe/edt-paths": "<0.12.13"
             },
             "require-dev": {
                 "doctrine/cache": "^1.11"
@@ -1326,34 +1326,34 @@
             ],
             "description": "Extension for demos-europe/edt-queries to use Doctrine ORM as data source.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-dql/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-dql/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:49+00:00"
+            "time": "2022-09-20T14:14:03+00:00"
         },
         {
             "name": "demos-europe/edt-extra",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-extra.git",
-                "reference": "b3121bb20a076d79988fa4672c39207f3c3d8fb1"
+                "reference": "e5223aedb69eec505e33e1f1b35fcb79b67a436e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-extra/zipball/b3121bb20a076d79988fa4672c39207f3c3d8fb1",
-                "reference": "b3121bb20a076d79988fa4672c39207f3c3d8fb1",
+                "url": "https://api.github.com/repos/demos-europe/edt-extra/zipball/e5223aedb69eec505e33e1f1b35fcb79b67a436e",
+                "reference": "e5223aedb69eec505e33e1f1b35fcb79b67a436e",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-jsonapi": "^0.12.10",
+                "demos-europe/edt-jsonapi": "^0.12.13",
                 "php": ">=7.3,<8",
                 "thecodingmachine/safe": "^1.3.3"
             },
             "conflict": {
-                "demos-europe/edt-access-definitions": "<0.12.10",
-                "demos-europe/edt-dql": "<0.12.10",
-                "demos-europe/edt-paths": "<0.12.10",
-                "demos-europe/edt-queries": "<0.12.10"
+                "demos-europe/edt-access-definitions": "<0.12.13",
+                "demos-europe/edt-dql": "<0.12.13",
+                "demos-europe/edt-paths": "<0.12.13",
+                "demos-europe/edt-queries": "<0.12.13"
             },
             "type": "library",
             "autoload": {
@@ -1373,28 +1373,28 @@
             ],
             "description": "Extension for edt-queries containing various convenience and use-case specific functionality.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-extra/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-extra/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:48+00:00"
+            "time": "2022-09-20T14:14:09+00:00"
         },
         {
             "name": "demos-europe/edt-jsonapi",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-jsonapi.git",
-                "reference": "e4ffea77b68fca360a7d2bf3a3e7e88e98b604c4"
+                "reference": "22ddf139ecec3d6abd00cb6488bff6c2f827cf97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-jsonapi/zipball/e4ffea77b68fca360a7d2bf3a3e7e88e98b604c4",
-                "reference": "e4ffea77b68fca360a7d2bf3a3e7e88e98b604c4",
+                "url": "https://api.github.com/repos/demos-europe/edt-jsonapi/zipball/22ddf139ecec3d6abd00cb6488bff6c2f827cf97",
+                "reference": "22ddf139ecec3d6abd00cb6488bff6c2f827cf97",
                 "shasum": ""
             },
             "require": {
                 "cebe/php-openapi": "^1.5",
-                "demos-europe/edt-access-definitions": "^0.12.10",
-                "demos-europe/edt-queries": "^0.12.10",
+                "demos-europe/edt-access-definitions": "^0.12.13",
+                "demos-europe/edt-queries": "^0.12.13",
                 "doctrine/collections": "^1.5",
                 "league/fractal": "^0.19",
                 "pagerfanta/pagerfanta": "^2.7",
@@ -1405,9 +1405,9 @@
                 "symfony/validator": "5.*.*"
             },
             "conflict": {
-                "demos-europe/edt-dql": "<0.12.10",
-                "demos-europe/edt-extra": "<0.12.10",
-                "demos-europe/edt-paths": "<0.12.10"
+                "demos-europe/edt-dql": "<0.12.13",
+                "demos-europe/edt-extra": "<0.12.13",
+                "demos-europe/edt-paths": "<0.12.13"
             },
             "type": "library",
             "autoload": {
@@ -1432,26 +1432,26 @@
             "description": "Expose Doctrine entities as JSON:API resources.",
             "support": {
                 "issues": "https://github.com/demos-europe/edt-jsonapi/issues",
-                "source": "https://github.com/demos-europe/edt-jsonapi/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-jsonapi/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:44+00:00"
+            "time": "2022-09-20T14:14:07+00:00"
         },
         {
             "name": "demos-europe/edt-paths",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-paths.git",
-                "reference": "6f3d4b7073a59d0b06285df6035e70d2e71db2e1"
+                "reference": "3d9f60aa03b49f23c8c2cfc1fbcb15623fa83660"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-paths/zipball/6f3d4b7073a59d0b06285df6035e70d2e71db2e1",
-                "reference": "6f3d4b7073a59d0b06285df6035e70d2e71db2e1",
+                "url": "https://api.github.com/repos/demos-europe/edt-paths/zipball/3d9f60aa03b49f23c8c2cfc1fbcb15623fa83660",
+                "reference": "3d9f60aa03b49f23c8c2cfc1fbcb15623fa83660",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-queries": "^0.12.10",
+                "demos-europe/edt-queries": "^0.12.13",
                 "nette/php-generator": "^3.5",
                 "nikic/php-parser": "^4.14",
                 "php": ">=7.3,<8",
@@ -1459,10 +1459,10 @@
                 "thecodingmachine/safe": "^1.3.3"
             },
             "conflict": {
-                "demos-europe/edt-access-definitions": "<0.12.10",
-                "demos-europe/edt-dql": "<0.12.10",
-                "demos-europe/edt-extra": "<0.12.10",
-                "demos-europe/edt-jsonapi": "<0.12.10"
+                "demos-europe/edt-access-definitions": "<0.12.13",
+                "demos-europe/edt-dql": "<0.12.13",
+                "demos-europe/edt-extra": "<0.12.13",
+                "demos-europe/edt-jsonapi": "<0.12.13"
             },
             "type": "library",
             "autoload": {
@@ -1483,33 +1483,33 @@
             ],
             "description": "Tools to create paths between entities and entity properties.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-paths/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-paths/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:48+00:00"
+            "time": "2022-09-20T14:14:08+00:00"
         },
         {
             "name": "demos-europe/edt-queries",
-            "version": "0.12.10",
+            "version": "0.12.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-queries.git",
-                "reference": "69d23aad1937c9a00266a0047eb31ff8a37c0d20"
+                "reference": "e59e534f2a3d8ed2c5248561a6fd5a1262e62ba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-queries/zipball/69d23aad1937c9a00266a0047eb31ff8a37c0d20",
-                "reference": "69d23aad1937c9a00266a0047eb31ff8a37c0d20",
+                "url": "https://api.github.com/repos/demos-europe/edt-queries/zipball/e59e534f2a3d8ed2c5248561a6fd5a1262e62ba8",
+                "reference": "e59e534f2a3d8ed2c5248561a6fd5a1262e62ba8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3,<8"
             },
             "conflict": {
-                "demos-europe/edt-access-definitions": "<0.12.10",
-                "demos-europe/edt-dql": "<0.12.10",
-                "demos-europe/edt-extra": "<0.12.10",
-                "demos-europe/edt-jsonapi": "<0.12.10",
-                "demos-europe/edt-paths": "<0.12.10"
+                "demos-europe/edt-access-definitions": "<0.12.13",
+                "demos-europe/edt-dql": "<0.12.13",
+                "demos-europe/edt-extra": "<0.12.13",
+                "demos-europe/edt-jsonapi": "<0.12.13",
+                "demos-europe/edt-paths": "<0.12.13"
             },
             "type": "library",
             "autoload": {
@@ -1529,9 +1529,9 @@
             ],
             "description": "Eases querying entities via property paths.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-queries/tree/0.12.10"
+                "source": "https://github.com/demos-europe/edt-queries/tree/0.12.13"
             },
-            "time": "2022-09-13T15:14:50+00:00"
+            "time": "2022-09-20T14:14:06+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/APIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/APIController.php
@@ -11,7 +11,6 @@
 namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
 use function array_key_exists;
-use function array_slice;
 use function data_get;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -21,6 +20,7 @@ use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Exception\PersistResourceException;
 use demosplan\DemosPlanCoreBundle\Exception\ResourceNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
+use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\DplanPropertyPathProcessorFactory;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Normalizer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PropertyUpdateAccessException;
@@ -33,9 +33,14 @@ use demosplan\DemosPlanCoreBundle\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
 use demosplan\DemosPlanStatementBundle\Exception\DuplicateInternIdException;
 use EDT\JsonApi\OutputTransformation\ExcludeException;
+use EDT\JsonApi\RequestHandling\MessageFormatter;
+use EDT\JsonApi\RequestHandling\UrlParameter;
 use EDT\JsonApi\ResourceTypes\ResourceTypeInterface;
-use EDT\Wrapping\Contracts\Types\ReadableTypeInterface;
+use EDT\JsonApi\Validation\FieldsValidator;
+use EDT\Wrapping\Contracts\PropertyAccessException;
 use EDT\Wrapping\Contracts\TypeRetrievalAccessException;
+use EDT\Wrapping\Utilities\SchemaPathProcessor;
+use EDT\Wrapping\Utilities\TypeAccessor;
 use InvalidArgumentException;
 use function is_array;
 use function is_string;
@@ -48,6 +53,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
+use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
 
@@ -93,6 +99,21 @@ abstract class APIController extends BaseController
      */
     private $apiLogger;
 
+    /**
+     * @var SchemaPathProcessor
+     */
+    private $schemaPathProcessor;
+
+    /**
+     * @var FieldsValidator
+     */
+    private $fieldsValidator;
+
+    /**
+     * @var MessageFormatter
+     */
+    private $messageFormatter;
+
     public function __construct(
         ApiLogger $apiLogger,
         PrefilledResourceTypeProvider $resourceTypeProvider,
@@ -101,10 +122,19 @@ abstract class APIController extends BaseController
         $this->translator = $translator;
         $this->resourceTypeProvider = $resourceTypeProvider;
         $this->apiLogger = $apiLogger;
+        $this->schemaPathProcessor = new SchemaPathProcessor(
+            new DplanPropertyPathProcessorFactory($apiLogger),
+            $resourceTypeProvider
+        );
+        $this->fieldsValidator = new FieldsValidator(
+            new TypeAccessor($resourceTypeProvider),
+            Validation::createValidator()
+        );
+        $this->messageFormatter = new MessageFormatter();
     }
 
     /**
-     * This method is called during the kernel.controller event for
+     * This method is called during the `kernel.controller` event for
      * Api controller specific initialization tasks. It is named
      * how it is named to avoid any conflicts and confusion with the
      * core `initialize` method.
@@ -141,7 +171,7 @@ abstract class APIController extends BaseController
         $this->fractal = $resourceService->getFractal();
 
         // include those entities if they are in the availableIncludes of the transformer
-        $rawIncludes = $this->request->get('include');
+        $rawIncludes = $this->request->get(UrlParameter::INCLUDE);
         $resourceType = $this->request->attributes->get('resourceType');
         $this->validateIncludes($rawIncludes, $resourceType);
         if (null === $rawIncludes) {
@@ -154,8 +184,9 @@ abstract class APIController extends BaseController
 
         // check if only specific fields were requested and (if so) parse them to access
         // them later
-        $fields = $this->request->get('fields');
+        $fields = $this->request->get(UrlParameter::FIELDS);
         if (null !== $fields) {
+            $fields = $this->fieldsValidator->validateFormat($fields);
             $this->validateFieldsets($fields);
             $this->fractal->parseFieldsets($fields);
         }
@@ -397,62 +428,28 @@ abstract class APIController extends BaseController
     }
 
     /**
-     * Logs if the given fieldset array does not have the expected format.
-     *
-     * Its keys string must be strings that correspond to a known resource type.
-     *
-     * Its values must be a comma-separated list of properties that exist in that type.
-     *
      * Its values must not be an array of properties even though Fractal supports it. This is
      * because this does not conform to the JSON:API and thus may not be supported by other
      * libraries, which may limit the options if Fractal is to be replaced by a different
      * library.
      *
+     * @param array<non-empty-string, string> $fieldset
+     *
      * @see https://jsonapi.org/format/#fetching-sparse-fieldsets
      */
     private function validateFieldsets(array $fieldset): void
     {
-        foreach ($fieldset as $key => $value) {
-            if (!is_string($key)) {
-                $this->apiLogger->warning('The key of the fields parameter MUST be a string.');
-
-                continue;
-            }
+        foreach ($fieldset as $typeIdentifier => $propertiesString) {
             try {
-                // Checking if the type exists.
-                // Ideally we would check if the type is available and readable as well, however
-                // this can only be done later as the permissions are not set up at this point.
-                $type = $this->resourceTypeProvider->getReadableAvailableType($key);
-            } catch (TypeRetrievalAccessException $exception) {
-                $this->apiLogger->warning("The key of the fields parameter MUST be an available resource type. Type '$key' not available for reading.");
-
-                continue;
-            }
-
-            if (!is_string($value)) {
-                $this->apiLogger->warning('The value of the fields parameter MUST be a comma-separated (U+002C COMMA, “,”) list as string, got type '.gettype($value).'.');
-
-                continue;
-            }
-
-            $requestedProperties = explode(',', $value);
-            // Checking if the property exists.
-            // Ideally we would check if the property is available and readable as well,
-            // however this can only be done later as the permissions are not set up at
-            // this point.
-            $allowedProperties = array_keys($type->getReadableProperties());
-            $disallowedProperties = array_diff($requestedProperties, $allowedProperties);
-            if ([] !== $disallowedProperties) {
-                $unknownPropertiesString = $this->propertiesToString($disallowedProperties);
-                $maxExistingPropertiesDisplayCount = 10;
-                if ($maxExistingPropertiesDisplayCount < count($allowedProperties)) {
-                    $hiddenExistingPropertiesCount = count($allowedProperties) - $maxExistingPropertiesDisplayCount;
-                    $slicedExistingProperties = array_slice($allowedProperties, 0, $maxExistingPropertiesDisplayCount);
-                    $existingPropertiesString = $this->propertiesToString($slicedExistingProperties)." and $hiddenExistingPropertiesCount more";
-                } else {
-                    $existingPropertiesString = $this->propertiesToString($allowedProperties);
+                // Checking if the type exists and is a resource type implementation.
+                $type = $this->resourceTypeProvider->getAvailableType($typeIdentifier, ResourceTypeInterface::class);
+                $nonReadableProperties = $this->fieldsValidator->getNonReadableProperties($propertiesString, $type);
+                if ([] !== $nonReadableProperties) {
+                    $unknownPropertiesString = $this->messageFormatter->propertiesToString($nonReadableProperties);
+                    $this->apiLogger->warning("The following requested fieldset properties are not readable in the resource type '$typeIdentifier': $unknownPropertiesString.");
                 }
-                $this->apiLogger->warning("The following requested fieldset properties are not available in the resource type '$key': $unknownPropertiesString. Possibly available properties are: $existingPropertiesString.");
+            } catch (TypeRetrievalAccessException $exception) {
+                $this->apiLogger->warning("The key of the fields parameter MUST be an available resource type. Type '$typeIdentifier' not available for reading.", ['exception' => $exception]);
             }
         }
     }
@@ -498,58 +495,32 @@ abstract class APIController extends BaseController
         // retrieve the accessed resource type from the request
         if (is_string($resourceTypeName)) {
             try {
-                $type = $this->resourceTypeProvider->getType($resourceTypeName);
+                $this->resourceTypeProvider->getType($resourceTypeName);
             } catch (TypeRetrievalAccessException $exception) {
                 // The accessed resource type is probably not a generic one, thus we can not
                 // continue to validate the 'include' properties.
                 return;
             }
 
-            if (!$type instanceof ReadableTypeInterface) {
-                throw new \demosplan\DemosPlanCoreBundle\Exception\AccessDeniedException("The resource type '$resourceTypeName' is not available.");
-            }
-
-            if (!$type->isAvailable()) {
-                $this->apiLogger->warning("The resource type '$resourceTypeName' is not available");
-            }
-
+            // if the type exists at all (see `getType` above) then it must be an
+            // available, directly accessible resource type
+            $type = $this->resourceTypeProvider->getAvailableType($resourceTypeName, ResourceTypeInterface::class);
             if (!$type->isDirectlyAccessible()) {
-                $this->apiLogger->warning("The resource type '$resourceTypeName' is not directly accessible");
+                throw new InvalidArgumentException("The resource type '$resourceTypeName' is not directly accessible");
             }
 
             $includes = explode(',', $rawIncludes);
-            // currently we check the first include path segment only
-            $includes = array_map(static function (string $include): string {
-                $includePath = explode('.', $include);
-
-                return array_shift($includePath);
+            array_map(function (string $include) use ($type): void {
+                try {
+                    $includePath = explode('.', $include);
+                    $this->schemaPathProcessor->mapExternReadablePath($type, $includePath, false);
+                } catch (PropertyAccessException $exception) {
+                    $this->apiLogger->warning(
+                        "The following include property path is not available in the resource type '{$type::getName()}': $include",
+                        ['exception' => $exception]
+                    );
+                }
             }, $includes);
-
-            $readableRelationships = array_filter(
-                $type->getReadableProperties(),
-                static function (?string $property): bool {
-                    return null !== $property;
-                });
-            $readableRelationships = array_keys($readableRelationships);
-            $unknownProperties = array_diff($includes, $readableRelationships);
-            if ([] !== $unknownProperties) {
-                $unknownPropertiesString = $this->propertiesToString($unknownProperties);
-                $this->apiLogger->warning("The following properties to include are not available in the resource type '$resourceTypeName': $unknownPropertiesString");
-            }
         }
-    }
-
-    /**
-     * Wraps each given property into quotes and concatenates them with a comma.
-     *
-     * @param array<int, string> $properties
-     */
-    private function propertiesToString(array $properties): string
-    {
-        $properties = array_map(static function (string $property): string {
-            return "`$property`";
-        }, $properties);
-
-        return implode(', ', $properties);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
@@ -52,7 +52,7 @@ class GenericApiController extends APIController
         string $resourceId
     ): Response {
         $requestJson = $this->getRequestJson();
-        $item = $resourceService->updateFromRequest($resourceType, $resourceId, $requestJson);
+        $item = $resourceService->updateFromRequest($resourceType, $resourceId, $requestJson, $this->request->query);
 
         if (null !== $item) {
             return $this->renderResource($item);
@@ -73,7 +73,7 @@ class GenericApiController extends APIController
     public function createAction(string $resourceType, JsonApiActionService $resourceService): Response
     {
         $requestJson = $this->getRequestJson();
-        $item = $resourceService->createFromRequest($resourceType, $requestJson);
+        $item = $resourceService->createFromRequest($resourceType, $requestJson, $this->request->query);
 
         if (null === $item) {
             return $this->renderEmpty(Response::HTTP_NO_CONTENT);
@@ -118,7 +118,7 @@ class GenericApiController extends APIController
         string $resourceType,
         string $resourceId
     ): Response {
-        $item = $resourceService->getFromRequest($resourceType, $resourceId);
+        $item = $resourceService->getFromRequest($resourceType, $resourceId, $this->request->query);
 
         return $this->renderResource($item);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/DplanPropertyPathProcessor.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/DplanPropertyPathProcessor.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest;
+
+use EDT\Wrapping\Contracts\PropertyAccessException;
+use EDT\Wrapping\Contracts\RelationshipAccessException;
+use EDT\Wrapping\Contracts\TypeRetrievalAccessException;
+use EDT\Wrapping\Contracts\Types\TypeInterface;
+use EDT\Wrapping\Utilities\PropertyPathProcessor;
+use EDT\Wrapping\Utilities\TypeAccessors\AbstractTypeAccessor;
+use Psr\Log\LoggerInterface;
+
+class DplanPropertyPathProcessor extends PropertyPathProcessor
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var AbstractTypeAccessor
+     */
+    private $typeAccessor;
+
+    public function __construct(AbstractTypeAccessor $typeAccessor, LoggerInterface $logger)
+    {
+        parent::__construct($typeAccessor);
+        $this->logger = $logger;
+        $this->typeAccessor = $typeAccessor;
+    }
+
+    /**
+     * Simulates old {@link PropertyPathProcessor} behavior in which the last path segment was not
+     * validated. But here we at least log invalid segments.
+     */
+    public function processPropertyPath(TypeInterface $type, array $newPath, string $currentPathPart, string ...$remainingParts): array
+    {
+        // Check if the current type needs mapping to the backing object schema, if so, apply it.
+        $pathToAdd = $this->typeAccessor->getDeAliasedPath($type, $currentPathPart);
+        // append the de-aliased path to the processed path
+        array_push($newPath, ...$pathToAdd);
+
+        if ([] === $remainingParts) {
+            try {
+                $propertyTypeIdentifier = $this->getPropertyTypeIdentifier($type, $currentPathPart);
+                if (null !== $propertyTypeIdentifier) {
+                    $this->typeAccessor->getType($propertyTypeIdentifier);
+                }
+            } catch (PropertyAccessException|TypeRetrievalAccessException $exception) {
+                $this->logger->warning($exception->getMessage(), ['exception' => $exception]);
+            }
+
+            return $newPath;
+        }
+
+        $propertyTypeIdentifier = $this->getPropertyTypeIdentifier($type, $currentPathPart);
+        if (null !== $propertyTypeIdentifier) {
+            try {
+                // even if we don't need the $nextTarget here because there may be no
+                // remaining segments, we still check with this call if the current
+                // relationship is valid in this path
+                $nextTarget = $this->typeAccessor->getType($propertyTypeIdentifier);
+
+                // otherwise, we continue the mapping recursively
+                return $this->processPropertyPath($nextTarget, $newPath, ...$remainingParts);
+            } catch (TypeRetrievalAccessException $exception) {
+                throw RelationshipAccessException::relationshipTypeAccess($type, $currentPathPart, $exception);
+            }
+        }
+
+        // the current segment is an attribute followed by more segments,
+        // thus we throw an exception
+        throw PropertyAccessException::nonRelationship($currentPathPart, $type);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/DplanPropertyPathProcessorFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/DplanPropertyPathProcessorFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest;
+
+use EDT\Wrapping\Utilities\PropertyPathProcessor;
+use EDT\Wrapping\Utilities\PropertyPathProcessorFactory;
+use EDT\Wrapping\Utilities\TypeAccessors\AbstractTypeAccessor;
+use Psr\Log\LoggerInterface;
+
+class DplanPropertyPathProcessorFactory extends PropertyPathProcessorFactory
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function createPropertyPathProcessor(AbstractTypeAccessor $typeAccessor): PropertyPathProcessor
+    {
+        return new DplanPropertyPathProcessor($typeAccessor, $this->logger);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/EntityFetcher.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/EntityFetcher.php
@@ -73,7 +73,7 @@ class EntityFetcher implements EntityFetcherInterface
      */
     private $schemaPathProcessor;
 
-    public function __construct(ManagerRegistry $managerRegistry, TypeProviderInterface $typeProvider)
+    public function __construct(ManagerRegistry $managerRegistry, SchemaPathProcessor $schemaPathProcessor)
     {
         $this->managerRegistry = $managerRegistry->getManager();
         $this->conditionFactory = new DqlConditionFactory();
@@ -84,7 +84,7 @@ class EntityFetcher implements EntityFetcherInterface
             }
         };
         $this->queryGenerator = new QueryGenerator($this->managerRegistry);
-        $this->schemaPathProcessor = new SchemaPathProcessor($typeProvider);
+        $this->schemaPathProcessor = $schemaPathProcessor;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -30,6 +30,7 @@ use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use demosplan\DemosPlanUserBundle\Logic\CustomerService;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
+use EDT\JsonApi\RequestHandling\MessageFormatter;
 use EDT\JsonApi\ResourceTypes\CachingResourceType;
 use EDT\JsonApi\ResourceTypes\ResourceTypeInterface;
 use EDT\PathBuilding\End;
@@ -121,6 +122,11 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
      * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
+
+    /**
+     * @var MessageFormatter
+     */
+    private $messageFormatter;
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
@@ -363,5 +369,14 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
         }
 
         return Carbon::instance($date)->toIso8601String();
+    }
+
+    protected function getMessageFormatter(): MessageFormatter
+    {
+        if (null === $this->messageFormatter) {
+            $this->messageFormatter = new MessageFormatter();
+        }
+
+        return $this->messageFormatter;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityWrapperFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityWrapperFactory.php
@@ -56,10 +56,10 @@ class EntityWrapperFactory implements WrapperFactoryInterface
 
     public function __construct(
         ManagerRegistry $managerRegistry,
+        SchemaPathProcessor $schemaPathProcessor,
         TypeProviderInterface $typeProvider
     ) {
         $this->propertyAccessor = new ProxyPropertyAccessor($managerRegistry->getManager());
-        $schemaPathProcessor = new SchemaPathProcessor($typeProvider);
         $this->propertyReader = new CachingPropertyReader($this->propertyAccessor, $schemaPathProcessor);
         $this->typeAccessor = new CacheableTypeAccessor($typeProvider);
         $this->conditionEvaluator = new ConditionEvaluator($this->propertyAccessor);

--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -182,6 +182,7 @@ services:
 
     demosplan\DemosPlanCoreBundle\Logic\EntityWrapperFactory:
         arguments:
+            $schemaPathProcessor: '@EDT\Wrapping\Utilities\SchemaPathProcessor'
             $typeProvider: '@demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
 
     demosplan\DemosPlanCoreBundle\Logic\Faq\FaqHandler:
@@ -238,7 +239,7 @@ services:
 
     demosplan\DemosPlanCoreBundle\Logic\ApiRequest\EntityFetcher:
         arguments:
-            $typeProvider: '@demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
+            $schemaPathProcessor: '@EDT\Wrapping\Utilities\SchemaPathProcessor'
 
     demosplan\DemosPlanCoreBundle\Logic\Logger\ApiLogger: ~
 
@@ -367,6 +368,10 @@ services:
         parent: demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Transformer\BaseTransformer
         tags:
             - name: dplan.json_api_transformer
+
+    demosplan\DemosPlanCoreBundle\Logic\ApiRequest\DplanPropertyPathProcessorFactory:
+        arguments:
+            $logger: '@demosplan\DemosPlanCoreBundle\Logic\Logger\ApiLogger'
 
     demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Transformer\TransformerLoader:
         lazy: true
@@ -1090,6 +1095,11 @@ services:
     EDT\Querying\ConditionParsers\Drupal\PredefinedOperatorProvider:
         arguments:
             $conditionFactory: '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+
+    EDT\Wrapping\Utilities\SchemaPathProcessor:
+        arguments:
+            $propertyPathProcessorFactory: '@demosplan\DemosPlanCoreBundle\Logic\ApiRequest\DplanPropertyPathProcessorFactory'
+            $typeProvider: '@demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
 
     Intervention\Image\ImageManager: ~
 

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsList/SegmentsList.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsList/SegmentsList.vue
@@ -494,7 +494,7 @@ export default {
           this.fetchSegmentIds({
             filter: filter,
             fields: {
-              StatementSegment: ['id']
+              StatementSegment: ['id'].join()
             }
           })
         })


### PR DESCRIPTION
The refactored warnings are currently no longer triggered in the application, thus exceptions can be used instead to prevent errorneous usage in the future.

Provide MessageFormatter where needed.

Provide API request handling with URL params.

Use validators in EDT for API request handling:

Validating the URL parameters `fields` and `includes` is now done by using superior logic provided by classes in EDT. Some checks were set to be more strict (exceptions instead of logging), because there were no occurrences of the logging messages in the last 3 months on any server.

In previous EDT version the validation of property paths was incomplete. The last path segment was always left out from the validation. E.g. when sorting via `procedure.name` it was not checked if `name` is allowed to be used to sort. Likewise, when including the procedure of a requested statement via the path `procedure` it was not checked if the `procedure` property is set as `readable` or if the referenced `Procedure` resource type is set as available.

The problem in EDT is fixed now, but because there are requests in dplan accessing properties that should not be available, a custom `PropertyPathProcessor` was added, which allows the old (invalid) access, while logging the violation. Thus, after the requests have been fixed the `DplanPropertyPathProcessor` and `DplanPropertyPathProcessorFactory` classes can be removed.

In case of the `ApiController` the new classes were initialized instead of being injected, as injection would have required to adjust multiple inheriting controller classes.