### PR TITLE
feat: Use container names

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
@@ -1,13 +1,13 @@
 # this file keeps specific params used
 # during development with DEMOS Containers
 parameters:
-    database_host: "172.22.255.3"
+    database_host: "db"
     database_user: "root"
     database_password: ""
 
     elasticsearch_populate_workers: 4
     elasticsearch_urls:
-        -   url: "http://172.22.255.6:9200"
+        -   url: "http://search6:9200"
 
     fileservice_filepath: "/opt/uploads"
 
@@ -38,7 +38,7 @@ parameters:
         - '*.demos-europe.eu'
         - 'cdnjs.cloudflare.com'
 
-    rabbitmq_host: "172.22.255.5"
+    rabbitmq_host: "mq"
     rabbitmq_routing_disabled: true
 
     gateway_url: '/app_dev.php/dplan/login'


### PR DESCRIPTION
We don't need to rely on the ip addresses in the config.
This also helps with making the configuration more resilient
against changes in the docker-compose network configuration
and reduces the need for environment variables by introducing
the conventions that

- the database is always reachable at `db`
- the message broker at `mq`
- and elasticsearch at `search6`

The names are likely subject to change, yet still an improvement
over hard coded ip addresses
