### PR TITLE
Do not purge demosplan-utils generated css selectors

### DIFF
--- a/client/setup/config.js
+++ b/client/setup/config.js
@@ -56,7 +56,8 @@ class Config {
         'demosplan/**/*.js.twig',
         'client/**/*.js',
         'client/**/*.vue',
-        ...glob.sync('node_modules/@demos-europe/demosplan-ui/dist/**/*.js', { nodir: true })
+        ...glob.sync('node_modules/@demos-europe/demosplan-ui/dist/**/*.js', { nodir: true }),
+        ...glob.sync('node_modules/@demos-europe/demosplan-utils/**/*.js', { nodir: true })
       ],
       safelist: {
         standard: [


### PR DESCRIPTION
Some CSS classes required for DpStickyElement were purged because the lib that sets them is located inside demosplan-utils. Until we move the latter into demosplan-ui we have to tell purgeCss to also look for CSS classes in demosplan-utils.

**How to test it**
After building, when scrolling down the assessment table, the side menu should stay fixed to the top of the page (instead of having a random offset top).