### PR TITLE
feat (refs T31375): use env var to connect to rabbitmq

### DIFF
--- a/.env
+++ b/.env
@@ -55,7 +55,7 @@ JWT_PASSPHRASE=0699e1b59a14e6fec876c06cb8279190
 ###< lexik/jwt-authentication-bundle ###
 
 ###> php-amqplib/rabbitmq-bundle ###
-RABBITMQ_URL=amqp://guest:guest@localhost:5672
+# You need to define RABBITMQ_URL in your .env.local
 ###< php-amqplib/rabbitmq-bundle ###
 
 ###> sentry/sentry-symfony ###

--- a/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/config_dev_container.yml
@@ -40,7 +40,6 @@ parameters:
         - '*.demos-europe.eu'
         - 'cdnjs.cloudflare.com'
 
-    rabbitmq_host: "mq"
     rabbitmq_routing_disabled: true
 
     gateway_url: '/app_dev.php/dplan/login'

--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/old_sound_rabbit_mq.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/old_sound_rabbit_mq.yaml
@@ -2,11 +2,7 @@
 old_sound_rabbit_mq:
     connections:
         default:
-            host:     "%rabbitmq_host%"
-            port:     "%rabbitmq_port%"
-            user:     "%rabbitmq_user%"
-            password: "%rabbitmq_password%"
-            vhost:    "%rabbitmq_vhost%"
+            url: '%env(string:default:rabbitmq_dsn:RABBITMQ_URL)%'
             lazy:     true
             connection_timeout: 3
             read_write_timeout: 3

--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
@@ -142,12 +142,7 @@ parameters:
     database_port: "3306"
 
     #RabbitMQ setting with default values
-    rabbitmq_host:     "localhost"
-    rabbitmq_port:     "5672"
-    rabbitmq_user:     ""
-    rabbitmq_password: ""
-    rabbitmq_vhost:    "/"
-
+    rabbitmq_dsn: "amqp://:@localhost:5672/%2f"
     rabbitmq_routing_disabled: false
 
     # dsn used for sending emails https://symfony.com/doc/current/mailer.html#transport-setup


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31375

Rabbitmq parameters are consolidated into `rabbitmq_dsn` to be able to use a single environment variable `RABBITMQ_URL` to define the rabitmq dsn.

### How to review/test
Define a valid `RABBITMQ_URL` env var in your `.env.local` and e.g. import a docx file

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
