### PR TITLE
feature (refs T31418): alters userCreate command to work without the entry subdomains_allowed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
@@ -88,25 +88,21 @@ class Helpers
 
     public function askCustomer(InputInterface $input, OutputInterface $output): Customer
     {
-        $availableCustomer = collect($this->customerRepository->findAll());
-        $customerSelection = $availableCustomer
-            ->filter(function (Customer $customer): bool {
-                return in_array($customer->getSubdomain(), $this->globalConfig->getSubdomainsAllowed(), true);
-            })
-            ->mapWithKeys(function (Customer $customer): array {
-                $name = $customer->getName();
-                $subdomain = $customer->getSubdomain();
+        $availableCustomers = collect($this->customerRepository->findAll());
+        $mappedCustomerInformation = $availableCustomers->mapWithKeys(function (Customer $customer): array {
+            $name = $customer->getName();
+            $subdomain = $customer->getSubdomain();
 
-                return [$subdomain => $name];
-            })
+            return [$subdomain => $name];
+        })
             ->toArray();
         $questionCustomer = new ChoiceQuestion(
             'Please select a customer: ',
-            $customerSelection
+            $mappedCustomerInformation
         );
         $answer = $this->helper->ask($input, $output, $questionCustomer);
 
-        return $availableCustomer->first(function (Customer $customer) use ($answer) {
+        return $availableCustomers->first(function (Customer $customer) use ($answer) {
             return $answer === $customer->getSubdomain();
         });
     }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31418

Description:
alters the userCreate command in order to work without the parameters_default entry subdomains_allowed
by presenting every customer to choose from that are listed within the DB.

### How to review/test
Try creating a new user with <project> dplan:user:create
You now have to choose the correct customer manually - taking the project context into account


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
