### PR TITLE
feat: be more cautious about the existence of files in request

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -898,10 +898,10 @@ class FileService extends CoreService implements FileServiceInterface
     {
         $fs = new DemosFilesystem();
         /** @var UploadedFile $file */
-        foreach ($this->requestStack->getCurrentRequest()->files->all() as $file) {
+        foreach ($this->requestStack->getCurrentRequest()->files?->all() as $file) {
             $fs->remove($file->getPathname());
         }
-        $this->requestStack->getCurrentRequest()->files->replace([]);
+        $this->requestStack->getCurrentRequest()->files?->replace([]);
     }
 
     /**


### PR DESCRIPTION
The current requestStack may not always have files attached, like in tests. Therefore, we need to be a bit more cautious about null pointer exceptions here. The php 8 feature is used by purpose, as we are able to use php 8.1 in following releases.

### How to review/test
run FileService test

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
