### PR TITLE
Fix phpstan issues with isset

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -737,7 +737,7 @@ class DemosPlanAssessmentTableController extends BaseController
         if (0 === count($statementAsArray)) {
             $this->getMessageBag()->add('error', 'error.statement.not.found');
 
-            $redirectReturn = $redirectReturn ?? $this->redirectToRoute(
+            $redirectReturn = $this->redirectToRoute(
                 'dplan_assessmenttable_view_table',
                 [
                     'procedureId' => $procedureId,

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -1784,8 +1784,8 @@ class DemosPlanDocumentController extends BaseController
                 $this->getLogger()->warning('Could not find file to add to zip', [$fileEntity->getId()]);
                 continue;
             }
-            // $fileName is nullable. If for some reasons it is null, better use a random string than fail
-            $fileName = $fileName ?? random_bytes(10);
+            // $fileName might be an empty string. If for some reasons it is empty, better use a random string than fail
+            $fileName = '' === $fileName ? random_bytes(10) : $fileName;
             $fileNamedPath = $elementHandler->getFileNamedPath($fileRequestInfo['path'], $fileName);
             $fileInfo[$singleDocId] = [
                 'fullPath'  => $fileFullPath,

--- a/demosplan/DemosPlanCoreBundle/Entity/File.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/File.php
@@ -354,11 +354,9 @@ class File extends CoreEntity implements UuidEntityInterface, FileInterface
     /**
      * Set filename.
      *
-     * @param string $filename
-     *
      * @return File
      */
-    public function setFilename($filename)
+    public function setFilename(?string $filename)
     {
         $this->filename = $this->sanitizeFilename($filename);
 
@@ -367,10 +365,8 @@ class File extends CoreEntity implements UuidEntityInterface, FileInterface
 
     /**
      * Get filename.
-     *
-     * @return string
      */
-    public function getFilename()
+    public function getFilename(): string
     {
         // do not allow invalid chars in Filenames
         $this->filename = $this->sanitizeFilename($this->filename);
@@ -390,12 +386,10 @@ class File extends CoreEntity implements UuidEntityInterface, FileInterface
 
     /**
      * Strip invalid chars from filename.
-     *
-     * @param string $filename
      */
-    protected function sanitizeFilename($filename): string
+    protected function sanitizeFilename(?string $filename): string
     {
-        return str_ireplace(FileService::INVALID_FILENAME_CHARS, '', $filename);
+        return str_ireplace(FileService::INVALID_FILENAME_CHARS, '', $filename ?? '');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
@@ -479,9 +479,7 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      */
     public function getMessageDecoded(bool $fixOrigMessage): array
     {
-        $return = $this->getDecoded($this->message, $fixOrigMessage);
-
-        return $return ?? [];
+        return $this->getDecoded($this->message, $fixOrigMessage);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementMeta.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementMeta.php
@@ -307,7 +307,7 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
     public function getSubmitLastName(): string
     {
         $pieces = explode(' ', $this->submitName);
-        if (is_array($pieces) && !empty($pieces)) {
+        if (1 !== count($pieces)) {
             return $pieces[count($pieces) - 1];
         }
 
@@ -387,7 +387,7 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
     public function getCaseWorkerLastName()
     {
         $pieces = explode(' ', $this->caseWorkerName);
-        if (is_array($pieces) && !empty($pieces)) {
+        if (1 !== count($pieces)) {
             return $pieces[count($pieces) - 1];
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeRollbackVersionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeRollbackVersionService.php
@@ -110,7 +110,7 @@ class EntityContentChangeRollbackVersionService extends CoreService
             $string = $service->removeLineBreaksAtHtmlDelimitersFromTipTapString($string);
         }
 
-        return $string ?? '';
+        return $string;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -133,7 +133,7 @@ class ZipExportService
             $this->logger->warning('Could not add file to Zip',
                 [
                     'file'      => $filePath,
-                    'path'      => $zipPath ?? '',
+                    'path'      => $zipPath,
                     'exception' => $e->getMessage(),
                 ]);
         }
@@ -155,7 +155,6 @@ class ZipExportService
         string ...$fileStrings): void
     {
         foreach ($fileStrings as $fileString) {
-            $path = '';
             try {
                 $fileInfo = $this->fileService->getFileInfoFromFileString($fileString);
 
@@ -174,7 +173,7 @@ class ZipExportService
                 $this->logger->warning('Could not add file to Zip',
                     [
                         'fileString' => $fileString ?? '',
-                        'path'       => $path ?? '',
+                        'path'       => '',
                     ]
                 );
             }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/LegacyResult.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/LegacyResult.php
@@ -55,7 +55,7 @@ class LegacyResult extends ValueObject
         $this->filterSet = $filterSet;
         $this->sortingSet = $sortingSet;
         $this->total = $total;
-        $this->search = $search ?? '';
+        $this->search = $search;
     }
 
 

--- a/demosplan/DemosPlanProcedureBundle/Logic/ProcedureToLegacyConverter.php
+++ b/demosplan/DemosPlanProcedureBundle/Logic/ProcedureToLegacyConverter.php
@@ -210,7 +210,7 @@ class ProcedureToLegacyConverter extends CoreService
      * Convert Result to Legacy.
      *
      * @param array  $list
-     * @param string $search
+     * @param string|null $search
      * @param array  $aggregation Elasticsearch aggregation converted to legacy
      *
      * @internal param array $filter

--- a/demosplan/DemosPlanReportBundle/Logic/ReportMessageConverter.php
+++ b/demosplan/DemosPlanReportBundle/Logic/ReportMessageConverter.php
@@ -142,7 +142,7 @@ class ReportMessageConverter
             $message = '';
         }
 
-        return $message ?? '';
+        return $message;
     }
 
     /**

--- a/demosplan/DemosPlanStatementBundle/Logic/DraftStatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/DraftStatementService.php
@@ -257,7 +257,7 @@ class DraftStatementService extends CoreService
      *
      * @param string      $procedureId
      * @param string      $scope
-     * @param string      $search
+     * @param string|null $search
      * @param array|null  $sort
      * @param User        $user
      * @param string|null $manualSortScope
@@ -1384,7 +1384,6 @@ class DraftStatementService extends CoreService
      * Convert Result to Legacy.
      *
      * @param array       $list
-     * @param string      $search
      * @param array|null  $filters
      * @param array|null  $sort
      * @param string|null $manualSortScope
@@ -1393,7 +1392,7 @@ class DraftStatementService extends CoreService
      *
      * @internal param array $filter
      */
-    protected function toLegacyResult($list, $search = '', $filters = [], $sort = [], $manualSortScope = null, $aggregation = [], $procedureId): DraftStatementResult
+    protected function toLegacyResult($list, ?string $search = '', $filters = [], $sort = [], $manualSortScope = null, $aggregation = [], $procedureId): DraftStatementResult
     {
         // Is the list manually sorted?
         $sorted['sorted'] = false;

--- a/demosplan/DemosPlanStatementBundle/Logic/ElasticSearchService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/ElasticSearchService.php
@@ -499,7 +499,7 @@ class ElasticSearchService extends CoreService
     /**
      * Convert Result to Legacy.
      *
-     * @param string $search
+     * @param string|null $search
      * @param array  $filters
      * @param array  $sort
      * @param string $resultKey

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementFragmentService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementFragmentService.php
@@ -1184,7 +1184,7 @@ class StatementFragmentService extends CoreService
                 // special format:
                 // tags:
                 $decoded = Json::decodeToMatchingType($latestVersion['tagAndTopicNames']);
-                $topics = $decoded ?? [];
+                $topics = is_array($decoded) ? $decoded : [];
                 $tagsOfVersion = \collect([]);
                 foreach ($topics as $topicTitle => $tags) {
                     $newTag = \collect([]);
@@ -1199,7 +1199,7 @@ class StatementFragmentService extends CoreService
                 // counties:
                 $result[$key]['counties'] = [];
                 $decoded = Json::decodeToMatchingType($latestVersion['countyNamesAsJson']);
-                $countyNames = $decoded ?? [];
+                $countyNames = is_array($decoded) ? $decoded : [];
                 foreach ($countyNames as $countyName) {
                     $result[$key]['counties'][]['name'] = $countyName;
                 }
@@ -1207,7 +1207,7 @@ class StatementFragmentService extends CoreService
                 // municipalities:
                 $result[$key]['municipalities'] = [];
                 $decoded = Json::decodeToMatchingType($latestVersion['municipalityNamesAsJson']);
-                $municipalityNames = $decoded ?? [];
+                $municipalityNames = is_array($decoded) ? $decoded : [];
                 foreach ($municipalityNames as $municipalityName) {
                     $result[$key]['municipalities'][]['name'] = $municipalityName;
                 }
@@ -1215,7 +1215,7 @@ class StatementFragmentService extends CoreService
                 // priorityAreas:
                 $result[$key]['priorityAreas'] = [];
                 $decoded = Json::decodeToMatchingType($latestVersion['priorityAreaNamesAsJson']);
-                $priorityAreaKeys = $decoded ?? [];
+                $priorityAreaKeys = is_array($decoded) ? $decoded : [];
                 foreach ($priorityAreaKeys as $priorityAreaKey) {
                     $result[$key]['priorityAreas'][]['key'] = $priorityAreaKey;
                 }


### PR DESCRIPTION
Phpstan found several issues about variables that are checked for null that are not described to be null. Some of them could be resolved by adding null to return type hints. Might be best to be reviewed commitwise

### How to review/test
 Might be best to be reviewed commitwise. Run phpstan to see the effects

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
