### PR TITLE
fix (ref T30459): Add child path to fix wrong behavior of sidemenu.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/menus.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/menus.yml
@@ -349,7 +349,7 @@ submenu_procedures:
     considerationtable:
         label: 'considerationtable'
         path: 'dplan_assessmenttable_view_table'
-        child_paths: ['dplan_assessmenttable_view_original_table']
+        child_paths: ['dplan_assessmenttable_view_original_table', 'dm_plan_assessment_single_view']
         path_params: ['procedureId', 'filterHash']
         permission: 'area_admin_assessmenttable'
         link_attributes:


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30459

Description: This PR adds a child path to "Abwaegungstabelle" to fix the collapsed state of the sidemenu if you go to the detail view of a statement.

### How to review/test
Login -> Verfahren -> AT -> ... -> STN Detailansicht

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
