### PR TITLE
fix: avoid syntax error in migrate command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
@@ -63,7 +63,7 @@ class MigrateCommand extends CoreCommand
         if (file_exists(DemosPlanPath::getProjectPath($lastRollupMigration))) {
             $commands[] = $migrationsSyncCommand.$migrationsConfigurationPath." {$db} --env={$env}";
             $commands[] = $migrationsCommand.$migrationsConfigurationPath.
-                    'Application\Migrations\Version20220914133419'." {$db} --env={$env}";
+                    ' Application\Migrations\Version20220914133419'." {$db} --env={$env}";
         }
 
         $commands[] = "doctrine:migrations:migrate {$db} --env={$env}";


### PR DESCRIPTION
A blank was missing between the configuration and the classname that lead to the error, that the rollup
migrations for the project where not performed

### How to review/test
code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
