### PR TITLE
bug(refs T27479): Fix bulk edit for documents

### DIFF
--- a/client/js/components/document/ElementsAdminList.vue
+++ b/client/js/components/document/ElementsAdminList.vue
@@ -84,11 +84,9 @@
 </template>
 
 <script>
-import { hasAnyPermissions, hasOwnProp } from '@demos-europe/demosplan-utils'
+import { DpBulkEditHeader, DpLoading, DpTreeList } from '@demos-europe/demosplan-ui'
+import { dpRpc, hasAnyPermissions, hasOwnProp } from '@demos-europe/demosplan-utils'
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { DpBulkEditHeader, DpTreeList } from '@demos-europe/demosplan-ui'
-import { DpLoading } from '@demos-europe/demosplan-ui'
-import { dpRpc } from '@demos-europe/demosplan-utils'
 import ElementsAdminItem from './ElementsAdminItem'
 import lscache from 'lscache'
 
@@ -242,12 +240,12 @@ export default {
       const roots = []
 
       // Initialize children in list elements
-      for (let i = 0; i < list.length; i++) {
-        list[i].children = []
+      for (const [index] of list.entries()) {
+        list[index].children = []
       }
 
-      for (let i = 0; i < list.length; i++) {
-        const node = list[i]
+      for (const [index] of list.entries()) {
+        const node = list[index]
 
         // If not already set, copy the `index` value to an additional field `idx`.
         if (!hasOwnProp(node.attributes, 'idx')) {
@@ -277,11 +275,11 @@ export default {
      */
     nodeSelectionChange (selected) {
       this.selectedFiles = selected
-        .filter(node => node.type === 'singleDocument')
-        .map(el => el.id)
+        .filter(node => node.nodeType === 'leaf')
+        .map(el => el.nodeId)
       this.selectedElements = selected
-        .filter(node => node.type === 'elements')
-        .map(el => el.id)
+        .filter(node => node.nodeType === 'branch')
+        .map(el => el.nodeId)
     },
 
     /**

--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -143,7 +143,8 @@ export default {
     },
 
     nodeSelectionChange (selected) {
-      this.selectedFiles = selected.filter(node => node.type === 'singleDocument')
+      const selectedFilesIds = selected.filter(node => node.nodeType === 'leaf').map(el => el.nodeId)
+      this.selectedFiles = this.allFiles.filter(file => selectedFilesIds.includes(file.id))
     },
 
     /*


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27479

The given objects in the change event for node selection have changed (in DpTreeListNode), so they also need to be changed in the methods listening to that event. 
Also some refactoring.

### How to review/test
Go to Verfahren -> Dokumente and select some documents. There should be a bulk edit header appear, where you can delete or publish the documents. 

### Related PRs:
https://github.com/demos-europe/demosplan-ui/pull/73
