### PR TITLE
feat: use relative path in addon to be compatible with different environments

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Addon;
 
 use demosplan\DemosPlanCoreBundle\Exception\AddonException;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Symfony\Component\Yaml\Yaml;
 
 final class FrontendAssetProvider
@@ -39,7 +40,7 @@ final class FrontendAssetProvider
             }
 
             $hookData = $uiData['hooks'][$hookName];
-            $manifestPath = $addonInfo->getInstallPath().'/'.$uiData['manifest'];
+            $manifestPath =  DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/'.$uiData['manifest'];
 
             try {
                 $entries = $this->getAssetPathsFromManifest($manifestPath, $hookData['entry']);
@@ -53,7 +54,7 @@ final class FrontendAssetProvider
 
                 foreach ($entries['js'] as $entry) {
                     // Try to get the content of the actual asset
-                    $entryFilePath = $addonInfo->getInstallPath().'/dist/'.$entry;
+                    $entryFilePath = DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/dist/'.$entry;
                     $assetContents[$entry] = file_get_contents($entryFilePath);
                 }
 

--- a/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
@@ -87,7 +87,8 @@ final class Registrator
         $this->addons[$addonName] = [
             'enabled'      => false,
             'installed_at' => Carbon::now()->toIso8601String(),
-            'install_path' => realpath($this->packageInformation->getInstallPath($addonName)),
+            // use relative path to be compatible with different environments
+            'install_path' => 'addons/vendor/'.$addonName,
             'manifest'     => $this->loadManifest($addonName),
         ];
     }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
 use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -42,9 +43,10 @@ class AddonBuildFrontendCommand extends CoreCommand
 
         $addonInfo = $this->registry[$input->getArgument('addon-name')];
 
+        $addonPath = DemosPlanPath::getRootPath($addonInfo->getInstallPath());
         $consoleReturn = Batch::create($this->getApplication(), $output)
-            ->addShell(['yarn', 'install', '--frozen-lockfile'], $addonInfo->getInstallPath())
-            ->addShell(['yarn', 'run', 'webpack', '--node-env=production'], $addonInfo->getInstallPath())
+            ->addShell(['yarn', 'install', '--frozen-lockfile'], $addonPath)
+            ->addShell(['yarn', 'run', 'webpack', '--node-env=production'], $addonPath)
             ->run();
 
         return 0 === $consoleReturn ? self::SUCCESS : self::FAILURE;


### PR DESCRIPTION
Addons should not store absolute paths as currently the configuration needs to be compatible with multiple environments with different paths. Therefore the path needs to be relative

### How to review/test
install addon 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
