### PR TITLE
minor (refs T29225): Reduce minimum length of search characters

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/fos_elastica.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/fos_elastica.yaml
@@ -29,7 +29,7 @@ fos_elastica:
                             country: DE
                         min_length_filter:
                             type: length
-                            min: 3
+                            min: 2
                     tokenizer:
                         split_word_separators:
                             type: pattern
@@ -244,7 +244,7 @@ fos_elastica:
                             country: DE
                         min_length_filter:
                             type: length
-                            min: 3
+                            min: 2
                     analyzer:
                         customHTMLGerman:
                             type: custom
@@ -315,7 +315,7 @@ fos_elastica:
                             country: DE
                         min_length_filter:
                             type: length
-                            min: 3
+                            min: 2
                     tokenizer:
                         split_word_separators:
                             type: pattern
@@ -686,7 +686,7 @@ fos_elastica:
                             country: DE
                         min_length_filter:
                             type: length
-                            min: 3
+                            min: 2
                     tokenizer:
                         split_word_separators:
                             type: pattern


### PR DESCRIPTION
**Ticket**: https://yaits.demos-deutschland.de/T29225

This PR reduces the number of needed characters in a search string from 3 to 2 for statement related entities. After an ES populate this allows searching for 2 letter strings with ES in those entities.
For the moment, it does not seem to be that relevant for users and procedures.