### PR TITLE
fix (refs T29293): Avoid csp error on form-action POST

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_header_userbox.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_header_userbox.html.twig
@@ -205,18 +205,13 @@
 
                 {# logout button #}
                 {% block logoutbtn %}
-                    <form action="{{ path("DemosPlan_user_logout") }}" method="POST">
-                        <button
-                            class="c-flyout__item c-flyout__item--btn cf {{ hasOrgaSwitcher ? '' : ' u-mt-0_5' }}"
-                            type="submit"
-
-                            data-actionmenu-menuitem>
-                            <i class="fa fa-sign-out float--left u-mt-0_125" aria-hidden="true"></i>
-                            <span class="display--block u-ml" data-extern-dataport="logout">
-                                {{ "logout"|trans }}
-                            </span>
-                        </button>
-                    </form>
+                    <a
+                        class="c-flyout__item c-flyout__item--btn cf {{ hasOrgaSwitcher ? '' : ' u-mt-0_5' }}"
+                        data-actionmenu-menuitem
+                        href="{{ path("DemosPlan_user_logout") }}">
+                        <i class="fa fa-sign-out" aria-hidden="true"></i>
+                        {{ "logout"|trans }}
+                    </a>
                 {% endblock %}
 
             </span>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_oeb_header_userbox.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_oeb_header_userbox.html.twig
@@ -198,17 +198,14 @@
 
                 {# logout button #}
                 {% block logoutbtn %}
-                    <form action="{{ path("DemosPlan_user_logout") }}" method="POST">
-                        <button
-                            class="{{ 'c-flyout__item c-flyout__item--btn cf'|prefixClass }} {{ hasOrgaSwitcher ? '' : ' u-mt-0_5'|prefixClass }}"
-                            type="submit"
-                            data-actionmenu-menuitem>
-                            <i class="{{ 'fa fa-sign-out float--left u-mt-0_125'|prefixClass }}" aria-hidden="true"></i>
-                            <span class="{{ 'display--block u-ml'|prefixClass }}" data-extern-dataport="logout">
-                                {{ "logout"|trans }}
-                            </span>
-                        </button>
-                    </form>
+                    <a
+                        class="{{ 'c-flyout__item c-flyout__item--btn cf'|prefixClass }} {{ hasOrgaSwitcher ? '' : ' u-mt-0_5'|prefixClass }}"
+                        data-actionmenu-menuitem
+                        data-extern-dataport="logout"
+                        href="{{ path("DemosPlan_user_logout") }}">
+                        <i class="{{ 'fa fa-sign-out float--left u-mt-0_125'|prefixClass }}" aria-hidden="true"></i>
+                        {{ "logout"|trans }}
+                    </a>
                 {% endblock %}
 
             </span>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29293

CSP problem can be avoided when calling /user/logout via GET, POST is not needed to log out user.

Initial PR https://github.com/demos-europe/demosplan-project-blp/pull/7

### How to review/test
Please take extra care of the data attributes and the `prefixClass`


### Linked PRs (optional)
https://github.com/demos-europe/demosplan-project-blp/pull/7#discussion_r998279979

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
