### PR TITLE
feature (refs T25516): add bom at start of csv file in order to make MS-excel display umlauts correctly

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
@@ -41,6 +41,7 @@ class DemosPlanAdminController extends BaseController
      *     path="/statistik/{part}/csv",
      *     defaults={"format": "csv"},
      * )
+     *
      * @DplanPermissions("area_statistics")
      *
      * @param string $part

--- a/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
@@ -123,6 +123,9 @@ class DemosPlanAdminController extends BaseController
             'title'        => $title,
             'part'         => $part,
         ]);
+        // T25516 UTF-8-MB for MS-excel umlauts support
+        $bom = chr(0xEF).chr(0xBB).chr(0xBF);
+        $response->setContent($bom.$response->getContent());
         $filename = 'export_'.$part.'_'.date('Y_m_d_His').'.csv';
         $response->headers->set('Content-Type', 'text/csv');
         $response->headers->set('Content-Disposition', $this->generateDownloadFilename($filename));

--- a/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
@@ -36,6 +36,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development",
      *     path="/development"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @return RedirectResponse|Response
@@ -85,6 +86,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_new",
      *     path="/development/release/new"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @return RedirectResponse|Response
@@ -128,6 +130,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_edit",
      *     path="/development/{releaseId}/edit"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @param string $releaseId
@@ -174,6 +177,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_delete",
      *     path="/development/delete/{releaseId}/{token}"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @param string $releaseId
@@ -212,6 +216,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_list",
      *     path="/development/release/list"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @return RedirectResponse|Response
@@ -244,6 +249,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_detail",
      *     path="/development/{releaseId}"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $releaseId
@@ -303,6 +309,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_voting",
      *     path="/development/{releaseId}/voting"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $releaseId
@@ -391,6 +398,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_new",
      *     path="/development/{releaseId}/story/new"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
@@ -435,6 +443,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_edit",
      *     path="/development/{releaseId}/story/edit/{storyId}"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
@@ -488,6 +497,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_delete",
      *     path="/development/{releaseId}/story/delete/{storyId}/{token}"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
@@ -522,6 +532,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_detail",
      *     path="/development/story/{storyId}"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
@@ -602,6 +613,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_threadentry_new",
      *     path="/development/{storyId}/entry/new"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
@@ -666,6 +678,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_threadentry_edit",
      *     path="/development/{storyId}/entry/{threadEntryId}/edit"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
@@ -771,6 +784,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_userstory_threadentry_delete",
      *     path="/development/{storyId}/entry/{threadEntryId}/delete/{token}"
      * )
+     *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
@@ -829,6 +843,7 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      *     name="DemosPlan_forum_development_release_export",
      *     path="/development/{releaseId}/export"
      * )
+     *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @return RedirectResponse|Response

--- a/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
@@ -877,7 +877,9 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
             'templateVars' => $templateVars,
             'title'        => 'forum.development.story.threadentry.delete',
         ]);
-
+        // T25516 UTF-8-MB for MS-excel umlauts support
+        $bom = chr(0xEF).chr(0xBB).chr(0xBF);
+        $response->setContent($bom.$response->getContent());
         $filename = 'export_'.$part.'_'.date('Y_m_d_His').'.csv';
         $response->headers->set('Content-Type', 'text/csv');
         $response->headers->set('Content-Disposition', $this->generateDownloadFilename($filename));


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T25516

Description:
add bom at start of csv file in order to make MS-excel display umlauts correctly.
Tried a few things like ```mb_convert_encoding``` within the setEscaper Callback for every word... 
but in the end only this did the trick.

### How to review/test
Unfortunately you need to have MS-Excel in order to test this.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
