### PR TITLE
bug (refs T29828): show ground settings

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureCoupleTokenSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureCoupleTokenSubscriber.php
@@ -28,9 +28,9 @@ use demosplan\DemosPlanCoreBundle\Logic\TokenFactory;
 use demosplan\DemosPlanCoreBundle\Repository\EntitySyncLinkRepository;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedureCoupleTokenRepository;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
+use demosplan\DemosPlanProcedureBundle\Exception\ProcedureCoupleTokenAlreadyUsedException;
 use demosplan\DemosPlanProcedureBundle\Logic\CurrentProcedureService;
 use demosplan\DemosPlanProcedureBundle\Logic\PrepareReportFromProcedureService;
-use demosplan\DemosPlanProcedureBundle\Exception\ProcedureCoupleTokenAlreadyUsedException;
 use demosplan\DemosPlanStatementBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use EDT\JsonApi\ResourceTypes\PropertyBuilder;
@@ -127,8 +127,6 @@ class ProcedureCoupleTokenSubscriber extends BaseEventSubscriber
 
     /**
      * @param BeforeResourceUpdateEvent|BeforeResourceDeletionEvent $event
-     *
-     * @return void
      */
     public function preventUpdateAndDeletion(DPlanEvent $event): void
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/GetPropertiesEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/GetPropertiesEvent.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest;
 
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
-use EDT\JsonApi\ResourceTypes\Property;
 use EDT\JsonApi\ResourceTypes\PropertyBuilder;
 use EDT\Wrapping\Contracts\Types\TypeInterface;
 
@@ -33,7 +32,7 @@ class GetPropertiesEvent extends DPlanEvent
     private $type;
 
     /**
-     * @param TypeInterface<O>     $type
+     * @param TypeInterface<O>            $type
      * @param array<int, PropertyBuilder> $properties
      */
     public function __construct(TypeInterface $type, array $properties)


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29828 and https://yaits.demos-deutschland.de/T29827

Description: If you login as AHB Admin then an error occur if you go to "Grundeinstellungen". Use PropertyBuilder instead of Property would fix it. It exits a draft: https://github.com/demos-europe/demosplan-core/pull/206 where this change is also implemented. Is this the right way to fix the bug or should we wait until the draft PR is merged.

### How to review/test
As AHB Admin -> verwalten > Grundeinstellungen


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
