### PR TITLE
Fix(refs:T25930): Add boilerplate and link-button in tiptap for consideration

### DIFF
--- a/client/js/components/statement/assessmentTable/Fragment.vue
+++ b/client/js/components/statement/assessmentTable/Fragment.vue
@@ -353,6 +353,8 @@ useful info about the component:
             field-key="fragment.considerationAdvice"
             :editable="isClaimed && editableConsiderationAdvice"
             edit-label="fragment.considerationAdvice"
+            link-button
+            :boiler-plate="hasPermission('area_admin_boilerplates')"
             height-limit-element-label="fragment"
             @field:save="saveFragment"
             ref="considerationAdvice"
@@ -369,6 +371,8 @@ useful info about the component:
             field-key="consideration"
             :editable="isClaimed && editableConsideration"
             edit-label="fragment.consideration"
+            link-button
+            :boiler-plate="hasPermission('area_admin_boilerplates')"
             height-limit-element-label="fragment"
             @field:save="saveFragment"
             ref="consideration"


### PR DESCRIPTION
**Ticket:** [https://yaits.demos-deutschland.de/Txxyyzz -->](https://yaits.demos-deutschland.de/T25930)

**Description:**

- boilerplate is missing in tiptap in consideration
- added link button, too, like in the screenshot in ticket

### How to review/test

- go to AT in `Datensätze` and claim a `Datensatz` and go to the section `Begründung`, look to the options if you would like to write or edit something

*important:* 

- the vue error you will see here is because assignee id is null and its fixed in another PR
- so, if you would like to test it, you need an existing claimed `Datensatz`, because the other PR is not merged yet

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-core/pull/737


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
