### PR TITLE
refactor(refs T29004): pass label props as object

### DIFF
--- a/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
+++ b/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
@@ -17,7 +17,9 @@
           :id="entity.key"
           :checked="entity.key === active"
           @change="active = entity.key"
-          :label="radioLabel(entity)"
+          :label="{
+            text: radioLabel(entity)
+          }"
           :value="entity.key" />
       </template>
       <p

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -37,14 +37,18 @@
               name="r_role"
               value="0"
               :id="`${instanceId}r_role_0`"
-              :label="Translator.trans('citizen')"
+              :label="{
+                text: Translator.trans('citizen')
+              }"
               :checked="values.submitter.institution === false || values.submitter.institution === undefined"
               @change="values.submitter.institution = false" />
             <dp-radio
               name="r_role"
               value="1"
               :id="`${instanceId}r_role_1`"
-              :label="Translator.trans('institution')"
+              :label="{
+                text: Translator.trans('institution')
+              }"
               :checked="values.submitter.institution === true"
               @change="values.submitter.institution = true" />
           </div>

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -83,16 +83,20 @@
             <dp-radio
               id="attachTextRadioId"
               v-model="actions.addRecommendations.isTextAttached"
-              :bold="false"
               :checked="actions.addRecommendations.isTextAttached"
-              :label="Translator.trans('segments.bulk.edit.recommendations.radio.text.attach')"
+              :label="{
+                bold: false,
+                text: Translator.trans('segments.bulk.edit.recommendations.radio.text.attach')
+              }"
               @change="actions.addRecommendations.isTextReplaced = false" />
             <dp-radio
               id="replaceTextRadioId"
               v-model="actions.addRecommendations.isTextReplaced"
-              :bold="false"
               :checked="actions.addRecommendations.isTextReplaced"
-              :label="Translator.trans('segments.bulk.edit.recommendations.radio.text.replace')"
+              :label="{
+                bold: false,
+                text: Translator.trans('segments.bulk.edit.recommendations.radio.text.replace')
+              }"
               @change="actions.addRecommendations.isTextAttached = false" />
           </div>
           <dp-editor

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -104,15 +104,19 @@
               class="u-mr-2"
               :checked="formData.r_isNegativeReport === '0'"
               @change="() => { setStatementData({ r_isNegativeReport: '0'}) }"
-              :label="Translator.trans('public.participation.participate')"
+              :label="{
+                text: Translator.trans('public.participation.participate')
+              }"
               value="0" />
             <dp-radio
               name="r_isNegativeReport"
               id="negative_report_true"
-              :hint="Translator.trans('link.title.indicationerror')"
               :checked="formData.r_isNegativeReport === '1'"
               @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
-              :label="Translator.trans('indicationerror')"
+              :label="{
+                hint: Translator.trans('link.title.indicationerror'),
+                text: Translator.trans('indicationerror')
+              }"
               value="1" />
           </div>
         </template>
@@ -451,7 +455,9 @@
               value="1"
               @change="val => setStatementData({r_useName: '1'})"
               :checked="formData.r_useName === '1'"
-              :label="Translator.trans('statement.detail.form.personal.post_publicly')" />
+              :label="{
+                text: Translator.trans('statement.detail.form.personal.post_publicly')
+              }" />
             <div
               v-show="formData.r_useName === '1'"
               :class="prefixClass('layout')">
@@ -476,7 +482,9 @@
               value="0"
               @change="val => setStatementData({r_useName: '0'})"
               :checked="formData.r_useName === '0'"
-              :label="Translator.trans('statement.detail.form.personal.post_anonymously')"
+              :label="{
+                text: Translator.trans('statement.detail.form.personal.post_anonymously')
+              }"
               aria-labelledby="statement-detail-post-anonymously"
               data-cy="submitAnonymously" />
           </div>

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupCitizenOrInstitution.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupCitizenOrInstitution.vue
@@ -32,7 +32,9 @@
             <div :class="prefixClass('layout__item u-1-of-2 u-1-of-1-lap-down')">
               <dp-radio
                 id="citizen"
-                :label="Translator.trans('citizen')"
+                :label="{
+                  text: Translator.trans('citizen')
+                }"
                 name="r_submitter_role"
                 :checked="statement.r_submitter_role === 'citizen'"
                 @change="() => { setStatementData({r_submitter_role: 'citizen'}) }"
@@ -41,7 +43,9 @@
          --><div :class="prefixClass('layout__item u-1-of-2 u-1-of-1-lap-down')">
               <dp-radio
                 id="publicagency"
-                :label="Translator.trans('invitable_institution')"
+                :label="{
+                  text: Translator.trans('invitable_institution')
+                }"
                 name="r_submitter_role"
                 :checked="statement.r_submitter_role === 'publicagency'"
                 @change="() => { setStatementData({r_submitter_role: 'publicagency'}) }"

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupCountyReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupCountyReference.vue
@@ -31,7 +31,9 @@
       ref="mapStatementRadio">
       <dp-radio
         id="locationcounty"
-        :label="Translator.trans('statement.map.reference.choose_county')"
+        :label="{
+          text: Translator.trans('statement.map.reference.choose_county')
+        }"
         name="r_location"
         :checked="statement.location_is_set === 'county'"
         @change="() => { setStatementData({ r_location: 'county', location_is_set: 'county' }) }"
@@ -62,7 +64,9 @@
       ]">
       <dp-radio
         id="locationNone"
-        :label="Translator.trans('statement.map.no_reference')"
+        :label="{
+          text: Translator.trans('statement.map.no_reference')
+        }"
         name="r_location"
         :checked="statement.location_is_set === 'notLocated'"
         @change="() => { setStatementData({r_location: 'notLocated', location_is_set: 'notLocated'}) }"

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
@@ -32,7 +32,9 @@
         @change="val => setStatementData({r_getEvaluation: 'email'})"
         :checked="statement.r_getEvaluation === 'email' && statement.r_getFeedback === 'on'"
         aria-labelledby="statement-detail-require-response-email"
-        :label="Translator.trans('statement.form.personal.require_answer_email')"
+        :label="{
+          text: Translator.trans('statement.form.personal.require_answer_email')
+        }"
         value="email" />
 
       <!--              {# email address #}-->
@@ -82,7 +84,9 @@
           :disabled="statement.r_useName === '0'"
           @change="val => setStatementData({r_getEvaluation: 'snailmail'})"
           :checked="statement.r_getEvaluation === 'snailmail'"
-          :label="Translator.trans('statement.form.personal.require_answer_post')"
+          :label="{
+            text: Translator.trans('statement.form.personal.require_answer_post')
+          }"
           aria-labelledby="statement-detail-require-response-post"
           value="snailmail" />
         <form-group-street-and-number

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
@@ -36,7 +36,9 @@
         class="u-mb-0_25"
         :checked="isLocationSelected"
         @change="() => { const location = (statement.r_location_priority_area_key !== '' ? 'priority_area' :'point'); setStatementData({r_location: 'point', location_is_set: location})}"
-        :label="Translator.trans('statement.map.reference.add_on_map')"
+        :label="{
+          text: Translator.trans('statement.map.reference.add_on_map')
+        }"
         value="point" />
 
       <a
@@ -67,7 +69,9 @@
       ]">
       <dp-radio
         id="locationcounty"
-        :label="Translator.trans('statement.map.reference.choose_county')"
+        :label="{
+          text: Translator.trans('statement.map.reference.choose_county')
+        }"
         name="r_location"
         class="u-mb-0_25"
         :checked="statement.r_location === 'county'"
@@ -100,7 +104,9 @@
       ]">
       <dp-radio
         id="locationNone"
-        :label="Translator.trans('statement.map.no_reference')"
+        :label="{
+          text: Translator.trans('statement.map.no_reference')
+        }"
         name="r_location"
         class="u-mb-0_25"
         data-cy="notLocated"

--- a/client/js/components/statement/voter/StatementVoter.vue
+++ b/client/js/components/statement/voter/StatementVoter.vue
@@ -119,13 +119,17 @@
             <div>
               <dp-radio
                 id="role_0"
-                :label="Translator.trans('role.citizen')"
+                :label="{
+                  text: Translator.trans('role.citizen')
+                }"
                 value="0"
                 :checked="formFields.role === 0"
                 @change="formFields.role = 0" />
               <dp-radio
                 id="role_1"
-                :label="Translator.trans('invitable_institution')"
+                :label="{
+                  text: Translator.trans('invitable_institution')
+                }"
                 value="1"
                 :checked="formFields.role === 1"
                 @change="formFields.role = 1" />

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_edit.html.twig
@@ -26,10 +26,12 @@
             <legend class="font-size-medium u-mb-0_25">{{ 'status'|trans }}</legend>
             <dp-radio
                 id="visbility_true"
-                :bold="false"
                 class="u-mr-2"
                 :checked="Boolean({{ document.visible == true }})"
-                :label="Translator.trans('released')"
+                :label="{
+                    bold: false,
+                    text: Translator.trans('released')
+                }"
                 name="r_visible"
                 value="1">
             </dp-radio>
@@ -37,7 +39,10 @@
                 id="visbility_false"
                 :bold="false"
                 :checked="Boolean({{ document.visible != true }})"
-                :label="Translator.trans('blocked')"
+                :label="{
+                    bold: false,
+                    text: Translator.trans('blocked')
+                }"
                 name="r_visible"
                 value="0">
             </dp-radio>
@@ -75,18 +80,22 @@
                 <legend class="font-size-medium u-mb-0_25">{{ 'statement.possible'|trans }}</legend>
                 <dp-radio
                     id="statement_enabled_true"
-                    :bold="false"
                     class="u-mr-2"
                     :checked="{{ document.statement_enabled == true ? 'true' : 'false' }}"
-                    :label="Translator.trans('yes')"
+                    :label="{
+                        bold: false,
+                        text: Translator.trans('yes')
+                    }"
                     name="r_statement_enabled"
                     value="1">
                 </dp-radio>
                 <dp-radio
                     id="statement_enabled_false"
-                    :bold="false"
                     :checked="{{ document.statement_enabled != true ? 'true' : 'false' }}"
-                    :label="Translator.trans('no')"
+                    :label="{
+                        bold: false,
+                        text: Translator.trans('no')
+                    }"
                     name="r_statement_enabled"
                     value="0">
                 </dp-radio>

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_new.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_new.html.twig
@@ -40,19 +40,23 @@
                     <legend class="font-size-medium u-mb-0_25">{{ 'statement.possible'|trans }}</legend>
                     <dp-radio
                         id="statement_enabled_true"
-                        :bold="false"
                         class="u-mr-2"
                         checked="{{ templateVars.request.r_statement_enabled is defined and templateVars.request.r_statement_enabled == '1' }}"
-                        :label="Translator.trans('yes')"
+                        :label="{
+                            bold: false,
+                            text: Translator.trans('yes')
+                        }"
                         name="r_statement_enabled"
                         data-cy="enableFileToStatement"
                         value="1">
                     </dp-radio>
                     <dp-radio
                         id="statement_enabled_false"
-                        :bold="false"
                         checked="{{ templateVars.request.r_statement_enabled is defined and templateVars.request.r_statement_enabled == '0' }}"
-                        :label="Translator.trans('no')"
+                        :label="{
+                            bold: false,
+                            text: Translator.trans('no')
+                        }"
                         name="r_statement_enabled"
                         data-cy="disableFileToStatement"
                         value="0">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29004

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
Adjust `DpRadio` usages after refactoring its label prop in https://github.com/demos-europe/demosplan-ui/pull/48

### Tasks
<!-- A list of all related tasks that need to be done before this can be merged.-->

- [x] Merge https://github.com/demos-europe/demosplan-ui/pull/48 
- [x] Publish new version
- [x] Bump new version in demosplan-core https://github.com/demos-europe/demosplan-core/pull/557
- [ ] Then merge this PR

### PR Checklist
<!-- Reminders for handling PRs -->

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
