### PR TITLE
fix (refs T31009): add fragments correctly and fix `if` check

### DIFF
--- a/demosplan/DemosPlanStatementBundle/Logic/AssessmentTableExporter/AssessmentTablePdfExporter.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/AssessmentTableExporter/AssessmentTablePdfExporter.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanStatementBundle\Logic\AssessmentTableExporter;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use Exception;
@@ -482,7 +483,7 @@ class AssessmentTablePdfExporter extends AssessmentTableFileExporterAbstract
      * @param array $entityArrayList Array of Statement or Statement Fragment in array form (not object!) which has
      *                               the format that is needed here and the correct set of statements,
      *                               but in the wrong order
-     * @param array $orderedList     Array of Statement objects or Statement Fragment objects that may include
+     * @param array<int|string, UuidEntityInterface> $orderedList Array of Statement objects or Statement Fragment objects that may include
      *                               more than the selected ones, but which has the correct order
      */
     protected function reorderStatementsOrStatementFragmentsAccordingToOtherList(array $entityArrayList, array &$orderedList): array

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -4917,7 +4917,7 @@ class StatementService extends CoreService implements StatementServiceInterface
      */
     private function includeStatementFragments(array $allowedClasses): bool
     {
-        return \in_array(Statement::class, $allowedClasses, true);
+        return \in_array(StatementFragment::class, $allowedClasses, true);
     }
 
     /**
@@ -4932,7 +4932,7 @@ class StatementService extends CoreService implements StatementServiceInterface
         }
 
         if ($this->includeStatementFragments($entityClassesToInclude)) {
-            $explodedStatement->push($statement->getFragments());
+            $explodedStatement->push(...$statement->getFragments());
         }
 
         return $explodedStatement;


### PR DESCRIPTION
Fragments should only get added if requested from the caller. Also, they need to be unpacked, instead of the collection being added to the list.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test

Look at the diff. Local testing may not be possible due to the exporter service not being reachable (broken pipe).

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
