### PR TITLE
fix: ExportFieldsConfiguration needs to be set on new procedures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -44,7 +44,6 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         ProcedureHandler $procedureHandler,
         TranslatorInterface $translator
     ) {
-
         parent::__construct($entityManager);
         $this->translator = $translator;
         $this->globalConfig = $globalConfig;
@@ -79,7 +78,7 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         $manager->persist($procedureMaster);
         $manager->flush();
 
-        //create GisLayerCategory for MasterBlueprint
+        // create GisLayerCategory for MasterBlueprint
         $gisLayerCategoryMaster = new GisLayerCategory();
         $gisLayerCategoryMaster->setName('rootGisLayer');
         $gisLayerCategoryMaster->setProcedure($procedureMaster);

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\ExportFieldsConfiguration;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
@@ -65,6 +66,7 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         $procedureMaster->setMaster(true);
         $procedureMaster->setMasterTemplate(true);
         $procedureMaster->setAgencyMainEmailAddress('ihre@emailadresse.de');
+        $procedureMaster->addExportFieldsConfiguration(new ExportFieldsConfiguration($procedureMaster));
         $slug = new Slug('master');
         $procedureMaster->addSlug($slug);
         $procedureMaster->setCurrentSlug($slug);


### PR DESCRIPTION
Prod fixtures are used to create databases from scratch. ExportFieldsConfiguration where introduced and never reflected in prod fixtures.

### How to review/test
create a new database and populate it with prod fixtures

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
