### PR TITLE
feat: remove obsolete plugin paths

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/twig.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/twig.yaml
@@ -10,5 +10,3 @@ twig:
         sentry_dsn: '%sentry_dsn%'
     form_themes:
         - '@DemosPlanCore/form/styled_fields.html.twig'
-    paths:
-        '%kernel.project_dir%/demosplan/plugins': 'DemosPlugin'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -22,7 +22,6 @@ parameters:
 #        - %rootDir%/../../../vendor/twig/twig/src/Extension/CoreExtension.php
 
     excludes_analyse:
-        - %rootDir%/../../../demosplan/plugins
         - %rootDir%/../../../demosplan/vendor
         - %rootDir%/../../../vendor
     level: 1


### PR DESCRIPTION
Since we don't have any plugins anymore, we also don't have the plugins directory or need fpr any corresponding namespace. This commit deletes those paths in 2 places as they are no longer needed and can actually create problems.

### How to review/test
everything should be as before except for some automated testing problems that should be resolved now.