### PR TITLE
Fix(refs:T30875): Contexthelp is showing not the expected key description

### DIFF
--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -124,11 +124,10 @@
 
                             {% apply spaceless %}
                                 {% if ownsProcedure(proceduresettings) %}
-                                    {# Display procedure phase of institutions AND citizens to enable planner user to quickly check correct settings #}
-                                    {{ getProcedurePhase(proceduresettings, 'internal') ~ ' / ' ~ getProcedurePhase(proceduresettings, 'public') }}
-                                {% else %}
-                                    {# Display procedure phase (depending on role) #}
-                                    {{ getProcedurePhase(proceduresettings) }}
+                                    {# Display procedure phase of institutions to enable planner user to quickly check correct settings #}
+                                    {{ getProcedurePhase(proceduresettings, 'internal') }}
+                                    {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'internal'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
+                                    {{ '\n'|nl2br }}
                                 {% endif %}
 
                                 {# Display a "legal notice" for institutions #}
@@ -136,9 +135,9 @@
                                     ({{ proceduresettings.settings.legalNotice }})
                                 {% endif %}
                             {% endapply %}
-
-                            {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
-
+                            {# Display public procedure phase (not depending on role) #}
+                            {{ getProcedurePhase(proceduresettings, 'public') }}
+                            {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
                         </div><!--
                     {% endif %}
 

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -134,10 +134,11 @@
                                 {% if hasPermission('feature_procedure_legal_notice_read') and proceduresettings.settings.legalNotice|default != '' %}
                                     ({{ proceduresettings.settings.legalNotice }})
                                 {% endif %}
+
+                                {# Display public procedure phase without login or logged as citizen  #}
+                                {{ getProcedurePhase(proceduresettings, 'public') }}
+                                {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
                             {% endapply %}
-                            {# Display public procedure phase without login or logged as citizen  #}
-                            {{ getProcedurePhase(proceduresettings, 'public') }}
-                            {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
                         </div><!--
                     {% endif %}
 

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -132,7 +132,7 @@
                                 {# Display a "legal notice" for institutions #}
                                 {% if hasPermission('feature_procedure_legal_notice_read') and proceduresettings.settings.legalNotice|default != '' %}
                                     ({{ proceduresettings.settings.legalNotice }})
-                                {% endif %}K
+                                {% endif %}
                                 {# Display public procedure phase without login or logged as citizen  #}
                                 {{ getProcedurePhase(proceduresettings, 'public') }}
                                 {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -122,7 +122,6 @@
                                 <i class="{{ 'fa fa-puzzle-piece u-mr-0_25'|prefixClass }}" aria-hidden="true"></i>{{ 'procedure.public.phase'|trans }}
                             </h3>
 
-                            {% apply spaceless %}
                                 {% if ownsProcedure(proceduresettings) %}
                                     {# Display procedure phase of institutions to enable planner user to quickly check correct settings #}
                                     {{ getProcedurePhase(proceduresettings, 'internal') }}
@@ -137,7 +136,6 @@
                                 {# Display public procedure phase without login or logged as citizen  #}
                                 {{ getProcedurePhase(proceduresettings, 'public') }}
                                 {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
-                            {% endapply %}
                         </div><!--
                     {% endif %}
 

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -135,7 +135,7 @@
                                     ({{ proceduresettings.settings.legalNotice }})
                                 {% endif %}
                             {% endapply %}
-                            {# Display public procedure phase (not depending on role) #}
+                            {# Display public procedure phase without login or logged as citizen  #}
                             {{ getProcedurePhase(proceduresettings, 'public') }}
                             {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}
                         </div><!--

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail.html.twig
@@ -133,8 +133,7 @@
                                 {# Display a "legal notice" for institutions #}
                                 {% if hasPermission('feature_procedure_legal_notice_read') and proceduresettings.settings.legalNotice|default != '' %}
                                     ({{ proceduresettings.settings.legalNotice }})
-                                {% endif %}
-
+                                {% endif %}K
                                 {# Display public procedure phase without login or logged as citizen  #}
                                 {{ getProcedurePhase(proceduresettings, 'public') }}
                                 {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['o-tooltip--question-circle'|prefixClass, 'c-infolist__help u-ml-0_25'|prefixClass]) -}}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30875#725835

Description: 
- the description of the phases with his belonging contextHelp tooltip are showing different descriptions due to the user role
- when no user is logged in or he is logged as citizen he only see the public phase and public contextHelp tooltip
- when user is logged as institution he can see two different phase names and contextHelp tooltip content, the public and the intern phase naming and contextHelp tooltip content
- the support role is able to add new contextHelp keys with other content
- important: if there is a key for contextHelp tooltip in database and the support does not add the same key in the application, he wont see any contextHelp tooltip.

### How to review/test

- Different cases:
- 1.) Go to the Startpage, dont login and chose a phase and click to a procedure. Above on the next page in `VERFAHRENSSCHRITT` you will see the public phase of the procedure and the correct belonging public contextHelp tooltip.
- 2.) Login as citizen, chose a phase and click to any procedure of the selected phase. On the next page look to the description of the phase in `VERFAHRENSSCHRITT` and you will see the correct public contextHelp tooltip of the public phase.
- -3.) Login as institution, choose a phase and click to a procedure. You will see two different phases and their belonging contextHelp tooltip, an intern and a public phase and their belonging contextHelp tooltip of the procedure.

- If you would like change the description for the public contexthelp key login as support and click to `Plattformtools` and go to `Kontexthilfe`. Click to `help.public.detail.phase.participation`, change in the description and save it. You dont need to login, just choose the phase `Öffentliche Auslegung` and click to a procedure. You will see that the contexthelp tooltip shows the new changed description for the public phase.

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
