### PR TITLE
bug(refs: T31401): fix wrong translation in master toeb list

### DIFF
--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
@@ -10,7 +10,7 @@
     {
         current: 'mastertoeblist' == highlighted|default,
         href: path('DemosPlan_user_mastertoeblist'),
-        label: 'publicagency.master',
+        label: 'invitable_institution.master',
         feature: 'area_manage_mastertoeblist'
     },
     {


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T31401

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
### Description 

The translation key was simply unknown. Since we already have a translation key to display "Master-TöB-Liste", the fix simply is to use the already existant translation key instead of the old unused one.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as Institutions-Koordination (Arya Stark)
- Navigate to http://bobhh.dplan.local/app_dev.php/mastertoeblist
- The translation key should now be translated correctly (see also screenshot)


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly


![Screenshot 2023-02-14 at 19-20-18 Master-TöB-Liste Bauleitplanung Online](https://user-images.githubusercontent.com/91727189/218825034-d2ef3770-7bfd-49a1-b6cc-dc37e524a819.png)
