### PR TITLE
bug(refs: T27370): fix createddate and submitteddate in dp public statement list

### DIFF
--- a/client/js/components/statement/publicStatementLists/DpPublicStatementList.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatementList.vue
@@ -261,8 +261,8 @@ export default {
       const statementParagraph = (paragraph && paragraph.title) || Translator.trans('notspecified')
       const text = statement.text
 
-      const transformedSubmitDate = submitted === false ? {} : { submittedDate: dayjs(submittedDate).format('DD.MM.YYYY HH:mm') }
-      const transformedCreatedDate = dayjs(createdDate).format('DD.MM.YYYY HH:mm')
+      const transformedSubmitDate = submitted === false ? {} : { submittedDate: dayjs.unix(statement.submit).format('DD.MM.YYYY HH:mm') }
+      const transformedCreatedDate = dayjs.unix(statement.createdDate / 1000).format('DD.MM.YYYY HH:mm')
 
       const transformedPolygon = polygon === '' ? {} : JSON.parse(polygon)
 
@@ -290,6 +290,7 @@ export default {
     },
 
     transformStatements (statements) {
+      console.log(statements.map(s => this.transformStatement(s)))
       return statements.map(s => this.transformStatement(s))
     }
   }

--- a/client/js/components/statement/publicStatementLists/DpPublicStatementList.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatementList.vue
@@ -290,7 +290,6 @@ export default {
     },
 
     transformStatements (statements) {
-      console.log(statements.map(s => this.transformStatement(s)))
       return statements.map(s => this.transformStatement(s))
     }
   }


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T27370

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The fix of this issue contains 2 approaches:

- The statement object which will be used to transform the data does not contain a `submittedDate` key but a submit key containing the unix timestamp
- The format of the unix timestamp of `statement.submit` and `statement.createdDate` are not consitent. The `createdDate` contains a 13 digit unix timestamp (miliseconds) and the `submit` only a 10 digit timestamp (seconds) hence a calculation is needed for dayjs to display the correct date (reference: https://day.js.org/docs/en/parse/unix-timestamp) by simply dividing the unix timestamp by 1000
- The values passed to dayjs were undefined and there must be some kind of callback in such cases in dayjs to return the current date. Which I assume was the underlying problem for shared statements containing always the current date in the header field.  

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Navigate to the public detail page of a procedure and have a look at submitted and created statements (e.g. draft statements and shared statement tabs and verify the dates in the header fields of `DpPublicStatement.vue `are correct - see also screenshots)

![image](https://user-images.githubusercontent.com/91727189/212894882-339a928e-0801-48a7-bfbb-e292b5e6d6eb.png)

![image](https://user-images.githubusercontent.com/91727189/212895082-182e436e-5d73-4de8-97b7-ee49406b535d.png)


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
