### PR TITLE
fix: Elasticsearch >7.10 does not allow forcemerge to have a body

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/PopulateElasticaListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/PopulateElasticaListener.php
@@ -60,7 +60,7 @@ class PopulateElasticaListener
         $settings = $index->getSettings();
 
         $settings->setNumberOfReplicas($this->globalConfig->getElasticsearchNumReplicas());
-        $index->getClient()->request('_forcemerge', 'POST', ['max_num_segments' => 5]);
+        $index->getClient()->request('_forcemerge?max_num_segments=5', 'POST');
 
         // set short refresh interval to avoid problems with outdated lists
         // might lead to performance hits


### PR DESCRIPTION
Elasticsearch >7.10 does not allow forcemerge to have a body. See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-forcemerge.html and https://discuss.elastic.co/t/refresh-is-throwing-error-post-indexname-refresh-does-not-support-having-a-body/279940/5

### How to review/test
try to populate elasticsearch with ES > 7.10

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
