### PR TITLE
feat(refs T31218): Fix docx encoding

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -44,6 +44,7 @@ use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Html;
+use PhpOffice\PhpWord\Style\Language;
 use PhpOffice\PhpWord\Writer\WriterInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
@@ -529,6 +530,7 @@ class DocxExporter
         Settings::setOutputEscapingEnabled(true);
         // https://stackoverflow.com/questions/33267654/
         $phpWord->getSettings()->setUpdateFields(true);
+        $phpWord->getSettings()->setThemeFontLang(new Language(Language::DE_DE));
 
         // http://phpword.readthedocs.org/en/latest/index.html
         // https://github.com/PHPOffice/PHPWord


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31218

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The default output encoding of PhpWord is en_US which leads to issues in post processing as they don't have all the beautiful umlauts.

In the future, we might need to make this dependent on the application or project locale, but for now, setting it to german should be enough.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Export to a docx, open in M$ Word, be happy about the correct language setting. Or just move on with life.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
