### PR TITLE
refactor(refs T29004): pass label props as object (DpUploadFiles)

### DIFF
--- a/client/js/components/core/DpUpload/DpUploadFiles.vue
+++ b/client/js/components/core/DpUpload/DpUploadFiles.vue
@@ -13,9 +13,13 @@
       class="hide-visually"
       v-text="Translator.trans('upload.files')" />
     <dp-label
-      v-if="label !== ''"
+      v-if="label.text !== ''"
       class="layout__item"
-      v-bind="labelProps" />
+      v-bind="{
+        for: id,
+        required: required,
+        ...label
+      }" />
     <dp-upload
       :allowed-file-types="allowedFileTypes"
       :chunk-size="chunkSize"
@@ -93,13 +97,6 @@ export default {
       default: false
     },
 
-    // Translated string
-    hint: {
-      type: String,
-      required: false,
-      default: ''
-    },
-
     id: {
       type: String,
       required: false,
@@ -107,9 +104,11 @@ export default {
     },
 
     label: {
-      type: String,
-      required: false,
-      default: ''
+      type: Object,
+      default: () => ({}),
+      validator: (prop) => {
+        return Object.keys(prop).every(key => ['hint', 'text', 'tooltip'].includes(key))
+      }
     },
 
     /**
@@ -160,12 +159,6 @@ export default {
       default: false
     },
 
-    tooltip: {
-      type: String,
-      required: false,
-      default: ''
-    },
-
     /**
      * Use to overwrite the default translations
      * you can find all available keys here
@@ -204,19 +197,6 @@ export default {
     return {
       fileHashes: [],
       uploadedFiles: []
-    }
-  },
-
-  computed: {
-    labelProps () {
-      const { id, hint, label, tooltip, required } = this
-      return {
-        for: id,
-        hint,
-        text: label,
-        tooltip,
-        required
-      }
     }
   },
 

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/CustomerSettings/CustomerSettingsBranding.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/CustomerSettings/CustomerSettingsBranding.vue
@@ -30,8 +30,7 @@
           :max-number-of-files="1"
           needs-hidden-input
           name="r_customerLogo"
-          :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '200 KB' }) }"
-          @upload-success="() => 'haha'" />
+          :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '200 KB' }) }" />
       </div><!--
    --><div
         class="layout__item u-1-of-2"

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/includes/single_document_file_upload.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/includes/single_document_file_upload.html.twig
@@ -2,8 +2,10 @@
     <dp-upload-files
         id="r_document"
         allowed-file-types="pdf-zip-video"
-        hint="{{ 'file.upload.pdf.zip.mp4'|trans }}"
-        label="{{ 'file'|trans }}"
+        :label="{
+          hint: Translator.trans('file.upload.pdf.zip.mp4'),
+          text: Translator.trans('file')
+        }"
         :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
         :max-number-of-files="1"
         name="r_document"
@@ -15,8 +17,10 @@
     <dp-upload-files
         id="r_document"
         allowed-file-types="pdf-video"
-        hint="{{ 'file.upload.pdf.mp4'|trans }}"
-        label="{{ 'file'|trans }}"
+        :label="{
+          hint: Translator.trans('file.upload.pdf.mp4'),
+          text: Translator.trans('file')
+        }"
         :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
         :max-number-of-files="1"
         name="r_document"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29004

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- instead of passing the label props (label, tooltip, hint) to DpUploadFiles one by one, we pass them as an object now
- this makes it easier to understand what they are used for

### Linked PRs (optional)
Documentation is updated in
- https://github.com/demos-europe/demosplan-documentation/pull/2

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
