### PR TITLE
Fix: remove DemosPlanFaq from configs yaml

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/bundles.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/bundles.php
@@ -34,7 +34,6 @@ return [
     demosplan\DemosPlanAssessmentTableBundle\DemosPlanAssessmentTableBundle::class     => ['all' => true],
     demosplan\DemosPlanCoreBundle\DemosPlanCoreBundle::class                           => ['all' => true],
     demosplan\DemosPlanDocumentBundle\DemosPlanDocumentBundle::class                   => ['all' => true],
-    demosplan\DemosPlanFaqBundle\DemosPlanFaqBundle::class                             => ['all' => true],
     demosplan\DemosPlanMapBundle\DemosPlanMapBundle::class                             => ['all' => true],
     demosplan\DemosPlanProcedureBundle\DemosPlanProcedureBundle::class                 => ['all' => true],
     demosplan\DemosPlanReportBundle\DemosPlanReportBundle::class                       => ['all' => true],


### PR DESCRIPTION
Description:  the templates are moved under DemosPlanCore

related PRs:
- Teilhabe : https://github.com/demos-europe/demosplan-project-teilhabe/pull/13
- regio: https://github.com/demos-europe/demosplan-project-regio/pull/22
- robobsh: https://github.com/demos-europe/demosplan-project-robobsh/pull/23