### PR TITLE
bug(refs T30938): add permission for paragraphs in statements

### DIFF
--- a/client/js/components/document/ElementsAdminList.vue
+++ b/client/js/components/document/ElementsAdminList.vue
@@ -84,11 +84,9 @@
 </template>
 
 <script>
-import { hasAnyPermissions, hasOwnProp } from '@demos-europe/demosplan-utils'
+import { DpBulkEditHeader, DpLoading, DpTreeList } from '@demos-europe/demosplan-ui'
+import { dpRpc, hasAnyPermissions, hasOwnProp } from '@demos-europe/demosplan-utils'
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { DpBulkEditHeader, DpTreeList } from '@demos-europe/demosplan-ui'
-import { DpLoading } from '@demos-europe/demosplan-ui'
-import { dpRpc } from '@demos-europe/demosplan-utils'
 import ElementsAdminItem from './ElementsAdminItem'
 import lscache from 'lscache'
 

--- a/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
@@ -159,7 +159,9 @@
           {{ document }}
         </div>
       </div><!--
-   --><div class="u-1-of-1 c-public-statement__content-item">
+   --><div
+        v-if="hasPermission('field_statement_paragraph')"
+        class="u-1-of-1 c-public-statement__content-item">
         <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
           {{ Translator.trans('paragraph') }}
         </div><!--

--- a/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
@@ -160,7 +160,7 @@
         </div>
       </div><!--
    --><div
-        v-if="hasPermission('field_statement_paragraph')"
+        v-if="hasPermission('feature_documents_new_statement')"
         class="u-1-of-1 c-public-statement__content-item">
         <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
           {{ Translator.trans('paragraph') }}

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -932,22 +932,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     }
 
     /**
-     * Rechte, die rollenunabhängig gesetzt werden, wenn ein schreibender Zugriff auf das Verfahren besteht.
-     */
-    protected function setProcedurePermissionsetWrite(): void
-    {
-        $this->logger->debug('Set Permissionset write');
-        $this->permissions['feature_documents_new_statement']['enabled'] = true; // Planungsdokumente Neue Stellungnahme
-        $this->permissions['feature_map_new_statement']['enabled'] = true; // Planzeichnung Neue Stellungnahme
-        $this->permissions['feature_new_statement']['enabled'] = true; // Stellungnahmen verfassen
-        $this->permissions['feature_new_statement_form']['enabled'] = true; // Stellungnahmen verfassen
-        $this->permissions['feature_statements_draft_delete']['enabled'] = true; // Eigene Stellungnahmen (Entwuerfe) Loeschen
-        $this->permissions['feature_statements_draft_edit']['enabled'] = true; // Eigene Stellungnahmen (Entwuerfe) Bearbeiten
-        $this->permissions['feature_statements_draft_release']['enabled'] = true; // Eigene Stellungnahmen (Entwuerfe) Freigeben
-        $this->permissions['feature_statements_draft_relocate']['enabled'] = true; // Eigene Stellungnahmen (Entwuerfe) Neu verorten
-    }
-
-    /**
      * Rechte, die rollenunabhängig gesetzt werden, wenn ein lesender Zugriff auf das Verfahren besteht.
      */
     protected function setProcedurePermissionsetRead(): void

--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -2584,6 +2584,12 @@ field_statement_municipality:
     label: 'Show field "municipality" (Gemeinde) and save its value'
     loginRequired: false
     parent: field_statement
+field_statement_paragraph:
+    description: 'Show statement field for paragraphs'
+    expose: true
+    label: 'Statement field for paragraphs'
+    loginRequired: true
+    parent: field_statement
 field_statement_phase:
     description: 'Defines in which procedure phase the statement was submitted. Feature itself is only use in frontend.'
     expose: true

--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -2584,12 +2584,6 @@ field_statement_municipality:
     label: 'Show field "municipality" (Gemeinde) and save its value'
     loginRequired: false
     parent: field_statement
-field_statement_paragraph:
-    description: 'Show statement field for paragraphs'
-    expose: true
-    label: 'Statement field for paragraphs'
-    loginRequired: true
-    parent: field_statement
 field_statement_phase:
     description: 'Defines in which procedure phase the statement was submitted. Feature itself is only use in frontend.'
     expose: true

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/listentry_content.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/listentry_content.html.twig
@@ -64,7 +64,7 @@
         </dd>
     {% endif %}
 
-    {% if hasPermission('field_statement_paragraph') %}
+    {% if hasPermission('feature_documents_new_statement') %}
         <dt class="{{ 'layout__item u-1-of-6 u-1-of-3-palm u-pl-palm weight--bold'|prefixClass }}{{ statement.paragraph.title|default()|isNot(' color--grey')|prefixClass }}">
             {{ "paragraph"|trans }}:
         </dt>

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/listentry_content.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/listentry_content.html.twig
@@ -20,7 +20,7 @@
         </dd>
     {% endif %}
 
-    {% if hasPermission( 'field_statement_polygon' ) %}
+    {% if hasPermission( 'field_statement_location' ) %}
         <dt class="{{ 'layout__item u-1-of-6 u-1-of-3-palm u-pl-palm weight--bold'|prefixClass }}{{ statement.polygon|default|isNot(' color--grey')|prefixClass }}">
             {{ "location"|trans }}:
         </dt>
@@ -64,6 +64,7 @@
         </dd>
     {% endif %}
 
+    {% if hasPermission('field_statement_paragraph') %}
         <dt class="{{ 'layout__item u-1-of-6 u-1-of-3-palm u-pl-palm weight--bold'|prefixClass }}{{ statement.paragraph.title|default()|isNot(' color--grey')|prefixClass }}">
             {{ "paragraph"|trans }}:
         </dt>
@@ -71,24 +72,25 @@
         <dd class="{{ 'layout__item o-hellip u-1-of-3 u-2-of-3-palm u-ml-0'|prefixClass }}{{ statement.paragraph.title|default()|isNot(' color--grey')|prefixClass }}">
             {{ statement.paragraph.title|default( "notspecified"|trans )|wysiwyg }}
         </dd>
+    {% endif %}
 
-        <dt class="{{ 'layout__item u-1-of-6 u-1-of-3-palm u-pl-palm weight--bold'|prefixClass }}{{ statement.file|isNot(' color--grey')|prefixClass }}">
-            {{ "attachments"|trans }}:
-        </dt>
-        <dd class="{{ 'layout__item u-1-of-3 u-2-of-3-palm u-ml-0 o-hellip'|prefixClass }}{{ statement.file|isNot(' color--grey')|prefixClass }}">
-            {% if statement.files|default([])|length > 0 %}
-                {% for file in statement.files %}
-                    <a
-                        target="_blank"
-                        rel="noopener"
-                        href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
-                        {{ file|getFile('name') }}
-                    </a><br>
-                {% endfor %}
-            {% else %}
-                {{ "notspecified"|trans }}
-            {% endif %}
-        </dd>
+    <dt class="{{ 'layout__item u-1-of-6 u-1-of-3-palm u-pl-palm weight--bold'|prefixClass }}{{ statement.file|isNot(' color--grey')|prefixClass }}">
+        {{ "attachments"|trans }}:
+    </dt>
+    <dd class="{{ 'layout__item u-1-of-3 u-2-of-3-palm u-ml-0 o-hellip'|prefixClass }}{{ statement.file|isNot(' color--grey')|prefixClass }}">
+        {% if statement.files|default([])|length > 0 %}
+            {% for file in statement.files %}
+                <a
+                    target="_blank"
+                    rel="noopener"
+                    href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                    {{ file|getFile('name') }}
+                </a><br>
+            {% endfor %}
+        {% else %}
+            {{ "notspecified"|trans }}
+        {% endif %}
+    </dd>
 
     {% if procedureStatementPriorityArea %}
         {% set priorityAreas = statement.statementAttributes.priorityAreaKey|default %}

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
@@ -16,29 +16,31 @@
         </dd><!--
 
         {% if hasPermission('field_statement_location') %}
-     --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
-            {{ "location"|trans }}:
-        </dt><!--
-     --><dd class="{{ 'layout__item u-1-of-3 u-ml-0-lap-up u-1-of-1-palm u-ml-0_5-palm'|prefixClass }}">
-            {% if statement.polygon|default != '' %}
-                <button
-                    class="{{ 'btn--blank o-link--default'|prefixClass }}"
-                    type="button"
-                    @click.prevent.stop="(function(){$refs.mapModal.toggleModal({{ statement.polygon|convertLegacyPolygon|escape('html_attr') }})})()">
-                    {{ 'see'|trans }}
-                </button>
-            {% else %}
-                {{ "notspecified"|trans }}
-            {% endif %}
-        </dd><!--
+         --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
+                {{ "location"|trans }}:
+            </dt><!--
+         --><dd class="{{ 'layout__item u-1-of-3 u-ml-0-lap-up u-1-of-1-palm u-ml-0_5-palm'|prefixClass }}">
+                {% if statement.polygon|default != '' %}
+                    <button
+                        class="{{ 'btn--blank o-link--default'|prefixClass }}"
+                        type="button"
+                        @click.prevent.stop="(function(){$refs.mapModal.toggleModal({{ statement.polygon|convertLegacyPolygon|escape('html_attr') }})})()">
+                        {{ 'see'|trans }}
+                    </button>
+                {% else %}
+                    {{ "notspecified"|trans }}
+                {% endif %}
+            </dd><!--
         {% endif %}
 
-	 --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
-            {{ "paragraph"|trans }}:
-        </dt><!--
-     --><dd class="{{ 'layout__item u-1-of-3 u-ml-0-lap-up u-1-of-1-palm u-ml-0_5-palm'|prefixClass }}">
-            {% if statement.paragraph.title is defined %}{{ statement.paragraph.title|striptags|default() }}{% endif %}
-        </dd><!--
+        {% if hasPermission('field_statement_paragraph') %}
+        --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
+                {{ "paragraph"|trans }}:
+            </dt><!--
+        --><dd class="{{ 'layout__item u-1-of-3 u-ml-0-lap-up u-1-of-1-palm u-ml-0_5-palm'|prefixClass }}">
+                {% if statement.paragraph.title is defined %}{{ statement.paragraph.title|striptags|default() }}{% endif %}
+            </dd><!--
+        {% endif %}
 
      --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
             {{ "file"|trans }}:

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
@@ -33,7 +33,7 @@
             </dd><!--
         {% endif %}
 
-        {% if hasPermission('field_statement_paragraph') %}
+        {% if hasPermission('feature_documents_new_statement') %}
         --><dt class="{{ 'layout__item u-1-of-6 weight--bold u-1-of-1-palm'|prefixClass }}">
                 {{ "paragraph"|trans }}:
             </dt><!--


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30938

There aren't paragraphs and location in statements in every project, so we need a permission for it.

### How to review/test
Login as citizen, go to a procedure and write a statement. There should be no option for paragraphs or location. 

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-project-teilhabe/pull/10
https://github.com/demos-europe/demosplan-project-robobsh/pull/15
https://github.com/demos-europe/demosplan-project-regio/pull/18
https://github.com/demos-europe/demosplan-project-planfestsh/pull/15
https://github.com/demos-europe/demosplan-project-diplanbau/pull/53
https://github.com/demos-europe/demosplan-project-bobsh/pull/16
https://github.com/demos-europe/demosplan-project-bobhh/pull/21
https://github.com/demos-europe/demosplan-project-bimschgsh/pull/19
https://github.com/demos-europe/demosplan-project-ewm/pull/27
https://github.com/demos-europe/demosplan-project-blp/pull/27
