### PR TITLE
Feat (ref: T30254): rename Message and LinkMessage classes

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceObject;
 use demosplan\DemosPlanCoreBundle\Logic\Logger\ApiLogger;
-use demosplan\DemosPlanCoreBundle\Logic\Message;
+use demosplan\DemosPlanCoreBundle\Logic\MessageSerializable;
 use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Response\APIResponse;
@@ -143,14 +143,14 @@ class DemosPlanDocumentDashboardAPIController extends APIController
 
         if ($documentDashboardData->isPresent('planText')) {
             $procedureSettings->setPlanText($documentDashboardData->get('planText'));
-            $successMessages[] = new Message('confirm', 'confirm.field.changes.saved', ['fieldName' => 'Planstand']);
+            $successMessages[] = new MessageSerializable('confirm', 'confirm.field.changes.saved', ['fieldName' => 'Planstand']);
         }
 
         if ($documentDashboardData->isPresent('planningArea') && $permissions->hasPermission(
                 'feature_procedure_planning_area_match'
             )) {
             $procedureSettings->setPlanningArea($documentDashboardData['planningArea']);
-            $successMessages[] = new Message('confirm', 'confirm.field.changes.saved', ['fieldName' => 'Planungsbereich']);
+            $successMessages[] = new MessageSerializable('confirm', 'confirm.field.changes.saved', ['fieldName' => 'Planungsbereich']);
         }
 
         /** @var ProcedureRepository $procedureRepository */

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -43,7 +43,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Export\EntityPreparator;
 use demosplan\DemosPlanCoreBundle\Logic\FileUploadService;
 use demosplan\DemosPlanCoreBundle\Logic\ILogic\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\Message;
+use demosplan\DemosPlanCoreBundle\Logic\MessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\MasterTemplateService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedurePhaseService;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureCoupleTokenFetcher;
@@ -796,7 +796,7 @@ class DemosPlanProcedureController extends BaseController
                 $procedure = $serviceStorage->administrationNewHandler($inData, $currentUser->getUser()->getId());
 
                 $this->messageBag->addObject(
-                    Message::createMessage(
+                    MessageSerializable::createMessage(
                         'confirm',
                         'confirm.procedure.created',
                         ['name' => $procedure->getName()]
@@ -901,7 +901,7 @@ class DemosPlanProcedureController extends BaseController
                 $procedure = $serviceStorage->administrationNewHandler($inData, $currentUser->getUser()->getId());
 
                 $this->messageBag->addObject(
-                    Message::createMessage(
+                    MessageSerializable::createMessage(
                         'confirm',
                         'confirm.procedure_template.created',
                         ['name' => $procedure->getName()]

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureProposal;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessage;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanProcedureBundle\Exception\ProcedureProposalNotFound;
 use demosplan\DemosPlanProcedureBundle\Logic\ProcedureProposalHandler;
 use demosplan\DemosPlanProcedureBundle\Logic\ProcedureProposalService;
@@ -165,7 +165,7 @@ class ProcedureProposalController extends BaseController
                 $this->procedureProposalService->generateProcedureFromProcedureProposal($procedureProposal);
 
             if ($generatedProcedure instanceof Procedure) {
-                $this->getMessageBag()->addObject(LinkMessage::createLinkMessage(
+                $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
                     'confirm',
                     'confirm.procedure.created',
                     ['name' => $generatedProcedure->getName()],

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -28,7 +28,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceObject;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\TopLevel;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiPaginationParser;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessage;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Logger\ApiLogger;
 use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\HeadStatementResourceType;
@@ -125,7 +125,7 @@ class DemosPlanStatementAPIController extends APIController
 
                 if ($ownsRemoteProcedure) {
                     $this->getMessageBag()->addObject(
-                        LinkMessage::createLinkMessage(
+                        LinkMessageSerializable::createLinkMessage(
                             'confirm',
                             $message,
                             $messageParameters,
@@ -234,7 +234,7 @@ class DemosPlanStatementAPIController extends APIController
                 ];
                 if ($ownsRemoteProcedure) {
                     $this->getMessageBag()->addObject(
-                        LinkMessage::createLinkMessage(
+                        LinkMessageSerializable::createLinkMessage(
                             'confirm',
                             $message,
                             $messageParameters,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -28,7 +28,7 @@ use demosplan\DemosPlanCoreBundle\Exception\SendMailException;
 use demosplan\DemosPlanCoreBundle\Exception\UserAlreadyExistsException;
 use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessage;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use demosplan\DemosPlanCoreBundle\Logic\SessionHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementAnonymizeService;
@@ -460,7 +460,7 @@ class DemosPlanUserController extends BaseController
             // as the email-address is used as login name the handling for both exceptions is the same
         } catch (UserAlreadyExistsException $e) {
             $emailAddress = $e->getValue();
-            $this->getMessageBag()->addObject(LinkMessage::createLinkMessage(
+            $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
                 'warning',
                 'warning.user.emailaddress.in_use',
                 ['emailAddress' => $emailAddress],

--- a/demosplan/DemosPlanCoreBundle/Logic/ILogic/MessageBagInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ILogic/MessageBagInterface.php
@@ -11,7 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\ILogic;
 
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
-use demosplan\DemosPlanCoreBundle\Logic\Message;
+use demosplan\DemosPlanCoreBundle\Logic\MessageSerializable;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Tightenco\Collect\Support\Collection;
 
@@ -75,7 +75,7 @@ interface MessageBagInterface
      *
      * @param bool $toStart if to add the parameter to the start of the list of messages
      */
-    public function addObject(Message $message, bool $toStart = false): void;
+    public function addObject(MessageSerializable $message, bool $toStart = false): void;
 
     /**
      * Generate error messages from a Symfony violation list.

--- a/demosplan/DemosPlanCoreBundle/Logic/LinkMessageSerializable.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/LinkMessageSerializable.php
@@ -13,7 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class LinkMessage extends Message
+class LinkMessageSerializable extends MessageSerializable
 {
     protected $routeName = '';
     protected $routeParameters = [];
@@ -44,7 +44,7 @@ class LinkMessage extends Message
      * @param array  $routeParameters
      * @param string $linkText
      *
-     * @return LinkMessage
+     * @return LinkMessageSerializable
      */
     public static function createLinkMessage($severity, $text, $textParameters = [], $routeName, $routeParameters = [], $linkText)
     {
@@ -76,7 +76,7 @@ class LinkMessage extends Message
     /**
      * @param string $routeName
      *
-     * @return LinkMessage
+     * @return LinkMessageSerializable
      */
     public function setRouteName($routeName)
     {
@@ -96,7 +96,7 @@ class LinkMessage extends Message
     /**
      * @param array $routeParameters
      *
-     * @return LinkMessage
+     * @return LinkMessageSerializable
      */
     public function setRouteParameters($routeParameters)
     {
@@ -116,7 +116,7 @@ class LinkMessage extends Message
     /**
      * @param string $linkText
      *
-     * @return LinkMessage
+     * @return LinkMessageSerializable
      */
     public function setLinkText($linkText)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/MessageBag.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MessageBag.php
@@ -171,10 +171,10 @@ class MessageBag implements MessageBagInterface
         string $linkText = ''
     ): void {
         if ('' === $routeName) {
-            $this->addObject(Message::createMessage($severity, $message, $params));
+            $this->addObject(MessageSerializable::createMessage($severity, $message, $params));
         } else {
             $this->addObject(
-                LinkMessage::createLinkMessage(
+                LinkMessageSerializable::createLinkMessage(
                     $severity,
                     $message,
                     $params,
@@ -191,7 +191,7 @@ class MessageBag implements MessageBagInterface
      *
      * @throws MessageBagException will not add a message if it already exists
      */
-    public function addObject(Message $message, bool $toStart = false): void
+    public function addObject(MessageSerializable $message, bool $toStart = false): void
     {
         $this->validateMessageInputData($message->getSeverity(), $message->getText());
 
@@ -291,7 +291,7 @@ class MessageBag implements MessageBagInterface
     {
         $this->initializeMessageBagForSeverity($severity);
 
-        $this->messages[$severity]->push(new Message($severity, $message));
+        $this->messages[$severity]->push(new MessageSerializable($severity, $message));
     }
 
     protected function initializeMessageBagForSeverity(string $severity)

--- a/demosplan/DemosPlanCoreBundle/Logic/MessageSerializable.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MessageSerializable.php
@@ -15,7 +15,7 @@ use JsonSerializable;
 /**
  * ViewObject for Messages.
  */
-class Message implements JsonSerializable
+class MessageSerializable implements JsonSerializable
 {
     protected $severity = '';
     protected $text = '';
@@ -38,7 +38,7 @@ class Message implements JsonSerializable
      * @param string $text           #TranslationKey
      * @param array  $textParameters
      *
-     * @return Message
+     * @return MessageSerializable
      */
     public static function createMessage($severity, $text, $textParameters = [])
     {
@@ -56,7 +56,7 @@ class Message implements JsonSerializable
     /**
      * @param string $severity
      *
-     * @return Message
+     * @return MessageSerializable
      */
     public function setSeverity($severity)
     {
@@ -76,7 +76,7 @@ class Message implements JsonSerializable
     /**
      * @param string $text
      *
-     * @return Message
+     * @return MessageSerializable
      */
     public function setText($text)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/TransformMessageBagService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/TransformMessageBagService.php
@@ -44,7 +44,7 @@ class TransformMessageBagService
     {
         $this->messageBag->get()->each(function (Collection $messages, $severity) {
             $messages->each(function ($message) use ($severity) {
-                if ($message instanceof LinkMessage) {
+                if ($message instanceof LinkMessageSerializable) {
                     $message->prepareUrl($this->router);
                 }
                 $this->flashBag->add($severity, $message);
@@ -60,8 +60,8 @@ class TransformMessageBagService
         return $this->messageBag->get()->mapWithKeys(
             function (Collection $messages, string $severity) {
                 $convertedMessages = $messages->map(
-                    function (Message $message) {
-                        if ($message instanceof LinkMessage) {
+                    function (MessageSerializable $message) {
+                        if ($message instanceof LinkMessageSerializable) {
                             $message->prepareUrl($this->router);
                         }
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
 use demosplan\DemosPlanCoreBundle\Event\RequestValidationWeakEvent;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessage;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -71,7 +71,7 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
         $violations = $this->passwordValidator->validate($credentials->getPassword());
         if (0 < $violations->count()) {
             $linkChangeText = $this->translator->trans('password.change');
-            $this->messageBag->addObject(LinkMessage::createLinkMessage(
+            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
                 'warning',
                 'warning.password.weak',
                 [],

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementHandler.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementHandler.php
@@ -47,7 +47,7 @@ use demosplan\DemosPlanCoreBundle\Logic\EntityContentChangeService;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiActionService;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessage;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\SearchIndexTaskService;
@@ -3079,7 +3079,7 @@ class StatementHandler extends CoreHandler
                     || $this->permissions->hasPermission('feature_segments_of_statement_list')
                     || $this->permissions->hasPermission('feature_statement_data_input_orga')) {
                     //success messages with link to created statement
-                    $this->getMessageBag()->addObject(LinkMessage::createLinkMessage(
+                    $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
                         'confirm',
                         'confirm.statement.new',
                         ['externId' => $assessableStatement->getExternId()],
@@ -4590,7 +4590,7 @@ class StatementHandler extends CoreHandler
             }
 
             $this->getMessageBag()->addObject(
-                LinkMessage::createLinkMessage(
+                LinkMessageSerializable::createLinkMessage(
                     'confirm',
                     'confirm.statement.cluster.created',
                     ['clusterId' => $newClusterStatement->getExternId()],

--- a/tests/backend/core/Core/Functional/MessageBagTest.php
+++ b/tests/backend/core/Core/Functional/MessageBagTest.php
@@ -10,7 +10,7 @@
 
 namespace Tests\Core\Core\Functional;
 
-use demosplan\DemosPlanCoreBundle\Logic\Message;
+use demosplan\DemosPlanCoreBundle\Logic\MessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Tests\Base\FunctionalTestCase;
 use Tightenco\Collect\Support\Collection;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30254

Description: 

The Message class is needed in demosplan addon so it has to implement an interface with will be used there. The MessageInterface exist already but its logic is not related to this class, that's why this class has to be renamed.

The 'LinkMessage' extends the 'Message' class, to keep the names relevant it was renamed too here.

Note : this class will be renamed in this PR as a first step, the relevant interface will be created in other PR 

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
