### PR TITLE
Feat_T31035: adjust design: about page - diplanbau

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/participation_area_skeleton.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/participation_area_skeleton.html.twig
@@ -15,18 +15,21 @@
     } %}
 {% endblock title_text %}
 
-<div id="content" class="{{ 'o-page__padded bg-color--white'|prefixClass }}">
-    {% apply spaceless %}
+{% block fullContent %}
+    <div id="content" class="{{ 'o-page__padded bg-color--white'|prefixClass }}">
+        {% apply spaceless %}
 
-        {% if full_width|default(false) != true %}
-            <aside class="{{ 'layout__item u-1-of-4 u-1-of-1-lap-down show-desk-up-ib-empty u-p-0_5-palm u-p-lap-up u-pr-0-lap-up'|prefixClass }}">
-                {% block aside %}{% endblock aside %}
-            </aside>
-        {% endif %}
+            {% if full_width|default(false) != true %}
+                <aside class="{{ 'layout__item u-1-of-4 u-1-of-1-lap-down show-desk-up-ib-empty u-p-0_5-palm u-p-lap-up u-pr-0-lap-up'|prefixClass }}">
+                    {% block aside %}{% endblock aside %}
+                </aside>
+            {% endif %}
 
-        <section class="{{ 'layout__item  u-1-of-1-palm'|prefixClass }}  {{ full_width|default == true ? '' : 'u-3-of-4'|prefixClass }} {{ (flush|default == true ? 'u-pl-0' : 'u-p-0_5-palm u-p-lap-up')|prefixClass }}">
-            {% block content %}{% endblock content %}
-        </section>
+            <section class="{{ 'layout__item u-1-of-1-palm'|prefixClass }}  {{ full_width|default == true ? '' : 'u-3-of-4'|prefixClass }} {{ (flush|default == true ? 'u-pl-0' : 'u-p-0_5-palm u-p-lap-up')|prefixClass }}">
+                {% block content %}{% endblock content %}
+            </section>
 
-    {% endapply %}
-</div>
+        {% endapply %}
+    </div>
+{% endblock fullContent %}
+


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T31035

**Description:** This PR adds a new block to the `participation_area_skeleton.html.twig` which makes it possible to override the template in the DiPlanBau project .

_It is connected with the same PR in the DiPlanBau project._

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
