### PR TITLE
Remove "palette" part of tokens name

### DIFF
--- a/client/ui/buildTokens.js
+++ b/client/ui/buildTokens.js
@@ -23,8 +23,8 @@ StyleDictionary.registerTransform({
   name: 'name/scss',
   type: 'name',
   transformer: (token) => {
-    // "scale" within colors should not be part of the variable name
-    if (token.path[0] === 'color' && token.path[1] === 'scale') {
+    // "palette" within colors should not be part of the variable name
+    if (token.path[0] === 'color' && token.path[1] === 'palette') {
       token.path.splice(1, 1)
     }
     return prefix + token.path.join('-')


### PR DESCRIPTION
After accidentally committing the change in the json files, this must be adapted in the build script, too.

See https://github.com/demos-europe/demosplan-core/pull/106/files#diff-c56ca63cd88a8a1a64ce6c433a6f4ef57fbcdd9ec27f2429a1237fb4fd8f9f7cR3

### How to review/test
- `yarn add file:client/ui`
- `yarn dev:<project>`
-> no build errors related to scss should occur.

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/106/

### PR Checklist
- [X] Link all relevant tickets
