### PR TITLE
Do not exclude all dep sourcemaps

### DIFF
--- a/client/setup/config.js
+++ b/client/setup/config.js
@@ -36,7 +36,7 @@ class Config {
     this.absoluteRoot = path.resolve(__dirname, this.relativeRoot) + '/'
     this.oldBundlesPath = path.resolve(__dirname, this.relativeRoot + 'demosplan/') + '/'
 
-    // Yes, technically this is not needed but it's here to document the possible use in `resolveAliases`
+    // Yes, technically this is not needed, but it's here to document the possible use in `resolveAliases`.
     const clientBundlesPath = path.resolve(__dirname, this.relativeRoot) + '/client/js/bundles'
     this.clientBundleGlob = clientBundlesPath + '/**/*.js'
 

--- a/client/setup/webpack/moduleRules.js
+++ b/client/setup/webpack/moduleRules.js
@@ -122,9 +122,9 @@ const moduleRules =
       test: /\.js$/,
       use: ['source-map-loader'],
       enforce: 'pre',
-      exclude: [
-        resolveDir('node_modules')
-      ]
+      exclude: (path) => {
+        return /[\\/]node_modules[\\/]/.test(path) && !/[\\/]node_modules[\\/](@sentry|popper|portal-vue|tooltip|fscreen)/.test(path)
+      }
     },
     {
       test: /\.s?css$/,


### PR DESCRIPTION
In Chrome devtools, there was a flood of messages with "DevTools failed to load SourceMap" warnings which made spotting the real logs harder. This seems to be an issue of sentry/browser and a few other libs that reference a sourcemap by url within their esm files. The workaround is to not exclude those modules from source-map-loader.

See https://github.com/getsentry/sentry-javascript/issues/2566