### PR TITLE
feature (refs T31096): Show statement attachments in originalSTNView

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -278,9 +278,9 @@ export default {
      * @return void
      */
     defineExtent (mapOptions) {
-      if (this._options.procedureExtent && mapOptions.procedureMaxExtent) {
+      if (this._options.procedureExtent && mapOptions.procedureMaxExtent && mapOptions.procedureMaxExtent.length > 0) {
         this.maxExtent = mapOptions.procedureMaxExtent
-      } else if (mapOptions.procedureDefaultMaxExtent) {
+      } else if (mapOptions.procedureDefaultMaxExtent && mapOptions.procedureDefaultMaxExtent.length > 0) {
         this.maxExtent = mapOptions.procedureDefaultMaxExtent
       } else {
         this.maxExtent = mapOptions.defaultMapExtent

--- a/composer.lock
+++ b/composer.lock
@@ -1645,16 +1645,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.14.2",
+            "version": "1.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "ad785217c1e9555a7d6c6c8c9f406395a5e2882b"
+                "reference": "fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ad785217c1e9555a7d6c6c8c9f406395a5e2882b",
-                "reference": "ad785217c1e9555a7d6c6c8c9f406395a5e2882b",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af",
+                "reference": "fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af",
                 "shasum": ""
             },
             "require": {
@@ -1715,9 +1715,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.14.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.14.3"
             },
-            "time": "2022-12-15T06:48:22+00:00"
+            "time": "2023-02-01T09:20:38+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -3035,16 +3035,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "2.5.6",
+            "version": "2.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "7729fc2a7e5efc8bbfa408a3b8adeb8f5b84f5d1"
+                "reference": "e36f22765f4d10a7748228babbf73da5edfeed3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/7729fc2a7e5efc8bbfa408a3b8adeb8f5b84f5d1",
-                "reference": "7729fc2a7e5efc8bbfa408a3b8adeb8f5b84f5d1",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/e36f22765f4d10a7748228babbf73da5edfeed3c",
+                "reference": "e36f22765f4d10a7748228babbf73da5edfeed3c",
                 "shasum": ""
             },
             "require": {
@@ -3117,7 +3117,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/2.5.6"
+                "source": "https://github.com/doctrine/persistence/tree/2.5.7"
             },
             "funding": [
                 {
@@ -3133,7 +3133,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T18:11:10+00:00"
+            "time": "2023-02-03T15:51:16+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -6376,21 +6376,21 @@
         },
         {
             "name": "knpuniversity/oauth2-client-bundle",
-            "version": "v2.12.0",
+            "version": "v2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/knpuniversity/oauth2-client-bundle.git",
-                "reference": "d162e3da5d2fd6e71401de8ce23c75abe1457a05"
+                "reference": "f7fe73e98f193503b8aaf2e11f50a0d72539dc7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/knpuniversity/oauth2-client-bundle/zipball/d162e3da5d2fd6e71401de8ce23c75abe1457a05",
-                "reference": "d162e3da5d2fd6e71401de8ce23c75abe1457a05",
+                "url": "https://api.github.com/repos/knpuniversity/oauth2-client-bundle/zipball/f7fe73e98f193503b8aaf2e11f50a0d72539dc7c",
+                "reference": "f7fe73e98f193503b8aaf2e11f50a0d72539dc7c",
                 "shasum": ""
             },
             "require": {
                 "league/oauth2-client": "^2.0",
-                "php": ">=7.2.5",
+                "php": ">=7.4",
                 "symfony/dependency-injection": "^4.4|^5.0|^6.0",
                 "symfony/framework-bundle": "^4.4|^5.0|^6.0",
                 "symfony/http-foundation": "^4.4|^5.0|^6.0",
@@ -6430,9 +6430,9 @@
             ],
             "support": {
                 "issues": "https://github.com/knpuniversity/oauth2-client-bundle/issues",
-                "source": "https://github.com/knpuniversity/oauth2-client-bundle/tree/v2.12.0"
+                "source": "https://github.com/knpuniversity/oauth2-client-bundle/tree/v2.13.1"
             },
-            "time": "2023-01-31T15:00:52+00:00"
+            "time": "2023-02-03T13:57:47+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -12078,16 +12078,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.19",
+            "version": "v5.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "99dae35f2b7d1bd9b800fcda4173215fc9f79ba3"
+                "reference": "8185ed0df129005a26715902f1a53bad0fe67102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/99dae35f2b7d1bd9b800fcda4173215fc9f79ba3",
-                "reference": "99dae35f2b7d1bd9b800fcda4173215fc9f79ba3",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8185ed0df129005a26715902f1a53bad0fe67102",
+                "reference": "8185ed0df129005a26715902f1a53bad0fe67102",
                 "shasum": ""
             },
             "require": {
@@ -12147,7 +12147,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.19"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.20"
             },
             "funding": [
                 {
@@ -12163,7 +12163,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-23T15:37:22+00:00"
+            "time": "2023-01-27T11:08:11+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -13406,16 +13406,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.19",
+            "version": "v5.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0"
+                "reference": "d0435363362a47c14e9cf50663cb8ffbf491875a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0",
-                "reference": "70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d0435363362a47c14e9cf50663cb8ffbf491875a",
+                "reference": "d0435363362a47c14e9cf50663cb8ffbf491875a",
                 "shasum": ""
             },
             "require": {
@@ -13462,7 +13462,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.19"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.20"
             },
             "funding": [
                 {
@@ -13478,20 +13478,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-01-29T11:11:52+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.19",
+            "version": "v5.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ee371cd7718c938d1bffdf868b665003aeeae69c"
+                "reference": "aaeec341582d3c160cc9ecfa8b2419ba6c69954e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ee371cd7718c938d1bffdf868b665003aeeae69c",
-                "reference": "ee371cd7718c938d1bffdf868b665003aeeae69c",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/aaeec341582d3c160cc9ecfa8b2419ba6c69954e",
+                "reference": "aaeec341582d3c160cc9ecfa8b2419ba6c69954e",
                 "shasum": ""
             },
             "require": {
@@ -13574,7 +13574,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.19"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.20"
             },
             "funding": [
                 {
@@ -13590,7 +13590,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-24T13:37:42+00:00"
+            "time": "2023-02-01T08:18:48+00:00"
         },
         {
             "name": "symfony/inflector",

--- a/composer.lock
+++ b/composer.lock
@@ -20184,21 +20184,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.15.10",
+            "version": "0.15.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "000bfb6f7974449399f39e1a210458395b75c887"
+                "reference": "9b9b8ed4d918abcd999f4a7c2575834a8aede929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/000bfb6f7974449399f39e1a210458395b75c887",
-                "reference": "000bfb6f7974449399f39e1a210458395b75c887",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9b9b8ed4d918abcd999f4a7c2575834a8aede929",
+                "reference": "9b9b8ed4d918abcd999f4a7c2575834a8aede929",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.9.7"
+                "phpstan/phpstan": "^1.9.14"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -20213,7 +20213,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "0.14-dev"
+                    "dev-main": "0.15-dev"
                 }
             },
             "autoload": {
@@ -20228,7 +20228,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.15.10"
+                "source": "https://github.com/rectorphp/rector/tree/0.15.12"
             },
             "funding": [
                 {
@@ -20236,7 +20236,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-21T14:30:16+00:00"
+            "time": "2023-02-03T17:49:48+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType;
 
 use Carbon\Carbon;
 
+use EDT\ConditionFactory\ConditionGroupFactoryInterface;
 use function collect;
 
 use DateTime;
@@ -104,10 +105,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
      * @var CustomerService
      */
     protected $currentCustomerService;
-    /**
-     * @var ConditionFactoryInterface
-     */
-    protected $conditionFactory;
+
+    protected DqlConditionFactory $conditionFactory;
 
     private TypeProviderInterface $typeProvider;
 

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -13,10 +13,6 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType;
 
 use Carbon\Carbon;
-
-use EDT\ConditionFactory\ConditionGroupFactoryInterface;
-use function collect;
-
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\GetPropertiesEventInterface;
@@ -33,7 +29,6 @@ use demosplan\DemosPlanCoreBundle\Logic\ResourceTypeService;
 use demosplan\DemosPlanProcedureBundle\Logic\CurrentProcedureService;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use demosplan\DemosPlanUserBundle\Logic\CustomerService;
-use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
 use EDT\JsonApi\RequestHandling\MessageFormatter;
@@ -49,14 +44,14 @@ use EDT\Wrapping\Contracts\Types\ExposableRelationshipTypeInterface;
 use EDT\Wrapping\Contracts\Types\TypeInterface;
 use EDT\Wrapping\Properties\UpdatableRelationship;
 use EDT\Wrapping\WrapperFactories\WrapperObjectFactory;
-
-use function in_array;
-use function is_array;
-
 use IteratorAggregate;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+
+use function collect;
+use function in_array;
+use function is_array;
 
 /**
  * @template T of object

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementAttachmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementAttachmentResourceType.php
@@ -33,22 +33,12 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class StatementAttachmentResourceType extends DplanResourceType implements CreatableDqlResourceTypeInterface
 {
-    /**
-     * @var StatementResourceType
-     */
-    private $statementResourceType;
 
-    /**
-     * @var FileService
-     */
-    private $fileService;
 
     public function __construct(
-        FileService $fileService,
-        StatementResourceType $statementResourceType
+        private readonly FileService  $fileService,
+        private readonly StatementResourceType $statementResourceType
     ) {
-        $this->statementResourceType = $statementResourceType;
-        $this->fileService = $fileService;
     }
 
     public static function getName(): string
@@ -82,7 +72,7 @@ final class StatementAttachmentResourceType extends DplanResourceType implements
     {
         // The access to an attachment is allowed only if access to the corresponding
         // statement is granted.
-        return $this->statementResourceType->buildAccessCondition($this->statement);
+        return $this->statementResourceType->buildAccessCondition($this->statement, true);
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -121,7 +121,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
      *
      * @return FunctionInterface<bool>
      */
-    public function buildAccessCondition(StatementResourceType $pathStartResourceType): FunctionInterface
+    public function buildAccessCondition(StatementResourceType $pathStartResourceType, bool $allowOriginals = false): FunctionInterface
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
@@ -140,13 +140,9 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         );
         $allowedProcedureIds[] = $procedure->getId();
 
-        return $this->conditionFactory->allConditionsApply(
+        $conditions = [
             // Statement resources can never be deleted
             $this->conditionFactory->propertyHasValue(false, $pathStartResourceType->deleted),
-            // Normally the path to the relationship would suffice for a NULL check, but the ES
-            // provides the 'original.id' path only hence we need the path to the ID to support
-            // ES queries beside Doctrine.
-            $this->conditionFactory->propertyIsNotNull($pathStartResourceType->original->id),
             $this->conditionFactory->propertyIsNull($pathStartResourceType->headStatement->id),
             // statement placeholders are not considered actual statement resources
             $this->conditionFactory->propertyIsNull($pathStartResourceType->movedStatement),
@@ -154,7 +150,15 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 $allowedProcedureIds,
                 $pathStartResourceType->procedure->id
             )
-        );
+        ];
+        if (!$allowOriginals) {
+            // Normally the path to the relationship would suffice for a NULL check, but the ES
+            // provides the 'original.id' path only hence we need the path to the ID to support
+            // ES queries beside Doctrine.
+            $conditions[] = $this->conditionFactory->propertyIsNotNull($pathStartResourceType->original->id);
+        }
+
+        return $this->conditionFactory->allConditionsApply(...$conditions);
     }
 
     public function updateObject(object $object, array $properties): ResourceChange


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31096

**Description:**

- in AT in the tab `Originalstellungnahme` you couldnt see the `Originalstellungnahme-Anhang`, only the `weitere Anhänge`
- in FE in store the relationship were in Singular, it should be in Plural because in the rules of JSON.API it requires this way

stops filtering attachments of original statements by skipping
the condition within the ```getAccessCondition``` of
the ```StatementResourceType``` when called from
the ```StatementAttachmentResourceType```.
Activate the needed permission to include
STN-attachments via api.

- now you can see the original attachment in the AT in the first assessment table view, too, before switching the tab to the original statement

**How to review:**

- go to AT, click to `Originalstellungnahmen`, you will see here `OriginalSTN-Anhang` as attachment
- if you dont have any attachment here, please insert one

### Linked PRs 
Robobsh Repo: https://github.com/demos-europe/demosplan-project-robobsh/pull/20

- [x] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
