### PR TITLE
fix(refs T30808): Check Permissions for Branding propperly

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettings.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettings.vue
@@ -190,12 +190,11 @@
 </template>
 
 <script>
+import { dpApi, dpValidateMixin } from '@demos-europe/demosplan-utils'
 import { DpLabel, DpLoading } from '@demos-europe/demosplan-ui'
 import CustomerSettingsBranding from './CustomerSettingsBranding'
 import CustomerSettingsSection from './CustomerSettingsSection'
 import CustomerSettingsSignLanguageVideo from './CustomerSettingsSignLanguageVideo'
-import { dpApi } from '@demos-europe/demosplan-utils'
-import { dpValidateMixin } from '@demos-europe/demosplan-utils'
 
 export default {
   name: 'CustomerSettings',
@@ -270,6 +269,8 @@ export default {
       },
       isLoading: true,
       isLoadingSignLanguageOverviewVideo: true,
+      requestFields: {},
+      requestIncludes: [],
       signLanguageOverviewVideo: {
         description: '',
         file: '',
@@ -288,6 +289,13 @@ export default {
   },
 
   methods: {
+    addAttributesToField (field, attributes) {
+      this.requestFields[field] = [
+        ...(this.requestFields[field] ? this.requestFields[field] : []),
+        ...attributes
+      ]
+    },
+
     fetchCustomerData () {
       this.isLoadingSignLanguageOverviewVideo = true
       const payload = this.getRequestPayload()
@@ -320,7 +328,7 @@ export default {
 
       // Find signLanguageOverviewVideo relationship, set video data
       if (hasPermission('field_sign_language_overview_video_edit')) {
-        if (customer.relationships.signLanguageOverviewVideo.data) {
+        if (customer.relationships?.signLanguageOverviewVideo?.data) {
           const signLanguageOverviewVideoId = customer.relationships.signLanguageOverviewVideo.data.id
           const signLanguageOverviewVideo = response.data.included.find(item => item.id === signLanguageOverviewVideoId) || null
           const file = response.data.included.find(item => item.id === signLanguageOverviewVideo.relationships?.file.data.id) || null
@@ -344,7 +352,59 @@ export default {
     },
 
     getRequestPayload () {
-      const payload = {
+      this.requestIncludes = []
+      this.requestFields = {}
+
+      if (hasPermission('feature_platform_logo_edit')) {
+        this.requestIncludes.push('branding', 'branding.logo')
+        this.addAttributesToField('Branding', ['logo'])
+        this.addAttributesToField('Customer', ['branding'])
+        this.addAttributesToField('File', ['hash'])
+      }
+
+      if (hasPermission('feature_customer_branding_edit')) {
+        this.requestIncludes.push('branding')
+        this.addAttributesToField('Branding', ['cssvars'])
+        this.addAttributesToField('Customer', ['branding'])
+      }
+
+      if (hasPermission('field_sign_language_overview_video_edit')) {
+        this.requestIncludes.push('signLanguageOverviewVideo', 'signLanguageOverviewVideo.file')
+        this.addAttributesToField('File', ['mimetype'])
+        this.addAttributesToField('Customer', ['signLanguageOverviewDescription', 'signLanguageOverviewVideo'])
+        this.addAttributesToField('SignLanguageOverviewVideo', ['description', 'file', 'title'])
+      }
+
+      if (hasPermission('field_simple_language_overview_description_edit')) {
+        this.addAttributesToField('Customer', ['overviewDescriptionInSimpleLanguage'])
+      }
+
+      if (hasPermission('field_customer_accessibility_explanation_edit')) {
+        this.addAttributesToField('Customer', ['accessibilityExplanation'])
+      }
+
+      if (hasPermission('feature_customer_xplanning_edit')) {
+        this.addAttributesToField('Customer', ['xplanning'])
+      }
+
+      if (hasPermission('feature_customer_terms_of_use_edit')) {
+        this.addAttributesToField('Customer', ['termsOfUse'])
+      }
+
+      if (hasPermission('feature_data_protection_text_customized_view')) {
+        this.addAttributesToField('Customer', ['dataProtection'])
+      }
+
+      if (hasPermission('feature_imprint_text_customized_view')) {
+        this.addAttributesToField('Customer', ['imprint'])
+      }
+
+      // Transform arrays to csv strings ready to be passed into query
+      for (const prop in this.requestFields) {
+        this.requestFields[prop] = this.requestFields[prop].join(',')
+      }
+
+      return {
         filter: {
           isCurrentCustomer: {
             condition: {
@@ -353,67 +413,9 @@ export default {
             }
           }
         },
-        include: [],
-        fields: {
-          Branding: [],
-          File: [],
-          Customer: [],
-          SignLanguageOverviewVideo: []
-        }
+        fields: this.requestFields,
+        includes: this.requestIncludes.join(',')
       }
-
-      if (hasPermission('feature_platform_logo_edit')) {
-        payload.include.push('branding', 'branding.logo')
-        payload.fields.Branding.push('logo')
-        payload.fields.File.push('hash')
-        payload.fields.Customer.push('branding')
-      }
-
-      if (hasPermission('feature_customer_branding_edit')) {
-        payload.include.push('branding')
-        payload.fields.Branding.push('cssvars')
-        payload.fields.Customer.push('branding')
-      }
-
-      if (hasPermission('field_sign_language_overview_video_edit')) {
-        payload.include.push('signLanguageOverviewVideo', 'signLanguageOverviewVideo.file')
-        payload.fields.Branding.push('logo')
-        payload.fields.File.push('mimetype')
-        payload.fields.Customer.push('signLanguageOverviewDescription', 'signLanguageOverviewVideo')
-        payload.fields.SignLanguageOverviewVideo.push('description', 'file', 'title')
-      }
-
-      if (hasPermission('field_simple_language_overview_description_edit')) {
-        payload.fields.Customer.push('overviewDescriptionInSimpleLanguage')
-      }
-
-      if (hasPermission('field_customer_accessibility_explanation_edit')) {
-        payload.fields.Customer.push('accessibilityExplanation')
-      }
-
-      if (hasPermission('feature_customer_xplanning_edit')) {
-        payload.fields.Customer.push('xplanning')
-      }
-
-      if (hasPermission('feature_customer_terms_of_use_edit')) {
-        payload.fields.Customer.push('termsOfUse')
-      }
-
-      if (hasPermission('feature_data_protection_text_customized_view')) {
-        payload.fields.Customer.push('dataProtection')
-      }
-
-      if (hasPermission('feature_imprint_text_customized_view')) {
-        payload.fields.Customer.push('imprint')
-      }
-
-      // Transform arrays to csv strings ready to be passed into query
-      payload.include = payload.include.join()
-      for (const prop in payload.fields) {
-        payload.fields[prop] = payload.fields[prop].join()
-      }
-
-      return payload
     },
 
     submit () {


### PR DESCRIPTION
 One big issue was, that the Branding got requested only beccause
 the permission "field_sign_language_overview_video_edit" was enabled

during investigationg this. I refactored the code a little, to hopefully make it better readable and to not send empty fields



**Ticket:** https://yaits.demos-deutschland.de/T30808

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

in bob-sh as support, try to open the "plattformeinstellungen" 
You may doublecheck if the page still works in other projects.

While this fixes, that the page can be visited again, it also reveals a bunch of new errors thrown from demosplan-ui. They have to be fixed in a separate PR.


### Linked PRs (optional)

Picked from https://github.com/demos-europe/demosplan-core/pull/592

<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
