### PR TITLE
F_(ref:30834) fix slicer caching

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -943,8 +943,7 @@ class DemosPlanAssessmentTableController extends BaseController
             $data = ['original' => $statement->getText()];
 
             if ($request->get('includeShortened')) {
-                $sliced = HTMLFragmentSlicer::slice($data['original']);
-                $data['shortened'] = $sliced->getShortenedFragment();
+                $data['shortened'] = HTMLFragmentSlicer::getShortened($data['original']);
             }
 
             return $this->renderJson($data);

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -2259,9 +2259,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
 
     public function getTextShort(): string
     {
-        $sliced = HTMLFragmentSlicer::slice($this->text);
-
-        return $sliced->getShortenedFragment();
+        return HTMLFragmentSlicer::getShortened($this->text);
     }
 
     /**
@@ -2298,9 +2296,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
 
     public function getRecommendationShort(): string
     {
-        $sliced = HTMLFragmentSlicer::slice($this->recommendation);
-
-        return $sliced->getShortenedFragment();
+        return HTMLFragmentSlicer::getShortened($this->recommendation);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
+++ b/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
@@ -22,9 +22,9 @@ use Tightenco\Collect\Support\Collection;
 
 class HTMLFragmentSlicer
 {
-    const SLICE_AT_END_OF_STRING = -1;
+    public const SLICE_AT_END_OF_STRING = -1;
 
-    const SLICE_DEFAULT = 500; // slice at about 500 characters into a string by default
+    public const SLICE_DEFAULT = 500; // slice at about 500 characters into a string by default
 
     /**
      * @var string
@@ -72,10 +72,11 @@ class HTMLFragmentSlicer
      * Returns the HTMLFragmentSlicer object. Please be aware
      * of the performance implications, as the result is not
      * cached here. Please use {@link HTMLFragmentSlicer::getShortened()}
-     * if you only need the shortened text instead
+     * if you only need the shortened text instead.
      *
      * @param string $htmlFragment
-     * @param int $sliceIndex
+     * @param int    $sliceIndex
+     *
      * @return HTMLFragmentSlicer
      */
     public static function slice(
@@ -91,12 +92,12 @@ class HTMLFragmentSlicer
     }
 
     /**
-     * Cached shorthand method for shortened text
+     * Cached shorthand method for shortened text.
      *
      * @param string $htmlFragment
-     * @param int $sliceIndex
+     * @param int    $sliceIndex
      */
-    public static function getShortened($htmlFragment, $sliceIndex = self::SLICE_DEFAULT):string
+    public static function getShortened($htmlFragment, $sliceIndex = self::SLICE_DEFAULT): string
     {
         $textHash = md5($htmlFragment);
         $cacheKey = 'htmlslicer_'.$textHash;

--- a/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
+++ b/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
@@ -72,23 +72,36 @@ class HTMLFragmentSlicer
         $htmlFragment,
         $sliceIndex = self::SLICE_DEFAULT
     ) {
+        $slicer = new self();
+
+        return $slicer
+            ->setOriginalFragment($htmlFragment)
+            ->setSliceIndex($sliceIndex)
+            ->execute();
+    }
+
+    /**
+     * Cached shorthand method for shortened text
+     *
+     * @param string $htmlFragment
+     * @param int $sliceIndex
+     */
+    public static function getShortened($htmlFragment, $sliceIndex = self::SLICE_DEFAULT):string
+    {
         $textHash = md5($htmlFragment);
         $cacheKey = 'htmlslicer_'.$textHash;
         if (DemosPlanTools::cacheExists($cacheKey)) {
             return DemosPlanTools::cacheGet($cacheKey);
         }
 
-        $slicer = new self();
+        $slicer = self::slice($htmlFragment, $sliceIndex);
 
-        $sliced = $slicer
-            ->setOriginalFragment($htmlFragment)
-            ->setSliceIndex($sliceIndex)
-            ->execute();
+        $shortened = $slicer->getShortenedFragment();
 
         // cache entry for 180 Days
-        DemosPlanTools::cacheAdd($cacheKey, $sliced, 15552000);
+        DemosPlanTools::cacheAdd($cacheKey, $shortened, 15552000);
 
-        return $sliced;
+        return $shortened;
     }
 
     public function execute()

--- a/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
+++ b/demosplan/DemosPlanCoreBundle/Services/HTMLFragmentSlicer.php
@@ -68,6 +68,16 @@ class HTMLFragmentSlicer
         $this->remainingList = new Collection();
     }
 
+    /**
+     * Returns the HTMLFragmentSlicer object. Please be aware
+     * of the performance implications, as the result is not
+     * cached here. Please use {@link HTMLFragmentSlicer::getShortened()}
+     * if you only need the shortened text instead
+     *
+     * @param string $htmlFragment
+     * @param int $sliceIndex
+     * @return HTMLFragmentSlicer
+     */
     public static function slice(
         $htmlFragment,
         $sliceIndex = self::SLICE_DEFAULT

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/HeightLimitExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/HeightLimitExtension.php
@@ -18,7 +18,7 @@ class HeightLimitExtension extends ExtensionBase
     public function getFilters(): array
     {
         return [
-            new TwigFilter('heightLimitData', [$this, 'heightLimitData']),
+            new TwigFilter('heightLimitShorten', [$this, 'heightLimitShorten']),
         ];
     }
 
@@ -28,10 +28,9 @@ class HeightLimitExtension extends ExtensionBase
      * @param string $content
      * @param int    $maxNbCharcters
      *
-     * @return array
      */
-    public function heightLimitData($content, $maxNbCharcters = 500)
+    public function heightLimitShorten($content, $maxNbCharcters = 500): string
     {
-        return HTMLFragmentSlicer::slice($content, $maxNbCharcters)->toArray();
+        return HTMLFragmentSlicer::getShortened($content, $maxNbCharcters);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/HeightLimitExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/HeightLimitExtension.php
@@ -27,7 +27,6 @@ class HeightLimitExtension extends ExtensionBase
      *
      * @param string $content
      * @param int    $maxNbCharcters
-     *
      */
     public function heightLimitShorten($content, $maxNbCharcters = 500): string
     {

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
@@ -496,11 +496,11 @@
                         {{ "statement.text"|trans}}
                     </div>
                     <span class="layout__item u-5-of-8" id="statementText">
-                        {% set statementTextHeightLimited = statement.text|default("notspecified"|trans)|heightLimitData %}
+                        {% set statementTextHeightShortened = statement.text|default("notspecified"|trans)|heightLimitShorten %}
                         <dp-height-limit
-                            short-text="{{ statementTextHeightLimited.shortened|default("notspecified"|trans) }}"
+                            short-text="{{ statementTextHeightShortened|default("notspecified"|trans) }}"
                             full-text="{{ statement.text|default("notspecified"|trans) }}"
-                            :is-shortened="{{ statementTextHeightLimited.shortened|length }} < {{ statement.text|length }}"
+                            :is-shortened="{{ statementTextHeightShortened|length }} < {{ statement.text|length }}"
                             element="statement"
                             no-event
                             class="c-styled-html u-mr"

--- a/tests/backend/core/Core/Unit/Utilities/Twig/HeightLimitExtensionTest.php
+++ b/tests/backend/core/Core/Unit/Utilities/Twig/HeightLimitExtensionTest.php
@@ -12,6 +12,7 @@ namespace Tests\Core\Core\Unit\Utilities\Twig;
 
 use demosplan\DemosPlanCoreBundle\Twig\Extension\HeightLimitExtension;
 use Tests\Base\UnitTestCase;
+use Twig\TwigFilter;
 
 /**
  * Teste HeightLimitExtension
@@ -37,10 +38,10 @@ class HeightLimitExtensionTest extends UnitTestCase
     {
         $result = $this->twigExtension->getFilters();
         static::assertTrue(is_array($result) && isset($result[0]));
-        static::assertTrue($result[0] instanceof \Twig_SimpleFilter);
+        static::assertInstanceOf(TwigFilter::class, $result[0]);
         $callable = $result[0]->getCallable();
-        static::assertEquals('heightLimitData', $callable[1]);
-        static::assertEquals('heightLimitData', $result[0]->getName());
+        static::assertEquals('heightLimitShorten', $callable[1]);
+        static::assertEquals('heightLimitShorten', $result[0]->getName());
     }
 
     public function testHeightLimit()
@@ -61,10 +62,7 @@ class HeightLimitExtensionTest extends UnitTestCase
             'actual real world result without it being a real world result. Damn it 500 '.
             'characters is a long stretch of';
 
-        $result = $this->twigExtension->heightLimitData($textToTest);
-
-        static::assertIsArray($result);
-        static::assertArrayHasKey('shortened', $result);
-        static::assertEquals($expected, $result['shortened']);
+        $result = $this->twigExtension->heightLimitShorten($textToTest);
+        static::assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30834
**Ticket:** https://yaits.demos-deutschland.de/T30853


Description: it was not possible to add (submit) a new statement with a long text. The slicer caching has to be fixed.

Note : this fix this problem in both projects bobsh and planfest.

### How to review/test
bobsh : 
 -  Procedure
 - AT 
 - New statement 
 - fill out and save

planfestsh : 
 - Login 
 - Procedure 
 - Have your say ('Reden Sie mit')
 - Save statement as draft
 - Go to draft folder
 - Release statement 
 - Institution releases 
 - Submit statement


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Tests updated/created
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
