### PR TITLE
Fix eslint errors

### DIFF
--- a/client/js-utils/index.js
+++ b/client/js-utils/index.js
@@ -8,8 +8,8 @@
  */
 
 import sortAlphabetically from './sortAlphabetically'
-import uniqueArrayByObjectKey from './uniqueArrayByObjectKey'
 import throttle from './throttle'
+import uniqueArrayByObjectKey from './uniqueArrayByObjectKey'
 
 export {
   sortAlphabetically,

--- a/client/js/bootstrap.js
+++ b/client/js/bootstrap.js
@@ -7,8 +7,6 @@
  * All rights reserved
  */
 
-
-
 import availableTranslations from '@DpJs/generated/translations.json'
 import exposedRoutes from '@DpJs/generated/routes.json'
 import { hasPermission } from '@DpJs/lib/utils/hasPermission'

--- a/client/js/bundles/admin/statistics.js
+++ b/client/js/bundles/admin/statistics.js
@@ -7,8 +7,6 @@
  * All rights reserved
  */
 
-
-
 /**
  * This is the entrypoint for statistics.html.twig
  */

--- a/client/js/components/core/DpAnonymizeText.vue
+++ b/client/js/components/core/DpAnonymizeText.vue
@@ -54,11 +54,11 @@ import {
   Underline
 } from 'tiptap-extensions'
 import { Editor, EditorContent, EditorMenuBubble } from 'tiptap'
-import PreventDrop from '@DpJs/components/core/DpEditor/libs/preventDrop'
-import PreventKeyboardInput from '@DpJs/components/core/DpEditor/libs/preventKeyboardInput'
 import EditorAnonymize from '@DpJs/components/core/DpEditor/libs/editorAnonymize'
 import EditorObscure from '@DpJs/components/core/DpEditor/libs/editorObscure'
 import EditorUnAnonymize from '@DpJs/components/core/DpEditor/libs/editorUnAnonymize'
+import PreventDrop from '@DpJs/components/core/DpEditor/libs/preventDrop'
+import PreventKeyboardInput from '@DpJs/components/core/DpEditor/libs/preventKeyboardInput'
 
 export default {
   name: 'DpAnonymizeText',

--- a/client/js/components/core/DpEditor/DpEditor.vue
+++ b/client/js/components/core/DpEditor/DpEditor.vue
@@ -405,9 +405,6 @@ import {
 import { CleanHtml } from 'demosplan-ui/directives'
 import { createSuggestion } from './libs/editorBuildSuggestion'
 import { DpIcon } from 'demosplan-ui/components'
-import { handleWordPaste } from './libs/handleWordPaste'
-import { maxlengthHint } from 'demosplan-ui/utils/lengthHint'
-import { prefixClassMixin } from 'demosplan-ui/mixins'
 import EditorCustomDelete from './libs/editorCustomDelete'
 import EditorCustomImage from './libs/editorCustomImage'
 import EditorCustomInsert from './libs/editorCustomInsert'
@@ -415,6 +412,9 @@ import EditorCustomLink from './libs/editorCustomLink'
 import EditorCustomMark from './libs/editorCustomMark'
 import EditorInsertAtCursorPos from './libs/editorInsertAtCursorPos'
 import EditorObscure from './libs/editorObscure'
+import { handleWordPaste } from './libs/handleWordPaste'
+import { maxlengthHint } from 'demosplan-ui/utils/lengthHint'
+import { prefixClassMixin } from 'demosplan-ui/mixins'
 
 export default {
   name: 'DpEditor',

--- a/client/js/components/core/DpTreeList/DpTreeListCheckbox.vue
+++ b/client/js/components/core/DpTreeList/DpTreeListCheckbox.vue
@@ -71,7 +71,7 @@ export default {
       this.$emit('check', !this.checked)
     },
 
-    toggleCheckedStatus(deselect, select) {
+    toggleCheckedStatus (deselect, select) {
       return Translator.trans(this.checked ? deselect : select)
     }
   }

--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -186,7 +186,7 @@
 
 <script>
 import { mapGetters, mapState } from 'vuex'
-import { CleanHtml } from "demosplan-ui/directives"
+import { CleanHtml } from 'demosplan-ui/directives'
 import { dpApi } from '@DemosPlanCoreBundle/plugins/DpApi'
 import DpFlyout from '@DpJs/components/core/DpFlyout'
 import DpHeightLimit from '@DpJs/components/core/HeightLimit'

--- a/client/js/components/statement/statement/DpVersionHistoryItem.vue
+++ b/client/js/components/statement/statement/DpVersionHistoryItem.vue
@@ -20,8 +20,12 @@
       <table>
         <tr class="hide-visually">
           <th>{{ Translator.trans('time') }}</th>
-          <th v-if="time.userName !== null">{{ Translator.trans('user') }}</th>
-          <th v-else>-</th>
+          <th v-if="time.userName !== null">
+            {{ Translator.trans('user') }}
+          </th>
+          <th v-else>
+            -
+          </th>
           <th>{{ Translator.trans('fields') }}</th>
           <th>{{ Translator.trans('aria.toggle') }}</th>
         </tr>
@@ -80,8 +84,16 @@
           <td colspan="4">
             <table>
               <tr class="hide-visually">
-                <th colspan="4" v-if="isOpen && isLoading">{{ Translator.trans('loading') }}</th>
-                <th colspan="4" v-if="isOpen && !isLoading">{{ Translator.trans('dropdown.open') }}</th>
+                <th
+                  colspan="4"
+                  v-if="isOpen && isLoading">
+                  {{ Translator.trans('loading') }}
+                </th>
+                <th
+                  colspan="4"
+                  v-if="isOpen && !isLoading">
+                  {{ Translator.trans('dropdown.open') }}
+                </th>
               </tr>
               <tr>
                 <td

--- a/client/setup/projectConfig.js
+++ b/client/setup/projectConfig.js
@@ -28,9 +28,9 @@ function projectConfig (mode, project) {
     beConfigOutput = spawnSync('php', frontendIntegratorCommand, {
       env: {
         ...process.env,
-        'ACTIVE_PROJECT': project,
+        ACTIVE_PROJECT: project
       },
-      windowsHide: true,
+      windowsHide: true
     })
 
     if (beConfigOutput.status !== 0) {

--- a/client/setup/webpack/bundleEntryPoints.js
+++ b/client/setup/webpack/bundleEntryPoints.js
@@ -15,7 +15,7 @@ function bundleEntryPoints (clientBundleGlob) {
   glob.sync(clientBundleGlob).forEach(filename => {
     const parts = filename.split('/')
 
-    const bundle = parts[parts.length - 2];
+    const bundle = parts[parts.length - 2]
     const name = parts[parts.length - 1].replace('.js', '')
 
     entries[bundle + '-' + name] = filename

--- a/client/setup/webpack/runWebpack.js
+++ b/client/setup/webpack/runWebpack.js
@@ -25,7 +25,7 @@ const resolveDir = require('./resolveDir').resolveDir
 function buildUserFeedbackFunction (options) {
   return (err, stats) => {
     showErrorMessage(err, stats)
-    showWebpackStatisticsMessage(options)
+    showWebpackStatisticsMessage(options, stats)
   }
 }
 
@@ -61,7 +61,7 @@ function configureBundleAnalysis (options, project, webpackConfig) {
   webpackConfig[0].plugins.unshift(bundleAnalyzer)
 }
 
-function configureProgressBar (options, webpackRunner ) {
+function configureProgressBar (options, webpackRunner) {
   if (!options.parent.silent) {
     const progressBar = new CliProgress.SingleBar({
       format: `{message}[${chalk.green('{bar}')}] ${chalk.bold('{percentage}%')}`,
@@ -197,7 +197,7 @@ function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConf
   }
 }
 
-function showWebpackStatisticsMessage (options) {
+function showWebpackStatisticsMessage (options, stats) {
   if (options.stats) {
     const webpackStatisticsOptions = {
       chunks: false

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/StatementSegmentsList/SegmentCommentsList.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/StatementSegmentsList/SegmentCommentsList.vue
@@ -44,7 +44,7 @@
         :segment-id="commentsList.segmentId"
         class="u-mt u-mb-0_5"
         :class="{'border--bottom' : idx < (comments.length -1) }"
-        data-cy="commentsListItem"/>
+        data-cy="commentsListItem" />
     </template>
     <dp-inline-notification
       v-else

--- a/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/DpAllowedSenderEmailList.vue
+++ b/demosplan/DemosPlanProcedureBundle/Resources/client/js/components/basicSettings/DpAllowedSenderEmailList.vue
@@ -18,7 +18,7 @@ import { dpApi } from '@DemosPlanCoreBundle/plugins/DpApi'
 import DpEmailList from '@DemosPlanProcedureBundle/components/basicSettings/DpEmailList'
 
 export default {
-  name: "DpAllowedSenderEmailList",
+  name: 'DpAllowedSenderEmailList',
 
   components: {
     DpEmailList
@@ -26,13 +26,13 @@ export default {
 
   props: {
     /*
-    * The procedureId is being passed from administration_edit.html.twig to enable a
-    * filtering to just receive the maillane connection of the current procedure.
-    */
+     * The procedureId is being passed from administration_edit.html.twig to enable a
+     * filtering to just receive the maillane connection of the current procedure.
+     */
     procedureId: {
       type: String,
       required: true,
-      default: '',
+      default: ''
     }
   },
 

--- a/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
+++ b/demosplan/DemosPlanUserBundle/Resources/client/js/components/portalUser/PersonalData.vue
@@ -143,13 +143,13 @@ export default {
 
   methods: {
     setUserData () {
-      let userData = {...this.user}
+      const userData = { ...this.user }
 
       return this.changeDefaultValues(userData)
     },
 
     changeDefaultValues (user) {
-      for (let key of userProperties) {
+      for (const key of userProperties) {
         if (!user[key]) {
           user[key] = '-'
         }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch:robobsh": "cross-env ./fe watch robobsh",
     "watch:teilhabe": "cross-env ./fe watch teilhabe",
     "watch:wmmsh": "cross-env ./fe watch wmmsh",
-    "lint": "eslint -c infrastructure/linters/eslintrc.js --ext .js,.vue",
+    "lint": "eslint -c eslintrc.js --ext .js,.vue",
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {


### PR DESCRIPTION
Linter errors keep coming up, as it seems that not everyone of us has ESLint properly configured. 

Errors that exist are fixed. Also, the broken showWebpackStatisticsMessage with `--stats` option is fixed, as well as the `yarn lint` command which had an outdated eslintrc file reference.

### How to review/test
- run `yarn lint demosplan` and `yarn lint client` - only warnings (no errors) should appear.
- run `yarn dev:<project> --stats` - build should work, stats should appear.
