### PR TITLE
feature (refs T26712): put empty filters back to es aggregations

### DIFF
--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -3471,7 +3471,8 @@ class StatementService extends CoreService implements StatementServiceInterface
             }
 
             $aggregations = $resultSet->getAggregations();
-            if (0 === $result['hits']['total']) {
+            $totalHits = $result['hits']['total'];
+            if (is_array($totalHits) && array_key_exists('value', $totalHits) && 0 === $totalHits['value']) {
                 $aggregations = $this->addFilterToAggregationsWhenCausedResultIsEmpty($aggregations, $userFilters);
             }
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T26712

Description:
adjust prev fix to match new es aggregations structure.
( https://github.com/demos-europe/demosplan-core/pull/73 )
probably changed due to an es update. 
I checked bimschgsh, robobsh, blp - the old structure is not in use anymore.


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
