### PR TITLE
chore: add missing override hook to permissions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -943,6 +943,11 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         $this->permissions['feature_statements_released_email']['enabled'] = true; // Eigene Stellungnahmen (Freigaben) E-Mail
     }
 
+    protected function setProcedurePermissionsetWrite(): void
+    {
+        // hook that may be overridden
+    }
+
     /**
      * Prüfe, ob ein bestimmtes Permissionset für die Rolle in dem Verfahren gilt.
      *


### PR DESCRIPTION
`Permissions` lacked a hook `setProcedurePermissionsetWrite` that is used in every childclass and better should be defined in parent

### How to review/test
code review

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
