### PR TITLE
Fix osi authenticator

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiAuthenticator.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use demosplan\DemosPlanUserBundle\Logic\UserMapperDataportGateway;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -22,8 +21,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
-abstract class OsiAuthenticator extends DplanAuthenticator
+abstract class OsiAuthenticator extends DplanAuthenticator implements AuthenticationEntryPointInterface
 {
     protected const LOGIN_ROUTES = ['DemosPlan_user_login_osi_legacy', 'DemosPlan_user_login_gateway'];
 
@@ -51,5 +51,12 @@ abstract class OsiAuthenticator extends DplanAuthenticator
         return new SelfValidatingPassport(new UserBadge($user->getLogin()));
     }
 
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        return new RedirectResponse(
+            '/', // might be the site, where users choose their oauth provider
+            Response::HTTP_TEMPORARY_REDIRECT
+        );
+    }
 
 }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiAuthenticator.php
@@ -44,8 +44,8 @@ abstract class OsiAuthenticator extends DplanAuthenticator implements Authentica
         return new RedirectResponse($this->urlGenerator->generate('core_home'));
     }
 
-    protected function getPassport(Credentials $credentials): Passport {
-
+    protected function getPassport(Credentials $credentials): Passport
+    {
         $user = $this->userMapper->getValidUser($credentials);
 
         return new SelfValidatingPassport(new UserBadge($user->getLogin()));
@@ -58,5 +58,4 @@ abstract class OsiAuthenticator extends DplanAuthenticator implements Authentica
             Response::HTTP_TEMPORARY_REDIRECT
         );
     }
-
 }


### PR DESCRIPTION
OSI Authenticators need to implement AuthenticationEntryPointInterface, as otherwise the call to any page throws an error. Not sure, which route might be the best to redirect to. Home at least seems to work, otherwise `gateway_url`  might be a valid candidate

### How to review/test
Code review.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
