### PR TITLE
feat: avoid static procedure id

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -756,6 +756,7 @@ class DemosPlanProcedureController extends BaseController
         CurrentUserInterface $currentUser,
         EntityWrapperFactory $wrapperFactory,
         FormFactoryInterface $formFactory,
+        MasterTemplateService $masterTemplateService,
         Request $request,
         ServiceStorage $serviceStorage,
         TranslatorInterface $translator
@@ -831,6 +832,7 @@ class DemosPlanProcedureController extends BaseController
         $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp('procedure.new');
         $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, false, $wrapperFactory);
         $templateVars = $this->procedureServiceOutput->fillTemplateVars($templateVars);
+        $templateVars['masterTemplateId'] = $masterTemplateService->getMasterTemplateId();
 
         return $this->renderTemplate(
             '@DemosPlanProcedure/DemosPlanProcedure/administration_new.html.twig',

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new.html.twig
@@ -5,7 +5,7 @@
         {{ "procedure.new"|trans }}
     </h1>
     {% if hasPermission('feature_procedure_templates') %}
-            {% set masterBlueprintId = 'ae65efdb-8414-4deb-bc81-26efdfc9560b' %}
+            {% set masterBlueprintId = templateVars.masterTemplateId %}
             {% set copyMasterOptions = [{ label: 'master.empty', value: masterBlueprintId, isMaster: true }] %}
             {% if templateVars.list.procedures is defined %}
                 {% for procedure in templateVars.list.procedures %}

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new_master.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new_master.html.twig
@@ -9,7 +9,7 @@
         {{ "text.master.new"|trans }}
     </p>
 
-    {% set copyMasterOptions = [{ label: 'master.empty', value: 'ae65efdb-8414-4deb-bc81-26efdfc9560b' }] %}
+    {% set copyMasterOptions = [{ label: 'master.empty', value: templateVars.masterTemplateId }] %}
     {% if templateVars.list.procedures is defined %}
         {% for procedure in templateVars.list.procedures %}
             {% set copyMasterOptions = copyMasterOptions|merge([{ label: procedure.name|default, value: procedure.ident|default }]) %}


### PR DESCRIPTION
We need to avoid static ids for entities in logic. MasterTemplateProcedure already is migrated from static Id usage to a flag but this was not always used.

### How to review/test
Create new procedure from master template.

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-project-bobhh/pull/11
