### PR TITLE
feat: halts jsrouting on 2.8.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,8 @@ updates:
           - "< 10"
       - dependency-name: symfony/*
         update-types: ["version-update:semver-major"]
+      - dependency-name: friendsofsymfony/jsrouting-bundle
+        update-types: [ "version-update:semver-major" ]
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
The update to 3.x requires us to use Symfony 6, which we will not in the next couple of weeks. So we're deactivating the update for the moment.

### Linked PRs (optional)
- Dependabot already alerted us to the update #{511}