### PR TITLE
Remove border if focus outline is applied

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_button.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_button.scss
@@ -213,7 +213,7 @@ $dp-form-element-spacing-vertical: $inuit-base-spacing-unit--tiny + 1px;
     @include keyboard-focus($outline: false) {
         background-color: $dp-color-white;
         box-shadow: 0 0 0 2px $dp-token-color-brand-link;
-        border-color: transparent;
+        border-color: transparent !important;
     }
 
     outline: 0 transparent !important;
@@ -327,7 +327,7 @@ $dp-form-element-spacing-vertical: $inuit-base-spacing-unit--tiny + 1px;
     @include keyboard-focus($outline: false) {
         background-color: $dp-color-white;
         box-shadow: 0 0 0 2px $dp-token-color-ui-interactive;
-        border-color: transparent;
+        border-color: transparent !important;
     }
 
     outline: 0 transparent !important;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29425

For whatever reason the transparent border is not applied properly because of too less specificity.
Good old !important to the rescue!

Otherwise, the border and the box shadow may be adding up to 3 px which looks weird.

### How to review/test
When tabbing into buttons, the outline should be 2, not 3 px.

### Linked PRs

- https://github.com/demos-europe/demosplan-project-diplanbau/pull/11

### PR Checklist

- [x] Link all relevant tickets
