### PR TITLE
feature (refs T31310): addShould does not

### DIFF
--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -10,8 +10,6 @@
 
 namespace demosplan\DemosPlanStatementBundle\Logic;
 
-use function array_map;
-
 use Carbon\Carbon;
 use Closure;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
@@ -145,6 +143,8 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Traversable;
 use UnexpectedValueException;
+
+use function array_map;
 
 class StatementService extends CoreService implements StatementServiceInterface
 {

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -3131,11 +3131,13 @@ class StatementService extends CoreService implements StatementServiceInterface
                 }
                 $statementMustIds = \array_unique($statementMustIds);
                 $shouldQuery = new BoolQuery();
-                $shouldQuery->addShould(
-                    $this->searchService->getElasticaTermsInstance(
-                        'id',
-                        $statementMustIds
-                    ));
+                foreach ($statementMustIds as $statementMustId) {
+                    $shouldQuery->addShould(
+                        $this->searchService->getElasticaTermsInstance(
+                            'id',
+                            $statementMustId
+                        ));
+                }
                 // add search query as a should request as we already found statements
                 // that have the searchstring at their fragment
                 if ($searchQuery instanceof AbstractQuery) {


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31310

Description:
This branch has already been merged into main - but this change is needed in release.
This just picks the changes and move them into release as well.
addShould does not accept an array of or conditions - they need
to be added separately.

### How to review/test
robobsh ->Abwägungstabelle filtern -> Datensatz
you should get results again.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
