### PR TITLE
Remove yellow line

### DIFF
--- a/client/setup/config.js
+++ b/client/setup/config.js
@@ -89,9 +89,7 @@ class Config {
         'tooltip' // V-tooltip
       ],
       defaultExcludePatterns: [
-        'has-tooltip',
-        // Ids (we can't use a simple regex here because of classes with the same scheme :-/ )
-        'drop-save-msg'
+        'has-tooltip'
       ]
     }
 

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/list_final_group_citizen.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/list_final_group_citizen.html.twig
@@ -78,8 +78,6 @@
 
                 </fieldset>
 
-                <p id="drop-save-msg" class="{{ 'flash-warning'|prefixClass }}"></p>
-
                 <dp-public-statement-list
                     class="layout__item"
                     :statements="JSON.parse('{{ templateVars.list.statementlist|default([])|json_encode|e('js', 'utf-8') }}')"


### PR DESCRIPTION
The "drop-save-message" was used to inform users about a changed manual sorting within the spublic statements list. however as this functionality is dropped, we can also drop the message container. 

![image](https://user-images.githubusercontent.com/40452344/195137038-c1a52716-cd23-44ec-b12e-c55bd1e65668.png)
