### PR TITLE
Center drawings in SegmentLocationMap

### DIFF
--- a/client/js/components/map/map/DpOlMapDrawFeature.vue
+++ b/client/js/components/map/map/DpOlMapDrawFeature.vue
@@ -43,7 +43,7 @@
   <usage variant="read-Only">
     <dp-ol-map-draw-feature
       :features="features"
-      :fitDrawing="true"
+      fit-drawing
     />
   </usage>
 </documentation>
@@ -289,6 +289,10 @@ export default {
     },
 
     fitMapToDrawing () {
+      // Return if nothing is to be centered
+      if (this.features.features.length === 0) {
+        return
+      }
       //  Add features to vector source if set via props
       if (this.features.type === 'FeatureCollection' &&
         this.features.features.length === 1 &&

--- a/client/js/components/map/map/DpOlMapEditFeature.vue
+++ b/client/js/components/map/map/DpOlMapEditFeature.vue
@@ -127,7 +127,10 @@ export default {
 
   data () {
     return {
-      selectInteraction: new Select({ wrapX: false }),
+      selectInteraction: new Select({
+        hitTolerance: 10,
+        wrapX: false
+      }),
       modifyInteraction: null,
       currentlyActive: this.initActive,
       selectedFeatureId: [],

--- a/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
@@ -25,6 +25,7 @@
             ref="drawPoint"
             data-cy="setMapRelation"
             :features="pointData"
+            fit-drawing
             icon
             icon-class="fa-map-marker u-mb-0_25 font-size-h2"
             name="Point"
@@ -37,6 +38,7 @@
             data-cy="setMapLine"
             ref="drawLine"
             :features="lineData"
+            fit-drawing
             icon
             icon-class="fa-minus u-mb-0_25 font-size-h2"
             name="Line"
@@ -48,6 +50,7 @@
             ref="drawPolygon"
             data-cy="setMapTerritory"
             :features="polygonData"
+            fit-drawing
             icon
             icon-class="fa-square-o u-mb-0_25 font-size-h2"
             name="Polygon"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29158

To improve usability, already existing drawings are now centered within the map when the sidebar opens. This way, users do not have to search for existing drawings.

Also, the threshold for selecting a geometry is increased so it is easier to select lines and dots. 

### How to review/test
Add some drawing to a statement (after panning the map). Save. Close the sidebar, and open it again. The drawing should be centered.

With the "edit drawing" tool activated, click some px beneath a drawing. It should be selected, even without being hit directly.

This is branched off https://github.com/demos-europe/demosplan-core/pull/224.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
