### PR TITLE
fix: prevent dependabot PRs to update to vue3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
             - ">= 27"
 
       # Is Vue 3 only
+      -   dependency-name: vue
+          versions:
+            - ">= 2.7.14"
+            -
       - dependency-name: vue-loader
         versions:
             - ">= 16"


### PR DESCRIPTION
- Since we are not ready to migrate to vue3 we must prevent dependabot to create update PRs for this dependecny
- The last version we can use is 2.7.14