### PR TITLE
bug(refs T30796): fix extra email addresses disapearing when not persisting the form

### DIFF
--- a/client/js/components/procedure/basicSettings/DpEmailList.vue
+++ b/client/js/components/procedure/basicSettings/DpEmailList.vue
@@ -84,7 +84,7 @@ export default {
 
   watch: {
     initEmails (newVal) {
-      this.newEmails = newVal
+      this.emails = newVal
     }
   },
 

--- a/client/js/components/procedure/basicSettings/DpEmailList.vue
+++ b/client/js/components/procedure/basicSettings/DpEmailList.vue
@@ -70,7 +70,7 @@ export default {
         mail: ''
       },
       itemIndex: null,
-      emails: this.initEmails,
+      emails: [],
       translationKeys: {
         new: Translator.trans('email.address.new'),
         add: Translator.trans('email.address.add'),
@@ -79,12 +79,6 @@ export default {
         noEntries: Translator.trans('email.address.no'),
         delete: Translator.trans('email.address.delete')
       }
-    }
-  },
-
-  watch: {
-    initEmails (newVal) {
-      this.emails = newVal
     }
   },
 
@@ -133,6 +127,8 @@ export default {
       this.formFields.mail = this.emails[index].mail
       this.itemIndex = index
     })
+
+    this.emails = this.initEmails
   }
 }
 </script>

--- a/client/js/components/procedure/basicSettings/DpEmailList.vue
+++ b/client/js/components/procedure/basicSettings/DpEmailList.vue
@@ -70,7 +70,7 @@ export default {
         mail: ''
       },
       itemIndex: null,
-      emails: [],
+      emails: [...this.initEmails],
       translationKeys: {
         new: Translator.trans('email.address.new'),
         add: Translator.trans('email.address.add'),
@@ -79,6 +79,12 @@ export default {
         noEntries: Translator.trans('email.address.no'),
         delete: Translator.trans('email.address.delete')
       }
+    }
+  },
+
+  watch: {
+    initEmails (newVal) {
+      this.newEmails = newVal
     }
   },
 
@@ -127,8 +133,6 @@ export default {
       this.formFields.mail = this.emails[index].mail
       this.itemIndex = index
     })
-
-    this.emails = this.initEmails
   }
 }
 </script>


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T30796

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- When not persisting the form but adding extra email addresses: these were removed from the form if in another DpSelect of that form was used to set a new value there.
- Somehow the watcher caused this problem. This led to a confusing data architecture because the initEmails prop and the emails data prop were updated at the same time when in fact initEmails should only contain an array of already persisted emails. This was fixed by removing the watcher, set the default emails data prop to an empty array and fill the data prop with the read-only initEmails prop on mounting the component.

However, it remains unclear why the initEmails were changed when setting a new value in a unrelated DpSelect. This PR fixes the Problem for now but the underlying problem could not be fully determined. This is why I suggest to refactor the DpBasicSettings.vue and administration_edit.html.twig files. From my perspective too much functionality has been wired here together which makes it a bit difficult to understand what is actually going on.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as FPA user
- navigate to basic settings
- add extra email addresses
- change values of any Select in other accordions (e.g.  Verfahrensschritt Institutionen )
-> the added email addresses should still be there and when persisting the form the added addresses should be displayed

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

![Screenshot 2023-01-04 at 16-35-10 Grundeinstellungen New Procedure All Planning Agency Admin Tests BOB-SH Bauleitplanung](https://user-images.githubusercontent.com/91727189/210591341-8b021ecc-61e2-4cc4-968e-dd4e74599b23.png)
