### PR TITLE
fix: Core permission tests needs to be adjusted after refactoring

### DIFF
--- a/tests/backend/core/Core/Functional/ProcedureExtensionTest.php
+++ b/tests/backend/core/Core/Functional/ProcedureExtensionTest.php
@@ -83,7 +83,7 @@ class ProcedureExtensionTest extends FunctionalTestCase
         $permissionCollection = self::$container->get(PermissionCollectionInterface::class);
 
         $this->permissionsStub = new Permissions(
-            [],
+            new \SplFixedArray(),
             $currentCustomerProvider,
             new NullLogger(),
             $this->globalConfig,

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -20,8 +20,11 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
+use demosplan\DemosPlanCoreBundle\Permissions\CachingYamlPermissionCollection;
+use demosplan\DemosPlanCoreBundle\Permissions\PermissionResolver;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use demosplan\DemosPlanProcedureBundle\Repository\ProcedureRepository;
+use demosplan\DemosPlanUserBundle\Logic\CustomerService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Exception;
@@ -29,7 +32,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Tests\Base\FunctionalTestCase;
 use Tests\Base\MockMethodDefinition;
 
@@ -122,14 +125,28 @@ class PermissionsTest extends FunctionalTestCase
         // generiere ein Stub vom GlobalConfig
         /** @var MockObject|GlobalConfigInterface $globalConfig */
         $globalConfig = self::$container->get(GlobalConfigInterface::class);
-
+        $corePermissions = self::$container->get(CachingYamlPermissionCollection::class);
+        $permissionsResolver = self::$container->get(PermissionResolver::class);
+        $validator = self::$container->get(ValidatorInterface::class);
         $procedureRepository = $this->getProcedureRepositoryMock();
         $permissionsClass = $this->getPermissionsClass();
+
+        $customerService = static::$container->get(CustomerService::class);
 
         $procedureAccessEvaluator = self::$container->get(ProcedureAccessEvaluator::class);
         /** @var Permissions $permissions */
         $permissions = (new ReflectionClass($permissionsClass))
-            ->newInstance(new FilesystemAdapter(), $logger, $globalConfig, $procedureAccessEvaluator, $procedureRepository);
+            ->newInstance(
+                new \SplFixedArray(),
+                $customerService,
+                $logger,
+                $globalConfig,
+                $corePermissions,
+                $permissionsResolver,
+                $procedureAccessEvaluator,
+                $procedureRepository,
+                $validator
+            );
 
         return $permissions;
     }


### PR DESCRIPTION
After restructuring the permissions in #479 the initialization needs to be adjusted in tests as well

### How to review/test
run phpunit tests

### Linked PRs (optional)
#479 

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
