### PR TITLE
bug(refs: T31401): fix edit menu does not trigger when selecting single statements in a-table

### DIFF
--- a/client/js/components/statement/assessmentTable/TocView/AssessmentTableGroup.vue
+++ b/client/js/components/statement/assessmentTable/TocView/AssessmentTableGroup.vue
@@ -27,8 +27,8 @@
         :is-selected="getSelectionStateById(statement.id)"
         :statement-id="statement.id"
         :statement-procedure-id="statement.procedureId"
-        @add-to-selection="addToSelectionAction"
-        @remove-from-selection="removeFromSelectionAction" />
+        @statement:addToSelection="addToSelectionAction"
+        @statement:removeFromSelection="removeFromSelectionAction" />
     </ul>
 
     <ul


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T31539

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- Since the event names for adding and removing statements from the selection the logic to trigger the edit menu of AssessmentTableFilter.vue was broken. By adding the correct event names the edit menu appears now when selecting a single or multiple statements.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as FPA user
- Navigate to a-table
- Select a single or multiple Statements
- The edit menu should trigger now and these statements should be exportable as a docx file


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly


![Screenshot 2023-02-22 at 15-27-12 Abwägungstabelle Alsterdorf1 Bauleitplanung Online](https://user-images.githubusercontent.com/91727189/220651042-892e2f08-7b28-40e0-969e-bb49e47176c7.png)
