### PR TITLE
feature (refs T29746): added property 'synchronized' to the StatementResourceType

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
@@ -94,6 +94,7 @@ use EDT\PathBuilding\End;
  * @property-read End $isManual
  * @property-read End $manual
  * @property-read End $anonymous
+ * @property-read End $synchronized
  * @property-read FileResourceType $files @deprecated Use {@link StatementResourceType::$attachments} instead (needs implementation changes)
  * @property-read TagResourceType $tags
  * @property-read PlanningDocumentCategoryResourceType $elements @deprecated Rename to 'element'


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T29746

Description:
StatementResourceType: event added property triggers Error
For a hearing agency it is not possible to load the statementList when the procedure is coupled.
(When the ```GetPropertiesEvent``` adds the property ```synchronized``` for the StatementResourceType)
More within the ticket description

This fix is not wanted by @dresslerdemos, but a fix is needed for now.
A ticket is created and assigned to let him know about this (https://yaits.demos-deutschland.de/T29746).

### How to review/test
After this PR https://github.com/demos-europe/demosplan-core/pull/166 adds a fix to the ProcedureCoupleTokenSubscriber.php
and the GetPropertiesEvent.php it should be possible to load the Statementlist for a hearing agency within a coupled procedure 
in EWM again.

### Linked PRs (optional)
[<!-- List other PRs that are somehow connected to this and explain the connection.]
https://github.com/demos-europe/demosplan-core/pull/166
-->


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
