### PR TITLE
Fix (ref: T29168): remove pipeline related parameters and methods from globalConfig

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/AiPipelineConfiguration.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/AiPipelineConfiguration.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Resources\config;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Validation;
 
 class AiPipelineConfiguration
 {
@@ -59,6 +61,12 @@ class AiPipelineConfiguration
      */
     private $parameterBag;
 
+    /** @var string */
+    protected $aiServiceSalt = '';
+
+    /** @var string */
+    protected $aiServicePostUrl = '';
+
     public function __construct(ParameterBagInterface $parameterBag)
     {
         $this->parameterBag = $parameterBag;
@@ -71,6 +79,20 @@ class AiPipelineConfiguration
         $this->piPipelineSegmentRecognitionId = $this->parameterBag->get('pi.pipeline.segment.recognition.id');
         if ($this->parameterBag->has('pipeline.ai.labels')) {
             $this->aiPipelineLabels = $this->parameterBag->get('pipeline.ai.labels');
+        }
+        if ($parameterBag->has('ai_service_salt')) {
+            $aiServiceSalt = $parameterBag->get('ai_service_salt');
+            if (is_string($aiServiceSalt)) {
+                $this->aiServiceSalt = $aiServiceSalt;
+            }
+        }
+        if ($parameterBag->has('ai_service_post_url')) {
+            $aiServicePostUrl = $parameterBag->get('ai_service_post_url');
+            $validator = Validation::createValidator();
+            $violations = $validator->validate($aiServicePostUrl, new Url());
+            if (0 === $violations->count()) {
+                $this->aiServicePostUrl = $aiServicePostUrl;
+            }
         }
     }
 
@@ -116,5 +138,21 @@ class AiPipelineConfiguration
     public function getAiPipelineLabels(): array
     {
         return $this->aiPipelineLabels;
+    }
+
+    /**
+     * @return string may be empty if not configured properly
+     */
+    public function getAiServiceSalt(): string
+    {
+        return $this->aiServiceSalt;
+    }
+
+    /**
+     * @return string may be empty if not configured properly
+     */
+    public function getAiServicePostUrl(): string
+    {
+        return $this->aiServicePostUrl;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
@@ -544,11 +544,6 @@ class GlobalConfig implements GlobalConfigInterface
     protected $entityContentChangeFieldMapping;
 
     /** @var string */
-    protected $aiServiceSalt = '';
-    /** @var string */
-    protected $aiServicePostUrl = '';
-
-    /** @var string */
     protected $publicIndexRoute;
 
     /** @var array */
@@ -823,22 +818,6 @@ class GlobalConfig implements GlobalConfigInterface
         }
         $this->subdomainMap = $parameterBag->get('subdomain_map');
         $this->subdomainsAllowed = $parameterBag->get('subdomains_allowed');
-
-        if ($parameterBag->has('ai_service_salt')) {
-            $aiServiceSalt = $parameterBag->get('ai_service_salt');
-            if (is_string($aiServiceSalt)) {
-                $this->aiServiceSalt = $aiServiceSalt;
-            }
-        }
-
-        if ($parameterBag->has('ai_service_post_url')) {
-            $aiServicePostUrl = $parameterBag->get('ai_service_post_url');
-            $validator = Validation::createValidator();
-            $violations = $validator->validate($aiServicePostUrl, new Url());
-            if (0 === $violations->count()) {
-                $this->aiServicePostUrl = $aiServicePostUrl;
-            }
-        }
 
         // set shared folder
         $this->sharedFolder = $parameterBag->get('is_shared_folder');
@@ -1784,22 +1763,6 @@ class GlobalConfig implements GlobalConfigInterface
     public function getPublicIndexRouteParameters(): array
     {
         return $this->publicIndexRouteParameters;
-    }
-
-    /**
-     * @return string may be empty if not configured properly
-     */
-    public function getAiServiceSalt(): string
-    {
-        return $this->aiServiceSalt;
-    }
-
-    /**
-     * @return string may be empty if not configured properly
-     */
-    public function getAiServicePostUrl(): string
-    {
-        return $this->aiServicePostUrl;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfigInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfigInterface.php
@@ -410,16 +410,6 @@ interface GlobalConfigInterface
     public function getPublicIndexRouteParameters(): array;
 
     /**
-     * @return string may be empty if not configured properly
-     */
-    public function getAiServiceSalt(): string;
-
-    /**
-     * @return string may be empty if not configured properly
-     */
-    public function getAiServicePostUrl(): string;
-
-    /**
      * @return array<int, string>
      */
     public function getRolesAllowed(): array;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29168

Description: 
Pipeline related parameters and methods are stored seperatly in 'AiPipelineConfiguration'. the parameters 'aiServiceSalt' and 'AiServicePostUrl' have to be moved there too. To have a better understanding see https://github.com/demos-europe/demosplan-core/pull/131

Note : the 'SegmentedStatementServiceTest' is already broken and skipped that's why it was not adjusted.

Delete the checkbox if it doesn't apply/isn't necessary.


- [X] Link all relevant tickets

