### PR TITLE
fix: fix build on non-dev environments

### DIFF
--- a/client/setup/projectConfig.js
+++ b/client/setup/projectConfig.js
@@ -27,8 +27,8 @@ function projectConfig (mode, project) {
   try {
     beConfigOutput = spawnSync('php', frontendIntegratorCommand, {
       env: {
+        ...process.env,
         'ACTIVE_PROJECT': project,
-        'DEVELOPMENT_CONTAINER': '1'
       },
       windowsHide: true,
     })


### PR DESCRIPTION
Environment variables needs to be passed to process, not to be defined statically. Otherwise build on non-docker environments will break as caches are written to faulty folders and not deleted on cache clear
