### PR TITLE
Use correct import syntax

### DIFF
--- a/client/js/bundles/faq/faqlist.js
+++ b/client/js/bundles/faq/faqlist.js
@@ -12,7 +12,7 @@
  */
 
 import { DpRegisterFlyout } from '@demos-europe/demosplan-ui'
-import highlightActiveLinks from '@DpJs/lib/core/libs'
+import { highlightActiveLinks } from '@DpJs/lib/core/libs'
 import { initialize } from '@DpJs/InitVue'
 
 const components = {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31169

As we moved the file from demosplan-ui into core again, the way it has to be imported has changed.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
