### PR TITLE
fix(T24505): vue warn: switchDate type error

### DIFF
--- a/demosplan/DemosPlanNewsBundle/Resources/client/js/components/DpNewsAdminList.vue
+++ b/demosplan/DemosPlanNewsBundle/Resources/client/js/components/DpNewsAdminList.vue
@@ -57,7 +57,7 @@
       <template v-slot:enabled="rowData">
         <dp-news-item-status
           class="flex space-inline-xs u-mt-0_125"
-          :switch-date="rowData.designatedSwitchDate || null"
+          :switch-date="rowData.designatedSwitchDate || ''"
           :switch-state="rowData.designatedState ? 'released' : 'blocked'"
           :news-status="rowData.enabled"
           :determined-to-switch="rowData.determinedToSwitch || false"

--- a/demosplan/DemosPlanNewsBundle/Resources/client/js/components/DpNewsItemStatus.vue
+++ b/demosplan/DemosPlanNewsBundle/Resources/client/js/components/DpNewsItemStatus.vue
@@ -45,9 +45,8 @@ export default {
     },
 
     switchDate: {
-      type: [Number, null],
-      required: true,
-      default: null
+      type: [Number, String],
+      required: true
     },
 
     switchState: {
@@ -58,7 +57,7 @@ export default {
 
   computed: {
     tooltipText () {
-      return this.switchDate !== null
+      return this.switchDate !== ''
         ? `${Translator.trans('phase.autoswitch.date')} ${(new Date(this.switchDate)).toLocaleDateString('de-DE')}<br>${Translator.trans('phase.autoswitch.value')} ${Translator.trans(this.switchState)}`
         : ''
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29219

**Description:** In case of a negative value `switchDate` prop will get an empty `string` instead of a `null`. Null does not belong to any prop types (String, Number, Boolean, Array, Object, Date, Function, Symbol). Because of that Vue throws a warning if the passed type is a `null`

There are several ways to avoid a warning:
- remove type checking (which I think is not a good idea)
- pass an empty String in case of a negative value 

