### PR TITLE
Reset items in DpAddOrganisationList after adding orgas

### DIFF
--- a/client/js/components/core/DpDataTable/DpDataTableExtended.vue
+++ b/client/js/components/core/DpDataTable/DpDataTableExtended.vue
@@ -87,6 +87,7 @@
       @items-selected="emitSelectedItems"
       :items="onPageItems"
       :search-string="searchString"
+      :should-be-selected-items="currentlySelectedItems"
       :track-by="trackBy">
       <template
         v-for="el in sortableFilteredFields"
@@ -147,6 +148,7 @@ import DpSelectPageItemCount from './DpSelectPageItemCount'
 import DpStickyElement from '@DpJs/components/core/shared/DpStickyElement'
 import hasOwnProp from '@DpJs/lib/utils/hasOwnProp'
 import SlidingPagination from 'vue-sliding-pagination'
+import tableSelectAllItems from '@DpJs/lib/utils/tableSelectAllItems'
 
 export default {
   name: 'DpDataTableExtended',
@@ -157,6 +159,8 @@ export default {
     DpStickyElement,
     SlidingPagination
   },
+
+  mixins: [tableSelectAllItems],
 
   props: {
     defaultSortOrder: {

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/admin/DpAddOrganisationList.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/admin/DpAddOrganisationList.vue
@@ -143,6 +143,8 @@ export default {
 
               // Reset selected items so that the footer updates accordingly
               this.selectedItems = []
+              // Also reset selection in DpDataTableExtended as this.selectedItems resets only local variable
+              this.$refs.dataTable.resetSelection()
             })
         })
         .catch(() => {


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T27811

As `this.selectedItems` is holding the local value for selected items (which is not propagated further down the component tree), also the selected items in DpDataTable need to be reset.

This is done utilizing our `tableSelectAllItems` mixin, which is included in DpDataTableExtended now.