### PR TITLE
feat: Add demos-europe/demosplan-addon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "cebe/php-openapi": "^1.5",
         "cocur/slugify": "^4.0",
         "composer/package-versions-deprecated": "1.11.99.5",
+        "demos-europe/demosplan-addon": "dev-main",
         "demos-europe/edt-dql": "^0.14.0",
         "demos-europe/edt-extra": "^0.14.0",
         "demos-europe/edt-jsonapi": "^0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d61ef9982c2f19ffe4d725021fcf8003",
+    "content-hash": "a38cf30051960f26acc6b05f22a04133",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1233,6 +1233,43 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "demos-europe/demosplan-addon",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/demos-europe/demosplan-addon.git",
+                "reference": "b91c62a3708b0601b626ae4661198fe0dfaac625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/b91c62a3708b0601b626ae4661198fe0dfaac625",
+                "reference": "b91c62a3708b0601b626ae4661198fe0dfaac625",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1"
+            },
+            "default-branch": true,
+            "type": "package",
+            "autoload": {
+                "psr-4": {
+                    "DemosEurope\\DemosplanAddon\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "This is the base package for all demosplan addons",
+            "support": {
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/main"
+            },
+            "time": "2022-11-25T16:02:15+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",
@@ -21592,7 +21629,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "demos-europe/demosplan-addon": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Add the base package required for addon interactions.

This will allow us to make progress on the addon loading inside demosplan
without compromising type checks on base classes
