### PR TITLE
feat: pick changes from former release

### DIFF
--- a/client/js/components/core/DpUpload/DpUpload.vue
+++ b/client/js/components/core/DpUpload/DpUpload.vue
@@ -170,7 +170,7 @@ export default {
          * Triggers uppy file-removed event (we are instead using a custom file-remove event. we do not want files to
          * be removed on resetting the uppy ui
          */
-        this.uppy.reset()
+        this.uppy.cancelAll()
       }, 2000)
 
       this.$emit('uploads-completed', result)

--- a/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
+++ b/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
@@ -322,7 +322,7 @@ class AssessmentTableServiceStorage
                 $this->getMessageBag()->add('error', 'error.date.invalid');
             }
 
-            //Ensure hour, minute and second will be untouched, to avoid change order in ATable.
+            //On UPDATE: Ensure hour, minute and second will stay untouched, to avoid changing of order by submitDate.
             $currentlySavedDate = Carbon::instance($currentStatement->getSubmitObject());
             $incomingDate = Carbon::createFromFormat('d.m.Y', $rParams['request']["submitted_date"]);
             $incomingDate->setTime($currentlySavedDate->hour, $currentlySavedDate->minute, $currentlySavedDate->second);

--- a/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
@@ -18,11 +18,11 @@ use EFrane\ConsoleAdditions\Batch\Action;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use EFrane\ConsoleAdditions\Batch\ShellAction;
 use Exception;
-use function register_shutdown_function;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function register_shutdown_function;
 
 /**
  * dplan:update.
@@ -63,6 +63,10 @@ EOT
         $fs = new DemosFilesystem();
 
         $isDeployment = $input->getOption('deploy');
+        // enforce deployment environment when deployed on production
+        if (!$isDeployment && $this->parameterBag->get('prod_deployment')) {
+            $isDeployment = true;
+        }
         $updateLockFile = DemosPlanPath::getRootPath('update.lock');
         $env = $isDeployment ? 'prod' : 'dev';
         $rootPath = DemosPlanPath::getRootPath();

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -1152,12 +1152,12 @@ class LoadUserData extends TestFixture
         $this->setReference(self::TEST_ORGA_WITH_REJECTED_ORGA_TYPE, $orga12);
 
         $anonymousUser = new User();
-        $anonymousUser->setId('73830656-3e48-11e4-a6a8-005056ae0004');
+        $anonymousUser->setId(User::ANONYMOUS_USER_ID);
         $anonymousUser->setGender('male');
         $anonymousUser->setFirstname('Bürger');
         $anonymousUser->setLastname('Bürger');
-        $anonymousUser->setEmail('anonym@bobsh.de');
-        $anonymousUser->setLogin('anonym@bobsh.de');
+        $anonymousUser->setEmail(User::ANONYMOUS_USER_LOGIN);
+        $anonymousUser->setLogin(User::ANONYMOUS_USER_LOGIN);
         $anonymousUser->setLogin(md5('$anonymousUser'));
         $anonymousUser->setAlternativeLoginPassword(md5('$anonymousUser'));
         $anonymousUser->setNewsletter(false);
@@ -1170,6 +1170,9 @@ class LoadUserData extends TestFixture
         $anonymousUser->setCurrentCustomer($customer);
 
         $manager->persist($anonymousUser);
+
+        $orgaBuerger->addUser($anonymousUser);
+        $manager->persist($orgaBuerger);
 
         $manager->flush();
     }

--- a/demosplan/DemosPlanCoreBundle/EventDispatcher/AnnotatedStatementPdfEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventDispatcher/AnnotatedStatementPdfEventSubscriber.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Event\AfterResourceUpdateEvent;
 use demosplan\DemosPlanCoreBundle\EventSubscriber\BaseEventSubscriber;
 use demosplan\DemosPlanCoreBundle\Exception\ConcurrentEditionException;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\AnnotatedStatementPdfPageResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\AnnotatedStatementPdfResourceType;
 use demosplan\DemosPlanStatementBundle\Exception\InvalidStatusTransitionException;
 use demosplan\DemosPlanStatementBundle\Logic\AnnotatedStatementPdf\AnnotatedStatementPdfHandler;
 use demosplan\DemosPlanStatementBundle\Logic\AnnotatedStatementPdf\PiBoxRecognitionRequester;
@@ -83,7 +84,7 @@ class AnnotatedStatementPdfEventSubscriber extends BaseEventSubscriber
     public function piBoxRecognitionRequest(AfterResourceCreationEvent $event): void
     {
         $targetResourceType = $event->getResourceChange()->getTargetResourceType();
-        if (!$targetResourceType instanceof AnnotatedStatementPdfPageResourceType) {
+        if (!$targetResourceType instanceof AnnotatedStatementPdfResourceType) {
             return;
         }
         /** @var AnnotatedStatementPdf $annotatedStatementPdf */

--- a/demosplan/DemosPlanCoreBundle/Permissions/PermissionsInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/PermissionsInterface.php
@@ -121,7 +121,7 @@ interface PermissionsInterface
      */
     public function hasPermissions(array $permissions, string $operator = 'AND'): bool;
 
-    public function setProcedure(Procedure $procedure);
+    public function setProcedure(?Procedure $procedure);
 
     /**
      * Enable a set of permissions.

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_accordion.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_accordion.scss
@@ -24,23 +24,14 @@
         opacity: 0;
     }
 
-    &--button {
-        width: 2.5%;
-
-        & i {
-            font-size: 1.8rem;
-            line-height: 1.2rem;
-        }
+    &--button i {
+        font-size: 1.8rem;
+        line-height: 1.2rem;
     }
 
     &--checkbox {
         cursor: pointer;
         width: 2.5%;
-    }
-
-    &--header-content {
-        cursor: pointer;
-        width: 96%;
     }
 
     &--title {

--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/cache.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/cache.yaml
@@ -2,7 +2,9 @@ framework:
     cache:
         # Put the unique name of your app here: the prefix seed
         # is used to compute stable namespaces for cache keys.
-        prefix_seed: 'DEMOS/dplan_%demosplan.project_name%'
+        prefix_seed: 'DEMOS/dplan_%project_prefix%'
         pools:
             doctrine.cache_pool:
                 adapter: 'cache.adapter.%cache_doctrine%'
+            doctrine.system_cache_pool:
+                adapter: 'cache.adapter.filesystem'

--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
@@ -119,6 +119,10 @@ parameters:
     # define whether local container setup is used
     is_shared_folder: false
 
+    # Is current project deployed in production environment? May be used to
+    # block specific test or development features
+    prod_deployment: false
+
     # #refactor: This could perhaps be defined as params for ModifyUserCommand
     organisationIds_user_to_modify: []
 

--- a/demosplan/DemosPlanCoreBundle/Security/User/SamlUserFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Security/User/SamlUserFactory.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\User;
 
-use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
@@ -109,7 +108,7 @@ class SamlUserFactory implements SamlUserFactoryInterface
         // when user with email exists, update login field to saml login
         // to allow Login via saml and dplan
 
-        $user = $this->userService->findDistinctUserByEmailOrLogin($attributes['mail'][0] ?? '');
+        $user = $this->userService->findDistinctUserByEmailOrLogin($attributes['email'][0] ?? '');
 
         if ($user instanceof User) {
             $this->logger->info('Tie existing user to SAML-Login');
@@ -124,14 +123,14 @@ class SamlUserFactory implements SamlUserFactoryInterface
 
         // user does not yet exist
         $user = $this->getNewUserWithDefaultValues();
-        $user->setEmail($attributes['mail'][0] ?? '');
+        $user->setEmail($attributes['email'][0] ?? '');
         $user->setFirstname($attributes['surname'][0] ?? '');
         $user->setLastname($attributes['givenName'][0] ?? '');
         $user->setLogin($login);
 
         $roleCodes = [Role::CITIZEN];
         $user = $this->addUserRoles($roleCodes, $user);
-        $anonymousUser = new AnonymousUser();
+        $anonymousUser = $this->userService->getValidUser(User::ANONYMOUS_USER_LOGIN);
 
         return $this->addUserToOrgaAndDepartment($anonymousUser->getOrga(), $user);
     }

--- a/demosplan/DemosPlanCoreBundle/Validator/ValidCssVarsConstraintValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/ValidCssVarsConstraintValidator.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Validator;
 
 use demosplan\DemosPlanCoreBundle\Constraint\ValidCssVarsConstraint;
+use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -39,22 +41,20 @@ class ValidCssVarsConstraintValidator extends ConstraintValidator
             $ymlParsedValues = Yaml::parse($value);
         } catch (ParseException $e) {
             $this->context->buildViolation($constraint->ymlExceptionMessage)->addViolation();
+
             return;
         }
-
         // is every variable on the list of allowed variables?
         $validAttributes = self::getValidCssVars();
+        $ymlFormatConstranits = $this->getFormatConstraints();
+        $violations = $this->context->getValidator()->validate($ymlParsedValues, $ymlFormatConstranits);
+        if (0 !== $violations->count()) {
+            throw ViolationsException::fromConstraintViolationList($violations);
+        }
         foreach ($ymlParsedValues as $var => $val) {
             if (!in_array($var, $validAttributes, true)) {
                 $this->context->buildViolation($constraint->invalidVarMessage)
                     ->setParameter('{{ var }}', $var)
-                    ->addViolation();
-            }
-
-            // Validate value to be cssColor
-            if (7 !== strlen($val) || 0 !== strpos($val, '#')) {
-                $this->context->buildViolation($constraint->invalidColorMessage)
-                    ->setParameter('{{ color }}', $val)
                     ->addViolation();
             }
         }
@@ -85,6 +85,22 @@ class ValidCssVarsConstraintValidator extends ConstraintValidator
             'nav',
             'nav-hover',
             'nav-current',
+        ];
+    }
+
+    /**
+     * @return non-empty-list<Constraint>
+     */
+    private function getFormatConstraints(): array
+    {
+        return [
+            new Assert\Type('array'),
+            new Assert\All([
+                new Assert\Type('string'),
+                new Assert\NotNull(),
+                new Assert\NotBlank(),
+                new Assert\Regex('/^#([0-9a-f]{3}|[0-9a-f]{6})$/'),
+            ]),
         ];
     }
 }

--- a/demosplan/DemosPlanMapBundle/Resources/client/js/components/publicdetail/controls/legendList/DpLayerLegend.vue
+++ b/demosplan/DemosPlanMapBundle/Resources/client/js/components/publicdetail/controls/legendList/DpLayerLegend.vue
@@ -10,7 +10,7 @@
 <template>
   <div>
     <div
-      v-if="displayLegendBox || hasPermission('feature_map_layer_legend_file') || hasPermission('feature_map_use_plan_draw_pdf')"
+      v-if="hasPermission('feature_map_layer_legend_file') || hasPermission('feature_map_use_plan_draw_pdf')"
       :class="prefixClass('c-map__group')">
       <button
         :class="[unfolded ? prefixClass('is-active') : '', prefixClass('c-map__group-header c-map__group-item c-map__toggle btn--blank o-link--default u-pv-0_25')]"
@@ -19,18 +19,18 @@
       </button>
     </div>
 
-    <template v-if="displayLegendBox && (hasPermission('feature_map_layer_get_legend') || hasPermission('feature_map_use_plan_draw_pdf'))">
+    <template v-if="hasPermission('feature_map_layer_get_legend') || hasPermission('feature_map_use_plan_draw_pdf')">
       <ul
         :class="prefixClass('c-map__group js__mapLayerLegends')"
         v-show="unfolded">
         <li
-          v-if="hasPermission('feature_map_use_plan_pdf') && planPdf.length > 0"
+          v-if="hasPermission('feature_map_use_plan_pdf') && planPdf.hash"
           :class="prefixClass('list-style-none')">
           <a
             :class="prefixClass('c-map__group-item display--block')"
             target="_blank"
             :href="Routing.generate('core_file', { hash: planPdf.hash })"
-            :title="Translator.trans('legend.download') (planPdf.mimeType, planPdf.size)">
+            :title="planPdfTitle">
             <i
               :class="prefixClass('fa fa-download')"
               aria-hidden="true" />
@@ -77,19 +77,14 @@ export default {
   mixins: [prefixClassMixin],
 
   props: {
-    displayLegendBox: {
-      type: Boolean,
-      required: true
-    },
-
     layersWithLegendFiles: {
       type: Array,
       default: () => []
     },
 
     planPdf: {
-      type: String,
-      default: ''
+      type: Object,
+      default: () => ({})
     }
   },
 
@@ -102,7 +97,15 @@ export default {
   computed: {
     ...mapGetters('layers', {
       legends: 'elementListForLegendSidebar'
-    })
+    }),
+
+    planPdfTitle () {
+      let fileInfo = ''
+      if (this.planPdf.mimeType && this.planPdf.size) {
+        fileInfo = ` (${this.planPdf.mimeType}, ${this.planPdf.size})`
+      }
+      return `${Translator.trans('legend.download')}${fileInfo}`
+    }
   },
 
   methods: {

--- a/demosplan/DemosPlanMapBundle/Resources/client/js/store/Layers.js
+++ b/demosplan/DemosPlanMapBundle/Resources/client/js/store/Layers.js
@@ -230,8 +230,8 @@ const LayersStore = {
       for (let i = 0; i < layers.length; i++) {
         const layer = layers[i]
         const layerParam = layer.attributes.layers
-        // We do only need url for getLegendGraphic, no custom params
-        const layerUrlSplit = layer.attributes.url.split('?')
+        const delimiter = (layer.attributes.url.indexOf('?') === -1) ? '?' : '&'
+        const legendUrlBase = layer.attributes.url + delimiter
         // Get layer layers
         const layerParamSplit = layerParam.split(',').map(function (item) {
           return item.trim()
@@ -239,7 +239,7 @@ const LayersStore = {
         // Add each layer layer to GetLegendGraphic request
         for (let j = 0; j < layerParamSplit.length; j++) {
           if (layer.attributes.isEnabled) {
-            const legendUrl = layerUrlSplit[0] + '?Layer=' + layerParamSplit[j] + '&Request=GetLegendGraphic&Format=image/png&version=1.1.1'
+            const legendUrl = legendUrlBase + 'Layer=' + layerParamSplit[j] + '&Request=GetLegendGraphic&Format=image/png&version=1.1.1'
             const legend = {
               layerId: layer.id,
               treeOrder: layer.attributes.treeOrder,

--- a/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
@@ -137,6 +137,11 @@ class ExportService
     private $currentUser;
 
     /**
+     * @var CurrentProcedureService
+     */
+    private $currentProcedureService;
+
+    /**
      * @var ZipExportService
      */
     private $zipExportService;
@@ -144,6 +149,7 @@ class ExportService
     public function __construct(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
+        CurrentProcedureService $currentProcedureService,
         CurrentUserInterface $currentUser,
         DraftStatementService $draftStatementService,
         ElementsService $elementsService,
@@ -179,6 +185,7 @@ class ExportService
         $this->statementService = $statementService;
         $this->translator = $translator;
         $this->zipExportService = $zipExportService;
+        $this->currentProcedureService = $currentProcedureService;
     }
 
     /**
@@ -235,76 +242,87 @@ class ExportService
             }
         }
 
+        //should be empty, because this method is triggered from procedure list.
+        $storedProcedure = $this->currentProcedureService->getProcedure();
+
         $startTime = microtime(true);
         $procedureIds = is_array($procedureIds) ? $procedureIds : [$procedureIds];
         foreach ($procedureIds as $procedureId) {
-            $procedureAsArray = $this->getProcedureOutput()->getProcedureWithPhaseNames($procedureId);
-            $procedureNameField = $useExternalProcedureName ? 'externalName' : 'name';
-            $procedureName = $this->toExportableProcedureName($procedureAsArray[$procedureNameField], $procedureId);
-            $this->logger->info('Creating Zips for Procedure', ['id' => $procedureId, 'name' => $procedureName]);
+            $procedureToExport = $this->procedureService->getProcedure($procedureId);
+            if ($procedureToExport instanceof Procedure) {
+                $this->permissions->setProcedure($procedureToExport);
+                $this->permissions->checkProcedurePermission();
 
-            //get all PDFs
+                $procedureAsArray = $this->getProcedureOutput()->getProcedureWithPhaseNames($procedureId);
+                $procedureNameField = $useExternalProcedureName ? 'externalName' : 'name';
+                $procedureName = $this->toExportableProcedureName($procedureAsArray[$procedureNameField], $procedureId);
+                $this->logger->info('Creating Zips for Procedure', ['id' => $procedureId, 'name' => $procedureName]);
 
-            //Institutionen-Liste
-            if ($this->permissions->hasPermission('feature_procedure_export_include_public_interest_bodies_member_list')) {
-                $zip = $this->addMemberListToZip($procedureId, $procedureName, $zip);
-            }
+                //get all PDFs
 
-            //Titelblatt
-            $zip = $this->addTitlePageToZip($procedureId, $procedureName, $zip);
+                //Institutionen-Liste
+                if ($this->permissions->hasPermission('feature_procedure_export_include_public_interest_bodies_member_list')) {
+                    $zip = $this->addMemberListToZip($procedureId, $procedureName, $zip);
+                }
 
-            //Aktuelles
-            $zip = $this->addNewsToZip($procedureId, $procedureName, $zip);
+                //Titelblatt
+                $zip = $this->addTitlePageToZip($procedureId, $procedureName, $zip);
 
-            //Abwägungstabelle mit Namen
-            if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table')) {
-                $zip = $this->addAssessmentTableToZip($procedureId, $procedureName, 'statementsOnly', $zip);
-            }
+                //Aktuelles
+                $zip = $this->addNewsToZip($procedureId, $procedureName, $zip);
 
-            if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_fragments')) {
-                $zip = $this->addAssessmentTableToZip($procedureId, $procedureName, 'statementsAndFragments', $zip);
-            }
+                //Abwägungstabelle mit Namen
+                if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table')) {
+                    $zip = $this->addAssessmentTableToZip($procedureId, $procedureName, 'statementsOnly', $zip);
+                }
 
-            //Abwägungstabelle ohne Namen (anonym)
-            if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_anonymous')) {
-                $zip = $this->addAssessmentTableAnonymousToZip($procedureId, $procedureName, 'statementsOnly', $zip);
-            }
+                if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_fragments')) {
+                    $zip = $this->addAssessmentTableToZip($procedureId, $procedureName, 'statementsAndFragments', $zip);
+                }
 
-            if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_fragments_anonymous')) {
-                $zip = $this->addAssessmentTableAnonymousToZip($procedureId, $procedureName, 'statementsAndFragments', $zip);
-            }
+                //Abwägungstabelle ohne Namen (anonym)
+                if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_anonymous')) {
+                    $zip = $this->addAssessmentTableAnonymousToZip($procedureId, $procedureName, 'statementsOnly', $zip);
+                }
 
-            //OriginalStellungnahmen
-            if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_original')) {
-                $zip = $this->addAssessmentTableOriginalToZip($procedureId, $procedureName, $zip);
-            }
+                if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_fragments_anonymous')) {
+                    $zip = $this->addAssessmentTableAnonymousToZip($procedureId, $procedureName, 'statementsAndFragments', $zip);
+                }
 
-            //Paragraph Elements
-            $zip = $this->addParagraphElementsToZip($procedureId, $procedureName, $zip);
+                //OriginalStellungnahmen
+                if ($this->permissions->hasPermission('feature_procedure_export_include_assessment_table_original')) {
+                    $zip = $this->addAssessmentTableOriginalToZip($procedureId, $procedureName, $zip);
+                }
 
-            //Planzeichnung
-            $zip = $this->addMapToZip($procedureId, $procedureName, $zip);
+                //Paragraph Elements
+                $zip = $this->addParagraphElementsToZip($procedureId, $procedureName, $zip);
 
-            //Planunsgdokumente ()
-            $zip = $this->addAllPlanningDocumentsToZip($procedureId, $procedureName, $zip);
+                //Planzeichnung
+                $zip = $this->addMapToZip($procedureId, $procedureName, $zip);
 
-            //Stellungnahmen ToeB (Endfassungen)
-            if ($this->permissions->hasPermission('feature_procedure_export_include_statement_final_group')) {
-                $zip = $this->addStatementsFinalGroupToZip($procedureId, $procedureName, $zip);
-            }
-            //Stellungnahmen ToeB (Freigaben)
-            if ($this->permissions->hasPermission('feature_procedure_export_include_statement_released')) {
-                $zip = $this->addStatementsReleasedToZip($procedureId, $procedureName, $zip);
-            }
-            //Stellungnahmen Buerger (Endfassungen)
-            if ($this->permissions->hasPermission('feature_procedure_export_include_public_statements')) {
-                $zip = $this->addPublicStatementsToZip($procedureId, $procedureName, $zip);
-            }
-            // reports
-            if ($this->permissions->hasPermission('feature_export_protocol')) {
-                $zip = $this->addReportToZip($procedureId, $procedureName, $zip);
+                //Planunsgdokumente ()
+                $zip = $this->addAllPlanningDocumentsToZip($procedureId, $procedureName, $zip);
+
+                //Stellungnahmen ToeB (Endfassungen)
+                if ($this->permissions->hasPermission('feature_procedure_export_include_statement_final_group')) {
+                    $zip = $this->addStatementsFinalGroupToZip($procedureId, $procedureName, $zip);
+                }
+                //Stellungnahmen ToeB (Freigaben)
+                if ($this->permissions->hasPermission('feature_procedure_export_include_statement_released')) {
+                    $zip = $this->addStatementsReleasedToZip($procedureId, $procedureName, $zip);
+                }
+                //Stellungnahmen Buerger (Endfassungen)
+                if ($this->permissions->hasPermission('feature_procedure_export_include_public_statements')) {
+                    $zip = $this->addPublicStatementsToZip($procedureId, $procedureName, $zip);
+                }
+                // reports
+                if ($this->permissions->hasPermission('feature_export_protocol')) {
+                    $zip = $this->addReportToZip($procedureId, $procedureName, $zip);
+                }
             }
         }
+
+        $this->permissions->setProcedure($storedProcedure);
 
         $this->logger->info('Time needed to create ProcedureZip: '.number_format(microtime(true) - $startTime, 2).'s');
 

--- a/demosplan/DemosPlanProcedureBundle/Logic/PrepareReportFromProcedureService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/PrepareReportFromProcedureService.php
@@ -281,7 +281,12 @@ class PrepareReportFromProcedureService extends CoreService
             $update['newPublicEndDate'] = $destinationProcedure->getPublicParticipationEndDate()->getTimestamp();
         }
 
-        $user = $this->currentUser->getUser();
+        $user = null;
+        try {
+            $user = $this->currentUser->getUser();
+        } catch (UserNotFoundException $e) {
+            $this->logger->info('No user found for log creation');
+        }
         $phaseChangeEntry = $this->createPhaseChangeReportEntryIfChangesOccurred(
             $sourceProcedure,
             $destinationProcedure,

--- a/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
@@ -12,32 +12,6 @@ namespace demosplan\DemosPlanProcedureBundle\Logic;
 
 use Carbon\Carbon;
 use DateTime;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\ORMException;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\TransactionRequiredException;
-use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
-use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
-use EDT\Querying\Contracts\ConditionFactoryInterface;
-use EDT\Querying\Contracts\FunctionInterface;
-use EDT\Querying\Contracts\PathException;
-use EDT\Querying\Contracts\SortMethodFactoryInterface;
-use EDT\Querying\Contracts\SortMethodInterface;
-use Exception;
-use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
-use ReflectionException;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
-use Throwable;
-use Tightenco\Collect\Support\Collection;
-use TypeError;
 use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\Location;
@@ -74,9 +48,9 @@ use demosplan\DemosPlanCoreBundle\Logic\Export\FieldConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\ILogic\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Logic\LocationService;
-use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\MasterTemplateService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\Plis;
+use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use demosplan\DemosPlanCoreBundle\Repository\EntityContentChangeRepository;
 use demosplan\DemosPlanCoreBundle\Repository\SettingRepository;
@@ -113,6 +87,32 @@ use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use demosplan\DemosPlanUserBundle\Logic\CustomerService;
 use demosplan\DemosPlanUserBundle\Logic\OrgaService;
 use demosplan\DemosPlanUserBundle\Logic\UserService;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\TransactionRequiredException;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
+use EDT\Querying\Contracts\ConditionFactoryInterface;
+use EDT\Querying\Contracts\FunctionInterface;
+use EDT\Querying\Contracts\PathException;
+use EDT\Querying\Contracts\SortMethodFactoryInterface;
+use EDT\Querying\Contracts\SortMethodInterface;
+use Exception;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
+use ReflectionException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+use Tightenco\Collect\Support\Collection;
+use TypeError;
 use function array_key_exists;
 use function array_merge;
 use function array_unique;
@@ -1255,6 +1255,12 @@ class ProcedureService extends CoreService
                 'id' => $procedureId,
             ];
 
+            // Necessary data for the PostProcedureDeletedEvent
+            $procedureData = [
+                'id'                => $procedureId,
+                'maillaneAccountId' => $procedure->getMaillaneConnection()->getMaillaneAccountId(),
+            ];
+
             // delete Procedure
             $repository->delete($procedureId);
 
@@ -1298,7 +1304,11 @@ class ProcedureService extends CoreService
                 $this->entityPreparator->prepareEntity($data['exportSettings'], $origSourceRepos->getDefaultExportFieldsConfiguration());
             }
 
-            $data['currentUser'] = $this->currentUser->getUser();
+            try {
+                $data['currentUser'] = $this->currentUser->getUser();
+            } catch (UserNotFoundException $e) {
+                $this->logger->info('Procedure updated without known user');
+            }
             $procedure = $this->procedureRepository->update($data['ident'], $data);
 
             $procedure = $this->phasePermissionsetLoader->loadPhasePermissionsets($procedure);

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/DpBasicSettings.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/DpBasicSettings.vue
@@ -161,41 +161,6 @@ export default {
 
     unselectAllAuthUsers () {
       this.selectedAuthUsers = []
-    },
-
-    // This method is only in use for bobHH.
-    updateParticipationDescriptionAndName (plisId) {
-      this.isLoadingPlisData = true
-      this.getDataPlis(plisId, 'DemosPlan_plis_get_procedure')
-        .then(data => {
-          if (data.code === 100 && data.success === true) {
-            const procedureDescriptionText = data.procedure.planungsanlass
-            let msg = Translator.trans('statement.save.notification')
-            if (procedureDescriptionText === this.procedureDescription) {
-              msg = Translator.trans('warning.plis.no.changes')
-            }
-            this.procedureDescription = procedureDescriptionText
-            dplan.notify.notify('confirm', Translator.trans(Translator.trans('information.short.imported.successfully') + ' ' + msg))
-          } else {
-            dplan.notify.notify('error', Translator.trans('error.plis.getplanningcause'))
-          }
-          this.isLoadingPlisData = false
-        })
-
-      this.getDataPlis(plisId, 'DemosPlan_plis_get_procedure_name')
-        .then(data => {
-          if (data.code === 100 && data.success === true) {
-            const procedureNameNew = data.procedureName
-            let msg = Translator.trans('statement.save.notification')
-            if (procedureNameNew === this.procedureName) {
-              msg = Translator.trans('warning.plis.no.changes')
-            }
-            this.procedureName = procedureNameNew
-            dplan.notify.notify('confirm', Translator.trans(Translator.trans('information.short.imported.successfully') + ' ' + msg))
-          } else {
-            dplan.notify.notify('error', Translator.trans('error.procedure.name.not.imported'))
-          }
-        })
     }
   },
 

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/splitStatement/CardPane.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/splitStatement/CardPane.vue
@@ -130,13 +130,30 @@ export default {
     setContainerHeight () {
       const cardBottomValues = this.$refs.card.map((card) => card.$el.getBoundingClientRect().bottom)
       const maxBottom = Math.max(...cardBottomValues)
-      const containerBounds = this.$el.getBoundingClientRect()
+      const containerBounds = this.getContainerBounds()
       this.containerMinHeight = `${maxBottom + containerBounds.height - containerBounds.bottom}px`
+    },
+
+    getContainerBounds () {
+      const offset = window.pageYOffset || document.documentElement.scrollTop
+
+      return {
+        bottom: -offset + this.containerSize.top + this.containerSize.height,
+        height: this.containerSize.height,
+        top: -offset + this.containerSize.top
+      }
     }
   },
 
   mounted () {
+    this.containerSize = this.$el.getBoundingClientRect()
     this.positionCards()
+
+    document.addEventListener('resize', this.positionCards)
+  },
+
+  unmounted () {
+    document.removeEventListener('resize', this.positionCards)
   }
 }
 </script>

--- a/demosplan/DemosPlanUserBundle/Logic/CurrentUserService.php
+++ b/demosplan/DemosPlanUserBundle/Logic/CurrentUserService.php
@@ -16,6 +16,7 @@ use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Security\Authentication\Token\DemosToken;
 use demosplan\DemosPlanUserBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanUserBundle\Exception\UserNotFoundException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class CurrentUserService implements CurrentUserInterface
@@ -33,8 +34,13 @@ class CurrentUserService implements CurrentUserInterface
      * @var PermissionsInterface
      */
     private $permissions;
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
 
     public function __construct(
+        LoggerInterface $logger,
         CustomerHandler $customerHandler,
         PermissionsInterface $permissions,
         TokenStorageInterface $tokenStorage
@@ -42,6 +48,7 @@ class CurrentUserService implements CurrentUserInterface
         $this->tokenStorage = $tokenStorage;
         $this->customerHandler = $customerHandler;
         $this->permissions = $permissions;
+        $this->logger = $logger;
     }
 
     public function getUser(): User
@@ -88,6 +95,7 @@ class CurrentUserService implements CurrentUserInterface
     {
         $token = $this->tokenStorage->getToken();
         if (!$token instanceof DemosToken) {
+            $this->logger->error('invalid user', [$token, debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 30)]);
             throw new UserNotFoundException('Token could not be found');
         }
 

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/DpOrganisationListItem.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/DpOrganisationListItem.vue
@@ -18,37 +18,30 @@
     :open="isOpen">
     <!-- Item header -->
     <template v-slot:header>
-      <div
-        v-if="editable && selectable"
-        class="u-mt-0_75 display--inline-block o-accordion--checkbox">
-        <!-- 'Select item' checkbox -->
+      <div class="flex">
         <input
+          v-if="editable && selectable"
           type="checkbox"
           :id="`selected` + organisation.id"
           :checked="selected"
           data-cy="organisationItemSelect"
           @change="$emit('item:selected', organisation.id)">
-      </div><!--
-   --><div
-        @click="isOpen = false === isOpen"
-        :class="{'u-pl-0_5': false === selectable}"
-        class="display--inline-block o-accordion--header-content">
         <div
-          class="weight--bold u-10-of-12 u-mt-0_75 u-mb-0_5 display--inline-block o-hellip--nowrap"
+          @click="isOpen = false === isOpen"
+          class="weight--bold cursor--pointer o-hellip--nowrap u-pv-0_75 u-ph-0_25 flex-grow"
           data-cy="organisationListTitle">
           {{ initialOrganisation.attributes.name }}
         </div>
-          <!-- Toggle expanded/collapsed -->
-        <div class="o-accordion--button float--right text--right u-mt-0_5 display--inline">
-          <button
-            type="button"
-            data-cy="accordionToggleBtn"
-            class="btn--blank o-link--default">
-            <i
-              class="fa"
-              :class="isOpen ? 'fa-angle-up': 'fa-angle-down'" />
-          </button>
-        </div>
+        <button
+          @click="isOpen = false === isOpen"
+          type="button"
+          data-cy="accordionToggleBtn"
+          class="btn--blank o-link--default">
+          <dp-icon
+            aria-hidden="true"
+            :aria-label="ariaLabel"
+            :icon="icon" />
+        </button>
       </div>
     </template>
 
@@ -78,6 +71,7 @@
 
 <script>
 import DpButtonRow from '@DpJs/components/core/DpButtonRow'
+import { DpIcon } from 'demosplan-ui/components'
 import DpTableCard from '@DpJs/components/core/DpTableCardList/DpTableCard'
 import dpValidateMixin from '@DpJs/lib/validation/dpValidateMixin'
 import { mapState } from 'vuex'
@@ -87,6 +81,7 @@ export default {
 
   components: {
     DpButtonRow,
+    DpIcon,
     DpOrganisationFormFields: () => import(/* webpackChunkName: "organisation-form-fields" */ './DpOrganisationFormFields'),
     DpTableCard
   },
@@ -145,6 +140,10 @@ export default {
       pendingOrganisations: 'items'
     }),
 
+    ariaLabel () {
+      return Translator.trans(this.isOpen ? 'aria.collapse' : 'aria.expand')
+    },
+
     initialOrganisation () {
       return (this.moduleName === '') ? this.$store.state.orga.initial[this.organisation.id] : this.$store.state.orga[this.moduleName].initial[this.organisation.id]
     },
@@ -154,6 +153,10 @@ export default {
      */
     editable () {
       return hasPermission('area_manage_orgas_all') || hasPermission('feature_orga_edit_all_fields') || hasPermission('area_organisations_applications_manage')
+    },
+
+    icon () {
+      return this.isOpen ? 'chevron-up' : 'chevron-down'
     }
   },
 

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/DpUserListItem.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/DpUserListItem.vue
@@ -20,89 +20,83 @@
     :open="isOpen">
     <!-- Item header -->
     <template v-slot:header>
-      <!-- 'Select item' checkbox -->
-      <div class="u-mt-0_75 display--inline-block u-valign--top o-accordion--checkbox">
-        <input
-          type="checkbox"
-          :id="`selected` + user.id"
-          :checked="selected"
-          name="elementsToAdminister[]"
-          :value="user.id"
-          data-cy="userItemSelect"
-          @change="$emit('item:selected', user.id)">
-      </div><!--
-         Toggle expanded/collapsed
-   --><div
-        @click="isOpen = false === isOpen"
-        class="display--inline-block o-accordion--header-content">
-          <div>
-           <div class="weight--bold u-10-of-12 u-mt-0_75 u-mb-0_5 display--inline-block">
-              {{ initialUser.attributes.firstname }} {{ initialUser.attributes.lastname }}
-           </div><!--
-         --><div class="o-accordion--button float--right text--right u-mt-0_75 display--inline">
-            <button
-              type="button"
-              data-cy="userListItemToggle"
-              class="btn--blank o-link--default">
-              <i
-                class="fa"
-                :class="isOpen ? 'fa-angle-up': 'fa-angle-down'" />
-            </button>
-          </div>
-
+      <div class="flex flex-items-start">
+        <div class="position--relative u-z-content-above u-mt-0_75">
+          <input
+            type="checkbox"
+            :checked="selected"
+            name="elementsToAdminister[]"
+            :value="user.id"
+            data-cy="userItemSelect"
+            @change="$emit('item:selected', user.id)">
+        </div>
         <div
-          data-cy="editItemToggle"
-          class="layout u-mb-0_5"
-          data-dp-validate="organisationForm">
+          @click="isOpen = false === isOpen"
+          class="cursor--pointer u-pv-0_75 u-ph-0_25 flex-grow"
+          data-cy="organisationListTitle">
           <div
-            class="u-1-of-2 layout__item"
-            v-if="hasRoles">
+            data-cy="editItemToggle"
+            class="layout">
+            <div class="layout__item u-1-of-1 weight--bold u-mb-0_5 o-hellip--nowrap">
+              {{ initialUser.attributes.firstname }} {{ initialUser.attributes.lastname }}
+            </div>
             <div
-              v-for="(role, idx) in userRoles"
-              :key="idx">
-              {{ Translator.trans(role.attributes.name) }}<br>
+              class="u-1-of-2 layout__item"
+              v-if="hasRoles">
+              <div
+                v-for="(role, idx) in userRoles"
+                :key="idx">
+                {{ Translator.trans(role.attributes.name) }}<br>
+              </div>
+            </div><!--
+         --><div
+              v-else
+              class="u-4-of-12 layout__item">
+              {{ Translator.trans('unknown') }}<br>
+            </div><!--
+         --><div
+              v-if="userOrga"
+              class="layout__item u-1-of-2">
+              {{ Translator.trans(userOrga.attributes.name) }}
+              <br>
+              <div
+                v-if="userDepartment !== null"
+                class="u-1-of-2 display--inline">
+                {{ Translator.trans(userDepartment.attributes.name) }}
+              </div>
             </div>
-          </div><!--
-       --><div
-            v-else
-            class="u-4-of-12 layout__item">
-            {{ Translator.trans('unknown') }}<br>
-          </div><!--
-       --><div
-            v-if="userOrga"
-            class="layout__item u-1-of-2">
-            {{ Translator.trans(userOrga.attributes.name) }}
-            <br>
-            <div
-              v-if="userDepartment !== null"
-              class="u-1-of-2 display--inline">
-              {{ Translator.trans(userDepartment.attributes.name) }}
-            </div>
-          </div>
-
-          <!--  Registration status --><!--
-       --><div class="layout__item u-pt-0_5 u-pb-0_5">
-            <div v-if="user.attributes.profileCompleted">
-              {{ Translator.trans('user.registration.completed') }}
-            </div>
-            <div v-else-if="user.attributes.accessConfirmed">
-              {{ Translator.trans('user.registration.confirmed') }}
-            </div>
-            <div v-else-if="user.attributes.invited">
-              {{ Translator.trans('user.registration.invitation.sent') }}
-            </div>
-            <div v-else>
-              {{ Translator.trans('user.registration.invitation.outstanding') }}
+            <!--  Registration status -->
+            <div class="layout__item u-pt-0_5">
+              <div v-if="user.attributes.profileCompleted">
+                {{ Translator.trans('user.registration.completed') }}
+              </div>
+              <div v-else-if="user.attributes.accessConfirmed">
+                {{ Translator.trans('user.registration.confirmed') }}
+              </div>
+              <div v-else-if="user.attributes.invited">
+                {{ Translator.trans('user.registration.invitation.sent') }}
+              </div>
+              <div v-else>
+                {{ Translator.trans('user.registration.invitation.outstanding') }}
+              </div>
             </div>
           </div>
         </div>
+        <button
+          @click="isOpen = false === isOpen"
+          type="button"
+          data-cy="userListItemToggle"
+          class="btn--blank o-link--default u-pv-0_75">
+          <dp-icon
+            aria-hidden="true"
+            :aria-label="ariaLabel"
+            :icon="icon" />
+        </button>
       </div>
-    </div>
     </template>
 
     <!-- Item content / editable data -->
     <div
-      class="u-mt"
       data-cy="userForm"
       data-dp-validate="userForm">
       <dp-user-form-fields
@@ -124,6 +118,7 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex'
 import DpButtonRow from '@DpJs/components/core/DpButtonRow'
+import { DpIcon } from 'demosplan-ui/components'
 import DpTableCard from '@DpJs/components/core/DpTableCardList/DpTableCard'
 import DpUserFormFields from './DpUserFormFields'
 import dpValidateMixin from '@DpJs/lib/validation/dpValidateMixin'
@@ -133,6 +128,7 @@ export default {
 
   components: {
     DpButtonRow,
+    DpIcon,
     DpTableCard,
     DpUserFormFields
   },
@@ -177,6 +173,10 @@ export default {
       roles: 'items'
     }),
 
+    ariaLabel () {
+      return Translator.trans(this.isOpen ? 'aria.collapse' : 'aria.expand')
+    },
+
     hasDepartment () {
       return this.initialUser.hasRelationship('department')
     },
@@ -201,6 +201,10 @@ export default {
         (this.userOrga !== null && this.userOrga.toString().toLowerCase().includes(this.filterValue.toLowerCase())) ||
         (this.userDepartment !== null && this.userDepartment.toString().toLowerCase().includes(this.filterValue.toLowerCase()))
       )
+    },
+
+    icon () {
+      return this.isOpen ? 'chevron-up' : 'chevron-down'
     },
 
     userDepartment () {

--- a/templates/bundles/DemosPlanMapBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanMapBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -298,7 +298,7 @@
 
                 {# Are there any global layer pdfs defined (feature_map_use_plan_pdf)? #}
                 {% set display_legend_box = procedureSettings.planPDF|default|length > 0 %}
-                {% set planPfd = { pdf: procedureSettings.planPDF|default, hash: '', mimeType: '', size: '' } %}
+                {% set planPdf = { pdf: procedureSettings.planPDF|default, hash: '', mimeType: '', size: '' } %}
                 {% if procedureSettings.planPDF|default|length > 0 %}
                     {% set planPdf = { pdf: procedureSettings.planPDF, hash: procedureSettings.planPDF|getFile('hash'), mimeType: procedureSettings.planPDF|getFile('mimeType'), size: procedureSettings.planPDF|getFile('size','MB') } %}
                 {% endif %}
@@ -318,7 +318,9 @@
                         }
                     }]) %}
                 {% endfor %}
-                {% set display_legend_box = layers_with_legend_files|length > 0 %}
+                {% if false == display_legend_box %}
+                    {% set display_legend_box = layers_with_legend_files|length > 0 %}
+                {% endif %}
 
                 {# When fetching legends dynamically via getLegendGraphic, we need to display the box anyhow, as we cannot know, whether we have legends or not #}
                 {% if false == display_legend_box %}
@@ -326,9 +328,9 @@
                 {% endif %}
 
                 <dp-layer-legend
-                    :display-legend-box="Boolean({{ display_legend_box }})"
+                    v-show="Boolean({{ display_legend_box }})"
                     :layers-with-legend-files="JSON.parse('{{ layers_with_legend_files|json_encode|e('js', 'utf-8') }}')"
-                    :plan-pdf="JSON.parse('{{ procedureSettings.planPDF|json_encode|e('js', 'utf-8') }}')">
+                    :plan-pdf="JSON.parse('{{ planPdf|json_encode|e('js', 'utf-8') }}')">
                 </dp-layer-legend>
 
             {% endblock map_toolbar_legend %}

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -135,9 +135,6 @@
                     - help.procedures.adjustments.public.postalCode
                 @TODO now that their contents are splitted across the fields + hardcoded into messages.de.yml, they could be deleted in the database. #}
 
-            {# bobhh special permission #}
-            {% block import_plis_data %}{% endblock import_plis_data %}
-
             {# This block can be used to place a more simple form here. #}
             {% block wizard_content %}
 

--- a/tests/backend/core/Core/Functional/SamlUserFactoryTest.php
+++ b/tests/backend/core/Core/Functional/SamlUserFactoryTest.php
@@ -61,25 +61,42 @@ class SamlUserFactoryTest extends FunctionalTestCase
     public function testCreateNewUserFromSAML(): void
     {
         $attributes = [
-            'country'      => [''],
-            'givenName'    => ['Hannah'],
-            'houseNumber'  => [''],
-            'ID'           => ['886227c04d14045c16c42d706427d8392fd64417'],
-            'localityName' => [''],
-            'mail'         => ['mail.needs@citiz.en'],
-            'orgaMail'     => [''],
-            'orgaName'     => [''],
-            'orgaType'     => [''],
-            'postalCode'   => [''],
-            'street'       => [''],
-            'surname'      => ['Lotta'],
+            'country'       => [''],
+            'givenName'     => ['Hannah'],
+            'houseNumber'   => [''],
+            'ID'            => ['886227c04d14045c16c42d706427d8392fd64417'],
+            'localityName'  => [''],
+            'email'         => ['mail.needs@citiz.en'],
+            'orgaMail'      => [''],
+            'orgaName'      => [''],
+            'orgaType'      => [''],
+            'postalCode'    => [''],
+            'street'        => [''],
+            'surname'       => ['Lotta'],
         ];
 
         $user = $this->sut->createUser($attributes['ID'][0], $attributes);
         self::assertInstanceOf(User::class, $user);
         $anonymousUser = new AnonymousUser();
         self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
-        self::assertEquals($anonymousUser->getOrga()->getDepartments()->first()->getId(), $user->getDepartment()->getId());
+        self::assertEquals($attributes['ID'][0], $user->getLogin());
+    }
+
+    public function testCreateNewUserFromSAMLServicekonto(): void
+    {
+        $attributes = [
+            'email'       => ['Sarah@connell.de'],
+            'givenName'   => ['Sarah'],
+            'bPK'         => ['VjEuQkI6OmRlLmFrZGIuYnBrLnNzb0Bsb2dpbi1zdGFnZS5iYXVsZWl0cGxhbnVuZy1vbmxpbmUuZGU6OmxvUlF1c25qTXQ0bVN4eUFtNExQZkZPbTdjd1JiWjRQc3FFNTltcERWbnc6OjIwMjItMDktMjNUMTU6MTQ6NTM='],
+            'surname'     => ['Connell'],
+            'ID'          => ['loRQusnjMt4mSxyAm4LPfFOm7cwRbZ4PsqE59mpDVnw'],
+            'sessionIndex'=> '54204e12-af28-4b20-806b-e21fced6ad8a::30065ff8-40b7-42b7-82c4-80c26d993959',
+        ];
+
+        $user = $this->sut->createUser($attributes['ID'][0], $attributes);
+        self::assertInstanceOf(User::class, $user);
+        $anonymousUser = new AnonymousUser();
+        self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
         self::assertEquals($attributes['ID'][0], $user->getLogin());
     }
 
@@ -124,18 +141,18 @@ class SamlUserFactoryTest extends FunctionalTestCase
     private function getOrgaLoginAttributes(): array
     {
         return [
-            'country'      => ['de'],
-            'givenName'    => [''],
-            'houseNumber'  => ['14'],
-            'ID'           => ['du-886227c04d14045c16c42d706427d8392fd64417'],
-            'localityName' => ['Erlangen'],
-            'mail'         => ['mail.needs@tobes.et'],
-            'orgaMail'     => ['orgaMailneeds@tobes.et'],
-            'orgaName'     => ['Franken Plus GmbH & Co. KGaA'],
-            'orgaType'     => ['NNatPers'],
-            'postalCode'   => ['91058'],
-            'street'       => ['Frauenweiherstr.'],
-            'surname'      => [''],
+            'country'       => ['de'],
+            'givenName'     => [''],
+            'houseNumber'   => ['14'],
+            'ID'            => ['du-886227c04d14045c16c42d706427d8392fd64417'],
+            'localityName'  => ['Erlangen'],
+            'email'         => ['mail.needs@tobes.et'],
+            'orgaMail'      => ['orgaMailneeds@tobes.et'],
+            'orgaName'      => ['Franken Plus GmbH & Co. KGaA'],
+            'orgaType'      => ['NNatPers'],
+            'postalCode'    => ['91058'],
+            'street'        => ['Frauenweiherstr.'],
+            'surname'       => [''],
         ];
     }
 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -88,7 +88,7 @@ adjustments.general.error.public.participation.maxlength: "\"Ansprechperson für
 adjustments.general.error.public.procedure.description.maxlength: "\"Öffentliche Verfahrensbeschreibung\" darf nicht länger als 10.000 Zeichen sein"
 adjustments: "Einstellungen"
 administer: "Verwalten"
-administration.alt: "Behörde"
+administration.alt: "Institution"
 administration: "Verwaltung"
 affirmative: "Zustimmend"
 advisory.board.activities: "Aktivitäten im virtuellen Anwenderbeirat"


### PR DESCRIPTION
This PR contains all changes that where committed to the old repository after the repository split. They where approved there.

To approve this PR it would be enough to scan through the changes for some weirdness that should not be in this change.

Somehow all changes from main are included into this PR, so it is targeted against main and needs to be cherry-picked later on to release.