### PR TITLE
feature (refs T25539): display actual date instead of ### in xlsx export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Consultation/BulkLetterExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Consultation/BulkLetterExporter.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\Export\XlsxExporter;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class BulkLetterExporter extends XlsxExporter
@@ -99,12 +100,17 @@ class BulkLetterExporter extends XlsxExporter
     {
         $sheet = $this->spreadsheet->getActiveSheet();
 
-        $sheet->getDefaultColumnDimension()->setWidth(24);
-
         // Set column to display as date
         $sheet->getStyle('J:J')
             ->getNumberFormat()
             ->setFormatCode('dd.mm.yyyy');
+        $sheet->getStyle('J:J')
+            ->getAlignment()
+            ->setHorizontal(Alignment::HORIZONTAL_LEFT);
+
+        $sheet->getDefaultColumnDimension()->setWidth(24);
+        // T25539 The Date does not seem to care about a default width - it needs to be told extra
+        $sheet->getColumnDimension('J')->setWidth(24);
     }
 
     /**


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T25539

Description:
the date gets displayed
as ### if not enough space is provided
to fit in the dateString.
Despite having set a default width - the date
cell needs to be told again about its Width.
Adjusted its alignment to match the others.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
