### PR TITLE
bug(refs T27124): Change height of menu

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_actionmenu.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_actionmenu.scss
@@ -138,10 +138,11 @@
 
         display: none;
         min-width: 100%;
-        max-height: 500px;
+        max-height: 510px;
         overflow-y: auto;
+        margin-top: 35px; // Height of &__trigger...
         padding-bottom: 10px;
-        padding-top: 35px; // Height of &__trigger...
+        padding-top: 10px;
 
         background-color: $dp-color-white;
         box-shadow: $dp-token-box-shadow-1;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27124

Both menu and items' container was set to max-height 500, but the menu also has some padding. This has to be added to the max height.

### How to review/test
Go to Master-Töb-Liste and hover over "Spalten ausblenden". You should see all menu items. 

