### PR TITLE
Make CSP form-action allowed sources configurable

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/nelmio_security.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/nelmio_security.yaml
@@ -29,8 +29,7 @@ nelmio_security:
             object-src:
                 - 'self'
             base-uri: '%demosplan_csp_base_uri%'
-            form-action:
-                - 'self'
+            form-action: '%demosplan_csp_form_action%'
             worker-src:
                 - 'none'
             upgrade-insecure-requests: '%https_only%' # upgrades HTTP requests to HTTPS transport

--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
@@ -349,6 +349,8 @@ parameters:
         - 'fonts.google.com'
         - 'fonts.gstatic.com'
         - 'data:'
+    demosplan_csp_form_action:
+        - 'self'
     demosplan_csp_frame_src: []
     demosplan_csp_frame_ancestors:
         - 'none'


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29293

As Chrome + Safari do not allow redirects after a form post, the SAML route that is redirected to in `DemosPlanUserAuthenticationController.php:334` must be allowed here, as well (in the project `parameters.yml`).

More can be found in https://stackoverflow.com/a/71352313/6234391

### How to review/test
One-Click Logout in Chrome should be possible.

### PR Checklist
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
