### PR TITLE
fix (refs T29701): disables default ES listeners for segments

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/fos_elastica.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/fos_elastica.yaml
@@ -112,7 +112,7 @@ fos_elastica:
                         model_to_elastica_transformer:
                             service: path_based_model_to_elastica_transformer
                         provider: ~
-                        listener: ~
+                        listener: { enabled: false }
                         finder: ~
 
         procedures:


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29701

We manage the ES updates based on Doctrine lifecycle events with our own listener. Our custom listener creates SearchIndexTasks in the database that will be used to update the ES on a Symfony ResponseEvent. Therefore we can't allow the default ES listeners to be active as they will update the ES instantly which leads to the ES being out of sync with Doctrine when Doctrine changes are not committed (because of an exception, error or rollback).

### How to review/test
If you have a procedure with a lot of segments (like 1000-2000) you can try to change the assignee of all of them via bulk edit. That should produce an error. Before, some segments would have been updated in the ES, with this change that shouldn't happen anymore.
