### PR TITLE
feat: Avoid call to elasticsearch to fix tests

### DIFF
--- a/demosplan/DemosPlanStatementBundle/Logic/StatementFragmentService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementFragmentService.php
@@ -876,7 +876,7 @@ class StatementFragmentService extends CoreService
      */
     public function areAllFragmentsClaimedByCurrentUser($statementId): bool
     {
-        $fragments = $this->getStatementFragmentsStatementES($statementId, [])->getResult();
+        $fragments = $this->getStatementFragmentsStatement($statementId);
         foreach ($fragments as $fragment) {
             if (!$this->isFragmentAssignedToCurrentUser($fragment)) {
                 return false;
@@ -895,9 +895,9 @@ class StatementFragmentService extends CoreService
      */
     public function isNoFragmentAssignedToReviewer($statementId): bool
     {
-        $fragments = $this->getStatementFragmentsStatementES($statementId, [])->getResult();
+        $fragments = $this->getStatementFragmentsStatement($statementId);
         foreach ($fragments as $fragment) {
-            if (null !== $fragment['departmentId']) {
+            if (null !== $fragment->getDepartmentId()) {
                 return false;
             }
         }


### PR DESCRIPTION
Some functional tests are skipped due to the need of elasticsearch which is not available in CI.

### How to review/test
Copy and clustering of StatementFragments should work as before

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
