### PR TITLE
add portal-vue dependency to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
         versions:
             - ">= 16"
 
+      - dependency-name: portal-vue
+        versions:
+            - ">= 3"
+
       # Can't be used as CommonJs but only ESM which will break our FE build atm
       - dependency-name: chalk
         versions:


### PR DESCRIPTION
The last version which is supported for vue2 is portal-vue^2.1.7 (which is the one we are using) hence this dependency should be added to dependabot.yml unless we migrate to vue3 in the near future.