### PR TITLE
fix(refs T30453): Use masterTemplateId instead of masterBlueprintId

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -832,7 +832,7 @@ class DemosPlanProcedureController extends BaseController
         $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp('procedure.new');
         $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, false, $wrapperFactory);
         $templateVars = $this->procedureServiceOutput->fillTemplateVars($templateVars);
-        $templateVars['masterBlueprintId'] = $masterTemplateService->getMasterTemplateId();
+        $templateVars['masterTemplateId'] = $masterTemplateService->getMasterTemplateId();
 
         return $this->renderTemplate(
             '@DemosPlanProcedure/DemosPlanProcedure/administration_new.html.twig',
@@ -937,7 +937,7 @@ class DemosPlanProcedureController extends BaseController
         $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp('procedure.master.new');
         $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, true, $wrapperFactory);
         $templateVars = $this->procedureServiceOutput->fillTemplateVars($templateVars);
-        $templateVars['masterBlueprintId'] = $masterTemplateService->getMasterTemplateId();
+        $templateVars['masterTemplateId'] = $masterTemplateService->getMasterTemplateId();
 
         return $this->renderTemplate(
             '@DemosPlanProcedure/DemosPlanProcedure/administration_new_master.html.twig',

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new.html.twig
@@ -5,7 +5,7 @@
         {{ "procedure.new"|trans }}
     </h1>
     {% if hasPermission('feature_procedure_templates') %}
-        {% set masterBlueprintId = templateVars.masterBlueprintId %}
+        {% set masterBlueprintId = templateVars.masterTemplateId %}
         {% set copyMasterOptions = [{ label: 'master.empty', value: masterBlueprintId, isMaster: true }] %}
         {% if templateVars.list.procedures is defined %}
             {% for procedure in templateVars.list.procedures %}

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new_master.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_new_master.html.twig
@@ -9,7 +9,7 @@
         {{ "text.master.new"|trans }}
     </p>
 
-    {% set copyMasterOptions = [{ label: 'master.empty', value: templateVars.masterBlueprintId }] %}
+    {% set copyMasterOptions = [{ label: 'master.empty', value: templateVars.masterTemplateId }] %}
     {% if templateVars.list.procedures is defined %}
         {% for procedure in templateVars.list.procedures %}
             {% set copyMasterOptions = copyMasterOptions|merge([{ label: procedure.name|default, value: procedure.ident|default }]) %}
@@ -43,7 +43,7 @@
         :is-customer-master-blueprint-existing="Boolean({{ templateVars.isCustomerMasterBlueprintExisting }})"
         public-participation-contact="{{ proceduresettings.publicParticipationContact|default('notspecified'|trans) }}"
         token-vars-value="{{ form._token.vars.value }}"
-        master-blueprint-id="{{ templateVars.masterBlueprintId }}"
+        master-blueprint-id="{{ templateVars.masterTemplateId }}"
         :blueprint-options="JSON.parse('{{ copyMasterOptions|json_encode|e('js', 'utf-8') }}')">
     </new-blueprint-form>
 {% endblock %}


### PR DESCRIPTION
 Use masterBlueprintId instead of masterTemplateId to unify usage.
These two names mean the same and therefore should be named equaly

**Ticket:** https://yaits.demos-deutschland.de/T30453

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

This may overrule https://github.com/demos-europe/demosplan-core/pull/492


### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
