### PR TITLE
Fix prosemirror view change

### DIFF
--- a/client/js/lib/procedure/prosemirrorRanges/plugins.js
+++ b/client/js/lib/procedure/prosemirrorRanges/plugins.js
@@ -351,7 +351,7 @@ const rangeCreator = (pluginKey, rangeEditingKey) => {
             return
           }
 
-          if (e.clientX !== view.lastClick.x || e.clientY !== view.lastClick.y) {
+          if (e.clientX !== view.input.lastClick.x || e.clientY !== view.input.lastClick.y) {
             const existingRanges = rangeEditingKey.getState(state)
             let positionsCovered = []
             Object.values(existingRanges).forEach(({ from, to }) => positionsCovered.push(...range(from, to)))


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29920

It seems like lastClick is now wrapped [in an `input` property](https://github.com/ProseMirror/prosemirror-view/blob/c47178ce2d5726f07a21d0759b3350ee1d185fd5/src/input.ts#L24) within the prosemirror view.

### How to review/test
The [+] bubble should appear after selecting a text range in the "split statement" view.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
