### PR TITLE
feat: include EuPL license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "demos/demosplan",
     "description": "demosplan",
     "type": "project",
-    "license": "proprietary",
+    "license": "EUPL-1.2",
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4,<8",


### PR DESCRIPTION
Defining the new EuPL-License was missing in composer.json file

### How to review/test
code review

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->
