### PR TITLE
fix (refs T29652): allow new orgas to be invited to a procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
@@ -96,7 +96,7 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
                     $procedure->getId(),
                     ...$this->procedureInvitations->id
                 ),
-                $this->conditionFactory->propertyIsNull(...$this->procedureInvitations->orga)
+                $this->conditionFactory->propertyIsNull(...$this->procedureInvitations)
             )
         );
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29652

A new organisation does not show up at all in the procedureInvitations table. Therefore the property can't have a value or not a value, it just can't be found. To no longer exclude these organisations, the alternative null check is added.

### How to review/test
newly registered organisations should now show up in the list of invitable orgas.
