### PR TITLE
fix: fixtures should use proper Dependency Injection instead of container

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/DemosFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/DemosFixture.php
@@ -16,30 +16,14 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
-abstract class DemosFixture extends AbstractFixture implements ContainerAwareInterface
+abstract class DemosFixture extends AbstractFixture
 {
-    /**
-     * @var ContainerInterface|null
-     */
-    private $container;
     private EntityManagerInterface $entityManager;
 
     public function __construct(EntityManagerInterface $entityManager)
     {
         $this->entityManager = $entityManager;
-    }
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
-
-    public function getContainer()
-    {
-        return $this->container;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -53,6 +53,7 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
 
     public function load(ObjectManager $manager)
     {
+        $masterProcedurePhase = 'configuration';
         $anonymousUser = new AnonymousUser();
         $this->permissions->initPermissions($anonymousUser);
 
@@ -60,8 +61,8 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         $procedureMaster->setName('Master');
         $procedureMaster->setOrga($this->getReference('orga_demos'));
         $procedureMaster->setOrgaName('DEMOS E-Partizipation GmbH');
-        $procedureMaster->setPhase($this->getContainer()->getParameter('master_procedure_phase'));
-        $procedureMaster->setPublicParticipationPhase($this->getContainer()->getParameter('master_procedure_phase'));
+        $procedureMaster->setPhase($masterProcedurePhase);
+        $procedureMaster->setPublicParticipationPhase($masterProcedurePhase);
         $procedureMaster->setMaster(true);
         $procedureMaster->setMasterTemplate(true);
         $procedureMaster->setAgencyMainEmailAddress('ihre@emailadresse.de');

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
@@ -39,6 +39,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
 class LoadProcedureData extends TestFixture implements DependentFixtureInterface
@@ -65,6 +66,14 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
     private $testOrgaFP;
     private $testUser;
 
+    public function __construct(EntityManagerInterface $entityManager, GlobalConfigInterface $globalConfig)
+    {
+        parent::__construct($entityManager);
+
+        $this->existingInternalPhasesWrite = $globalConfig->getInternalPhaseKeys('write');
+        $this->existingExternalPhasesWrite = $globalConfig->getExternalPhaseKeys('write');
+    }
+
     public function load(ObjectManager $manager): void
     {
         $this->manager = $manager;
@@ -73,9 +82,6 @@ class LoadProcedureData extends TestFixture implements DependentFixtureInterface
         $this->testOrgaFP = $this->getReference('testOrgaFP');
         /* @var User $testUser */
         $this->testUser = $this->getReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
-        $globalConfig = $this->getContainer()->get(GlobalConfigInterface::class);
-        $this->existingInternalPhasesWrite = $globalConfig->getInternalPhaseKeys('write');
-        $this->existingExternalPhasesWrite = $globalConfig->getExternalPhaseKeys('write');
 
         // Erstelle die Masterblaupause.
         // sie hat eine festgeschriebene Id, kann aber nicht ohne weiteres via doctrine

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -21,6 +21,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanUserBundle\Logic\OrgaService;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
 class LoadUserData extends TestFixture
@@ -116,6 +117,14 @@ class LoadUserData extends TestFixture
     public const TEST_USER_2_PLANNER_ADMIN = 'testUser2';
 
     public const DEFAULT_PW_HASH = '2308912f941bd13be84578fa73877453f0e3eef455e6674aee57c78cd354fda94087762e9ea4d5e7a56a330f824edf7d125950ce7e5fda7080b34fe1836a0b4e';
+    private OrgaService $orgaService;
+
+
+    public function __construct(EntityManagerInterface $entityManager, OrgaService $orgaService)
+    {
+        parent::__construct($entityManager);
+        $this->orgaService = $orgaService;
+    }
 
     public function load(ObjectManager $manager)
     {
@@ -989,7 +998,7 @@ class LoadUserData extends TestFixture
             '_o_name',
             User::ANONYMOUS_USER_ORGA_NAME
         );
-        $orgaBuerger = $this->getContainer()->get(OrgaService::class)->getOrga(User::ANONYMOUS_USER_ORGA_ID);
+        $orgaBuerger = $this->orgaService->getOrga(User::ANONYMOUS_USER_ORGA_ID);
 
         $orgaBuerger->addUser($this->getReference(self::TEST_USER_CITIZEN));
         $orgaBuerger->addDepartment($this->getReference(self::TEST_DEPARTMENT));

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -116,13 +116,9 @@ class LoadUserData extends TestFixture
 
     public const TEST_USER_2_PLANNER_ADMIN = 'testUser2';
 
-    public const DEFAULT_PW_HASH = '2308912f941bd13be84578fa73877453f0e3eef455e6674aee57c78cd354fda94087762e9ea4d5e7a56a330f824edf7d125950ce7e5fda7080b34fe1836a0b4e';
-    private OrgaService $orgaService;
-
-    public function __construct(EntityManagerInterface $entityManager, OrgaService $orgaService)
+    public function __construct(EntityManagerInterface $entityManager, private readonly OrgaService $orgaService)
     {
         parent::__construct($entityManager);
-        $this->orgaService = $orgaService;
     }
 
     public function load(ObjectManager $manager)

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -119,7 +119,6 @@ class LoadUserData extends TestFixture
     public const DEFAULT_PW_HASH = '2308912f941bd13be84578fa73877453f0e3eef455e6674aee57c78cd354fda94087762e9ea4d5e7a56a330f824edf7d125950ce7e5fda7080b34fe1836a0b4e';
     private OrgaService $orgaService;
 
-
     public function __construct(EntityManagerInterface $entityManager, OrgaService $orgaService)
     {
         parent::__construct($entityManager);


### PR DESCRIPTION
The better we get in using dependency injection and private services the more important it gets to drop the usage of the container an the dynamic service fetching. 
The Fixtures did not use DI in every cases and thus the tests where broken

### How to review/test
Run any test it should not complain about inlined or removed services

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
