### PR TITLE
Simplify svg coloring

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_nav.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_nav.scss
@@ -182,20 +182,16 @@ $dp-nav-item-font-family:                   $headings-font-family !default;
                     color: $nav-item-color-hover;
 
                     text-decoration: none;
+                }
 
-                    svg path {
-                        fill: $nav-item-color-hover;
-                    }
+                svg path {
+                    fill: currentColor;
                 }
             }
 
             &.current > a {
                 background-color: $nav-item-bg-color-current;
                 color: $nav-item-color-current;
-
-                svg path {
-                    fill: $nav-item-color-current;
-                }
             }
 
             // On mobile devices, indicate current/active state with the same colors.


### PR DESCRIPTION
Tickets:
- https://yaits.demos-deutschland.de/T29425
- https://yaits.demos-deutschland.de/T29831

As the fill color of the svg icon illustrating a nav item should always be of the same color as the item text, we can easily use `currentColor` here.

### PR Checklist

- [X] Link all relevant tickets
