### PR TITLE
feature (refs T31210): include email in authorizedUsersExport

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Consultation/BulkLetterExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Consultation/BulkLetterExporter.php
@@ -77,9 +77,10 @@ class BulkLetterExporter extends XlsxExporter
         foreach ($tokenList as $token) {
             $statement = $token->getStatement();
             $statementMeta = $statement->getMeta();
-            $authorName = '' !== $statementMeta->getSubmitName() ? $statementMeta->getSubmitName() : $statementMeta->getAuthorName();
+            $authorName = '' !== $statementMeta->getSubmitName() ?
+                $statementMeta->getSubmitName() : $statementMeta->getAuthorName();
             $author = trim($statement->getAuthorName());
-            $email = '' !== $author && !$statement->hasDefaultGuestUser()
+            $email = '' !== $author && !$statement->isAnonymous()
                 ? $statement->getSubmitterEmailAddress()
                 : User::ANONYMOUS_USER_DEPARTMENT_NAME;
             $sheet->setCellValue('A'.$i, $authorName);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31210

Description:
dont exclude email-address in authorizedUsersExport for all Guests - just if chosen to anonymize.

### How to review/test
you can hand in a statement as a guest -> choose anonymous -> it should be anonymized within the export.
For non-anonymized statements the email address should be shown within the export.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
