### PR TITLE
Increase input width to match placeholder length

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -68,7 +68,7 @@
             name="controls" />
           <div :class="prefixClass('float--right')">
             <dp-autocomplete
-              :class="prefixClass('u-mb display--inline-block width-200 bg-color--white')"
+              :class="prefixClass('u-mb display--inline-block width-250 bg-color--white')"
               v-if="_options.autoSuggest.enabled"
               :options="autoCompleteOptions"
               :route="_options.autoSuggest.serviceUrlPath"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29799

Due to the way `vue-omnibox` (which is used by DpAutocomplete) is implemented, the easiest way to fix the layout bug is to just increase the width of the input field.

### How to review/test
As a planner, go to "Grundeinstellungen" > "Verortung des Verfahrens". The placeholder "Ort oder PLZ suchen..." should not break onto a new line.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
