### PR TITLE
Make optgroup appear bold 

### DIFF
--- a/client/js/components/statement/assessmentTable/DpEditFieldMultiSelect.vue
+++ b/client/js/components/statement/assessmentTable/DpEditFieldMultiSelect.vue
@@ -44,7 +44,7 @@
         :group-label="groupLabel"
         :group-select="groupSelect">
         <template v-slot:option="{ option }">
-          <span v-if="option.$isLabel"><strong>{{ option.$groupLabel }}</strong></span>
+          <strong v-if="option.$isLabel">{{ option.$groupLabel }}</strong>
           <span v-else>{{ option.name }}</span>
         </template>
         <template v-slot:tag="props">

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
@@ -65,9 +65,9 @@
                     data-cy="fragmentTopicsTags"
                 >
                     <template v-slot:option="props">
-                        <span v-if="props.option.$isLabel">
-                            <strong>{% verbatim %}{{ props.option.$groupLabel }}{% endverbatim %}</strong>
-                        </span>
+                        <strong v-if="props.option.$isLabel">
+                            {% verbatim %}{{ props.option.$groupLabel }}{% endverbatim %}
+                        </strong>
                         <span v-else>
                             {% verbatim %}{{ props.option.title }}{% endverbatim %}
                         </span>

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
@@ -66,7 +66,7 @@
                 >
                     <template v-slot:option="props">
                         <span v-if="props.option.$isLabel">
-                            {% verbatim %}{{ props.option.$groupLabel }}{% endverbatim %}
+                            <strong>{% verbatim %}{{ props.option.$groupLabel }}{% endverbatim %}</strong>
                         </span>
                         <span v-else>
                             {% verbatim %}{{ props.option.title }}{% endverbatim %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31303

To better differentiate between options and optgroups, the latter are displayed bold, as we already do it within the assessment table.

### How to review/test
Go to "Stellungnahme in Datensätze aufteilen", watch "Schlagworte" Multiselect.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
