### PR TITLE
feat(refs T28046): Add function for deleting single users

### DIFF
--- a/client/js/components/user/DpUserListExtended.vue
+++ b/client/js/components/user/DpUserListExtended.vue
@@ -51,7 +51,7 @@
         :key="user.id"
         :all-organisations="organisations"
         :user="user"
-        @delete="deleteUsers([user.id])"
+        @delete="deleteSingelUser(user.id)"
         :is-open="expandedCardId === id"
         @card:toggle="setExpandedCardId(id)"
         @item:selected="dpToggleOne"
@@ -140,6 +140,17 @@ export default {
       deleteUser: 'delete'
     }),
 
+    deleteSingelUser (id) {
+      if (dpconfirm(Translator.trans('check.user.delete')) === false) {
+        return
+      }
+
+      return this.deleteUser(id)
+        .then(() => {
+          this.deleteUserFromSelection(id)
+        })
+    },
+
     deleteUsers (ids) {
       if (!this.selectedItems.length || dpconfirm(Translator.trans('check.entries.marked.delete')) === false) {
         return
@@ -148,11 +159,17 @@ export default {
       ids.map(id => {
         return this.deleteUser(id)
           .then(() => {
-            // Remove deleted item from itemSelections
-            Vue.delete(this.itemSelections, id)
-            dplan.notify.notify('confirm', Translator.trans('confirm.user.deleted'))
+            this.deleteUserFromSelection(id)
           })
       })
+    },
+
+    /**
+     * Remove deleted item from itemSelections
+     */
+    deleteUserFromSelection (id) {
+      Vue.delete(this.itemSelections, id)
+      dplan.notify.notify('confirm', Translator.trans('confirm.user.deleted'))
     },
 
     /**

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -361,7 +361,7 @@ check.survey.comment.disapprove: "Sind Sie sicher, dass Sie die Veröffentlichun
 check.tag.delete: "Sind Sie sicher, daß Sie das Schlagwort \"{tag}\" löschen möchten?"
 check.topic.delete.tags: "Sind Sie sicher, daß Sie das Thema \"{topic}\" und alle zugeordneten Schlagworte löschen möchten?"
 check.topic.delete: "Sind Sie sicher, daß Sie das Thema und alle Beiträge dazu löschen möchten?"
-check.user.delete: "Sind Sie sicher, dass Sie diese Nutzenden löschen möchten?"
+check.user.delete: "Sind Sie sicher, dass Sie diese(n) Nutzenden löschen möchten?"
 check.user.department.changed: "Bitte bestätigen Sie, dass Sie in eine neue Abteilung gewechselt sind."
 check.user.department.renamed: "Bitte bestätigen Sie, dass Ihre Abteilung umbenannt wurde."
 check.user.organisation.changed: "Bitte bestätigen Sie, dass Sie in eine neue Organisation gewechselt sind."


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T28046

When clicking on the delete icon of a user nothing happened, because there are no selected items. I implemented a new function for deleting single users with a different confirmation text, so it is more clear that only the single user is deleted and not the selected items. 

### How to review/test
Login as support and delete an user via the trash icon. 