### PR TITLE
bug(refs T31159): Add check for empty array

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -278,9 +278,9 @@ export default {
      * @return void
      */
     defineExtent (mapOptions) {
-      if (this._options.procedureExtent && mapOptions.procedureMaxExtent) {
+      if (this._options.procedureExtent && mapOptions.procedureMaxExtent && mapOptions.procedureMaxExtent.length > 0) {
         this.maxExtent = mapOptions.procedureMaxExtent
-      } else if (mapOptions.procedureDefaultMaxExtent) {
+      } else if (mapOptions.procedureDefaultMaxExtent && mapOptions.procedureDefaultMaxExtent.length > 0) {
         this.maxExtent = mapOptions.procedureDefaultMaxExtent
       } else {
         this.maxExtent = mapOptions.defaultMapExtent


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31159

Map wasn't loading when the procedure extent was empty, because we didn't check for empty arrays.

## How to review/test

Go to Verfahren -> Grundeinstellungen -> Verortung. You should see the map and be able to use the search. 
