### PR TITLE
fix: WIP set demosplan-ui/utils to the current hashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#9eb450c3163db7b8955ee199cdcc514b8852dc98",
-    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a",
+    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#d4c028d4156b9e924f76411c7a1a85e8a356ff37",
+    "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,14 +1330,14 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
   integrity sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==
 
-"@demos-europe/demosplan-ui@github:demos-europe/demosplan-ui#9eb450c3163db7b8955ee199cdcc514b8852dc98":
+"@demos-europe/demosplan-ui@github:demos-europe/demosplan-ui#d4c028d4156b9e924f76411c7a1a85e8a356ff37":
   version "0.0.2"
-  resolved "https://codeload.github.com/demos-europe/demosplan-ui/tar.gz/9eb450c3163db7b8955ee199cdcc514b8852dc98"
+  resolved "https://codeload.github.com/demos-europe/demosplan-ui/tar.gz/d4c028d4156b9e924f76411c7a1a85e8a356ff37"
   dependencies:
     "@babel/core" "^7.20.2"
     "@babel/preset-env" "^7.20.2"
     "@braintree/sanitize-url" "^6.0.1"
-    "@demos-europe/demosplan-utils" "github:demos-europe/demosplan-js-utils#93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a"
+    "@demos-europe/demosplan-utils" "github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf"
     "@storybook/addon-actions" "6.5.13"
     "@storybook/addon-docs" "6.5.13"
     "@storybook/addon-essentials" "6.5.12"
@@ -1384,12 +1384,14 @@
     webpack "^5.75.0"
     webpack-cli "^5.0.0"
 
-"@demos-europe/demosplan-utils@github:demos-europe/demosplan-js-utils#93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a":
+"@demos-europe/demosplan-utils@github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf":
   version "0.0.3"
-  resolved "https://codeload.github.com/demos-europe/demosplan-js-utils/tar.gz/93b3875b81fbfd367d6ca68cb710d50eb2d3ca2a"
+  resolved "https://codeload.github.com/demos-europe/demosplan-js-utils/tar.gz/86b11570ce9287cd62457c8071cf959b1674a8bf"
   dependencies:
     axios "^0.27.2"
+    fscreen "^1.2.0"
     qs "^6.11.0"
+    tooltip.js "^1.3.3"
     uuid "^9.0.0"
 
 "@demos-europe/dp-consent@^1.1.2":


### PR DESCRIPTION
With the Changes in demosplan-ui and demosplan-utils async components are loaded again.

This is just a quick fix. We still have to manage the chunks to benefit from the lazy loading.