### PR TITLE
Also use initial filters to show fragment toggle

### DIFF
--- a/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
+++ b/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
@@ -162,7 +162,7 @@ export default {
 
   methods: {
     hasFragmentFilters (filters) {
-      return filters.length ? filters.some((filter) => filter.type !== 'statement') : false
+      return filters.length ? filters.some(filter => filter.type === 'fragment') : false
     },
 
     showAllFragments () {

--- a/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
+++ b/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
@@ -105,8 +105,11 @@ export default {
 
     ...mapGetters('filter', ['selectedFilterOptions']),
 
-    ...mapState('fragment', ['fragments']),
+    ...mapState('assessmentTable', ['assessmentBase']),
+
     ...mapState('filter', ['currentSearch']),
+
+    ...mapState('fragment', ['fragments']),
 
     filteredFragmentsLength () {
       if (!this.fragments[this.statementId]) {
@@ -138,11 +141,11 @@ export default {
     },
 
     showFragmentResults () {
-      // Evaluates to true if there are any selected filters that apply to fragments
-      const hasFragmentFilters = this.selectedFilterOptions.length ? typeof (this.selectedFilterOptions.find(filter => filter.type !== 'statement')) !== 'undefined' : false
+      const hasInitialFragmentFilters = this.hasFragmentFilters(this.assessmentBase.appliedFilters)
+      const hasFragmentFilters = this.hasFragmentFilters(this.selectedFilterOptions)
 
-      // The search may influence fragment results. Therefore display fragmentResults when a search term is used
-      return hasFragmentFilters || this.currentSearch.length > 0
+      // The search may influence fragment results. Therefor display fragmentResults when a search term is used
+      return hasInitialFragmentFilters || hasFragmentFilters || this.currentSearch.length > 0
     },
 
     totalFragmentsLength () {
@@ -157,6 +160,10 @@ export default {
   },
 
   methods: {
+    hasFragmentFilters (filters) {
+      return filters.length ? filters.some((filter) => filter.type !== 'statement') : false
+    },
+
     showAllFragments () {
       this.allFragmentsShown = !this.allFragmentsShown
       this.$emit('fragments:showall', this.allFragmentsShown)

--- a/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
+++ b/client/js/components/statement/assessmentTable/DpFragmentsSwitcher.vue
@@ -140,12 +140,13 @@ export default {
       return text
     },
 
+    /**
+     * Determine whether to show the "Die Suche ergab X Treffer in Y Datensätzen" UI.
+     * This should happen if results are filtered, or a search term is applied.
+     * @type {boolean}
+     */
     showFragmentResults () {
-      const hasInitialFragmentFilters = this.hasFragmentFilters(this.assessmentBase.appliedFilters)
-      const hasFragmentFilters = this.hasFragmentFilters(this.selectedFilterOptions)
-
-      // The search may influence fragment results. Therefor display fragmentResults when a search term is used
-      return hasInitialFragmentFilters || hasFragmentFilters || this.currentSearch.length > 0
+      return this.hasFragmentFilters(this.assessmentBase.appliedFilters) || this.currentSearch.length > 0
     },
 
     totalFragmentsLength () {

--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -765,6 +765,7 @@ export default {
             if (hasPermission('area_statements_fragment')) {
               this.setProcedureIdForFragment(this.procedureId)
             }
+
             this.triggerApiCallForStatements()
           })
           .then(() => {

--- a/client/js/store/statement/Filter.js
+++ b/client/js/store/statement/Filter.js
@@ -7,8 +7,7 @@
  * All rights reserved
  */
 
-import { dpApi } from '@demos-europe/demosplan-utils'
-import { hasOwnProp } from '@demos-europe/demosplan-utils'
+import { dpApi, hasOwnProp } from '@demos-europe/demosplan-utils'
 
 const Filter = {
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31314

selectedFilterOptions are only fetched when the filter modal is opened for the first time (we implemented this to improve initial loading speed). to show the info despite this, we can grab the filters from the assessmentTable store, where it is persisted as passed via twig/prop into DpTable.

### How to review/test
Build, find a procedure where there are fragments with both states "new" and "editing", go to procedure dashboard, find the "Datensätze nach Status" chart, click on the link for "new" or "editing" filter.

In the assessment table which opens then, the UI which reads "Die Suche ergab X Treffer in Y Datensätzen" should show up.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
