### PR TITLE
Improve display of statement count

### DIFF
--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -103,9 +103,10 @@
         v-if="showStatementCount"
         v-slot:header-count>
         {{ Translator.trans('quantity') }}
-        <i
-          class="fa fa-question-circle u-pt-0_125 display--inline-block float--right"
-          v-tooltip="Translator.trans('procedures.statements.count.and.original')" />
+        <dp-icon
+          v-tooltip="Translator.trans('procedures.statements.count')"
+          icon="info"
+          size="small" />
       </template>
 
       <template
@@ -130,6 +131,15 @@
         </div>
       </template>
 
+      <template
+        v-if="showStatementCount"
+        v-slot:count="{ statementsCount, originalStatementsCount }">
+        <div
+          v-tooltip="statementsTooltipCount(statementsCount, originalStatementsCount)"
+          v-text="statementsCount"
+          class="text--center" />
+      </template>
+
       <template v-slot:internalPhase="{internalPhase, internalStartDate, internalEndDate}">
         <div
           class="float--left u-m-0">
@@ -148,7 +158,7 @@
 
 <script>
 import { dpApi, formatDate } from '@demos-europe/demosplan-utils'
-import { DpButton, DpDataTable, DpLoading, DpSearchField, DpSelect } from '@demos-europe/demosplan-ui'
+import { DpButton, DpDataTable, DpIcon, DpLoading, DpSearchField, DpSelect } from '@demos-europe/demosplan-ui'
 
 export default {
   name: 'AdministrationProceduresList',
@@ -156,6 +166,7 @@ export default {
   components: {
     DpButton,
     DpDataTable,
+    DpIcon,
     DpLoading,
     DpSearchField,
     DpSelect
@@ -294,7 +305,6 @@ export default {
           response.data.data.forEach(el => this.items.push({
             creationDate: formatDate(el.attributes.creationDate.date),
             creationDateRaw: el.attributes.creationDate.date,
-            count: `${el.attributes.statementsCount} (${el.attributes.originalStatementsCount})`,
             name: el.attributes.name,
             externalName: el.attributes.externalName,
             externalEndDate: formatDate(el.attributes.externalEndDate.date),
@@ -303,7 +313,9 @@ export default {
             id: el.id,
             internalEndDate: formatDate(el.attributes.internalEndDate.date),
             internalPhase: el.attributes.internalPhaseTranslationKey,
-            internalStartDate: formatDate(el.attributes.internalStartDate.date)
+            internalStartDate: formatDate(el.attributes.internalStartDate.date),
+            originalStatementsCount: el.attributes.originalStatementsCount,
+            statementsCount: el.attributes.statementsCount
           }))
           this.isLoading = false
         })
@@ -324,6 +336,12 @@ export default {
 
     setSelectedItems (items) {
       this.selectedItems = items
+    },
+
+    statementsTooltipCount (statementsCount, originalStatementsCount) {
+      const statements = Translator.trans('procedures.statements.count.description', { statements: statementsCount })
+      const originalStatements = Translator.trans('procedures.statements.count.original.description', { statements: originalStatementsCount })
+      return `${statements.trim()}, ${originalStatements.trim()}`
     }
   },
 

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2572,7 +2572,19 @@ procedures.none: "Es sind noch keine Verfahren vorhanden."
 procedures.orga: "Verfahren Ihrer Organisation"
 procedures.participation.none: "Derzeit befinden sich keine Verfahren in Beteiligung."
 procedures.phase.overview: "Phasenübersicht aller Verfahren"
-procedures.statements.count.and.original: "Anzahl Stellungnahmen (Originalstellungnahmen)"
+procedures.statements.count: "Anzahl aller Stellungnahmen im Verfahren"
+procedures.statements.count.description: |
+    {statements, plural,
+        =0 {Keine Stellungnahme}
+        =1 {Eine Stellungnahme}
+        other {# Stellungnahmen}
+    }
+procedures.statements.count.original.description: |
+    {statements, plural,
+        =0 {keine Originalstellungnahme}
+        =1 {eine Originalstellungnahme}
+        other {# Originalstellungnahmen}
+    }
 procedures.statements.total: |
     {statementCount, plural,
         =1 {Eine Stellungnahme in {procedureCount} Verfahren}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31258

Showing both numbers (statement and originalStatement count) by default turned out to be not  understandable. To improve this, original statements are now only shown within a tooltip that is triggered when hovering the numbers. Hiding the original statements by default is the better option as users are mostly interested in this metric.

### How to review/test
Checkout, build the frontend, visit admin area with procedures list.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
