### PR TITLE
fix (refs T29766): Do not use write permission for read access.

### DIFF
--- a/demosplan/DemosPlanUserBundle/Logic/OrgaService.php
+++ b/demosplan/DemosPlanUserBundle/Logic/OrgaService.php
@@ -575,16 +575,14 @@ class OrgaService extends CoreService
     {
         $orga->setSubmissionType($this->globalConfig->getProjectSubmissionType());
 
-        if ($this->permissions->hasPermission('feature_change_submission_type')) {
-            $settingSubmissionType = $this->contentService->getSettings(
-                'submissionType',
-                SettingsFilter::whereOrga($orga)->lock(),
-                false
-            );
-            if (is_array($settingSubmissionType) && 1 === count($settingSubmissionType)) {
-                $orga->setSubmissionType($settingSubmissionType[0]->getContent());
-                $this->logger->debug('loadOrgaSubmissionType Loaded: '.DemosPlanTools::varExport($settingSubmissionType[0]->getContent(), true));
-            }
+        $settingSubmissionType = $this->contentService->getSettings(
+            'submissionType',
+            SettingsFilter::whereOrga($orga)->lock(),
+            false
+        );
+        if (is_array($settingSubmissionType) && 1 === count($settingSubmissionType)) {
+            $orga->setSubmissionType($settingSubmissionType[0]->getContent());
+            $this->logger->debug('loadOrgaSubmissionType Loaded: '.DemosPlanTools::varExport($settingSubmissionType[0]->getContent(), true));
         }
     }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29766

Permission "feature_change_submission_type" is used to allow changing the current submission type but has not to be enabled to use the already changed submission type.

Reapply change from former repository

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
https://github.com/demos-europe/demosplan/pull/8540

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
