### PR TITLE
fix (refs T30990): Escape any special chars for output

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -135,6 +135,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     public function exportStatementSegmentsInSeparateDocx(Statement $statement, Procedure $procedure): PhpWord
     {
         $phpWord = new PhpWord();
+        Settings::setOutputEscapingEnabled(true);
         $section = $phpWord->addSection($this->styles['globalSection']);
         $this->addHeader($section, $procedure);
         $this->exportStatement($section, $statement);


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T30990

In most cases we store texts with already escaped special chars in the database to avoid any later problems. But in some rare cases and for reasons I don't, some special chars make their way into the database. Without the here added line of code (which is present in most if not all other docx exports) those will break the docx generation as that is based on a xml file.
How to review/test

Exporting all statements as a zip with individual docx files should now also produce working docx files for statements with xml breaking special chars (for example '&') in their texts.
