### PR TITLE
feature (refs T31171): show flash messages again

### DIFF
--- a/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
+++ b/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
@@ -14,6 +14,7 @@ use BadMethodCallException;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Controller\AssessmentTable\DemosPlanAssessmentTableController;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -25,7 +26,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Traits\DI\RefreshElasticsearchIndexTrait;
@@ -84,7 +84,7 @@ class AssessmentTableServiceStorage
     protected $fileService;
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -123,7 +123,7 @@ class AssessmentTableServiceStorage
         GlobalConfigInterface $config,
         IndexManager $indexManager,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         PermissionsInterface $permissions,
         PrepareReportFromProcedureService $prepareReportFromProcedureService,
         StatementAttachmentService $statementAttachmentService,
@@ -148,7 +148,7 @@ class AssessmentTableServiceStorage
         $this->currentUser = $currentUser;
     }
 
-    protected function getMessageBag(): MessageBag
+    protected function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
@@ -11,11 +11,11 @@
 namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidPostDataException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\InitializeService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\ViewRenderer;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use demosplan\DemosPlanCoreBundle\Traits\CanTransformRequestVariablesTrait;
@@ -60,7 +60,7 @@ abstract class BaseController extends AbstractController
     protected $allowedCookieNames = [PreviousRouteCookie::NAME];
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -115,7 +115,7 @@ abstract class BaseController extends AbstractController
      *
      * @required
      */
-    public function setMessageBag(MessageBag $messageBag): void
+    public function setMessageBag(MessageBagInterface $messageBag): void
     {
         $this->messageBag = $messageBag;
     }
@@ -140,7 +140,7 @@ abstract class BaseController extends AbstractController
         $this->initializeService = $initializeService;
     }
 
-    protected function getMessageBag(): MessageBag
+    protected function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use demosplan\DemosPlanCoreBundle\Traits\CanTransformRequestVariablesTrait;
 use demosplan\DemosPlanCoreBundle\Traits\IsProfilableTrait;
@@ -59,7 +60,7 @@ class CoreHandler
     protected $logger;
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -68,7 +69,7 @@ class CoreHandler
      */
     protected $requestStack;
 
-    public function __construct(MessageBag $messageBag)
+    public function __construct(MessageBagInterface $messageBag)
     {
         $this->messageBag = $messageBag;
     }
@@ -188,7 +189,7 @@ class CoreHandler
         return $this->requestStack->getSession();
     }
 
-    public function getMessageBag(): MessageBag
+    public function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayHandler.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\ValueObject\HistoryDay;
 
 class EntityContentChangeDisplayHandler extends CoreHandler
@@ -19,7 +20,7 @@ class EntityContentChangeDisplayHandler extends CoreHandler
      */
     protected $entityContentChangeDisplayService;
 
-    public function __construct(EntityContentChangeDisplayService $entityContentChangeDisplayService, MessageBag $messageBag)
+    public function __construct(EntityContentChangeDisplayService $entityContentChangeDisplayService, MessageBagInterface $messageBag)
     {
         $this->entityContentChangeDisplayService = $entityContentChangeDisplayService;
         parent::__construct($messageBag);

--- a/demosplan/DemosPlanCoreBundle/Logic/LegacyFlashMessageCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/LegacyFlashMessageCreator.php
@@ -23,7 +23,7 @@ class LegacyFlashMessageCreator
      */
     private $translator;
     /**
-     * @var \demosplan\DemosPlanCoreBundle\Logic\ILogic\MessageBagInterface
+     * @var MessageBagInterface
      */
     private $messageBag;
 

--- a/demosplan/DemosPlanMapBundle/Logic/MapHandler.php
+++ b/demosplan/DemosPlanMapBundle/Logic/MapHandler.php
@@ -10,12 +10,12 @@
 
 namespace demosplan\DemosPlanMapBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
 use demosplan\DemosPlanCoreBundle\Exception\AttachedChildException;
 use demosplan\DemosPlanCoreBundle\Exception\FunctionalLogicException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanMapBundle\Exception\GisLayerCategoryTreeTooDeepException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,7 +33,7 @@ class MapHandler extends CoreHandler
      */
     private $entityManager;
 
-    public function __construct(MapService $mapService, MessageBag $messageBag, EntityManagerInterface $entityManager)
+    public function __construct(MapService $mapService, MessageBagInterface $messageBag, EntityManagerInterface $entityManager)
     {
         $this->mapService = $mapService;
         parent::__construct($messageBag);


### PR DESCRIPTION
Ticket: 
https://yaits.demos-deutschland.de/T31171

Description:
Only use the MessageBagInterface
- There seems to be a mismatch by dependency injection - which lead to
different instances of the Messagebag.
(One getting filled - another empty one goes
to the TransformMessageBagService)


### How to review/test
The flash messages should appear again.
An easy one that was not working for instance is to bulk copy an original statement without choosing one. 

### Linked PRs (optional)
Bimschg-Antrag Repo: https://github.com/demos-europe/demosplan-plugin-bimschg-antrag/pull/2
Statement-Similarity Repo: https://github.com/demos-europe/demosplan-plugin-statement-similarity/pull/2

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
