### PR TITLE
fix(refs T30455, T30939): Handle unset bounds

### DIFF
--- a/client/js/lib/procedure/CreateProcedure.js
+++ b/client/js/lib/procedure/CreateProcedure.js
@@ -6,8 +6,33 @@
  *
  * All rights reserved
  */
-
 import { dpApi } from '@demos-europe/demosplan-utils'
+
+const statusBox = document.querySelector('#js__statusBox')
+const mapExtentInput = document.querySelector('input[name="r_mapExtent"]')
+const saveBtn = document.getElementById('saveBtn')
+
+const setWarningForUnsetBounds = function () {
+  // Fill error-data for initialExtend into hidden fields
+  mapExtentInput.setAttribute('value', '')
+  statusBox.innerText = Translator.trans('map.import.bounds.warning')
+  statusBox.classList.remove('hide-visually')
+  statusBox.classList.remove('flash-confirm')
+  statusBox.classList.add('flash-warning')
+  // Enable save-button
+  saveBtn.removeAttribute('disabled')
+}
+
+const setConfirmForBounds = function (data) {
+  // Fill data for initialExtend into hidden fields
+  mapExtentInput.setAttribute('value', data.procedure.bounds)
+  statusBox.innerText = Translator.trans('map.import.bounds.success')
+  statusBox.classList.remove('hide-visually')
+  statusBox.classList.remove('flash-warning')
+  statusBox.classList.add('flash-confirm')
+  // Enable save-button
+  saveBtn.removeAttribute('disabled')
+}
 
 function getXplanboxBounds (procedureName) {
   return dpApi({
@@ -17,35 +42,14 @@ function getXplanboxBounds (procedureName) {
     url: Routing.generate('DemosPlan_xplanbox_get_bounds', { procedureName: procedureName })
   })
     .then(data => {
-      const statusBox = document.querySelector('#js__statusBox')
       if (data.data.code === 100 && data.data.success === true) {
-        // {# fill data for initialExtend into hidden fields #}
-        document.querySelector('input[name="r_mapExtent"]').setAttribute('value', data.data.procedure.bounds)
-        statusBox.innerText = Translator.trans('map.import.bounds.success')
-        statusBox.classList.remove('hide-visually')
-        statusBox.classList.remove('flash-warning')
-        statusBox.classList.add('flash-confirm')
-        // Enable save-button
-        document.getElementById('saveBtn').removeAttribute('disabled')
+        setConfirmForBounds(data.data)
       } else {
-        // {# fill error-data for initialExtend into hidden fields #}
-        document.querySelector('input[name="r_mapExtent"]').setAttribute('value', '')
-        statusBox.innerText = Translator.trans('map.import.bounds.warning')
-        statusBox.classList.remove('hide-visually')
-        statusBox.classList.remove('flash-confirm')
-        statusBox.classList.add('flash-warning')
-        // Enable save-button
-        document.getElementById('saveBtn').removeAttribute('disabled')
+        setWarningForUnsetBounds()
       }
     })
-    .catch(data => {
-      // {# fill error-data for initialExtend into hidden fields #}
-      document.querySelector('input[name="r_mapExtent"]').setAttribute('value', '')
-      const statusBox = document.querySelector('#js__statusBox')
-      statusBox.innerText = Translator.trans('map.import.bounds.error')
-      statusBox.classList.remove('hide-visually')
-      statusBox.classList.remove('flash-confirm')
-      statusBox.classList.add('flash-error')
+    .catch(() => {
+      setWarningForUnsetBounds()
     })
 }
 
@@ -56,7 +60,6 @@ export default function CreateProcedure () {
    * @improve T15008
    * disable save-button - user can only save if we have a valid  plis-id seleced
    */
-  const saveBtn = document.getElementById('saveBtn')
   saveBtn.setAttribute('disabled', true)
 
   const planningCauseSelect = document.getElementById('js__plisPlanungsanlass')

--- a/client/js/lib/procedure/CreateProcedure.js
+++ b/client/js/lib/procedure/CreateProcedure.js
@@ -8,30 +8,30 @@
  */
 import { dpApi } from '@demos-europe/demosplan-utils'
 
-const statusBox = document.querySelector('#js__statusBox')
-const mapExtentInput = document.querySelector('input[name="r_mapExtent"]')
-const saveBtn = document.getElementById('saveBtn')
+const setWarningForUnsetBounds = () => {
+  const statusBox = document.querySelector('#js__statusBox')
 
-const setWarningForUnsetBounds = function () {
   // Fill error-data for initialExtend into hidden fields
-  mapExtentInput.setAttribute('value', '')
+  document.querySelector('input[name="r_mapExtent"]').setAttribute('value', '')
   statusBox.innerText = Translator.trans('map.import.bounds.warning')
   statusBox.classList.remove('hide-visually')
   statusBox.classList.remove('flash-confirm')
   statusBox.classList.add('flash-warning')
   // Enable save-button
-  saveBtn.removeAttribute('disabled')
+  document.getElementById('saveBtn').removeAttribute('disabled')
 }
 
 const setConfirmForBounds = function (data) {
+  const statusBox = document.querySelector('#js__statusBox')
+
   // Fill data for initialExtend into hidden fields
-  mapExtentInput.setAttribute('value', data.procedure.bounds)
+  document.querySelector('input[name="r_mapExtent"]').setAttribute('value', data.procedure.bounds)
   statusBox.innerText = Translator.trans('map.import.bounds.success')
   statusBox.classList.remove('hide-visually')
   statusBox.classList.remove('flash-warning')
   statusBox.classList.add('flash-confirm')
   // Enable save-button
-  saveBtn.removeAttribute('disabled')
+  document.getElementById('saveBtn').removeAttribute('disabled')
 }
 
 function getXplanboxBounds (procedureName) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30455
https://yaits.demos-deutschland.de/T30939


In BobHH Boundingbox-Informations for a new Procedure get fetched by an API-Call. If the response fails for whatever reason,it still should be possible to create the Procedure. (since to bounds can be set manually later on)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Try to create a procedure in BobHH with a failing API-Request for the Boundingbox (I Know - hard to test)

This is just a copy/paste-PR from the old Repos

### Linked PRs (optional)

https://github.com/demos-europe/demosplan/pull/8542
https://github.com/demos-europe/demosplan/pull/8543

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
