### PR TITLE
Feat_(T31035): adjust design: global news list - diplanbau

### DIFF
--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
@@ -14,7 +14,7 @@
 
     <div class="{{ 'layout'|prefixClass }}">
         {% set cols = templateVars.list.newslist|length %}
-        {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm o-page__news--item' %}
+        {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm o-page__news-item' %}
         {% for newsItem in templateVars.list.newslist %}
 
             <div class="{{ classes|prefixClass }}">

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
@@ -5,14 +5,16 @@
             {{ "news.announcements"|trans }}
         </h2>
         <a class="{{ 'layout__item u-1-of-2 text--right u-mb-0_5 u-pl-0'|prefixClass }}" href="{{ path('DemosPlan_globalnews_news') }}">
-            {{ "news.see.all"|trans }}
+            <span>
+                {{ "news.see.all"|trans }}
+            </span>
             <i class="{{ 'fa fa-angle-right'|prefixClass }}" aria-hidden="true"></i>
         </a>
     </header>
 
     <div class="{{ 'layout'|prefixClass }}">
         {% set cols = templateVars.list.newslist|length %}
-        {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm' %}
+        {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm o-page__news--item' %}
         {% for newsItem in templateVars.list.newslist %}
 
             <div class="{{ classes|prefixClass }}">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

**Description:** This PR presents small changes in the `public_index_globalnewslist.html.twig` file in order to apply required design in the DiPlanbau project.

- place link into the` <span>` tag
- add new class _o-page__news--item_ to a div

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
