### PR TITLE
fix(refs T30791): Wrap twig-var with quotes

### DIFF
--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
@@ -61,7 +61,7 @@
             id="r_email_address"
             checked
             :label="{
-                text: Translator.trans('procedure.testmail.submitters.send', { email: templateVars.userMail }),
+                text: Translator.trans('procedure.testmail.submitters.send', { email: '{{ templateVars.userMail }}' }),
                 tooltip: Translator.trans('explanation.organisation.email.procedure.agency')
             }"
             name="r_email_address"


### PR DESCRIPTION
When using vue in twig, passing twig-vars within the vue-context is confusing sometimes. 

If we want to use  twig string with a js object, we have to wrap it in quotes and {{ . Otherwise js think its a variable that can't be resolved.

**Ticket:** https://yaits.demos-deutschland.de/T30791

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
