### PR TITLE
fix(refs:T25931): Add strikethrough and remove insertAndDelete

### DIFF
--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/shared/v1/assessment_statement_detail_statement_text.html.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/shared/v1/assessment_statement_detail_statement_text.html.twig
@@ -25,9 +25,9 @@
                                     hidden-input="r_text"
                                     procedure-id="{{ templateVars.table.procedure.ident }}"
                                     :toolbar-items="{
-                                        insertAndDelete: true,
+                                        mark: true,
                                         obscure: hasPermission('feature_obscure_text'),
-                                        mark: true
+                                        strikethrough: true
                                     }"
                                     :value="JSON.parse('{{ statement.text|json_encode|e('js') }}')">
                                 </dp-editor>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T25931

**Description:** 

- in detail view of a statement, if you would like to edit the statement of a claimed statement, in tiptap the option  `Durchstreichen` is missing and `Als hinzugefügt markieren` and  `Als entfernt markieren` are not needed here
- because there should be the same options like if you claim and edit the statement without using the detailview

### How to review/test

- go to AT, claim a statement, go to detailview and edit this statement

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
