### PR TITLE
F t31171 delete static self reference from message bag

### DIFF
--- a/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
+++ b/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableServiceStorage.php
@@ -14,6 +14,7 @@ use BadMethodCallException;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Controller\AssessmentTable\DemosPlanAssessmentTableController;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -25,7 +26,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Traits\DI\RefreshElasticsearchIndexTrait;
@@ -84,7 +84,7 @@ class AssessmentTableServiceStorage
     protected $fileService;
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -123,7 +123,7 @@ class AssessmentTableServiceStorage
         GlobalConfigInterface $config,
         IndexManager $indexManager,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         PermissionsInterface $permissions,
         PrepareReportFromProcedureService $prepareReportFromProcedureService,
         StatementAttachmentService $statementAttachmentService,
@@ -148,7 +148,7 @@ class AssessmentTableServiceStorage
         $this->currentUser = $currentUser;
     }
 
-    protected function getMessageBag(): MessageBag
+    protected function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
@@ -11,11 +11,11 @@
 namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidPostDataException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\InitializeService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\ViewRenderer;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use demosplan\DemosPlanCoreBundle\Traits\CanTransformRequestVariablesTrait;
@@ -60,7 +60,7 @@ abstract class BaseController extends AbstractController
     protected $allowedCookieNames = [PreviousRouteCookie::NAME];
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -115,7 +115,7 @@ abstract class BaseController extends AbstractController
      *
      * @required
      */
-    public function setMessageBag(MessageBag $messageBag): void
+    public function setMessageBag(MessageBagInterface $messageBag): void
     {
         $this->messageBag = $messageBag;
     }
@@ -140,7 +140,7 @@ abstract class BaseController extends AbstractController
         $this->initializeService = $initializeService;
     }
 
-    protected function getMessageBag(): MessageBag
+    protected function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use demosplan\DemosPlanCoreBundle\Traits\CanTransformRequestVariablesTrait;
 use demosplan\DemosPlanCoreBundle\Traits\IsProfilableTrait;
@@ -59,7 +60,7 @@ class CoreHandler
     protected $logger;
 
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $messageBag;
 
@@ -68,7 +69,7 @@ class CoreHandler
      */
     protected $requestStack;
 
-    public function __construct(MessageBag $messageBag)
+    public function __construct(MessageBagInterface $messageBag)
     {
         $this->messageBag = $messageBag;
     }
@@ -188,7 +189,7 @@ class CoreHandler
         return $this->requestStack->getSession();
     }
 
-    public function getMessageBag(): MessageBag
+    public function getMessageBag(): MessageBagInterface
     {
         return $this->messageBag;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayHandler.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\ValueObject\HistoryDay;
 
 class EntityContentChangeDisplayHandler extends CoreHandler
@@ -19,7 +20,7 @@ class EntityContentChangeDisplayHandler extends CoreHandler
      */
     protected $entityContentChangeDisplayService;
 
-    public function __construct(EntityContentChangeDisplayService $entityContentChangeDisplayService, MessageBag $messageBag)
+    public function __construct(EntityContentChangeDisplayService $entityContentChangeDisplayService, MessageBagInterface $messageBag)
     {
         $this->entityContentChangeDisplayService = $entityContentChangeDisplayService;
         parent::__construct($messageBag);

--- a/demosplan/DemosPlanCoreBundle/Logic/LegacyFlashMessageCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/LegacyFlashMessageCreator.php
@@ -23,7 +23,7 @@ class LegacyFlashMessageCreator
      */
     private $translator;
     /**
-     * @var \demosplan\DemosPlanCoreBundle\Logic\ILogic\MessageBagInterface
+     * @var MessageBagInterface
      */
     private $messageBag;
 

--- a/demosplan/DemosPlanCoreBundle/Logic/MessageBag.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MessageBag.php
@@ -33,13 +33,6 @@ class MessageBag implements MessageBagInterface
     ];
 
     /**
-     * Keeps an Instance of $this to be used in statically called context.
-     *
-     * @var MessageBag
-     */
-    protected static $self;
-
-    /**
      * @var Collection
      */
     protected $messages;
@@ -59,26 +52,7 @@ class MessageBag implements MessageBagInterface
             ->map(static function () {
                 return collect();
             });
-
-        self::$self = $this;
         $this->translator = $translator;
-    }
-
-    /**
-     * Call MessageBag:add() from a static context.
-     *
-     * @param string $message #TranslationKey
-     * @param string $domain  #TranslationDomain
-     *
-     * @throws MessageBagException
-     */
-    public static function addMessage(
-        string $severity,
-        string $message,
-        array $params = [],
-        string $domain = 'messages'
-    ) {
-        self::$self->add($severity, $message, $params, $domain);
     }
 
     /**

--- a/demosplan/DemosPlanMapBundle/Logic/MapHandler.php
+++ b/demosplan/DemosPlanMapBundle/Logic/MapHandler.php
@@ -10,12 +10,12 @@
 
 namespace demosplan\DemosPlanMapBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
 use demosplan\DemosPlanCoreBundle\Exception\AttachedChildException;
 use demosplan\DemosPlanCoreBundle\Exception\FunctionalLogicException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanMapBundle\Exception\GisLayerCategoryTreeTooDeepException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,7 +33,7 @@ class MapHandler extends CoreHandler
      */
     private $entityManager;
 
-    public function __construct(MapService $mapService, MessageBag $messageBag, EntityManagerInterface $entityManager)
+    public function __construct(MapService $mapService, MessageBagInterface $messageBag, EntityManagerInterface $entityManager)
     {
         $this->mapService = $mapService;
         parent::__construct($messageBag);

--- a/demosplan/DemosPlanStatementBundle/EventSubscriber/OrganisationUpdateSubscriber.php
+++ b/demosplan/DemosPlanStatementBundle/EventSubscriber/OrganisationUpdateSubscriber.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanStatementBundle\EventSubscriber;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Event\User\OrgaEditedEvent;
 use demosplan\DemosPlanCoreBundle\EventSubscriber\BaseEventSubscriber;
@@ -23,9 +24,12 @@ class OrganisationUpdateSubscriber extends BaseEventSubscriber
      */
     protected $draftStatementService;
 
-    public function __construct(DraftStatementService $draftStatementService)
+    protected MessageBagInterface $messageBag;
+
+    public function __construct(DraftStatementService $draftStatementService, MessageBagInterface $messageBag)
     {
         $this->draftStatementService = $draftStatementService;
+        $this->messageBag = $messageBag;
     }
 
     public static function getSubscribedEvents(): array
@@ -45,9 +49,9 @@ class OrganisationUpdateSubscriber extends BaseEventSubscriber
             && Orga::STATEMENT_SUBMISSION_TYPE_SHORT == $orgaUpdated->getSubmissionType()) {
             $success = $this->draftStatementService->resetDraftStatementsOfProceduresOfOrga($event->getOrganisationUpdated());
             if ($success) {
-                MessageBag::addMessage('confirm', 'confirm.statement.orgaedit.submissiontype.short');
+                $this->messageBag->add('confirm', 'confirm.statement.orgaedit.submissiontype.short');
             } else {
-                MessageBag::addMessage('error', 'error.statement.orgaedit.submissiontype.short');
+                $this->messageBag->add('error', 'error.statement.orgaedit.submissiontype.short');
             }
         }
 
@@ -55,7 +59,7 @@ class OrganisationUpdateSubscriber extends BaseEventSubscriber
         if ($orgaBefore->getSubmissionType() != $orgaUpdated->getSubmissionType()
             && Orga::STATEMENT_SUBMISSION_TYPE_DEFAULT == $orgaUpdated->getSubmissionType()) {
             // Nothing to do but tell user that resetting worked
-            MessageBag::addMessage('confirm', 'confirm.statement.orgaedit.submissiontype.default');
+            $this->messageBag->add('confirm', 'confirm.statement.orgaedit.submissiontype.default');
         }
     }
 }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31171

Description:
Deletes the static self reference from the MessageBag as it is fortunately not needed anymore.
Removed the static method for adding messages and changed the caller of this method to use the proper method instead
by injecting the MessagBagInterface.

### How to review/test
Everything should work as before.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
