### PR TITLE
fix(refs T31010): Catch undefined maxExtend

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -278,9 +278,9 @@ export default {
      * @return void
      */
     defineExtent (mapOptions) {
-      if (this._options.procedureExtent && mapOptions.procedureMaxExtent.length !== 0) {
+      if (this._options.procedureExtent && mapOptions.procedureMaxExtent) {
         this.maxExtent = mapOptions.procedureMaxExtent
-      } else if (mapOptions.procedureDefaultMaxExtent.length !== 0) {
+      } else if (mapOptions.procedureDefaultMaxExtent) {
         this.maxExtent = mapOptions.procedureDefaultMaxExtent
       } else {
         this.maxExtent = mapOptions.defaultMapExtent


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31010

As "support" Goto
-> /einstellungen/plattform (Plattform-Einstellungen) 
The Map should load without errors

(there may be other Errors in the Console, but they are not related to this Bug)

There are circumstances, where we don't get a maxExtend. Instead of an empty Array we receive `undefined` which was not expected. 


### PR Checklist

- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
