### PR TITLE
Move frontend libs into core chunk

### DIFF
--- a/client/setup/webpack/optimization.js
+++ b/client/setup/webpack/optimization.js
@@ -18,7 +18,11 @@ const chunkSplitting = {
       name: 'core',
       chunks: 'all',
       enforce: true,
-      test: /([\\/]node_modules[\\/](@demos-europe|vue[\\/]|vuex|v-tooltip|portal-vue|axios|popper|dayjs|dompurify|lodash|@efrane|@sentry|core-js|qs|tooltip\.js|deep-object-diff|js-base64))|([\\/]demosplan[\\/]DemosPlanCoreBundle[\\/]Resources[\\/]client[\\/]js[\\/](InitVue\.js|VueConfigCore\.js|bootstrap\.js))/,
+      test (module) {
+        const nodeModulesCoreTest = /[\\/]node_modules[\\/](@demos-europe|vue[\\/]|vuex|v-tooltip|portal-vue|axios|popper|dayjs|dompurify|lodash|@efrane|@sentry|core-js|qs|tooltip|deep-object-diff|js-base64)/
+        const baseModulesCoreTest = /[\\/]demosplan[\\/]DemosPlanCoreBundle[\\/]Resources[\\/]client[\\/]js[\\/](InitVue\.js|VueConfigCore\.js)/
+        return module.resource && (nodeModulesCoreTest.test(module.resource) || baseModulesCoreTest.test(module.resource))
+      },
       priority: 2,
       reuseExistingChunk: true
     },


### PR DESCRIPTION
As demosplan-ui isn't tree shakeable atm, this is an obvious performance gain. However, we should move towards tree shaking.