### PR TITLE
fix: LoadAddressBookEntryData is dependant of LoadUserData

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
@@ -34,7 +34,7 @@ class LoadAddressBookEntryData extends TestFixture implements DependentFixtureIn
     public function getDependencies(): array
     {
         return [
-          LoadUserData::class
+          LoadUserData::class,
         ];
     }
 }


### PR DESCRIPTION
LoadAddressBookEntryData is dependant of LoadUserData, therefore all tests are failing

### How to review/test
try to fire a unit test

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
