### PR TITLE
bug(refs T23632): enable automatic name extraction in bimschg antrag x

### DIFF
--- a/client/js/bundles/procedure/administrationNew.js
+++ b/client/js/bundles/procedure/administrationNew.js
@@ -14,10 +14,14 @@
 import CreateProcedure from '@DpJs/lib/procedure/CreateProcedure'
 import DpNewProcedure from '@DpJs/components/procedure/admin/DpNewProcedure/DpNewProcedure'
 import { initialize } from '@DpJs/InitVue'
+import NewProcedure from '@DpJs/store/procedure/NewProcedure'
 
 const components = { DpNewProcedure }
+const stores = {
+  NewProcedure: NewProcedure
+}
 
-initialize(components)
+initialize(components, stores)
   .then(() => {
     // Prevent multiple form submits
     document.addEventListener('customValidationPassed', (e) => {

--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -77,7 +77,7 @@
           :label="{ text: Translator.trans('name') }"
           :maxlength="200"
           name="r_name"
-          required
+          :required="requireField"
           type="text" />
       </dp-form-row>
       <dp-form-row v-if="hasPermission('feature_procedure_templates')">
@@ -215,6 +215,7 @@ import {
 } from '@demos-europe/demosplan-ui'
 import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import CoupleTokenInput from './CoupleTokenInput'
+import { mapState } from 'vuex'
 
 export default {
   name: 'DpNewProcedure',
@@ -291,6 +292,10 @@ export default {
   },
 
   computed: {
+    ...mapState('newProcedure', [
+      'requireField'
+    ]),
+
     currentProcedureTypeId () {
       return this.currentProcedureType.id || ''
     }

--- a/client/js/store/procedure/NewProcedure.js
+++ b/client/js/store/procedure/NewProcedure.js
@@ -18,9 +18,9 @@ const NewProcedure = {
 
   mutations: {
     /**
-     *
+     * Sets required attribute of a form field dynamically to true/false if the attribute is bound to requireField.
      * @param state {Object}
-     * @param value {Boolean} Sets required form field dynamically to true/false.
+     * @param value {Boolean}
      */
     setRequiredField (state, value) {
       state.requireField = value

--- a/client/js/store/procedure/NewProcedure.js
+++ b/client/js/store/procedure/NewProcedure.js
@@ -1,0 +1,30 @@
+/**
+ * (c) 2010-present DEMOS E-Partizipation GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+const NewProcedure = {
+  namespaced: true,
+
+  name: 'newProcedure',
+
+  state: {
+    requireField: true
+  },
+
+  mutations: {
+    /**
+     *
+     * @param state {Object}
+     * @param value {Boolean} Sets required form field dynamically to true/false.
+     */
+    setRequiredField (state, value) {
+      state.requireField = value
+    }
+  },
+}
+export default NewProcedure


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T23632

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- To enable the communication between the upload component and DpNewProcedure, which inherits the AntragX upload component, a store has been introduced to dynamically determine if the name field is required when creating a new procedure. This field is only required when no AntragX file is being uploaded since the procedure name will be extracted from there. The problem is that the name can only be extracted after submitting the form but to submit the form the name field was required.

- Now the store holds the state weather or not the name field is required. The decision for a store has been made because I simply do not like to $root emit events since this is an easy way to lose the ability to read easily through the code and also the $root pattern is not recommended to use since it can be dangerous to use it due to being prone to unwanted behavior in the application.

- Now the vuex store is the single source of truth weather the name field is required or not.

- The form field is only required when not uploading an AntragX file since the name will be extracted from it after submitting the form and the name input would be overwritten anyways so it was simply not useful to have the requirement to add a name when uploading an AntragX.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Create a new procedure in bimschgsh
- Upload a AntragX file
- When uploaded the name field should not be required anymore since the name will be extracted from the uploaded file
- When deleting the uploaded file without submitting, the name field should be set to required automatically

### Linked PRs (optional)
- [This is the addon PR](https://github.com/demos-europe/demosplan-addon-bimschg-antrag/pull/3) 

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
