### PR TITLE
fix(refs T29992): disable button if statement is not claimed

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -167,8 +167,8 @@
               {{ Translator.trans('original.pdf') }}
             </a>
             <button
-              :class="`${ assignee.id === currentUserId ? 'text-decoration-underline--hover' : 'is-disabled' } btn--blank o-link--default`"
-              :disabled="synchronized"
+              :class="`${ !synchronized || assignee.id === currentUserId ? 'text-decoration-underline--hover' : 'is-disabled' } btn--blank o-link--default`"
+              :disabled="synchronized || assignee.id !== currentUserId"
               type="button"
               @click="triggerStatementDeletion(id)">
               {{ Translator.trans('delete') }}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29992

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- if a user hasn't claimed a statement, they should not be allowed to delete it
- previously, only styling was applied in that case, but deleting the statement was still possible

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Go to the statement list and try to delete a statement that is assigned to you as well as a statement that is not assigned to you. The former should be possible, the latter should not.

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
