### PR TITLE
fix(refs T31312): Allow access to hashedQuery via API

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/HashedQueryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/HashedQueryResourceType.php
@@ -49,7 +49,7 @@ class HashedQueryResourceType extends DplanResourceType
 
     public function isReferencable(): bool
     {
-        return false;
+        return true;
     }
 
     public function isDirectlyAccessible(): bool
@@ -59,6 +59,6 @@ class HashedQueryResourceType extends DplanResourceType
 
     public function getAccessCondition(): PathsBasedInterface
     {
-        return $this->conditionFactory->false();
+        return $this->conditionFactory->true();
     }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31312

The resource type seems to have been non-functional since it was created (during a refactoring). Opening it like it is done in this PR is fine, as it can only be accessed via `UserFilterSetResourceType`, that already contains checks to limit access via permission check, the user that created the filter and the procedure in which the filter was created.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
