### PR TITLE
add chalk version >4.1.2 to dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       # Can't be used as CommonJs but only ESM which will break our FE build atm
       - dependency-name: chalk
         versions:
-            - ">= 4.1.2"
+            - ">= 5"
     labels:
       - dependencies:yarn
 


### PR DESCRIPTION
Since greater Version of chalk 4.1.2 have a requirement of only using ESM, this would break our current FE build otherwise. Therefore this version shall not be updated without a (probably) bigger refactoring of our webpack configs
