### PR TITLE
fix(refs T29882): check if statement is claimed by another user

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -37,7 +37,7 @@
           :text="Translator.trans('procedure.share_statements.bulk.share')" />
       </dp-bulk-edit-header>
       <div class="flex space-inline-xs">
-        <dp-flyout align="left">
+        <dp-flyout :align="'left'">
           <template v-slot:trigger>
             {{ Translator.trans('export.verb') }}
             <i
@@ -166,7 +166,7 @@
               {{ Translator.trans('original.pdf') }}
             </a>
             <button
-              :class="`${ statementsObject[id].relationships.assignee.data && currentUserId === statementsObject[id].relationships.assignee.data.id ? '' : 'opacity-7 pointer-events-none' } btn--blank o-link--default text-decoration-underline--hover`"
+              :class="`${ assignee.id === currentUserId ? 'text-decoration-underline--hover' : 'is-disabled' } btn--blank o-link--default`"
               :disabled="synchronized"
               type="button"
               @click="triggerStatementDeletion(id)">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29882

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

A check is implemented to disable the "Aufteilen" link if a statement is claimed by another user. I.e., the current user should only be able to split statements that are not claimed or claimed by themselves.

Additionaly, I simplified another assignee check in the component that was unnecessarily verbose, and I used the `is-disabled` class to make the disabled button look more similar to the disabled links in the flyout.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Go to the statement list and make sure the "Aufteilen" link in the flyout menu of a statement is disabled if the statement is claimed by another user.

### PR Checklist
<!-- Reminders for handling PRs -->

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
