### PR TITLE
fix: Repair addons.yaml format

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
@@ -66,7 +66,7 @@ final class Registrator
             'addons' => $this->addons,
         ];
 
-        $content = '# This file is auto-generated and should not be edited manually unless you know what you\'re doing.';
+        $content = "# This file is auto-generated and should not be edited manually unless you know what you're doing.\n";
         $content .= Yaml::dump($yamlContent, self::ADDON_YAML_INLINE_DEPTH);
 
         file_put_contents(


### PR DESCRIPTION
The auto-generation info was lacking a newline and thus broke the loading as the format of the saved yaml was not parsable anymore.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
