### PR TITLE
feat: update test configuration to Elasticsearch 7 syntax

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/test/fos_elastica.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/test/fos_elastica.yaml
@@ -2,36 +2,26 @@ fos_elastica:
     indexes:
         procedures:
             index_name: '%project_prefix%_procedures_test'
-            types:
-                procedure:
-                    persistence:
-                        listener: { enabled: false }
+            persistence:
+            listener: { enabled: false }
         draftStatements:
             index_name: '%project_prefix%_draft_statements_test'
-            types:
-                draftStatement:
-                    persistence:
-                        listener: { enabled: false }
+            persistence:
+                listener: { enabled: false }
         statements:
             index_name: '%project_prefix%_statements_test'
         statementFragments:
             index_name: '%project_prefix%_statement_fragments_test'
-            types:
-                statementFragment:
-                    persistence:
-                        listener: { enabled: false }
+            persistence:
+                listener: { enabled: false }
         statementSegments:
             index_name: '%project_prefix%_segments_test'
-            types:
-                statementSegment:
-                    persistence:
-                        listener: { enabled: false }
+            persistence:
+                listener: { enabled: false }
         users:
             index_name: '%project_prefix%_user_test'
-            types:
-                user:
-                    persistence:
-                        listener: { enabled: false }
+            persistence:
+                listener: { enabled: false }
 
 imports:
     - { resource: "@DemosPlanCoreBundle/Resources/config/elasticsearch.yml" }


### PR DESCRIPTION
Our configuration to disable elasticsearch in tests needs to be updated to be compatible to ES7

Elasticsearch 7 does not have any types any more so these ones need to be skipped in the configuration file

### How to review/test
reviewdog action should not throw an error regarding elasticsearch configuration /update/ Reviewdog won't run as no php files are touched /update/

