### PR TITLE
fix (refs T30865): Count normal statements of procedure

### DIFF
--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -264,7 +264,8 @@ export default {
             'internalEndDate',
             'internalPhaseIdentifier',
             'internalPhaseTranslationKey',
-            'originalStatementsCount'
+            'originalStatementsCount',
+            'statementsCount'
           ].join()
         },
         filter: {
@@ -285,7 +286,7 @@ export default {
           response.data.data.forEach(el => this.items.push({
             creationDate: formatDate(el.attributes.creationDate.date),
             creationDateRaw: el.attributes.creationDate.date,
-            count: el.attributes.originalStatementsCount > 0 ? el.attributes.originalStatementsCount : '0',
+            count: `${el.attributes.statementsCount} (${el.attributes.originalStatementsCount})`,
             name: el.attributes.name,
             externalName: el.attributes.externalName,
             externalEndDate: formatDate(el.attributes.externalEndDate.date),

--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -104,7 +104,7 @@
         v-slot:header-count>
         {{ Translator.trans('quantity') }}
         <i
-          class="fa fa-question-circle u-pt-0_25 display--inline-block float--right"
+          class="fa fa-question-circle u-pt-0_125 display--inline-block float--right"
           v-tooltip="Translator.trans('procedures.statements.count.and.original')" />
       </template>
 
@@ -205,7 +205,7 @@ export default {
           label: Translator.trans('name')
         },
         {
-          colClass: 'width-60',
+          colClass: 'width-85',
           field: 'count',
           isVisible: this.showStatementCount,
           label: Translator.trans('quantity')

--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -99,6 +99,14 @@
         <span v-text="Translator.trans('procedure.public.phase')" />
         <div v-text="Translator.trans('institution')" />
       </template>
+      <template
+        v-if="showStatementCount"
+        v-slot:header-count>
+        {{ Translator.trans('quantity') }}
+        <i
+          class="fa fa-question-circle u-pt-0_25 display--inline-block float--right"
+          v-tooltip="Translator.trans('statements.count.and.original')" />
+      </template>
 
       <template
         v-if="showInternalPhases"

--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -105,7 +105,7 @@
         {{ Translator.trans('quantity') }}
         <i
           class="fa fa-question-circle u-pt-0_25 display--inline-block float--right"
-          v-tooltip="Translator.trans('statements.count.and.original')" />
+          v-tooltip="Translator.trans('procedures.statements.count.and.original')" />
       </template>
 
       <template

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -126,8 +126,10 @@ final class AdminProcedureResourceType extends DplanResourceType
                     return $counts[$procedureId] ?? 0;
                 }),
                 $this->createAttribute($this->statementsCount)->readable(false, function (Procedure $procedure): int {
-                    // todo
-                    return 0;
+                    $procedureId = $procedure->getId();
+                    $counts = $this->procedureService->getStatementsCounts([$procedureId]);
+
+                    return $counts[$procedureId] ?? 0;
                 }),
                 $this->createAttribute($this->internalPhaseIdentifier)->readable()->aliasedPath($this->phase),
                 $this->createAttribute($this->internalPhaseTranslationKey)

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -126,7 +126,7 @@ final class AdminProcedureResourceType extends DplanResourceType
                     return $counts[$procedureId] ?? 0;
                 }),
                 $this->createAttribute($this->statementsCount)->readable(false, function (Procedure $procedure): int {
-                    //todo
+                    // todo
                     return 0;
                 }),
                 $this->createAttribute($this->internalPhaseIdentifier)->readable()->aliasedPath($this->phase),

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanProcedureBundle\Logic\ProcedureService;
 use EDT\PathBuilding\End;
@@ -125,12 +126,16 @@ final class AdminProcedureResourceType extends DplanResourceType
 
                     return $counts[$procedureId] ?? 0;
                 }),
-                $this->createAttribute($this->statementsCount)->readable(false, function (Procedure $procedure): int {
-                    $procedureId = $procedure->getId();
-                    $counts = $this->procedureService->getStatementsCounts([$procedureId]);
-
-                    return $counts[$procedureId] ?? 0;
-                }),
+                $this->createAttribute($this->statementsCount)
+                    ->readable(false, function (Procedure $procedure): int {
+                        return $procedure->getStatements()->filter(function (Statement $statement) {
+                            return (!$statement->isOriginal()
+                                && !$statement->isDeleted()
+                                && !$statement->isPlaceholder()
+                                && !$statement->isInCluster()
+                            );
+                        })->count();
+                    }),
                 $this->createAttribute($this->internalPhaseIdentifier)->readable()->aliasedPath($this->phase),
                 $this->createAttribute($this->internalPhaseTranslationKey)
                     ->readable(false, static function (Procedure $procedure) use ($internalPhases): string {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -39,6 +39,7 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  * @property-read End                   $endDate
  * @property-read End                   $internalEndDate
  * @property-read End                   $originalStatementsCount
+ * @property-read End                   $statementsCount
  * @property-read End                   $phase
  * @property-read End                   $phaseName
  * @property-read End                   $internalPhaseIdentifier
@@ -123,6 +124,10 @@ final class AdminProcedureResourceType extends DplanResourceType
                     $counts = $this->procedureService->getOriginalStatementsCounts([$procedureId]);
 
                     return $counts[$procedureId] ?? 0;
+                }),
+                $this->createAttribute($this->statementsCount)->readable(false, function (Procedure $procedure): int {
+                    //todo
+                    return 0;
                 }),
                 $this->createAttribute($this->internalPhaseIdentifier)->readable()->aliasedPath($this->phase),
                 $this->createAttribute($this->internalPhaseTranslationKey)

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -129,11 +129,11 @@ final class AdminProcedureResourceType extends DplanResourceType
                 $this->createAttribute($this->statementsCount)
                     ->readable(false, function (Procedure $procedure): int {
                         return $procedure->getStatements()->filter(function (Statement $statement) {
-                            return (!$statement->isOriginal()
+                            return !$statement->isOriginal()
                                 && !$statement->isDeleted()
                                 && !$statement->isPlaceholder()
                                 && !$statement->isInCluster()
-                            );
+                            ;
                         })->count();
                     }),
                 $this->createAttribute($this->internalPhaseIdentifier)->readable()->aliasedPath($this->phase),

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_width.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_width.scss
@@ -34,7 +34,7 @@
 $width-map-px: (
     'max-width': (350, 600),
     'min-width': (25),
-    'width': (16, 20, 25, 40, 60, 100, 120, 160, 200, 250, 300, 350, 450, 600)
+    'width': (16, 20, 25, 40, 60, 85, 100, 120, 160, 200, 250, 300, 350, 450, 600)
 );
 @each $property, $widths in $width-map-px {
     @each $width in $widths {

--- a/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
@@ -2662,16 +2662,6 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     }
 
     /**
-     * @param array<int, string> $procedureIds
-     *
-     * @return array<string, int>
-     */
-    public function getStatementsCounts(array $procedureIds): array
-    {
-        return $this->statementRepository->getStatementsCounts($procedureIds);
-    }
-
-    /**
      * @throws ProcedureNotFoundException
      * @throws Exception
      */

--- a/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ProcedureService.php
@@ -2662,6 +2662,16 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     }
 
     /**
+     * @param array<int, string> $procedureIds
+     *
+     * @return array<string, int>
+     */
+    public function getStatementsCounts(array $procedureIds): array
+    {
+        return $this->statementRepository->getStatementsCounts($procedureIds);
+    }
+
+    /**
      * @throws ProcedureNotFoundException
      * @throws Exception
      */

--- a/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
@@ -1438,7 +1438,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             ->leftJoin('statement.meta', 'meta')
             ->andWhere('statement.original IS NULL')
             ->andWhere($queryBuilder->expr()->orX(
-            // submitted statements
+                // submitted statements
                 $queryBuilder->expr()->eq('meta.submitUId', ':userId'),
                 // authored statements
                 $queryBuilder->expr()->eq('statement.user', ':userId')

--- a/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
@@ -11,6 +11,8 @@
 namespace demosplan\DemosPlanStatementBundle\Repository;
 
 use Carbon\Carbon;
+use DateInterval;
+use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\Document\ParagraphVersion;
 use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocumentVersion;
@@ -56,6 +58,7 @@ use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
 use EDT\Querying\FluentQueries\FluentQuery;
 use Exception;
+use ReflectionException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Tightenco\Collect\Support\Collection;
 
@@ -89,7 +92,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement|null
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function get($entityId)
     {
@@ -131,7 +134,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return statement - headStatement of the created statement-cluster
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function addCluster(Statement $headStatement, array $statementIdsToCluster)
     {
@@ -156,7 +159,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             }
 
             return $headStatement;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning('Create Statement failed Message: ', [$e]);
             throw $e;
         }
@@ -167,7 +170,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @param Statement $statement
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function addObject($statement): Statement
     {
@@ -181,7 +184,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $manager->flush();
 
             return $statement;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->getLogger()->warning('Add StatementObject failed Message: ', [$e]);
             throw $e;
         }
@@ -192,7 +195,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function add(array $data)
     {
@@ -206,7 +209,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $statement = $this->generateObjectValues($statement, $data);
 
             return $this->addObject($statement);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning('Create Statement failed Message: ', [$e]);
             throw $e;
         }
@@ -222,7 +225,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement|object
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function submitDraftStatement($draftStatement, $user, $notificationReceiver = null, bool $gdprConsentReceived = false)
     {
@@ -244,8 +247,8 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             if ($draftStatement->isPublicAllowed()) {
                 $statement->setPublicVerified(Statement::PUBLICATION_PENDING);
             }
-            $statement->setSubmit(new \DateTime());
-            $statement->setDeletedDate(new \DateTime());
+            $statement->setSubmit(new DateTime());
+            $statement->setDeletedDate(new DateTime());
             $statementMeta = $statement->getMeta();
             // speichere bei InstitutionStellungnahmen den Einreicher
             if (DraftStatement::INTERNAL === $draftStatement->getPublicDraftStatement()) {
@@ -260,7 +263,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $statementMeta->setOrgaPostalCode($draftStatement->getUPostalCode());
             $statementMeta->setOrgaCity($draftStatement->getUCity());
             $statementMeta->setOrgaEmail($draftStatement->getUEmail());
-            $statementMeta->setAuthoredDate(new \DateTime());
+            $statementMeta->setAuthoredDate(new DateTime());
             $statementMeta->setHouseNumber($draftStatement->getHouseNumber());
             $statementMeta->setAuthorFeedback($draftStatement->getUFeedback());
             // Bundesteilhabegesetz
@@ -341,7 +344,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             }
 
             return $statement;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning('Create Statement failed Message: ', [$e]);
             throw $e;
         }
@@ -354,7 +357,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function update($entityId, array $data)
     {
@@ -368,7 +371,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $em->flush();
 
             return $statement;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning(
                 'Update Statement failed. Message: ', [$e, $e->getTraceAsString()]);
             throw $e;
@@ -381,7 +384,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement The updated statement. Always an object. Never null.
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function updateObject($statement)
     {
@@ -393,7 +396,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $em->flush();
 
             return $statement;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning(
                 'Update Statement failed. Message: ', [$e]);
             throw $e;
@@ -404,7 +407,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      * Unlike {@see updateObject()} this method allows the caller to be sure
      * what to expect as return type.
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function updateStatementObject(Statement $statement): Statement
     {
@@ -482,7 +485,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @param string $statementId Id of an statement
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function delete($statementId): bool
     {
@@ -514,7 +517,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $em->flush();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning('Delete Statement failed ', [$e]);
 
             return false;
@@ -526,7 +529,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @param array $data
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function addRecommendationVersion($data): StatementVersionField
     {
@@ -549,7 +552,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $em->flush();
 
             return $statementVersionField;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning(
                 'Create StatementVersionField failed Message: ', [$e]);
             throw $e;
@@ -561,7 +564,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return \demosplan\DemosPlanCoreBundle\Entity\Statement\StatementLike
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function addLike(array $data)
     {
@@ -581,7 +584,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $em->flush();
 
             return $statementLike;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger->warning('Create StatementLike failed Message: ', [$e]);
             throw $e;
         }
@@ -597,7 +600,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @throws EntityNotFoundException
      * @throws ORMException
-     * @throws \Exception
+     * @throws Exception
      */
     public function generateObjectValues($statement, array $data)
     {
@@ -785,7 +788,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
 
         if (array_key_exists('submittedDate', $data)) {
             $date = Carbon::createFromTimestamp(strtotime($data['submittedDate']))->toDateTime();
-            if ($date instanceof \DateTime) {
+            if ($date instanceof DateTime) {
                 $statement->setSubmit($date);
             }
         }
@@ -871,9 +874,9 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $statement->setSentAssessment($data['sentAssessment']);
         }
         if (array_key_exists('authoredDate', $data) && 0 < strlen($data['authoredDate'])) {
-            $dateTime = new \DateTime();
+            $dateTime = new DateTime();
             $date = $dateTime->createFromFormat('d.m.Y', $data['authoredDate']);
-            if ($date instanceof \DateTime) {
+            if ($date instanceof DateTime) {
                 $statement->getMeta()->setAuthoredDate($date);
             }
         }
@@ -953,7 +956,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      * @return Collection<int, StatementVote>
      *
      * @throws EntityNotFoundException
-     * @throws \Exception
+     * @throws Exception
      */
     public function handleVotesOnStatement(Statement $statement, $votesToSet)
     {
@@ -1079,7 +1082,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return Statement
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     protected function generateObjectValuesFromObject($copyToEntity, $copyFromEntity, $excludeProperties = [])
     {
@@ -1494,22 +1497,20 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      */
     private function createStatementsCountsQueryBuilder(array $procedureIds): QueryBuilder
     {
-        {
-            $queryBuilder = $this->getEntityManager()->createQueryBuilder();
-            $queryBuilder
-                ->select('IDENTITY(statement.procedure) as procedureId')
-                ->addSelect('count(statement.id) as count')
-                ->from(Statement::class, 'statement')
-                ->groupBy('statement.procedure')
-                ->andWhere('statement.deleted = :deleted')
-                ->setParameter('deleted', false)
-                ->andWhere('statement.clusterStatement = :clusterStatement')
-                ->setParameter('clusterStatement', false)
-                ->andWhere($queryBuilder->expr()->isNull('statement.movedStatement'))
-                ->andWhere($queryBuilder->expr()->in('statement.procedure', $procedureIds));
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+        $queryBuilder
+            ->select('IDENTITY(statement.procedure) as procedureId')
+            ->addSelect('count(statement.id) as count')
+            ->from(Statement::class, 'statement')
+            ->groupBy('statement.procedure')
+            ->andWhere('statement.deleted = :deleted')
+            ->setParameter('deleted', false)
+            ->andWhere('statement.clusterStatement = :clusterStatement')
+            ->setParameter('clusterStatement', false)
+            ->andWhere($queryBuilder->expr()->isNull('statement.movedStatement'))
+            ->andWhere($queryBuilder->expr()->in('statement.procedure', $procedureIds));
 
-            return $queryBuilder;
-        }
+        return $queryBuilder;
     }
 
     /**
@@ -1521,7 +1522,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @throws ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Exception
+     * @throws Exception
      */
     public function deleteByProcedure(string $procedureId): int
     {
@@ -1536,7 +1537,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             try {
                 $this->hardDelete($statementToDelete, true);
                 ++$deletedEntities;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->getLogger()->error('deleteByProcedure failed ', [$e, $statementToDelete->getId()]);
             }
         }
@@ -1572,7 +1573,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      *
      * @return bool|null
      *
-     * @throws \Exception
+     * @throws Exception
      */
     protected function hardDelete(Statement $statementToDelete, $allowDeletionOfOriginal = false)
     {
@@ -1649,7 +1650,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
      * If there are Statements in the cluster, which can not be detached from the cluster,
      * the cluster will not be deleted.
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function resolveCluster(Statement $headStatement)
     {
@@ -1669,7 +1670,7 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             $removedStatement = $this->updateObject($statement);
             if (!$removedStatement instanceof Statement) {
                 $notDetachedStatements->push($statement);
-                throw new \Exception('error.statement.cluster.resolve'.$headStatement->getId());
+                throw new Exception('error.statement.cluster.resolve'.$headStatement->getId());
             }
         }
 
@@ -1678,13 +1679,13 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             try {
                 $this->getEntityManager()->remove($headStatement);
                 $this->getEntityManager()->flush();
-            } catch (\Exception $exception) {
+            } catch (Exception $exception) {
                 $this->getLogger()->debug('11111 exeption on resolve cluster!');
             }
         } else {
             $headStatement->setCluster($notDetachedStatements->toArray());
             $this->updateObject($headStatement);
-            throw new \Exception('Some statements of Cluster {$headStatement->getId()} are not detached.');
+            throw new Exception('Some statements of Cluster {$headStatement->getId()} are not detached.');
         }
     }
 
@@ -1766,10 +1767,10 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
 
         $newOriginalStatement->setId(null);
         $newOriginalStatement->setInternId($internIdToSet);
-        $newOriginalStatement->setCreated(new \DateTime());
-        $newOriginalStatement->setDeletedDate(new \DateTime());
-        $newOriginalStatement->setModified(new \DateTime());
-        $newOriginalStatement->setSubmit($originalToCopy->getSubmitObject()->add(new \DateInterval('PT1S')));
+        $newOriginalStatement->setCreated(new DateTime());
+        $newOriginalStatement->setDeletedDate(new DateTime());
+        $newOriginalStatement->setModified(new DateTime());
+        $newOriginalStatement->setSubmit($originalToCopy->getSubmitObject()->add(new DateInterval('PT1S')));
         $newStatementMeta = clone $originalToCopy->getMeta();
         $newOriginalStatement->setMeta($newStatementMeta);
 

--- a/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
@@ -52,7 +52,6 @@ use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
-use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;

--- a/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
@@ -1451,10 +1451,10 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
     }
 
     /**
-     * @param array $procedureIds the procedure IDs to get the number of original statements for
+     * @param array $procedureIds the procedure IDs to get the number of statements for
      *
      * @return array<string, int> unordered array with procedure IDs as keys and the count of corresponding
-     *                            original statements which are no placeholders and not deleted as values
+     *                            statements which are no placeholders and not deleted as values
      */
     public function getOriginalStatementsCounts(array $procedureIds): array
     {
@@ -1462,55 +1462,24 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             return [];
         }
 
-        $queryBuilder = $this->createStatementsCountsQueryBuilder($procedureIds);
-        $queryBuilder->andWhere($queryBuilder->expr()->isNull('statement.original'));
-        $queryResult = $queryBuilder->getQuery()->getArrayResult();
-
-        return array_map(static function (string $count): int {
-            return (int) $count;
-        }, array_column($queryResult, 'count', 'procedureId'));
-    }
-
-    /**
-     * @param array $procedureIds the procedure IDs to get the number of statements for
-     *
-     * @return array<string, int> unordered array with procedure IDs as keys and the count of corresponding
-     *                            statements which are no placeholders and not deleted as values
-     */
-    public function getStatementsCounts(array $procedureIds): array
-    {
-        if ([] === $procedureIds) {
-            return [];
-        }
-
-        $queryBuilder = $this->createStatementsCountsQueryBuilder($procedureIds);
-        $queryBuilder->andWhere($queryBuilder->expr()->isNotNull('statement.original'));
-        $queryResult = $queryBuilder->getQuery()->getArrayResult();
-
-        return array_map(static function (string $count): int {
-            return (int) $count;
-        }, array_column($queryResult, 'count', 'procedureId'));
-    }
-
-    /**
-     * @param array $procedureIds the procedure IDs to get the number of statements for
-     */
-    private function createStatementsCountsQueryBuilder(array $procedureIds): QueryBuilder
-    {
-        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
-        $queryBuilder
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $queryResult = $qb
             ->select('IDENTITY(statement.procedure) as procedureId')
             ->addSelect('count(statement.id) as count')
             ->from(Statement::class, 'statement')
             ->groupBy('statement.procedure')
             ->andWhere('statement.deleted = :deleted')
             ->setParameter('deleted', false)
+            ->andWhere($qb->expr()->isNull('statement.original'))
             ->andWhere('statement.clusterStatement = :clusterStatement')
             ->setParameter('clusterStatement', false)
-            ->andWhere($queryBuilder->expr()->isNull('statement.movedStatement'))
-            ->andWhere($queryBuilder->expr()->in('statement.procedure', $procedureIds));
+            ->andWhere($qb->expr()->in('statement.procedure', $procedureIds))
+            ->getQuery()
+            ->getArrayResult();
 
-        return $queryBuilder;
+        return array_map(static function (string $count): int {
+            return (int) $count;
+        }, array_column($queryResult, 'count', 'procedureId'));
     }
 
     /**

--- a/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanStatementBundle/Repository/StatementRepository.php
@@ -50,6 +50,7 @@ use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
@@ -1447,10 +1448,10 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
     }
 
     /**
-     * @param array $procedureIds the procedure IDs to get the number of statements for
+     * @param array $procedureIds the procedure IDs to get the number of original statements for
      *
      * @return array<string, int> unordered array with procedure IDs as keys and the count of corresponding
-     *                            statements which are no placeholders and not deleted as values
+     *                            original statements which are no placeholders and not deleted as values
      */
     public function getOriginalStatementsCounts(array $procedureIds): array
     {
@@ -1458,24 +1459,57 @@ class StatementRepository extends FluentRepository implements ArrayInterface, Ob
             return [];
         }
 
-        $qb = $this->getEntityManager()->createQueryBuilder();
-        $queryResult = $qb
-            ->select('IDENTITY(statement.procedure) as procedureId')
-            ->addSelect('count(statement.id) as count')
-            ->from(Statement::class, 'statement')
-            ->groupBy('statement.procedure')
-            ->andWhere('statement.deleted = :deleted')
-            ->setParameter('deleted', false)
-            ->andWhere($qb->expr()->isNull('statement.original'))
-            ->andWhere('statement.clusterStatement = :clusterStatement')
-            ->setParameter('clusterStatement', false)
-            ->andWhere($qb->expr()->in('statement.procedure', $procedureIds))
-            ->getQuery()
-            ->getArrayResult();
+        $queryBuilder = $this->createStatementsCountsQueryBuilder($procedureIds);
+        $queryBuilder->andWhere($queryBuilder->expr()->isNull('statement.original'));
+        $queryResult = $queryBuilder->getQuery()->getArrayResult();
 
         return array_map(static function (string $count): int {
             return (int) $count;
         }, array_column($queryResult, 'count', 'procedureId'));
+    }
+
+    /**
+     * @param array $procedureIds the procedure IDs to get the number of statements for
+     *
+     * @return array<string, int> unordered array with procedure IDs as keys and the count of corresponding
+     *                            statements which are no placeholders and not deleted as values
+     */
+    public function getStatementsCounts(array $procedureIds): array
+    {
+        if ([] === $procedureIds) {
+            return [];
+        }
+
+        $queryBuilder = $this->createStatementsCountsQueryBuilder($procedureIds);
+        $queryBuilder->andWhere($queryBuilder->expr()->isNotNull('statement.original'));
+        $queryResult = $queryBuilder->getQuery()->getArrayResult();
+
+        return array_map(static function (string $count): int {
+            return (int) $count;
+        }, array_column($queryResult, 'count', 'procedureId'));
+    }
+
+    /**
+     * @param array $procedureIds the procedure IDs to get the number of statements for
+     */
+    private function createStatementsCountsQueryBuilder(array $procedureIds): QueryBuilder
+    {
+        {
+            $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+            $queryBuilder
+                ->select('IDENTITY(statement.procedure) as procedureId')
+                ->addSelect('count(statement.id) as count')
+                ->from(Statement::class, 'statement')
+                ->groupBy('statement.procedure')
+                ->andWhere('statement.deleted = :deleted')
+                ->setParameter('deleted', false)
+                ->andWhere('statement.clusterStatement = :clusterStatement')
+                ->setParameter('clusterStatement', false)
+                ->andWhere($queryBuilder->expr()->isNull('statement.movedStatement'))
+                ->andWhere($queryBuilder->expr()->in('statement.procedure', $procedureIds));
+
+            return $queryBuilder;
+        }
     }
 
     /**

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2572,6 +2572,7 @@ procedures.none: "Es sind noch keine Verfahren vorhanden."
 procedures.orga: "Verfahren Ihrer Organisation"
 procedures.participation.none: "Derzeit befinden sich keine Verfahren in Beteiligung."
 procedures.phase.overview: "Phasenübersicht aller Verfahren"
+procedures.statements.count.and.original: "Anzahl Stellungnahmen (Originalstellungnahmen)"
 procedures.statements.total: |
     {statementCount, plural,
         =1 {Eine Stellungnahme in {procedureCount} Verfahren}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30865
Count normal statements of procedure to allow showing a count of normal statements in procedure-list, additionally to count of original-statements.

### How to review/test
In the list of the procedures, should be two counts of statements now, including a tooltip, which discripe

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
