### PR TITLE
refactor(refs T29004): pass label props as object (DpCheckbox)

### DIFF
--- a/client/js/components/core/DpCheckboxGroup.vue
+++ b/client/js/components/core/DpCheckboxGroup.vue
@@ -16,13 +16,15 @@
       :class="inline ? 'float--left' : 'u-mb-0_25'" />
     <dp-checkbox
       v-for="(option, idx) in options"
-      :key="`option_${idx}`"
       :id="option.id"
-      :name="option.name || ''"
-      :class="inline ? 'display--inline-block u-ml' : ''"
+      :key="`option_${idx}`"
       v-model="selected[option.id]"
-      @change="$emit('update', selected)"
-      :label="option.label" />
+      :class="inline ? 'display--inline-block u-ml' : ''"
+      :label="{
+        text: option.label
+      }"
+      :name="option.name || ''"
+      @change="$emit('update', selected)" />
   </fieldset>
 </template>
 

--- a/client/js/components/core/DpDataTable/DpColumnSelector.vue
+++ b/client/js/components/core/DpDataTable/DpColumnSelector.vue
@@ -33,11 +33,13 @@
     <div class="space-stack-xs u-pv-0_25">
       <dp-checkbox
         v-for="([value, label]) in selectableColumns"
-        :key="value"
         :id="`columnSelector:${value}`"
+        :key="value"
         :checked="selectedColumns.has(value)"
-        @change="broadcastSelection(value, !selectedColumns.has(value))"
-        :label="label" />
+        :label="{
+          text: label
+        }"
+        @change="broadcastSelection(value, !selectedColumns.has(value))" />
     </div>
   </dp-flyout>
 </template>

--- a/client/js/components/core/DpEditor/DpLinkModal.vue
+++ b/client/js/components/core/DpEditor/DpLinkModal.vue
@@ -37,8 +37,10 @@
           type="url" />
         <dp-checkbox
           id="newTab"
-          :label="Translator.trans('open.in.new.tab')"
-          v-model="newTab" />
+          v-model="newTab"
+          :label="{
+            text: Translator.trans('open.in.new.tab')
+          }" />
         <dp-button-row
           class="u-mt"
           primary

--- a/client/js/components/core/DpTableCardList/DpTableCardListHeader.vue
+++ b/client/js/components/core/DpTableCardList/DpTableCardListHeader.vue
@@ -20,10 +20,10 @@
     <!-- header with checkbox and labels-->
     <div class="layout__item u-pv-0_5 border--bottom">
       <dp-checkbox
+        v-if="selectable"
         id="selectAll"
         class="display--inline-block"
-        @change="val => $emit('select-all', val)"
-        v-if="selectable" /><!--
+        @change="val => $emit('select-all', val)" /><!--
     --><div
         class="layout__item weight--bold"
         :class="[item.classes ? item.classes : '', item.width ? item.width : '']"

--- a/client/js/components/core/form/DpCheckbox.vue
+++ b/client/js/components/core/form/DpCheckbox.vue
@@ -24,10 +24,15 @@
       true-value="1"
       false-value="0">
     <dp-label
-      v-if="label !== ''"
+      v-if="label.text !== ''"
       :class="prefixClass('o-form__label')"
-      :bold="standalone"
-      v-bind="labelProps" />
+      v-bind="{
+        bold: false,
+        text: '',
+        for: id,
+        required: required,
+        ...label,
+      }" />
   </div>
 </template>
 
@@ -62,21 +67,17 @@ export default {
       default: false
     },
 
-    hint: {
-      type: String,
-      required: false,
-      default: ''
-    },
-
     id: {
       type: String,
       required: true
     },
 
     label: {
-      type: String,
-      required: false,
-      default: ''
+      type: Object,
+      default: () => ({}),
+      validator: (prop) => {
+        return Object.keys(prop).every(key => ['bold', 'hint', 'text', 'tooltip'].includes(key))
+      }
     },
 
     name: {
@@ -97,34 +98,10 @@ export default {
       default: false
     },
 
-    standalone: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-
-    tooltip: {
-      type: String,
-      required: false,
-      default: ''
-    },
-
     valueToSend: {
       type: String,
       required: false,
       default: '1'
-    }
-  },
-
-  computed: {
-    labelProps () {
-      return {
-        for: this.id,
-        hint: this.hint,
-        required: this.required,
-        text: this.label,
-        tooltip: this.tooltip
-      }
     }
   }
 }

--- a/demosplan/DemosPlanDocumentBundle/Resources/client/js/components/ElementsAdminBulkEdit/ElementsAdminBulkEdit.vue
+++ b/demosplan/DemosPlanDocumentBundle/Resources/client/js/components/ElementsAdminBulkEdit/ElementsAdminBulkEdit.vue
@@ -25,12 +25,14 @@
         v-if="hasPermission('feature_auto_switch_element_state')"
         class="border--bottom u-pt u-pb-0_5">
         <dp-checkbox
-          class="display--inline-block"
           id="autoSwitchAction"
-          :label="Translator.trans('change.state.at.date')"
-          disabled
           v-model="actions.setEnabled.checked"
-          :standalone="actions.setEnabled.checked" />
+          class="display--inline-block"
+          disabled
+          :label="{
+            bold: actions.setEnabled.checked,
+            text: Translator.trans('change.state.at.date')
+          }" />
         <div
           v-if="actions.setEnabled.checked"
           class="u-mv-0_5 flex space-inline-m">

--- a/demosplan/DemosPlanMapBundle/Resources/client/js/components/admin/LayerSettings.vue
+++ b/demosplan/DemosPlanMapBundle/Resources/client/js/components/admin/LayerSettings.vue
@@ -50,13 +50,15 @@
 
     <dp-checkbox
       v-if="hasPermission('feature_xplan_defaultlayers') && showXplanDefaultLayer"
-      style="display: none;"
-      value="1"
-      :title="Translator.trans('explanation.gislayer.default.defined') + ': ' + xplanDefaultLayer"
-      :label="Translator.trans('explanation.gislayer.xplan.default')"
       id="r_xplanDefaultlayers"
+      class="u-mb-0_5"
+      :label="{
+        text: Translator.trans('explanation.gislayer.xplan.default')
+      }"
       name="r_xplanDefaultlayers"
-      class="u-mb-0_5" />
+      style="display: none;"
+      :title="Translator.trans('explanation.gislayer.default.defined') + ': ' + xplanDefaultLayer"
+      value="1" />
 
     <dp-label
       :text="Translator.trans('layers')"

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/AdministrationImport/ExcelImport/ExcelImportErrors.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/AdministrationImport/ExcelImport/ExcelImportErrors.vue
@@ -36,10 +36,12 @@
           <div v-if="errors.length > 1">
             <dp-checkbox
               :id="`error:${error.id}`"
-              class="display--inline-block"
-              :label="lineTransKey(error.lineNumber)"
               :checked="checkedItems[error.id]"
-              standalone />
+              class="display--inline-block"
+              :label="{
+                bold: true,
+                text: lineTransKey(error.lineNumber)
+              }" />
             <span>
               {{ error.message }}
             </span>

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsBulkEdit/ActionStepper/ActionStepperAction.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsBulkEdit/ActionStepper/ActionStepperAction.vue
@@ -17,11 +17,13 @@
 <template>
   <div class="u-pv space-stack-s">
     <dp-checkbox
-      :label="label"
       :id="id"
       :checked="checked"
-      @change="isChecked => $emit('change', isChecked)"
-      :standalone="checked" />
+      :label="{
+        bold: checked,
+        text: label
+      }"
+      @change="isChecked => $emit('change', isChecked)" />
     <div
       v-if="checked"
       class="u-ml">

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsList/CustomSearch.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/SegmentsList/CustomSearch.vue
@@ -41,10 +41,12 @@
             v-if="isLoading === false">
             <dp-checkbox
               v-for="({label, value}, i) in fields"
-              :checked="selectedFields.includes(value)"
-              :key="i"
               :id="value"
-              :label="Translator.trans(label)"
+              :key="i"
+              :checked="selectedFields.includes(value)"
+              :label="{
+                text: Translator.trans(label)
+              }"
               @change="handleChange(value, !selectedFields.includes(value))" />
           </div>
           <div

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/StatementSegmentsList/StatementSegment.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/StatementSegmentsList/StatementSegment.vue
@@ -115,7 +115,9 @@
         <dp-checkbox
           :id="'showWorkflowActions_' + segment.id"
           v-model="showWorkflowActions"
-          :label="Translator.trans('workflow.change.assignee.place')" />
+          :label="{
+            text: Translator.trans('workflow.change.assignee.place')
+          }" />
         <div
           v-if="showWorkflowActions"
           class="u-mv-0_5">

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/admin/NewBlueprintForm.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/admin/NewBlueprintForm.vue
@@ -103,11 +103,13 @@
 
         <dp-checkbox
           v-if="hasPermission('feature_admin_customer_master_procedure_template')"
-          :label="Translator.trans('master.of.customer.set')"
-          name="r_customerMasterBlueprint"
-          :hint="Translator.trans('explanation.customer.masterblueprint')"
           id="r_customerMasterBlueprint"
-          :disabled="isCustomerMasterBlueprintExisting" />
+          :disabled="isCustomerMasterBlueprintExisting"
+          :label="{
+            hint: Translator.trans('explanation.customer.masterblueprint'),
+            text: Translator.trans('master.of.customer.set')
+          }"
+          name="r_customerMasterBlueprint" />
 
         <p
           v-if="isCustomerMasterBlueprintExisting && hasPermission('feature_admin_customer_master_procedure_template')"

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -11,10 +11,12 @@
   <div class="cf">
     <dp-checkbox
       :id="checkboxId"
+      v-model="autoSwitchPhase"
       :disabled="hasPermission('feature_auto_switch_to_procedure_end_phase') && isParticipationPhaseSelected"
-      :label="Translator.trans('procedure.public.phase.autoswitch')"
-      :name="checkboxId"
-      v-model="autoSwitchPhase" />
+      :label="{
+        text: Translator.trans('procedure.public.phase.autoswitch')
+      }"
+      :name="checkboxId" />
 
     <transition
       name="slide-fade"

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/ExportSettings.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/ExportSettings.vue
@@ -14,11 +14,13 @@
     </p>
     <dp-checkbox
       id="check_all"
-      :label="Translator.trans('select.all')"
-      @change="toggleAll"
       v-model="allChecked"
-      standalone
-      class="u-mb" />
+      class="u-mb"
+      :label="{
+        bold: true,
+        text: Translator.trans('select.all')
+      }"
+      @change="toggleAll" />
     <div class="display--inline-block u-pr u-valign--top u-1-of-4-wide u-1-of-2-desk u-1-of-2-lap u-1-of-1-palm u-mb">
       <p
         class="weight--bold u-mb-0_25"

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/survey/DpPublicSurvey.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/survey/DpPublicSurvey.vue
@@ -61,23 +61,29 @@
             <div>
               <dp-checkbox
                 id="r_privacy"
-                required
                 v-model="checks.privacy"
-                :label="Translator.trans('explanation.statement.privacy')" />
+                :label="{
+                  text: Translator.trans('explanation.statement.privacy')
+                }"
+                required />
             </div>
             <div>
               <dp-checkbox
                 id="r_gdpr_consent"
-                required
                 v-model="checks.gdpr"
-                :label="Translator.trans('confirm.gdpr.consent', { link: Routing.generate('DemosPlan_misccontent_static_dataprotection'), orgaId: orgaId })" />
+                :label="{
+                  text: Translator.trans('confirm.gdpr.consent', { link: Routing.generate('DemosPlan_misccontent_static_dataprotection'), orgaId: orgaId })
+                }"
+                required />
             </div>
             <div>
               <dp-checkbox
                 id="r_confirm_locality"
-                required
                 v-model="checks.localityAndTerms"
-                :label="Translator.trans('statement.confirm.terms', { path: Routing.generate('DemosPlan_misccontent_terms_of_use') })" />
+                :label="{
+                  text: Translator.trans('statement.confirm.terms', { path: Routing.generate('DemosPlan_misccontent_terms_of_use') })
+                }"
+                required />
             </div>
             <button
               @click.prevent="sendVote"

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/DpStatementAnonymize.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/DpStatementAnonymize.vue
@@ -21,11 +21,13 @@
     <!-- Step 1 - selection of actions -->
     <template v-if="currentStep === 1">
       <dp-checkbox
-        :class="{'u-mb-0_5': !actions.anonymizeStatementMeta}"
         id="r_anonymize_statement_meta"
         v-model="actions.anonymizeStatementMeta"
-        hint="statement.anonymize.meta.hint"
-        :label="Translator.trans('statement.anonymize.meta.label')" />
+        :class="{'u-mb-0_5': !actions.anonymizeStatementMeta}"
+        :label="{
+          hint: Translator.trans('statement.anonymize.meta.hint'),
+          text: Translator.trans('statement.anonymize.meta.label')
+        }" />
       <ul
         v-show="actions.anonymizeStatementMeta"
         class="o-list o-list--col-2 u-mb u-ml">
@@ -38,18 +40,22 @@
       </ul>
 
       <dp-checkbox
-        class="u-mb-0_5"
         id="r_delete_statement_text_history"
         v-model="actions.deleteStatementTextHistory"
-        hint="statement.anonymize.delete.history.hint"
-        :label="Translator.trans('statement.anonymize.delete.history.label')" />
+        class="u-mb-0_5"
+        :label="{
+          hint: Translator.trans('statement.anonymize.delete.history.hint'),
+          text: Translator.trans('statement.anonymize.delete.history.label')
+        }" />
 
       <dp-checkbox
-        :class="{'u-mb-0_5': !actions.anonymizeStatementText}"
         id="r_anonymize_statement_text"
         v-model="actions.anonymizeStatementText"
-        hint="statement.anonymize.text.hint"
-        :label="Translator.trans('statement.anonymize.text.label')" />
+        :class="{'u-mb-0_5': !actions.anonymizeStatementText}"
+        :label="{
+          hint: Translator.trans('statement.anonymize.text.hint'),
+          text: Translator.trans('statement.anonymize.text.label')
+        }" />
       <div
         v-show="actions.anonymizeStatementText"
         class="u-ml">
@@ -66,11 +72,13 @@
       </div>
 
       <dp-checkbox
-        class="u-mb-0_5"
         id="r_delete_statement_attachments"
         v-model="actions.deleteStatementAttachments"
-        hint="statement.anonymize.delete.attachments.hint"
-        :label="Translator.trans('statement.anonymize.delete.attachments.label')" />
+        class="u-mb-0_5"
+        :label="{
+          hint: Translator.trans('statement.anonymize.delete.attachments.hint'),
+          text: Translator.trans('statement.anonymize.delete.attachments.label')
+        }" />
 
       <div class="cf">
         <dp-button

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/assessmentTable/SearchModal/SearchModal.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/assessmentTable/SearchModal/SearchModal.vue
@@ -85,12 +85,14 @@
           <div class="layout--flush">
             <dp-checkbox
               v-for="checkbox in filterCheckBoxesItems"
+              :id="checkbox.id"
               :key="'checkbox_' + checkbox.id"
               v-model="checkbox.checked"
-              :id="checkbox.id"
               class="layout__item u-1-of-2"
-              name="search_fields[]"
-              :label="Translator.trans(checkbox.label)" />
+              :label="{
+                text: Translator.trans(checkbox.label)
+              }"
+              name="search_fields[]" />
 
             <!-- department is added as hidden field when organisation is selected -->
             <input

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/assessmentTable/StatementReplySelect.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/assessmentTable/StatementReplySelect.vue
@@ -15,11 +15,13 @@
 
     <dp-checkbox
       id="r_replied"
-      name="r_replied"
-      class="u-mb-0_5 u-1-of-2 display--inline-block u-valign--middle"
-      :label="Translator.trans('statement.in.compass.was.answered')"
       v-model="checked"
-      :disabled="readonly" /><!--
+      class="u-mb-0_5 u-1-of-2 display--inline-block u-valign--middle"
+      :disabled="readonly"
+      :label="{
+        text: Translator.trans('statement.in.compass.was.answered')
+      }"
+      name="r_replied" /><!--
  --><div class="u-1-of-2 display--inline-block">
       <dp-label
         for="r_bthg_kompass_answer"

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/StatementModal.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/StatementModal.vue
@@ -144,22 +144,26 @@
           :class="prefixClass('u-mb')">
           <dp-checkbox
             id="confirmPrivacy"
-            name="r_privacy"
-            @change="val => setStatementData({r_privacy: val ? 'on' : 'off'})"
             :checked="formData.r_privacy === 'on'"
-            :label="Translator.trans('explanation.statement.privacy')"
             data-cy="privacyCheck"
-            required />
+            :label="{
+              text: Translator.trans('explanation.statement.privacy')
+            }"
+            name="r_privacy"
+            required
+            @change="val => setStatementData({r_privacy: val ? 'on' : 'off'})" />
         </div>
         <div
           :class="prefixClass('u-mb')">
           <dp-checkbox
             v-if="hasPermission('field_statement_public_allowed') && publicParticipationPublicationEnabled && hasPermission('feature_statement_public_allowed_needs_verification')"
             id="r_makePublic"
-            name="r_makePublic"
-            @change="val => setStatementData({r_makePublic: val ? 'on' : 'off'})"
             :checked="formData.r_makePublic === 'on'"
-            :label="makePublicLabel" />
+            :label="{
+              text: makePublicLabel
+            }"
+            name="r_makePublic"
+            @change="val => setStatementData({r_makePublic: val ? 'on' : 'off'})" />
         </div>
 
         <template v-if="hasPermission('field_statement_add_assignment') && hasPlanningDocuments">
@@ -534,14 +538,16 @@
 
         <dp-checkbox
           v-if="hasPermission('feature_statement_gdpr_consent_submit')"
-          :class="prefixClass('u-mv-0_5')"
           id="gdpr_consent"
-          name="r_gdpr_consent"
-          @change="val => setStatementData({r_gdpr_consent: val ? 'on' : 'off'})"
           :checked="formData.r_gdpr_consent === 'on'"
-          :label="Translator.trans('confirm.gdpr.consent', { link: Routing.generate('DemosPlan_misccontent_static_dataprotection'), orgaId: orgaId })"
+          :class="prefixClass('u-mv-0_5')"
           data-cy="gdprCheck"
-          required />
+          :label="{
+            text: Translator.trans('confirm.gdpr.consent', { link: Routing.generate('DemosPlan_misccontent_static_dataprotection'), orgaId: orgaId })
+          }"
+          name="r_gdpr_consent"
+          required
+          @change="val => setStatementData({r_gdpr_consent: val ? 'on' : 'off'})" />
 
         <div :class="prefixClass('text--right')">
           <dp-loading

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/formGroups/FormGroupEvaluationMailViaEmail.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/formGroups/FormGroupEvaluationMailViaEmail.vue
@@ -11,11 +11,13 @@
   <div :class="[statement.r_getFeedback === 'on' ? prefixClass('bg-color--grey-light-2') : '', prefixClass('c-statement__formblock')]">
     <dp-checkbox
       id="r_getFeedback"
-      name="r_getFeedback"
-      @change="val => setStatementData({r_getFeedback: val ? 'on' : 'off'})"
+      aria-labelledby="statement-detail-require-information-mail"
       :checked="statement.r_getFeedback === 'on'"
-      :label="Translator.trans('statement.detail.form.personal.require_information_mail')"
-      aria-labelledby="statement-detail-require-information-mail" />
+      :label="{
+        text: Translator.trans('statement.detail.form.personal.require_information_mail')
+      }"
+      name="r_getFeedback"
+      @change="val => setStatementData({r_getFeedback: val ? 'on' : 'off'})" />
 
     <div
       v-show="statement.r_getFeedback === 'on'"

--- a/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
+++ b/demosplan/DemosPlanStatementBundle/Resources/client/js/components/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
@@ -11,11 +11,13 @@
   <div :class="[statement.r_getFeedback === 'on' ? prefixClass('bg-color--grey-light-2') : '', prefixClass('c-statement__formblock')]">
     <dp-checkbox
       id="r_getFeedback"
-      name="r_getFeedback"
-      @change="val => setStatementData({r_getFeedback: val ? 'on' : 'off'})"
+      aria-labelledby="statement-detail-require-information-mail"
       :checked="statement.r_getFeedback === 'on'"
-      :label="Translator.trans('statement.detail.form.personal.require_information_mail')"
-      aria-labelledby="statement-detail-require-information-mail" />
+      :label="{
+        text: Translator.trans('statement.detail.form.personal.require_information_mail')
+      }"
+      name="r_getFeedback"
+      @change="val => setStatementData({r_getFeedback: val ? 'on' : 'off'})" />
 
     <div
       v-show="statement.r_getFeedback === 'on'"

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/CustomerSettings/CustomerSettingsBranding.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/CustomerSettings/CustomerSettingsBranding.vue
@@ -45,10 +45,12 @@
           style="max-width: 300px;">
         <dp-checkbox
           id="r_logoDelete"
-          :label="Translator.trans('logo.delete')"
+          :label="{
+            bold: true,
+            text: Translator.trans('logo.delete')
+          }"
           name="r_logoDelete"
-          value-to-send="deleteLogo"
-          standalone />
+          value-to-send="deleteLogo" />
       </div>
     </template>
     <div

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/citizenRegisterForm/CitizenRegisterForm.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/citizenRegisterForm/CitizenRegisterForm.vue
@@ -57,9 +57,11 @@
           </dp-form-row>
 
           <dp-checkbox
-            :class="prefixClass('u-mb-0_5')"
             id="gdpr_consent"
-            :label="Translator.trans('confirm.gdpr.consent.registration.new', { terms: Routing.generate('DemosPlan_misccontent_static_terms'), dataprotectionUrl: Routing.generate('DemosPlan_misccontent_static_dataprotection') })"
+            :class="prefixClass('u-mb-0_5')"
+            :label="{
+              text: Translator.trans('confirm.gdpr.consent.registration.new', { terms: Routing.generate('DemosPlan_misccontent_static_terms'), dataprotectionUrl: Routing.generate('DemosPlan_misccontent_static_dataprotection') })
+            }"
             name="gdpr_consent"
             required
             value="on" />

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/orgaRegisterForm/OrgaRegisterForm.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/orgaRegisterForm/OrgaRegisterForm.vue
@@ -53,21 +53,27 @@
             </legend>
             <div :class="hasPermission('feature_identity_broker_login') ? prefixClass('space-stack-xs') : prefixClass('o-form__group')">
               <dp-checkbox
-                :class="prefixClass('o-form__group-item')"
                 id="orgatype_invitable_institution"
-                :label="Translator.trans('invitable_institution')"
+                :class="prefixClass('o-form__group-item')"
+                :label="{
+                  text: Translator.trans('invitable_institution')
+                }"
                 name="r_orgatype[]"
                 value-to-send="OPSORG" />
               <dp-checkbox
-                :class="prefixClass('o-form__group-item')"
                 id="orgatype_municipality"
-                :label="Translator.trans('municipality')"
+                :class="prefixClass('o-form__group-item')"
+                :label="{
+                  text: Translator.trans('municipality')
+                }"
                 name="r_orgatype[]"
                 value-to-send="OLAUTH" />
               <dp-checkbox
-                :class="prefixClass('o-form__group-item')"
                 id="orgatype_planningagency"
-                :label="Translator.trans('planningagency')"
+                :class="prefixClass('o-form__group-item')"
+                :label="{
+                  text: Translator.trans('planningagency')
+                }"
                 name="r_orgatype[]"
                 value-to-send="OPAUTH" />
             </div>
@@ -112,9 +118,11 @@
           </fieldset>
 
           <dp-checkbox
-            :class="prefixClass('u-mb-0_5')"
             id="gdpr_consent"
-            :label="Translator.trans('confirm.gdpr.consent.registration.new', { terms: Routing.generate('DemosPlan_misccontent_static_terms'), dataprotectionUrl: Routing.generate('DemosPlan_misccontent_static_dataprotection') })"
+            :class="prefixClass('u-mb-0_5')"
+            :label="{
+              text: Translator.trans('confirm.gdpr.consent.registration.new', { terms: Routing.generate('DemosPlan_misccontent_static_terms'), dataprotectionUrl: Routing.generate('DemosPlan_misccontent_static_dataprotection') })
+            }"
             name="gdpr_consent"
             required
             value-to-send="on" />

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
@@ -64,12 +64,14 @@
     <template v-if="hasPermission('feature_send_assigned_task_notification_email_setting')">
       <dp-checkbox
         id="assignedTaskNotification"
-        name="assignedTaskNotification"
-        class="u-mb-0_25"
-        :label="Translator.trans('email.daily.subscribe')"
         v-model="isDailyDigestChecked"
-        value-to-send="on"
-        standalone />
+        class="u-mb-0_25"
+        :label="{
+          bold: true,
+          text: Translator.trans('email.daily.subscribe')
+        }"
+        name="assignedTaskNotification"
+        value-to-send="on" />
       <p>
         {{ Translator.trans('email.daily.assigned.tasks.explanation') }}
       </p>

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
@@ -59,12 +59,14 @@
 
         <dp-checkbox
             id="r_email_address"
-            name="r_email_address"
-            valueToSend="{{ templateVars.preparationMail.sendMail }}"
-            label="{{ 'procedure.testmail.submitters.send'|trans ({ email: templateVars.userMail }) }}"
-            tooltip="{{ 'explanation.organisation.email.procedure.agency'|trans }}"
             checked
-            required>
+            :label="{
+                text: Translator.trans('procedure.testmail.submitters.send', { email: templateVars.userMail }),
+                tooltip: Translator.trans('explanation.organisation.email.procedure.agency')
+            }"
+            name="r_email_address"
+            required
+            valueToSend="{{ templateVars.preparationMail.sendMail }}">
         </dp-checkbox>
 
         <div class="text--right">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29004 

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- instead of passing the label props (label, tooltip, hint, standalone) to DpCheckbox one by one, we pass them as an object now
- this makes it easier to understand what they are used for
- the `standalone` prop has been removed, as we can now directly use the label prop `bold`
- default values are passed to DpLabel and overwritten by the label prop (if set)
- additionally, attributes have been sorted according to https://eslint.vuejs.org/rules/attributes-order.html

### Linked PRs (optional)
Documentation is updated in
- https://github.com/demos-europe/demosplan-documentation/pull/1

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
