### PR TITLE
feat T29403: ensure orga name stays unique

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -270,9 +270,9 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
         }
         /*
          * This check prevents the case that someone tries to change the orga name to
-         * @link User::ANONYMOUS_USER_ORGA_NAME. This name has to stay unique for the Citizen Orga.
+         * an already existing one. The name has to stay unique for the Orga.
          */
-        if (User::ANONYMOUS_USER_ORGA_NAME !== $this->ozgKeycloakResponseValueObject->getVerfahrenstraeger()) {
+        if (null !== $this->tryLookupOrgaByName()) {
             $existingOrga->setName($this->ozgKeycloakResponseValueObject->getVerfahrenstraeger());
         }
         // what OrgaTypes are needed to be set and accepted regarding the requested Roles?


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29403

Description: Currently it is possible to update the orga name with an already used. So it will be possible to have more then one "Amt Nordwest" for example. This PR adjust a if statement to prevent this.

### Linked PRs
https://github.com/demos-europe/demosplan-core/pull/410


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
