### PR TITLE
fix: The newsdetail.html.twig got lost

### DIFF
--- a/templates/bundles/DemosPlanNewsBundle/DemosPlanNews/newsdetail.html.twig
+++ b/templates/bundles/DemosPlanNewsBundle/DemosPlanNews/newsdetail.html.twig
@@ -1,0 +1,43 @@
+{% extends procedure is not null ? '@DemosPlanCore/DemosPlanCore/procedure.html.twig' : '@DemosPlanCore/DemosPlanCore/base_oeb.html.twig' %}
+{% set news = templateVars.news %}
+
+{% block component_part %}
+
+    {% embed '@DemosPlanCore/DemosPlanCore/includes/participation_area_skeleton.html.twig' with {
+        'content_heading': news.title,
+        'link': path('DemosPlan_globalnews_news'),
+        'link_caption': 'news.see.all'|trans
+    }%}
+
+        {% block aside %}
+            {% if news.picture is defined and news.picture != "" %}
+                <img class="c-image c-image--detail max-width-100p" src="{{ path("core_logo", { 'hash': news.picture|getFile('hash') }) }}">
+                <p class="font-size-smaller">{{ news.pictitle }}</p>
+            {% endif %}
+        {% endblock aside %}
+
+        {% block content %}
+            <div class="u-3-of-4-desk-up">
+                <p><strong>{{ news.description|wysiwyg }}</strong></p>
+                <p>{{ news.text|wysiwyg }}</p>
+                {% if news.pdf is defined and news.pdf != '' %}
+                    <p>
+                        <a
+                            target="_blank"
+                            rel="noopener"
+                            href="{{ path("core_file", { 'hash': news.pdf|getFile('hash') }) }}">
+                            <i class="fa fa-file-o" aria-hidden="true"></i>
+                            {{ news.pdftitle|default(news.pdf|getFile('name')) }}
+                            {% if(news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}
+                                ({{ news.pdf|getFile('mimeType') }}
+                                {{ news.pdf|getFile('size') }} )
+                            {% endif %}
+                        </a>
+                    </p>
+                {% endif %}
+            </div>
+        {% endblock content %}
+
+    {% endembed %}
+
+{% endblock component_part %}


### PR DESCRIPTION
somehow during the repro-split the template got lost

goto `/news` and click on a news-entry. If that leads You to the details and not to and error its fixed
