### PR TITLE
Add missing mutation to original statements view

### DIFF
--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -187,8 +187,7 @@
 <script>
 import { CleanHtml, DpFlyout, DpHeightLimit } from '@demos-europe/demosplan-ui'
 import { dpApi, formatDate, hasOwnProp } from '@demos-europe/demosplan-utils'
-import { mapGetters, mapState } from 'vuex'
-
+import { mapGetters, mapMutations, mapState } from 'vuex'
 
 export default {
   name: 'OriginalStatementsTableItem',
@@ -301,6 +300,10 @@ export default {
   },
 
   methods: {
+    ...mapMutations('statement', [
+      'updateStatement'
+    ]),
+
     formatDate (date) {
       return formatDate(date)
     },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31094

While the mutation is called in the event handler, it was nowhere imported. This breaks the whole thing.

### How to review/test
In the "Originalstellungnahmen" view, find a statement that is long enough to have the "Mehr anzeigen +" button below the statement text. This button should be functional.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
