### PR TITLE
feature (refs T31158): add statement synced in source / target to procedureReportEntryExport

### DIFF
--- a/demosplan/DemosPlanReportBundle/Logic/ExportReportService.php
+++ b/demosplan/DemosPlanReportBundle/Logic/ExportReportService.php
@@ -290,6 +290,8 @@ class ExportReportService extends CoreService
                 ReportEntry::CATEGORY_DELETE_ATTACHMENTS,
                 ReportEntry::CATEGORY_DELETE_TEXT_FIELD_HISTORY,
                 ReportEntry::CATEGORY_MOVE,
+                ReportEntry::CATEGORY_STATEMENT_SYNC_INSOURCE,
+                ReportEntry::CATEGORY_STATEMENT_SYNC_INTARGET,
             ]
         );
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31158

Description:
add statement synced in source / target to procedureReportEntryExport by imply adding the categories for the db-query.

These changes are very similar to:
https://github.com/demos-europe/demosplan-core/pull/722

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
