### PR TITLE
fix (refs TXXXXX): fixed forAll method usages.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
@@ -108,12 +108,11 @@ class SignLanguageOverviewVideoResourceType extends DplanResourceType implements
         $resourceChange = new ResourceChange($video, $this, $properties);
 
         // until the FE supports multiple sign language videos we automatically remove the old one when a new one is created
-        $customer->getSignLanguageOverviewVideos()->forAll(
-            static function (int $index, Video $oldVideo) use ($resourceChange, $customer): bool {
-                $customer->removeSignLanguageOverviewVideo($oldVideo);
-                $resourceChange->addEntityToDelete($oldVideo);
-                return true;
-        });
+        /** @var Video $oldVideo */
+        foreach ($customer->getSignLanguageOverviewVideos() as $oldVideo) {
+            $customer->removeSignLanguageOverviewVideo($oldVideo);
+            $resourceChange->addEntityToDelete($oldVideo);
+        }
 
         $customer->addSignLanguageOverviewVideo($video);
 

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -831,13 +831,13 @@ class StatementService extends CoreService
         $updater->ifPresent(
             $this->similarStatementSubmitterResourceType->similarStatements,
             static function (Collection $similarStatements) use ($change, $submitter): void {
-                $similarStatements->forAll(
-                    static function (int $index, Statement $statement) use ($change, $submitter): bool {
-                        $statement->getSimilarStatementSubmitters()->add($submitter);
-                        $change->addEntityToPersist($statement);
-                        return true;
-                });
-        });
+                /** @var Statement $statement */
+                foreach ($similarStatements as $statement){
+                    $statement->getSimilarStatementSubmitters()->add($submitter);
+                    $change->addEntitiesToPersist($statement);
+                }
+            }
+        );
 
         return $change;
     }


### PR DESCRIPTION
Description:
Found two places where the ```forAll()``` method on Doctrine\Common\Collections was implemented incorrectly.
If the callback returns void - only the first element of the collection gets actually called.
It should /  has to be implemented as bool and should return true or it stops at that point and the remaining elements wont be checked.