### PR TITLE
fix (refs T31518): Use Event that is triggered on manual login

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/UserLoginSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/UserLoginSubscriber.php
@@ -17,9 +17,8 @@ use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanUserBundle\Logic\UserService;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\JWTUserToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 
 class UserLoginSubscriber extends BaseEventSubscriber
 {
@@ -28,20 +27,14 @@ class UserLoginSubscriber extends BaseEventSubscriber
      */
     private $userService;
 
-    /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
-    public function __construct(TokenStorageInterface $tokenStorage, UserService $userService)
+    public function __construct(UserService $userService)
     {
         $this->userService = $userService;
-        $this->tokenStorage = $tokenStorage;
     }
 
-    public function onLogin(): void
+    public function onLogin(AuthenticationSuccessEvent $event): void
     {
-        $token = $this->tokenStorage->getToken();
+        $token = $event->getAuthenticationToken();
         if ($token instanceof TokenInterface && !$token instanceof JWTUserToken) {
             $user = $token->getUser();
             if ($user instanceof User && !$user instanceof FunctionalUser) {
@@ -54,7 +47,7 @@ class UserLoginSubscriber extends BaseEventSubscriber
     public static function getSubscribedEvents(): array
     {
         return [
-            InteractiveLoginEvent::class => 'onLogin',
+            AuthenticationSuccessEvent::class => 'onLogin',
         ];
     }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31518

Field `last_login` was not updated any more after upgrading the symfony authentication system

### How to review/test
login via login form and the field should be updated

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
