### PR TITLE
Fix(T29774): Give to the personal data link another style and open in a new tab

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
@@ -99,7 +99,8 @@
         &::before {
             @extend .fa;
 
-            padding-right: .5em;
+            padding-left: .2em;
+            padding-right: .2em;
             content: $fa-var-external-link;
             font-size: .85em;
         }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#95131b0f02b3533554d26259c6bb27a7b570e772",
+    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#0adb789914b45e389587f5443453fd1a5df25aea",
     "@demos-europe/demosplan-utils": "github:demos-europe/demosplan-js-utils#86b11570ce9287cd62457c8071cf959b1674a8bf",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -459,7 +459,7 @@ confirm.fragment.assignment.unassigned: "Der Datensatz wurde erfolgreich freigeg
 confirm.fragment.deleted: "Der Datensatz wurde gelöscht."
 confirm.fragment.edit: "Die Änderungen am Datensatz {id} wurden gespeichert."
 confirm.fragment.update.complete: "Die Bearbeitung des Datensatzes {id} wurde von Ihnen abgeschlossen."
-confirm.gdpr.consent: "Ich bin mit der Verarbeitung der mich betreffenden <a class=\"o-link--default\" href=\"{link}#{orgaId}\" target=\"_blank\" aria-label=\"zum Datenschutz\">personenbezogenen Daten</a> einverstanden."
+confirm.gdpr.consent: "Ich bin mit der Verarbeitung der mich betreffenden <a class=\"o-link--external\" href=\"{link}#{orgaId}\" target=\"_blank\" aria-label=\"zum Datenschutz\">personenbezogenen Daten</a> einverstanden."
 confirm.gdpr.consent.registration: "Hiermit bestätige ich, dass ich die <a class=\"o-link--default\" href=\"{gdpr}\" target=\"_blank\" aria-label=\"Hinweise zum Datenschutz\">Hinweise zum Datenschutz</a> gelesen habe und erkläre mich mit der Speicherung und Verarbeitung meiner personenbezogenen Daten einverstanden."
 confirm.gislayer.delete: "Die Kartenebene wurde gelöscht."
 confirm.gislayerCategory.delete: "Die Kartenebenen-Kategorie wurde gelöscht."


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29774

Description: In personal data link its not clear that it is a link to click and it should open the privacy information in a new tab.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs

- https://github.com/demos-europe/demosplan-ui/pull/34

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
