### PR TITLE
fix: caching needs to take customer into account

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -189,7 +189,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
         return $this->renderTemplate(
             '@DemosPlanUser/DemosPlanUser/password_recover.html.twig',
             [
-                'title'        => 'user.password.recover',
+                'title' => 'user.password.recover',
                 'templateVars' => [],
             ]
         );
@@ -258,20 +258,22 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
 
         $users = [];
         $usersOsi = [];
+        $customerKey = $customerService->getCurrentCustomer()->getSubdomain();
 
         if (true === $parameterBag->get('alternative_login_use_testuser')) {
             // collect users for Login as
-            $users = $cache->get('login_testuser_list', function (ItemInterface $item) use ($parameterBag) {
-                $item->expiresAfter(UserRepository::LOGIN_LIST_CACHE_DURATION);
+            $users = $cache->get('login_testuser_list'.$customerKey,
+                function (ItemInterface $item) use ($parameterBag) {
+                    $item->expiresAfter(UserRepository::LOGIN_LIST_CACHE_DURATION);
 
-                $testPassword = $parameterBag->get('alternative_login_testuser_defaultpass');
+                    $testPassword = $parameterBag->get('alternative_login_testuser_defaultpass');
 
-                return $this->userService->getTestUsers($testPassword);
-            });
+                    return $this->userService->getTestUsers($testPassword);
+                });
         }
 
         if (true === $parameterBag->get('alternative_login_use_testuser_osi')) {
-            $usersOsi = $cache->get('login_testuser_list_osi', function (ItemInterface $item) {
+            $usersOsi = $cache->get('login_testuser_list_osi'.$customerKey, function (ItemInterface $item) {
                 $item->expiresAfter(UserRepository::LOGIN_LIST_CACHE_DURATION);
 
                 return $this->userService->getTestUsersOsi($this->globalConfig->getProjectFolder());
@@ -288,11 +290,11 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
         return $this->renderTemplate(
             '@DemosPlanUser/DemosPlanUser/alternative_login.html.twig',
             [
-                'title'     => 'user.login',
-                'useSaml'   => $useSaml,
+                'title' => 'user.login',
+                'useSaml' => $useSaml,
                 'loginList' => [
-                    'enabled'  => 0 < count($users) || 0 < count($usersOsi),
-                    'users'    => $users,
+                    'enabled' => 0 < count($users) || 0 < count($usersOsi),
+                    'users' => $users,
                     'usersOsi' => $usersOsi,
                 ],
             ]
@@ -404,8 +406,8 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
         return $this->renderTemplate(
             '@DemosPlanUser/DemosPlanUser/user_set_password.html.twig',
             [
-                'token'    => $token,
-                'uId'      => $uId,
+                'token' => $token,
+                'uId' => $uId,
             ]
         );
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29301

When customer is omitted logins from wrong customer are shown on login list when showing a different customer

### How to review/test
show login list and change customer. Users should differ

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
