### PR TITLE
feature (refs T25542): include negativeReport on publicParagraph Route

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -1374,6 +1374,7 @@ class DemosPlanDocumentController extends BaseController
         CurrentProcedureService $currentProcedureService,
         DocumentHandler $documentHandler,
         EditorService $editorService,
+        ElementsService $elementsService,
         Request $request,
         $procedure,
         $elementId,
@@ -1454,6 +1455,10 @@ class DemosPlanDocumentController extends BaseController
             $orgaBranding = $brandingService->createOrgaBrandingFromProcedureId($procedureId);
             $templateVars['orgaBranding'] = $orgaBranding;
         }
+
+        // is the negative statement plannindocument category enabled?
+        $templateVars['planningDocumentsHasNegativeStatement'] =
+            $elementsService->hasNegativeReportElement($procedureId);
 
         $templateVars['procedure'] = $currentProcedureService->getProcedure();
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T25542

It is possible to create statements via route: .../public/paragraph/...
For the statement modal the key ```planningDocumentsHasNegativeStatement```
is needed in order to show the radio button 'Fehlanzeige'

This key was only present via the route: .../public/detail/... and the logic to set this key was simply copied over to be used
for the .../public/paragraph/... route as well.

### How to review/test
See related ticket

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
