### PR TITLE
Feat(T24505): add PersonalData Vue-component to portal_profile.html.twig

### DIFF
--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
@@ -53,23 +53,23 @@
     </dl>
 
     <input
-        type="hidden"
-        name="email"
-        :value="user.email">
+      type="hidden"
+      name="email"
+      :value="user.email">
     <input
-        type="hidden"
-        name="lastname"
-        :value="user.lastName">
+      type="hidden"
+      name="lastname"
+      :value="user.lastName">
 
     <template v-if="hasPermission('feature_send_assigned_task_notification_email_setting')">
       <dp-checkbox
-          id="assignedTaskNotification"
-          name="assignedTaskNotification"
-          class="u-mb-0_25"
-          :label="Translator.trans('email.daily.subscribe')"
-          v-model="isDailyDigestChecked"
-          value-to-send="on"
-          standalone />
+        id="assignedTaskNotification"
+        name="assignedTaskNotification"
+        class="u-mb-0_25"
+        :label="Translator.trans('email.daily.subscribe')"
+        v-model="isDailyDigestChecked"
+        value-to-send="on"
+        standalone />
       <p>
         {{ Translator.trans('email.daily.assigned.tasks.explanation') }}
       </p>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T24505

**Description:** `PersonalData.vue` component should be applied to the `portal_profile.html.twig` file in all projects (personalData block). To make it easier all projects should have a unified style by displaying a personal data. 

As it was discussed with Stefan, we take **ewm/regio** personalData templates as a base. Fields and it order will be the same in all projects, as well as user name field should be displayed in all projects. 
