### PR TITLE
fix (refs T30546): set GlobalNewsResourceType as directly accessible

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
@@ -85,7 +85,7 @@ final class GlobalNewsResourceType extends AbstractNewsResourceType implements D
 
     public function isDirectlyAccessible(): bool
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30546

Description:
set the GlobalNewsResourceType as directly accessible
since FE needs direct access (on delete)

### How to review/test
login as a customer-master-user (Plattform-Administration)
try to delete a global-news entry (Portal-Mitteilung).

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
