### PR TITLE
feat: ensure that project rollup migrations are performed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
@@ -49,17 +49,32 @@ class MigrateCommand extends CoreCommand
             $db = '--conn='.$db;
         }
 
+
+        $commands = [
+            "dplan:migrations:cache --env={$env}",
+            "doctrine:migrations:sync-metadata-storage {$db} --env={$env}",
+        ];
+
+        $migrationsConfigurationPath = DemosPlanPath::getProjectPath('app/config/project_migrations.yml');
+        $migrationsSyncCommand = 'doctrine:migrations:sync-metadata-storage --configuration ';
+        $migrationsCommand = 'doctrine:migrations:migrate --configuration ';
+        $lastRollupMigration = 'app/Resources/DemosPlanCoreBundle/DoctrineMigrations/2022/09/Version20220914133419.php';
+
+        // ensure that rollup migrations are applied before core migrations are performed
+        if (file_exists(DemosPlanPath::getProjectPath($lastRollupMigration))) {
+            $commands[] = $migrationsSyncCommand . $migrationsConfigurationPath . " {$db} --env={$env}";
+            $commands[] = $migrationsCommand . $migrationsConfigurationPath .
+                    'Application\Migrations\Version20220914133419' . " {$db} --env={$env}";
+
+        }
+
+        $commands[] = "doctrine:migrations:migrate {$db} --env={$env}";
+        $commands[] = $migrationsSyncCommand . $migrationsConfigurationPath . " {$db} --env={$env}";
+        $commands[] = $migrationsCommand . $migrationsConfigurationPath . " {$db} --env={$env}";
+
         $batch = Batch::create($this->getApplication(), $output);
 
-        \collect(
-            [
-                "dplan:migrations:cache --env={$env}",
-                "doctrine:migrations:sync-metadata-storage {$db} --env={$env}",
-                "doctrine:migrations:migrate {$db} --env={$env}",
-                'doctrine:migrations:sync-metadata-storage --configuration '.DemosPlanPath::getProjectPath('app/config/project_migrations.yml')." {$db} --env={$env}",
-                'doctrine:migrations:migrate --configuration '.DemosPlanPath::getProjectPath('app/config/project_migrations.yml')." {$db} --env={$env}",
-            ]
-        )->map(
+        \collect($commands)->map(
             function (string $commandString) {
                 $command = collect(sprintf(
                     'bin/%s',


### PR DESCRIPTION
Project migrations need to be performed in two parts. The project migrations up to Version 20220914133419 contains all migrations that needs to be executed before the core migration rollup is performed.

### How to review/test
you might perform `bin/<project> dplan:migrate` on an old database that has outstanding migrations before core migration rollup

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
