### PR TITLE
Fix(T29291): Private planning agency should not be able to create a new procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -746,7 +746,7 @@ class DemosPlanProcedureController extends BaseController
      *     options={"expose": true}
      * )
      *
-     * @DplanPermissions("area_admin_procedures")
+     * @DplanPermissions("feature_admin_new_procedure")
      *
      * @return RedirectResponse|Response
      *


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29291

In the path  `/verfahren/neu` the private planning agency was able to create a new procedure. Setting the correct permission `feature_admin_new_procedure` instead of `area_admin_procedures`  for creating a new procedure according to the route solves the problem.

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly