### PR TITLE
feat: use php 8.1 for reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: gd soap sockets zip
           tools: composer:v2
 


### PR DESCRIPTION
Reviewdog should be configured to run with current php8.1 to be compatible with composer.lock
