### PR TITLE
fix(T29716): missing relationships in store after update

### DIFF
--- a/client/js/components/user/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserFormFields.vue
@@ -251,22 +251,28 @@ export default {
      * - user is set: roles for current organisation
      */
     allowedRolesForOrga () {
-      let allowedRoles = this.rolesInRelationshipFormat
-      if (this.currentUserOrga.id !== '' && hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
+      let allowedRoles
+
+      if (this.currentUserOrga.id === '') {
+        allowedRoles = this.rolesInRelationshipFormat
+      } else if (hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
         allowedRoles = Object.values(this.organisations[this.currentUserOrga.id].relationships.allowedRoles.list())
-      } else if (this.currentUserOrga.id !== '' && !hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
+      } else {
         allowedRoles = this.getOrgaAllowedRoles(this.currentUserOrga.id)
       }
+
       return allowedRoles
     },
 
     currentOrgaDepartments () {
       const departments = sortAlphabetically(Object.values(this.currentUserOrga.departments), 'name')
       const noDepartmentIdx = departments.findIndex(el => el.name === Translator.trans('department.none'))
+
       if (noDepartmentIdx > -1) {
         const noDepartment = departments.splice(noDepartmentIdx, 1)[0]
         departments.unshift(noDepartment)
       }
+
       return departments
     },
 
@@ -349,6 +355,7 @@ export default {
      */
     getOrgaAllowedRoles (orgaId) {
       let allowedRoles = this.rolesInRelationshipFormat
+
       this.fetchOrgaById(orgaId).then((orga) => {
         this.setOrga(orga.data.data)
         if (hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
@@ -465,7 +472,7 @@ export default {
         relationships: {
           allowedRoles: {
             data: payloadRel.allowedRoles?.data[0].id
-              ? payloadRel.allowedRoles?.data.map(el => {
+              ? payloadRel.allowedRoles.data.map(el => {
                 return {
                   ...el,
                   type: 'role'
@@ -481,7 +488,7 @@ export default {
           },
           departments: {
             data: payloadRel.departments?.data[0].id
-              ? payloadRel.departments?.data.map(el => {
+              ? payloadRel.departments.data.map(el => {
                 return {
                   ...el,
                   type: 'department'
@@ -491,6 +498,7 @@ export default {
           }
         }
       }
+
       this.setItem(payloadWithNewType)
     }
   },

--- a/client/js/components/user/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserFormFields.vue
@@ -252,10 +252,9 @@ export default {
      */
     allowedRolesForOrga () {
       let allowedRoles = this.rolesInRelationshipFormat
-
-      if (this.currentUserOrga.id !== '' && hasOwnProp(this.$store.state.orga.items[this.currentUserOrga.id].relationships, 'allowedRoles')) {
-        allowedRoles = Object.values(this.$store.state.orga.items[this.currentUserOrga.id].relationships.allowedRoles.list())
-      } else if (this.currentUserOrga.id !== '' && !hasOwnProp(this.$store.state.orga.items[this.currentUserOrga.id].relationships, 'allowedRoles')) {
+      if (this.currentUserOrga.id !== '' && hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
+        allowedRoles = Object.values(this.organisations[this.currentUserOrga.id].relationships.allowedRoles.list())
+      } else if (this.currentUserOrga.id !== '' && !hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
         allowedRoles = this.getOrgaAllowedRoles(this.currentUserOrga.id)
       }
       return allowedRoles
@@ -337,6 +336,9 @@ export default {
       return new Promise((resolve, reject) => resolve(true))
     },
 
+    /**
+     *  Handle cases in which allowedRoles are missing in the orga relationships (after user update action)
+     */
     getOrgaAllowedRoles (orgaId) {
       let allowedRoles = []
       this.getOrganisations().then(() => {

--- a/client/js/components/user/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserFormFields.vue
@@ -344,15 +344,17 @@ export default {
       return new Promise((resolve, reject) => resolve(true))
     },
 
+    /**
+     *  Handle cases in which organisation lost allowedRoles from the relationships after user update action
+     *  a separate method is used to avoid fetching allowedRoles by mounting (DpUserList component fetches orga.allowedRoles)
+     *  @param types {String}
+     */
     fetchOrgaById (orgaId) {
       const url = Routing.generate('dplan_api_orga_get', { id: orgaId })
 
       return dpApi.get(url, { include: ['allowedRoles', 'departments'].join() })
     },
 
-    /**
-     *  Handle cases in which allowedRoles are missing in the orga relationships (after user update action)
-     */
     getOrgaAllowedRoles (orgaId) {
       let allowedRoles = this.rolesInRelationshipFormat
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29716

**Description:** This PR fixes an issue with `orga` relationships after vuex store update. Once the `saveAction` method is triggered in the **DpUserFormFields** component (`module: user, action: update, url: /1.0/user/{id}`), the response we get overrides the store and `orga` lost `allowedRoles` from the relationships. 

An additional check was added for that case. It checks if `orga` has `allowedRoles` property in the relationships, if not it re-fetches organization with the `allowedRoles`

**How to review/test**
login with Demos Support > take user from the list > select a new organisation/role > click on save button 

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
