### PR TITLE
fix (refs T31312): use correct access modifier in value object

### DIFF
--- a/demosplan/DemosPlanStatementBundle/ValueObject/CountyNotificationData.php
+++ b/demosplan/DemosPlanStatementBundle/ValueObject/CountyNotificationData.php
@@ -23,35 +23,15 @@ use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
 class CountyNotificationData extends ValueObject
 {
     /**
-     * @var string|null
-     */
-    private $orgaName;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $procedure;
-
-    /**
-     * @var array<int,string>
-     */
-    private $files;
-
-    /**
-     * @var PdfFile
-     */
-    private $pdfResult;
-
-    /**
      * @param array<string, mixed> $procedure
-     * @param array<int,string>    $files
+     * @param array<int, string>   $files
      */
-    public function __construct(?string $orgaName, array $procedure, array $files, PdfFile $pdfResult)
-    {
-        $this->orgaName = $orgaName;
-        $this->procedure = $procedure;
-        $this->files = $files;
-        $this->pdfResult = $pdfResult;
+    public function __construct(
+        protected ?string $orgaName,
+        protected array $procedure,
+        protected array $files,
+        protected PdfFile $pdfResult
+    ) {
         $this->lock();
     }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31308

Properties in classes extending from `ValueObject` must be set to `protected` for the `@method` tag to work.

Also used PHP 8+ syntax for properties to keep the code modern.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
