### PR TITLE
fix(T30433): multiselect inside the data table is hidden

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_data-table.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_data-table.scss
@@ -117,8 +117,6 @@
         text-align: left;
         padding: $data-table-padding-cell;
         vertical-align: top;
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     th .c-data-table__drag-handle {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30433

**Description:** The property `overflow: hidden` was removed from the table data cell element (.c-data-table td). It was hidden by default, which led to problems with the dropdown (multiselect) inside the table.