### PR TITLE
fix(refs T29632): Rework handleIsertText in DpEditor

### DIFF
--- a/client/js/components/core/DpEditor/DpEditor.vue
+++ b/client/js/components/core/DpEditor/DpEditor.vue
@@ -874,9 +874,7 @@ export default {
     insertTextAtCursorPos (text) {
       // Remove p tags so text is inserted without adding new paragraph
       if (this.startsWithTag(text, 'p')) {
-        text = text
-          .slice(3)
-          .slice(0, -4)
+        text = text.slice(3, -4)
       }
 
       this.editor.commands.insertHTML(text)


### PR DESCRIPTION
It seems the Tiptap Methods changed somewhen.
And we can now drop some custom logic and use the tiptap methods straigt away

**Ticket:** https://yaits.demos-deutschland.de/T29632

To test this, goto "Verfahren -> Email an alle Einreichenden" and insert a "Textbaustein". 
Try to insert it without setting a focus before and just within or at the End from some content.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
