### PR TITLE
fix: `deleteObject` needs to return boolean

### DIFF
--- a/demosplan/DemosPlanUserBundle/Repository/InstitutionTagRepository.php
+++ b/demosplan/DemosPlanUserBundle/Repository/InstitutionTagRepository.php
@@ -87,5 +87,7 @@ class InstitutionTagRepository extends CoreRepository implements ObjectInterface
         } catch (\Exception $e) {
             $this->logger->error('Delete statementVote failed: ', [$e]);
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
 `deleteObject` needs to return boolean

### How to review/test
code review and/or ask phpstan

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
