### PR TITLE
feature (refs T26712): let FE know what searchFilter was used even if result is empty

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -337,16 +337,18 @@ class DemosPlanAssessmentTableController extends BaseController
             'defaultToggleView'               => $this->globalConfig->getAssessmentTableDefaultToggleView(),
         ];
 
+        $usedFilters = $statementFilterHandler->getRequestedFiltersInfo(
+            $assessmentTableQuery->getFilters(),
+            $table->getFilterSet()['filters']
+        );
+
         return $this->renderTemplate(
             '@DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_view.html.twig',
             [
                 'templateVars' => $templateVars,
                 'title'        => 'assessment.table',
                 'procedure'    => $procedureId,
-                'filters'      => $statementFilterHandler->getRequestedFiltersInfo(
-                    $assessmentTableQuery->getFilters(),
-                    $table->getFilterSet()['filters']
-                ),
+                'filters'      => $usedFilters,
             ]
         );
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchFilterArrayTransformer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchFilterArrayTransformer.php
@@ -34,24 +34,22 @@ class ElasticsearchFilterArrayTransformer
     {
         $filter = [];
         if ((!\is_array($bucket) || 0 === \count($bucket)) && 0 === \count($labelMap)) {
+
             return $filter;
         }
 
         foreach ($bucket as $entry) {
-            // No need to return emtpy filters
-            if ($entry[$countKey] > 0) {
-                $filterEntry = [
-                    'count' => $entry[$countKey],
-                    'label' => \array_key_exists($entry[$labelKey], $labelMap) ? $labelMap[$entry[$labelKey]] : $entry[$labelKey],
-                    'value' => $entry[$valueKey],
-                ];
-                // Setze einen Stadardwert, wenn kein Label angegeben ist
-                if ('' === $filterEntry['label']) {
-                    $filterEntry['label'] = 'Keine Zuordnung';
-                    $filterEntry['value'] = ElasticSearchService::EMPTY_FIELD;
-                }
-                $filter[] = $filterEntry;
+            $filterEntry = [
+                'count' => $entry[$countKey],
+                'label' => \array_key_exists($entry[$labelKey], $labelMap) ? $labelMap[$entry[$labelKey]] : $entry[$labelKey],
+                'value' => $entry[$valueKey],
+            ];
+            // Setze einen Stadardwert, wenn kein Label angegeben ist
+            if ('' === $filterEntry['label']) {
+                $filterEntry['label'] = 'Keine Zuordnung';
+                $filterEntry['value'] = ElasticSearchService::EMPTY_FIELD;
             }
+            $filter[] = $filterEntry;
         }
 
         // sortiere nach Label

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -3478,6 +3478,10 @@ class StatementService extends CoreService
             }
 
             $aggregations = $resultSet->getAggregations();
+            if (0 === $result['hits']['total']) {
+                $aggregations = $this->addFilterToAggregationsWhenCausedResultIsEmpty($aggregations, $userFilters);
+            }
+
             $aggregation = [];
             $elementsAdminList = $this->serviceElements->getElementsAdminList($procedureId);
             $elementMap = collect($elementsAdminList)
@@ -4968,5 +4972,22 @@ class StatementService extends CoreService
         }
 
         return ToBy::create($propertyName, $direction);
+    }
+
+    private function addFilterToAggregationsWhenCausedResultIsEmpty(array $aggregations, array $userfilters): array
+    {
+        foreach ($userfilters as $label => $value) {
+                if (array_key_exists($label, $aggregations)
+                    && is_array($aggregations[$label])
+                    && array_key_exists('buckets', $aggregations[$label])
+                    && empty($aggregations[$label]['buckets'])
+                ) {
+                    // A filter was set by the user that caused an empty search result - therefore the filter ist not
+                    // set within the aggregations by default - add those filters manually to let the FE know we used a filter
+                    $aggregations[$label]['buckets'] = [['key' => $value[0], 'doc_count' => 0]];
+                }
+        }
+
+        return $aggregations;
     }
 }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T26712

Description:
When the search result of a given filter is empty - the filter is not
included in the aggregations retrieved via
the $paginator->getCurrentPageResults().

A method to add those empty filters to the
aggregations was added.

There is still a hitCount hinting the result is empty with 0 hits
but the FE knows a Filter was used as it is now listed within the filters passed inside the templateVars.

How to test:
setup:
Go to the AT
Choose a filter that results in just 1 match
Edit/Change the document listed - so it does not match the search criteria(s) anymore.
Reload the AT
-> the filter is still set but there are no search-hits now.

Before these changes the FE could not highlight the filter button / used filter(s) because we did not send filters causing an empty result.
Now the filter button / used filter(s) are highlighted as they are sent even if the result is empty.