### PR TITLE
fix: update removed logger calls

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -528,7 +528,7 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
                 try {
                     $maxExtent = Json::decodeToMatchingType($request->query->get('filterByExtent'));
                 } catch (Exception $e) {
-                    $this->logger->err('Could not get mapExtent to generate autocomplete.', [$e]);
+                    $this->logger->error('Could not get mapExtent to generate autocomplete.', [$e]);
                     $maxExtent = null;
                 }
             }

--- a/tests/backend/core/Survey/Unit/SurveyCreateHandlerTest.php
+++ b/tests/backend/core/Survey/Unit/SurveyCreateHandlerTest.php
@@ -38,7 +38,7 @@ class SurveyCreateHandlerTest extends SurveyTestUtils
             $actualSurvey = $this->sut->jsonToEntity($surveyJson);
             $this->checkSurveysEquals($expectedSurvey, $actualSurvey);
         } catch (SurveyInputDataException $e) {
-            $this->logger->err($e->getUserMsg());
+            $this->logger->error($e->getUserMsg());
         }
         $this->assertTrue(true);
     }

--- a/tests/backend/core/Survey/Unit/SurveyUpdateHandlerTest.php
+++ b/tests/backend/core/Survey/Unit/SurveyUpdateHandlerTest.php
@@ -38,7 +38,7 @@ class SurveyUpdateHandlerTest extends SurveyTestUtils
             $actualSurvey = $this->sut->jsonToEntity($surveyJson);
             $this->checkSurveysEquals($expectedSurvey, $actualSurvey);
         } catch (SurveyInputDataException $e) {
-            $this->logger->err($e->getUserMsg());
+            $this->logger->error($e->getUserMsg());
         }
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Some logger calls to deprecated and now deleted method `err` remained.

### How to review/test
Code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
