### PR TITLE
fix(refs T30796): Prevent newly added e-Mails in Email-List to get overwritten

### DIFF
--- a/client/js/components/procedure/admin/NewBlueprintForm.vue
+++ b/client/js/components/procedure/admin/NewBlueprintForm.vue
@@ -90,6 +90,7 @@
           :tooltip="Translator.trans('email.address.more.explanation.help')" />
         <dp-email-list
           id="emailList"
+          allow-updates-from-outside
           :class="`${mainEmail === '' ? 'opacity-7 pointer-events-none' : '' } u-mt-0_25`"
           :init-emails="emailAddresses" />
 

--- a/client/js/components/procedure/basicSettings/DpEmailList.vue
+++ b/client/js/components/procedure/basicSettings/DpEmailList.vue
@@ -52,6 +52,12 @@ export default {
   },
 
   props: {
+    allowUpdatesFromOutside: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     initEmails: {
       required: true,
       type: Array
@@ -84,7 +90,9 @@ export default {
 
   watch: {
     initEmails (newVal) {
-      this.emails = newVal
+      if (this.allowUpdatesFromOutside) {
+        this.emails = newVal
+      }
     }
   },
 


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T30796

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- When not persisting the form but adding extra email addresses: these were removed from the form if in another DpSelect of that form was used to set a new value there.
- Somehow the watcher caused this problem. This led to a confusing data architecture because the initEmails prop and the emails data prop were updated at the same time when in fact initEmails should only contain an array of already persisted emails. This was fixed by removing the watcher, set the default emails data prop to an empty array and fill the data prop with the read-only initEmails prop on mounting the component.

However, it remains unclear why the initEmails were changed when setting a new value in a unrelated DpSelect. This PR fixes the Problem for now but the underlying problem could not be fully determined. This is why I suggest to refactor the DpBasicSettings.vue and administration_edit.html.twig files. From my perspective too much functionality has been wired here together which makes it a bit difficult to understand what is actually going on.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as FPA user
- navigate to basic settings
- add extra email addresses
- change values of any Select in other accordions (e.g.  Verfahrensschritt Institutionen )
-> the added email addresses should still be there and when persisting the form the added addresses should be displayed

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

![Screenshot 2023-01-04 at 16-35-10 Grundeinstellungen New Procedure All Planning Agency Admin Tests BOB-SH Bauleitplanung](https://user-images.githubusercontent.com/91727189/210591341-8b021ecc-61e2-4cc4-968e-dd4e74599b23.png)

:warning: 
This PR should overrule https://github.com/demos-europe/demosplan-core/pull/530 
(If the fix here is sufficient, the other one can be closed.)
