### PR TITLE
Fix(T30794): Set a default for currentPage and maxPerPage

### DIFF
--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/dhtml/v1/assessment_table_original_view.html.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/dhtml/v1/assessment_table_original_view.html.twig
@@ -28,7 +28,7 @@
                 current_page: {{ templateVars.pager.currentPage|default(1) }},
                 per_page: {{ templateVars.pager.maxPerPage|default(1) }},
                 count: {{ templateVars.totalResults|default(1) }},
-                limits: [{{ templateVars.pager.limits|default(1) }}]
+                limits: [{{ templateVars.pager.limits|default(1)|join(',') }}]
             }"
             procedure-id="{{ templateVars.table.procedure.ident }}"
         >


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30794

Description: The page for `Originalstellungnahmen`throwed an error in twig. There were missing defaults for currentPage and maxForPage.

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
