### PR TITLE
fix(refs T30550): Prevent undefined SourceAttachment to break Things

### DIFF
--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -151,7 +151,7 @@ function transformStatementStructure ({ el, includes, meta }) {
           const type = relation.data[0].type
 
           statement[relationKey] = includes.filter(incl => ids.includes(incl.id) && type === incl.type)
-          statement[relationKey] = statement[relationKey].map(st => Object.assign(st.attributes, { id: st.id }))
+          statement[relationKey] = statement[relationKey].map(statementRel => Object.assign(statementRel.attributes, { id: statementRel.id }))
 
           if (type === 'StatementAttachment' && hasOwnProp(statement[relationKey][0], 'id')) {
             const attachment = includes
@@ -162,7 +162,7 @@ function transformStatementStructure ({ el, includes, meta }) {
               const sourceAttachment = includes
                 .filter(incl => incl.type === 'File')
                 .filter(incl => attachment[0].relationships.file.data.id === incl.id)
-                .map(sa => Object.assign(sa.attributes, { id: sa.id }))
+                .map(sourceAtt => Object.assign(sourceAtt.attributes, { id: sourceAtt.id }))
 
               statement.sourceAttachment = sourceAttachment[0]
             } else {


### PR DESCRIPTION
It looks like the attachments doesn't always have a relationship. We have to catch that.

along fix minor linting issues

 **Ticket:** https://yaits.demos-deutschland.de/T30550

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

As FP-A - Goto A-table in procedures linked in the Ticket. (not all procedures have that issue :warning: )


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
