### PR TITLE
build: Disable virus scan in dev environment

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
@@ -1,6 +1,8 @@
 # this file keeps specific params used
 # during development with DEMOS Containers
 parameters:
+    avscan_enable: false
+
     database_host: "db"
     database_user: "root"
     database_password: ""


### PR DESCRIPTION
Since the clam setup in the current dev environment is rather brittle disabling the virus scanning on uploads, while technically a security risk, makes it easier to debug and use the remainder of the file upload processes. This should only be a temporary fix and developers should be aware that they can cause harm on their systems if they use testfiles for uploading which contain malware of any kind.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Uploads on the local dev environment work as expected.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.
