### PR TITLE
feature (refs T31261): fix import of docx paragraph-elements & deletion of imported docx file after processing.

### DIFF
--- a/demosplan/DemosPlanDocumentBundle/Repository/ParagraphRepository.php
+++ b/demosplan/DemosPlanDocumentBundle/Repository/ParagraphRepository.php
@@ -490,18 +490,20 @@ class ParagraphRepository extends CoreRepository implements ArrayInterface, Obje
             $paragraphIdMapping[$paragraphToCopy->getId()] = $copiedParagraph->getId();
         }
         $this->getEntityManager()->persist($copiedElement);
+        $this->getEntityManager()->flush();
 
         $copiedParagraphs = $this->getParagraphOfElement($copiedElement);
         foreach ($copiedParagraphs as $copiedParagraph) {
             if ($copiedParagraph->getParent() instanceof Paragraph) {
                 $oldParentId = $copiedParagraph->getParent()->getId();
                 $relatedCopiedParagraph = $this->getEntityManager()->getReference(
-                    Procedure::class, $paragraphIdMapping[$oldParentId]
+                    Paragraph::class, $paragraphIdMapping[$oldParentId]
                 );
                 $copiedParagraph->setParent($relatedCopiedParagraph);
             }
             $this->getEntityManager()->persist($copiedParagraph);
         }
+        $this->getEntityManager()->flush();
     }
 
     /**


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31261

Description:
fix import of docx paragraph-elements.
fix deletion of imported docx file after processing.
The change made in the paragraph-repository fixes the import problem, but lead to an error message regarding a non existing
docx. After importing its content - the docx file should get deleted. The imported docx was never deleted as file entity represented in our database just its content got deleted.
When creating procedures from this 'broken' blueprint - the procedure-related files get copied which breaks when fetching the non existant file.

### How to review/test
create a new blueprint - create planingDocuments Begründung - upload the example file within the ticket - then use this bluprint to create a new procedure - check the planing-documents

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
