### PR TITLE
feature (refs T27190): pdf attached to a paraDoc gets exportet even if no chapters exists for that specific paraDoc.

### DIFF
--- a/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ExportService.php
@@ -579,12 +579,12 @@ class ExportService
                     $elementTitle = $procedureElement->getTitle();
                     try {
                         $elementFile = $procedureElement->getFile();
+                        if (0 !== strlen($elementFile)) {
+                            $this->zipExportService->addFilePathToZipStream($elementFile, $procedureName.'/'.$this->literals['elements'].'/'.$elementTitle, $zip);
+                        }
                         $agreement = $this->paragraphExporter->generatePdf($procedureId, $elementTitle, $procedureElement->getId());
                         if (null !== $agreement) {
                             $this->zipExportService->addStringToZipStream($procedureName.'/'.$this->literals['elements'].'/'.Utf8::toAscii($elementTitle).'.pdf', $agreement, $zip);
-                            if (0 !== strlen($elementFile)) {
-                                $this->zipExportService->addFilePathToZipStream($elementFile, $procedureName.'/'.$this->literals['elements'].'/'.$elementTitle, $zip);
-                            }
                             $this->logger->info('ParagraphElement created',
                                 ['elementTitle' => $elementTitle, 'id' => $procedureId, 'name' => $procedureName]);
                         } else {


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T27190

Description:
if there was a planningDocument of category paragraph without any chapters but an attached pdf file - this file was excluded
due to a faulty if condition. The document was only attached if the paradoc was not empty.
When exporting a procedure this change assures that a pdf attached to a paraDoc gets exportet even if no chapters exists for that specific paraDoc.

How to test:
Due to a non functional RabbitMQ connection - this can only be testet on dev.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
