### PR TITLE
feature (refs T29158): adds statement-polygon to ahb/vhb sync-Method

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -33,8 +33,8 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Exception;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use function in_array;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class StatementSynchronizer
 {


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T29158

Description:
adds the Statement::polygon to be taken into account by the syncMethod (StatementSynchronizer::opyAsOriginalStatement() )

Other PRs:
StatementPolygon Update/manualCreate setup: https://github.com/demos-europe/demosplan-core/pull/119

Permissions:
Core: https://github.com/demos-europe/demosplan-core/pull/112
EWM: https://github.com/demos-europe/demosplan-project-ewm/pull/3
Bimschgsh: https://github.com/demos-europe/demosplan-project-bimschgsh/pull/1
BLP: https://github.com/demos-europe/demosplan-project-blp/pull/8
BOBHH: https://github.com/demos-europe/demosplan-project-bobhh/pull/3
BOBSH: https://github.com/demos-europe/demosplan-project-bobsh/pull/1
DIPLANBAU: https://github.com/demos-europe/demosplan-project-diplanbau/pull/9
REGIO: https://github.com/demos-europe/demosplan-project-regio/pull/3
ROBOBSH: https://github.com/demos-europe/demosplan-project-robobsh/pull/1
