### PR TITLE
bug(refs T27762): correct wrong spelling in export

### DIFF
--- a/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
@@ -189,7 +189,7 @@ class ExportService
         // Dictonary with keys to obtain
         $dictionary = [
             'statements'         => 'statements',
-            'considerationtable' => 'considerationtable',
+            'considerationtable' => 'considerationtable_ascii',
             'originals'          => 'statements.original',
             'attachment'         => 'attachment',
             'elements'           => 'elements',
@@ -435,14 +435,14 @@ class ExportService
                 AssessmentTableViewMode::DEFAULT_VIEW,
                 false
             );
-            $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->translator->trans('considerationtable').'/%s.docx';
+            $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {
                 case 'statementsOnly':
-                    $filename = sprintf($filename, $this->translator->trans('considerationtable').'_Liste');
+                    $filename = sprintf($filename, $this->literals['considerationtable'].'_Liste');
                     break;
 
                 case 'statementsAndFragments':
-                    $filename = sprintf($filename, $this->translator->trans('considerationtable').'_Liste_mit_Datensaetzen');
+                    $filename = sprintf($filename, $this->literals['considerationtable'].'_Liste_mit_Datensaetzen');
                     break;
             }
 
@@ -484,14 +484,14 @@ class ExportService
                 AssessmentTableViewMode::DEFAULT_VIEW,
                 false
             );
-            $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->translator->trans('considerationtable').'/%s.docx';
+            $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {
                 case 'statementsOnly':
-                    $filename = sprintf($filename, $this->translator->trans('considerationtable').'_Liste_Anonym');
+                    $filename = sprintf($filename, $this->literals['considerationtable'].'_Liste_Anonym');
                     break;
 
                 case 'statementsAndFragments':
-                    $filename = sprintf($filename, $this->translator->trans('considerationtable').'_Liste_mit_Datensaetzen_Anonym');
+                    $filename = sprintf($filename, $this->literals['considerationtable'].'_Liste_mit_Datensaetzen_Anonym');
                     break;
             }
 
@@ -503,7 +503,7 @@ class ExportService
                 $outputResult->getStatements(),
                 [$this->statementService, 'getStatementsByIds']
             );
-            $folderName = $procedureName.'/'.$this->literals['statements'].'/'.$this->translator->trans('considerationtable').'/'.$this->literals['attachment'].'/';
+            $folderName = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/'.$this->literals['attachment'].'/';
             $this->attachStatementFilesToZip($statementEntities, $folderName, $zip);
 
             $this->logger->info('abwaegung_list_anonym created',

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -623,6 +623,7 @@ considerationadvice: "Abwägung / Empfehlung"
 considerationtable.back: "Zurück zur Abwägungstabelle"
 # deliberation table?
 considerationtable: "Abwägungstabelle"
+considerationtable_ascii: "Abwaegungstabelle"
 # considerationtext = considerationadvice
 considerationtext: "Abwägungstext"
 consolidate: "Gruppieren"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27762

Description: If you export procedures then you have a wrong spelling of "Abägungstabelle" in the zip archive. Instead of "ä" you have an "a" there. The "ä" is being replaced by "a" from a Utf8::toAscii() call when setting $this->literals. I replaced the using of the literals calls by directly calling the trans() function to avoid the exchange.

How to review/test
login as Walter West (FPA) --> export procedure --> in zip file: skip through the file an check the spelling

### PR Checklist

Delete the checkbox if it doesn't apply/isn't necessary.
- [X] Link all relevant tickets
- [x] Move the tickets on the board accordingly