### PR TITLE
fix: remove bogus import in Test

### DIFF
--- a/tests/backend/core/Map/Functional/MapCapabilitiesLoaderTest.php
+++ b/tests/backend/core/Map/Functional/MapCapabilitiesLoaderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Tests\Core\Map\Functional;
 
 use demosplan\DemosPlanCoreBundle\Logic\Maps\MapCapabilitiesLoader;
-use string;
 use Tests\Base\FunctionalTestCase;
 
 class MapCapabilitiesLoaderTest extends FunctionalTestCase


### PR DESCRIPTION
This PR removes a useless import in a class that leads to a parse error

### How to review/test
run `MapCapabilitiesLoaderTest.php`

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
