### PR TITLE
fix(refs T30074): do not purge demosplan-ui styles

### DIFF
--- a/client/setup/config.js
+++ b/client/setup/config.js
@@ -7,6 +7,7 @@
  * All rights reserved
  */
 
+const glob = require('glob')
 const path = require('path')
 
 class Config {
@@ -54,7 +55,8 @@ class Config {
         'demosplan/**/*.js',
         'demosplan/**/*.js.twig',
         'client/**/*.js',
-        'client/**/*.vue'
+        'client/**/*.vue',
+        ...glob.sync('node_modules/@demos-europe/demosplan-ui/dist/**/*.js', { nodir: true })
       ],
       safelist: {
         standard: [


### PR DESCRIPTION
To tell purgeCss about demosplan-ui classes, for now, the dist folder is added to the `content` option of purgeCss.