### PR TITLE
Fix(refs:T31100): vue warn and error in datensätze

### DIFF
--- a/client/js/components/statement/assessmentTable/Fragment.vue
+++ b/client/js/components/statement/assessmentTable/Fragment.vue
@@ -726,6 +726,8 @@ export default {
           }
         }
 
+        dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
+
         // Used in DpVersionHistory to update items in version history sidebar
         this.$root.$emit('entity:updated', this.fragmentId, 'fragment')
 

--- a/client/js/components/statement/assessmentTable/Fragment.vue
+++ b/client/js/components/statement/assessmentTable/Fragment.vue
@@ -407,21 +407,6 @@ export default {
   },
 
   props: {
-    procedureId: {
-      required: true,
-      type: String
-    },
-
-    initialFragment: {
-      required: true,
-      type: Object
-    },
-
-    statement: {
-      type: Object,
-      required: true
-    },
-
     currentUserId: {
       type: String,
       required: true
@@ -435,17 +420,30 @@ export default {
     fragmentId: {
       type: String,
       required: true
+    },
+
+    initialFragment: {
+      required: true,
+      type: Object
+    },
+    procedureId: {
+      required: true,
+      type: String
+    },
+    statement: {
+      type: Object,
+      required: true
     }
   },
 
   data () {
     return {
       editing: false,
+      forwardTags: false,
       notifyOrga: false,
       reviewerEditing: false,
-      updatingClaimState: false,
       tagsEditing: false,
-      forwardTags: false
+      updatingClaimState: false,
     }
   },
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
@@ -135,12 +135,18 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
 
             if (isset($resElements['documents'])) {
                 $templateVars['documents'] = $resElements['documents'];
+            } else {
+                // assure that at least one planningCategory Group is present if no documents are available
+                $templateVars['documents'][$statement->getElementId()] = [];
             }
             if (isset($resElements['elements'])) {
                 $templateVars['elements'] = $resElements['elements'];
             }
             if (isset($resElements['paragraph'])) {
                 $templateVars['paragraph'] = $resElements['paragraph'];
+            } else {
+                // assure that at least one planningCategory Group is present if no paragraph are available
+                $templateVars['paragraph'][$statement->getElementId()] = [];
             }
 
             $templateVars['availableTags'] = $statementHandler->getTopicsAndTagsOfProcedureAsArray($procedureId);
@@ -176,6 +182,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     name="DemosPlan_statement_fragment_list_fragment_archived_reviewer",
      *     path="/datensatz/liste/archive"
      * )
+     *
      *  @DplanPermissions({"area_statement_fragments_department_archive","feature_statements_fragment_list"})
      *
      * @return RedirectResponse|Response
@@ -262,6 +269,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     path="/datensatz/liste",
      *     options={"expose": true}
      * )
+     *
      *  @DplanPermissions({"area_statement_fragments_department","feature_statements_fragment_list"})
      *
      * @return RedirectResponse|\Symfony\Component\HttpFoundation\Response
@@ -372,6 +380,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     defaults={"isReviewer": true},
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("feature_statements_fragment_edit")
      *
      * @return RedirectResponse|\Symfony\Component\HttpFoundation\Response
@@ -444,6 +453,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     methods={"POST"},
      *     options={"expose": true}
      * )
+     *
      *  @DplanPermissions({"area_admin_assessmenttable","feature_statements_fragment_edit"})
      *
      * @param string $fragmentId
@@ -496,6 +506,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     path="/_ajax/procedure/{procedure}/statement/{statementId}/fragment/{fragmentId}",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_statements_fragment")
      *
      * @param string $procedure
@@ -523,6 +534,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     path="/_ajax/procedure/{procedure}/statement/{statementId}/fragmentconsiderations",
      *     options={"expose": true}
      * )
+     *
      *  @DplanPermissions({"area_admin_assessmenttable","area_statements_fragment"})
      *
      * @param string $statementId
@@ -561,6 +573,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Fragment Statement into multiple slices.
      *
      * @DplanPermissions({"area_statements_fragment", "feature_statements_fragment_add"})
+     *
      * @Route(
      *     name="DemosPlan_statement_fragment_add",
      *     path="/verfahren/{procedure}/fragment/{statementId}/add"
@@ -655,6 +668,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     name="DemosPlan_statement_fragment_update_redirect",
      *     path="/datensatz/update",
      * )
+     *
      *  @DplanPermissions({"area_statements_fragment","feature_statements_fragment_edit"})
      *
      * @param bool $isReviewer
@@ -742,6 +756,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Returns fragment data for a statement on the assessment table.
      *
      * @DplanPermissions("area_admin_assessmenttable")
+     *
      * @Route(
      *     name="DemosPlan_assessment_statement_fragments_ajax",
      *     path="/_ajax/assessment/{procedureId}/{statementId}",
@@ -819,6 +834,7 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *     path="/datensatz/liste/export",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_statements_fragment")
      *
      * @param Request $request ;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31100

-> this bugfix could have fix another bug of a red bugticket for `Datensätze`

**Description:**

- the originally problem at begin were the vue warns described in the ticket that for props `documents` and `paragraph` expected an object and got an array
- first set a safety check in backend that if no documents or paragraph exists,
that there is at least one group for the `elementId` available in Frontend, even if its an empty array, 
which is created in `getElementBlock` function and which is set in relation with `elementId` 
- however there exists another error that the assigne.id is null, so that the tab `Datensätze` didnt show the details
- the problem was that that there is no assignee before switching in frontend to the `Datensätze` tab, because
you are available to claim it after switching to this part and seeing which `Datensätze` are available to claim,
otherwise you are not able to claim, so before claiming there is no assignee and you need to check if there is an assignee, than it should take the id of the assignee only in the case that an assignee exists
- another important thing is the computed `isClaim` -> this needs a check if the permission 'feature_statement_assignment' is activated, a statement or fragment is claimed in the case if an assignee exists and the assignee is the logged user so that a statement or fragment(='Datensatz') is claimed
- if this permission is not activated in other projects, the statement or fragment looks like already is claimed,
so that any user can edit this part without claim because in the some projects there is no opportunity that different user could have claimed this statement or fragment
- I added a confirm message, if the `Begründung` get updated in `Datensätze`

-> needed to close the other PR because of issues cause of refactoring vue gave some new errors

### Linked PRs

- https://github.com/demos-europe/demosplan-core/pull/737

### How to review/test

- Go to the AT in the tab `Datensätze` for example in Robob
- claim a `Datensatz`, change the `Begründung` or `Textabschnitt der Stellungnahme` 
- in the case that there is no `Datensatz`, click to `Datensätze aufteilen` and save this


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
