### PR TITLE
fix(refs T30824): catches LockedByAssignmentException

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Controller\Segment;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Exception\LockedByAssignmentException;
 use demosplan\DemosPlanCoreBundle\Exception\StatementAlreadySegmentedException;
 use demosplan\DemosPlanCoreBundle\Validator\SegmentableStatementValidator;
 use demosplan\DemosPlanStatementBundle\Exception\StatementNotFoundException;
@@ -106,8 +107,8 @@ class DraftsInfoController extends BaseController
         } catch (StatementNotFoundException $e) {
             $this->getMessageBag()->add('error', 'error.statement.not.found');
             throw $e;
-        } catch (StatementAlreadySegmentedException $e) {
-            $this->getMessageBag()->add('error', 'error.statement.already.segmented');
+        } catch (StatementAlreadySegmentedException|LockedByAssignmentException $e) {
+            $this->messageBag->add('error', $e->getMessage());
             throw $e;
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
@@ -108,8 +108,11 @@ class DraftsInfoController extends BaseController
         } catch (StatementNotFoundException $e) {
             $this->getMessageBag()->add('error', 'error.statement.not.found');
             throw $e;
-        } catch (StatementAlreadySegmentedException|LockedByAssignmentException $e) {
-            $this->messageBag->add('error', $e->getMessage());
+        } catch (StatementAlreadySegmentedException $e) {
+            $this->messageBag->add('error', 'error.statement.already.segmented');
+            throw $e;
+        } catch (LockedByAssignmentException $e) {
+            $this->messageBag->add('error', 'error.statement.not.assigned');
             throw $e;
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
@@ -20,6 +20,7 @@ use demosplan\DemosPlanStatementBundle\Exception\StatementNotFoundException;
 use demosplan\DemosPlanStatementBundle\Logic\StatementHandler;
 use demosplan\DemosPlanStatementBundle\Logic\StatementService;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserService;
+use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -78,7 +79,7 @@ class DraftsInfoController extends BaseController
      *     options={"expose": true}
      * )
      *
-     * @throws \Exception
+     * @throws Exception
      *
      * @DplanPermissions("area_statement_segmentation")
      */


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30824

As it was previously uncaught which lead to no readable message being added to the message bag.

This is based on an incident, but I decided to fix it on `main` as that project is going to be updated with `main` very soon anyaway.

### How to review/test
I think a code review should suffice here.