### PR TITLE
fix (refs T31331): move UI-logic into twig

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -249,40 +249,14 @@ class DemosPlanAssessmentController extends BaseController
         StatementHandler $statementHandler,
         TranslatorInterface $translator,
         string $procedureId,
-        string $statementId): Response
-    {
-        $statement = $statementHandler->getStatement($statementId);
-        $procedure = $procedureService->getProcedure($procedureId);
+        string $statementId
+    ): Response {
+        $statement = $statementHandler->getStatementWithCertainty($statementId);
+        $procedure = $procedureService->getProcedureWithCertainty($procedureId);
+
         $templateVars = [];
         $templateVars['table']['statement'] = $statement;
-
-        $templateVars['table']['procedure'] = null;
-        if (null !== $statement) {
-            $templateVars['table']['procedure'] = $procedure;
-        }
-
-        $templateVars['sendFinalEmail'] = true;
-
-        // wenn es Mitzeichner gibt, dann wird die Option "Schlussmitteilung versenden" plus Extra-Erklärung im template wieder einblendet
-        $templateVars['finalEmailOnlyToVoters'] = false;
-        if (array_key_exists('feedback', $templateVars['table']['statement'])) {
-            switch ($templateVars['table']['statement']['feedback']) {
-                case 'snailmail':
-                    if (empty($templateVars['table']['statement']['votes'])) {
-                        $templateVars['table']['statement']['feedback'] = $translator->trans('via.post');
-                        $templateVars['sendFinalEmail'] = false;
-                    } else {
-                        $templateVars['table']['statement']['feedback'] = $translator->trans('via.post');
-                        $templateVars['sendFinalEmail'] = true;
-                        $templateVars['finalEmailOnlyToVoters'] = true;
-                    }
-                    break;
-                case 'email':
-                    $templateVars['table']['statement']['feedback'] = $translator->trans('via.mail');
-                    $templateVars['sendFinalEmail'] = true;
-                    break;
-            }
-        }
+        $templateVars['table']['procedure'] = $procedure;
 
         $title = 'statement.view';
         $breadcrumb->addItem(

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -10,9 +10,6 @@
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Statement;
 
-use function array_key_exists;
-use function array_merge;
-
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanAssessmentTableBundle\ValueObject\SubmitterValueObject;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
@@ -38,15 +35,15 @@ use demosplan\DemosPlanUserBundle\Logic\CurrentUserService;
 use demosplan\DemosPlanUserBundle\Logic\UserService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
-
-use function strcmp;
-
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function array_key_exists;
+use function array_merge;
+use function strcmp;
 use function usort;
 
 /**
@@ -73,6 +70,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_assessment_set_statement_assignment",
      *     path="/assignment/statement/{entityId}/{assignOrUnassign}",
      * )
+     *
      * @DplanPermissions("feature_statement_assignment")
      *
      * @throws Exception
@@ -126,6 +124,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_statement_orga_list",
      *     path="/statement/manual/list/{procedureId}",
      * )
+     *
      * @DplanPermissions("feature_statement_data_input_orga")
      *
      * @throws Exception
@@ -163,6 +162,7 @@ class DemosPlanAssessmentController extends BaseController
      *     path="/statement/new/manual/{procedureId}",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("feature_statement_data_input_orga")
      *
      * @throws Exception
@@ -239,6 +239,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_statement_single_view",
      *     path="procedure/{procedureId}/statement/{statementId}/dataInput"
      * )
+     *
      * @DplanPermissions("feature_statement_data_input_orga")
      *
      * @throws Exception
@@ -287,6 +288,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_cluster_single_statement_view",
      *     path="/verfahren/{procedure}/cluster/statement/{statementId}"
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @throws Exception
@@ -314,6 +316,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_cluster_detach_statement",
      *     path="/verfahren/{procedure}/cluster/statement/{statementId}/detach",
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @throws Exception
@@ -343,6 +346,7 @@ class DemosPlanAssessmentController extends BaseController
      *     name="DemosPlan_cluster_resolve",
      *     path="/verfahren/{procedure}/cluster/resolve/{headStatementId}",
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @throws Exception
@@ -372,6 +376,7 @@ class DemosPlanAssessmentController extends BaseController
      *     path="/_ajax/assessment/{procedureId}",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("feature_procedure_get_base_data")
      */
     public function assessmentBaseAjaxAction(

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
@@ -1,17 +1,10 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
 
-{# if there are statement votes ("Mitzeichner"), then the option "Schlussmitteilung versenden" plus corresponding hint will be shown #}
-{% set templateVars.sendFinalEmail = true %}
-{% set templateVars.finalEmailOnlyToVoters = false %}
+{% set sendFinalEmail = true %}
 {% if templateVars.table.statement.feedback == 'snailmail' %}
-  {% set templateVars.table.statement.feedback = "via.post"|trans %}
   {% if templateVars.table.statement.votes is empty %}
-    {% set templateVars.sendFinalEmail = false %}
-  {% else %}
-    {% set templateVars.finalEmailOnlyToVoters = true %}
+    {% set sendFinalEmail = false %}
   {% endif %}
-{% elseif templateVars.table.statement.feedback == 'email' %}
-    {% set templateVars.table.statement.feedback = "via.email"|trans %}
 {% endif %}
 
 {% set statement = templateVars.table.statement %}
@@ -319,7 +312,7 @@
                                     {{ "author.misc"|trans }}
                                 </span><!--
                              --><span class="layout__item u-5-of-8">
-                                    {% if templateVars.sendFinalEmail is defined and templateVars.sendFinalEmail == false %}
+                                    {% if sendFinalEmail == false %}
                                         {{ "statement.final.send.postal"|trans }}<br>
                                     {% endif %}
                                     {{ statement.meta.orgaEmail|default('----') }}

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanAssessment/view_statement.html.twig
@@ -1,5 +1,19 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
 
+{# if there are statement votes ("Mitzeichner"), then the option "Schlussmitteilung versenden" plus corresponding hint will be shown #}
+{% set templateVars.sendFinalEmail = true %}
+{% set templateVars.finalEmailOnlyToVoters = false %}
+{% if templateVars.table.statement.feedback == 'snailmail' %}
+  {% set templateVars.table.statement.feedback = "via.post"|trans %}
+  {% if templateVars.table.statement.votes is empty %}
+    {% set templateVars.sendFinalEmail = false %}
+  {% else %}
+    {% set templateVars.finalEmailOnlyToVoters = true %}
+  {% endif %}
+{% elseif templateVars.table.statement.feedback == 'email' %}
+    {% set templateVars.table.statement.feedback = "via.email"|trans %}
+{% endif %}
+
 {% set statement = templateVars.table.statement %}
 {% set procedure = templateVars.table.procedure.id %}
 


### PR DESCRIPTION
https://yaits.demos-deutschland.de/T31331

Originally the statement entity was converted into an associative array in the backend and the field
`feedback` overridden with the corresponding
translation value before passing the array into the twig file.

However, `getStatement` did no
longer return the array representation of the statement but the statement object instead, which caused a bug. Returning the object is fine, because
we want to handle objects in the backend and avoid unnecessary conversions.

As it would be very bad practice to write a translation value into the `feedback` property of the (now object) statement (as
it may be persisted by accident after refactorings), the approach was changed and the logic determining flags and translation values was moved into the twig file, as this seems to be a frontend-code responsibility anyway.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
