### PR TITLE
feat: initialize system under test class explicitly

### DIFF
--- a/tests/backend/core/ExternalFileSaver/Functional/ExternalFileSaverTest.php
+++ b/tests/backend/core/ExternalFileSaver/Functional/ExternalFileSaverTest.php
@@ -12,8 +12,11 @@ declare(strict_types=1);
 
 namespace Tests\Core\ExternalFileSaver\Functional;
 
+use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use Intervention\Image\Exception\NotReadableException;
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Tests\Base\FunctionalTestCase;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadProcedureData;
 use demosplan\DemosPlanCoreBundle\Logic\ExternalFileSaver;
@@ -50,7 +53,8 @@ class ExternalFileSaverTest extends FunctionalTestCase
 
         $this->client = $this->makeClient();// self::createClient();
         $this->currentProcedureService = $this->getContainer()->get(CurrentProcedureService::class);
-        $this->sut = self::$container->get(ExternalFileSaver::class);
+        $fileService = $this->getContainer()->get(FileService::class);
+        $this->sut = new ExternalFileSaver($fileService, new MockHttpClient(), new NullLogger());
         $this->router = self::$container->get(Router::class);
     }
 


### PR DESCRIPTION
It is better practice to initialize the sut in tests. Moreover, the test failed when fetching the sut from the container

### How to review/test
run ExternalFileSaverTest

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
