### PR TITLE
feature(refs: T29168) load EmailImport as umd.js addon of web folder

### DIFF
--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -8,26 +8,24 @@
 </license>
 
 <template>
-  <div>
-    <dp-tabs
-      :active-id="activeTabId"
-      use-url-fragment
-      @change="setActiveTabId">
-      <dp-tab
-        v-for="(option, index) in availableImportOptions"
-        :key="index"
-        :id="option.name"
-        :label="Translator.trans(option.title)">
-        <slot>
-          <keep-alive>
-            <component
-              class="u-mt"
-              :is="option.name" />
-          </keep-alive>
-        </slot>
-      </dp-tab>
-    </dp-tabs>
-  </div>
+  <dp-tabs
+    :active-id="activeTabId"
+    use-url-fragment
+    @change="setActiveTabId">
+    <dp-tab
+      v-for="(option, index) in availableImportOptions"
+      :key="index"
+      :id="option.name"
+      :label="Translator.trans(option.title)">
+      <slot>
+        <keep-alive>
+          <component
+            class="u-mt"
+            :is="option.name" />
+        </keep-alive>
+      </slot>
+    </dp-tab>
+  </dp-tabs>
 </template>
 
 <script>


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz --> https://yaits.demos-deutschland.de/T29264

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR enables the dynamic loading of umd.js components off the projects web folder.

- This is a way to dynamically import the EmailImport component out of the projects web folder
- This is achieved by creating a new script in the documents head section and load the code off the projects web folder
- By adding the component name to this.$options.components[name] vues internals can process the email import section and the component can be loaded dynamically without the need to run through the webpack build process
- Also this is a preparation to addonize the PDFImport section and load it by the same way
- In future PRs a installation process will be implemented hence the build chain needs to generate addons in that case and move them in the web folder on its own
- In the moment we need the location for the file hence the url must be hardcoded atm until a installation routine can be implemented

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-addon-maillane/pull/1 (add infrastructure to create fe addon modules)
https://github.com/demos-europe/demosplan-project-ewm/pull/5 (add addonized EmailImport to ewm web folder)

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->
All mentioned PRs should be merged together to avoid breaking the project

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
