### PR TITLE
feature (refs T30671): cockpit related tasks - adjust planningDocumentCategories - address bugs

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
@@ -929,7 +929,6 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
             Elements::FILE_TYPE_VERTEILER,
             Elements::FILE_TYPE_NIEDERSCHRIFT_SONSTIGE,
             Elements::FILE_TYPE_SCOPING_PAPIER,
-            // added elements in bobhh master-template
             Elements::FILE_TYPE_GUTACHTEN,
             Elements::FILE_TYPE_ARBEITSKREISPAPIER_I,
             Elements::FILE_TYPE_ARBEITSKREISPAPIER_II,

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
@@ -97,6 +97,7 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
         $manager->flush();
 
         $this->loadMasterBluePrintFileElements($manager, $procedureMaster);
+        $this->loadMasterBluePrintParagraphElements($manager, $procedureMaster);
 
         $this->setReference('masterBlaupause', $procedureMaster);
 
@@ -928,6 +929,13 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
             Elements::FILE_TYPE_VERTEILER,
             Elements::FILE_TYPE_NIEDERSCHRIFT_SONSTIGE,
             Elements::FILE_TYPE_SCOPING_PAPIER,
+            // added elements in bobhh master-template
+            Elements::FILE_TYPE_GUTACHTEN,
+            Elements::FILE_TYPE_ARBEITSKREISPAPIER_I,
+            Elements::FILE_TYPE_ARBEITSKREISPAPIER_II,
+            Elements::FILE_TYPE_NIEDERSCHRIFT_GROBABSTIMMUNG_ARBEITSKREISE,
+            Elements::FILE_TYPE_GROBABSTIMMUNGSPAPIER,
+            Elements::FILE_TYPE_SCOPING_PROTOKOLL,
         ];
 
         foreach ($elementsToCreate as $key => $elementTitle) {
@@ -944,6 +952,31 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
 
             $manager->persist($element);
             $this->setReference("masterBlueprintElement-$key", $element);
+        }
+    }
+
+    protected function loadMasterBluePrintParagraphElements(
+        ObjectManager $manager,
+        Procedure $masterBlueprint
+    ): void {
+        $elementsToCreate = [
+            Elements::FILE_TYPE_VERORDNUNG,
+            Elements::FILE_TYPE_BEGRUENDUNG,
+        ];
+        foreach ($elementsToCreate as $key => $elementTitle) {
+            $element = new Elements();
+            $element->setProcedure($masterBlueprint);
+            $element->setCategory(Elements::ELEMENTS_CATEGORY_PARAGRAPH);
+            $element->setOrder($key);
+            $element->setEnabled(1);
+            $element->setTitle($elementTitle);
+            $manager->persist($element);
+
+            $this->loadTestProcedureSingleDocument($masterBlueprint, $element);
+            $this->loadTestProcedureSingleDocumentVersion($masterBlueprint, $element);
+
+            $manager->persist($element);
+            $this->setReference("masterBlueprintElement-paragraph$key", $element);
         }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
@@ -36,6 +36,8 @@ class Elements extends CoreEntity implements UuidEntityInterface
     public const FILE_TYPE_ANSCHREIBEN_BETEILIGUNGSVERFAHREN = 'Anschreiben Beteiligungsverfahren';
     public const FILE_TYPE_ANTRAGS_AUFTRAGSDOKUMENTE = 'Antrags- und Auftragsdokumente (Veranstaltung)';
     public const FILE_TYPE_ARBEITSKREISPAPIER = 'Arbeitskreispapier I und II';
+    public const FILE_TYPE_ARBEITSKREISPAPIER_I = 'AKI-Papier';
+    public const FILE_TYPE_ARBEITSKREISPAPIER_II = 'AKII-Papier';
     public const FILE_TYPE_AUBS_DRITTER_BLATT = 'AuBS 3er-Blatt';
     public const FILE_TYPE_AUFHEBUNGSBESCHLUSS = 'Aufhebungsbeschluss';
     public const FILE_TYPE_AUFSTELLUNGSBESCHLUSS = 'Aufstellungsbeschluss';
@@ -47,7 +49,7 @@ class Elements extends CoreEntity implements UuidEntityInterface
     public const FILE_TYPE_BESCHLUSS_ZUR_LAPRO_ANDERUNG = 'Beschluss zur Lapro-Änderung';
     public const FILE_TYPE_DRUCKSACHE = 'Drucksache';
     public const FILE_TYPE_DURCHFUHRUNGSVERTRAG = 'Durchführungsvertrag';
-    public const FILE_TYPE_ERGAENZENDE_UNTERLAGE = 'Ergänzende Unterlage';
+    public const FILE_TYPE_ERGAENZENDE_UNTERLAGE = 'ergänzende Unterlage';
     public const FILE_TYPE_ERSCHLIESSUNGSVERTRAG = 'Erschließungsvertrag';
     public const FILE_TYPE_FESTSTELLUNG_PLANREIFE = 'Feststellung Planreife';
     public const FILE_TYPE_FESTSTELLUNGSBESCHLUSS = 'Feststellungsbeschluss';
@@ -71,7 +73,7 @@ class Elements extends CoreEntity implements UuidEntityInterface
     public const FILE_TYPE_PLANZEICHNUNG = 'Planzeichnung';
     public const FILE_TYPE_PRAESENTATION = 'Präsentation';
     public const FILE_TYPE_SCHLUSSMITTEILUNG = 'Schlussmitteilung';
-    public const FILE_TYPE_SCOPING_PAPIER = 'Scoping-Papier';
+    public const FILE_TYPE_SCOPING_PAPIER = 'Scopingpapier';
     public const FILE_TYPE_SCOPING_PROTOKOLL = 'Scoping-Protokoll';
     public const FILE_TYPE_SITZUNGSUNTERLAGE = 'Sitzungsunterlage';
     public const FILE_TYPE_SONSTIGE_UNTERLAGE = 'sonstige Unterlage';


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30671

Description:
regarding MainStory (refs T30524): https://yaits.demos-deutschland.de/T30524
Adds migration to alter the procedure master-templates elements (Planungskategorien) to match the ones received via a cockpit-msg.
regarding (refs TT29526): https://yaits.demos-deutschland.de/T29526
Adjust the map-section shown for a procedure created via cockpit-msg by mapping the given coords to the coords used for our EPSG3857 projection.
regarding (refs TT29527): https://yaits.demos-deutschland.de/T29527
Two tests indicated that the service-type has to be provided as a lower-key string. This should not be necessary but since I am not 100% sure on this one - this got adjusted on BE-side in XtaGisLayerManager.php -> setMessageGisValues()

### Linked PRs (optional)
The changes were made here https://github.com/demos-europe/demosplan/pull/8544 originally and have to be carried over
here.

different affected repos:
https://github.com/demos-europe/demosplan-plugin-xbauleitplanung/pull/2
https://github.com/demos-europe/demosplan-project-bobhh/pull/19

