### PR TITLE
bug(refs T30632): Create baselayers always with layersource

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -574,7 +574,7 @@ export default {
     createLayer ({ layer, opacity = 1, visibility = true, preload = 0 }) {
       const name = layer.id.replaceAll('-', '')
       const visible = layer.attributes.hasDefaultVisibility && visibility
-      const source = this.createLayerSource(layer)
+      const source = visibility ? this.createLayerSource(layer) : null
 
       return new TileLayer({
         name: name,
@@ -1166,6 +1166,9 @@ export default {
           }
 
           allPrintLayers.forEach(printLayer => {
+            if (!printLayer.getSource()) {
+              this.setLayerSource(printLayer)
+            }
             const printLayerName = printLayer.getProperties().name
             const source = printLayer.getSource()
             const tileUrlFunction = source.getTileUrlFunction()

--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -574,8 +574,7 @@ export default {
     createLayer ({ layer, opacity = 1, visibility = true, preload = 0 }) {
       const name = layer.id.replaceAll('-', '')
       const visible = layer.attributes.hasDefaultVisibility && visibility
-      const source = visibility ? this.createLayerSource(layer) : null
-      // Const source = this.createLayerSource(layer, serviceType)
+      const source = this.createLayerSource(layer)
 
       return new TileLayer({
         name: name,


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30632

Creating the layersource was removed for hidden layers because of performance, but we also need the layer sources for hidden layers. Otherwise when updating the map fields right after loading the page (eg with drawing in the map) we get an error, because not all print layers have a source.

### How to review/test
Login as FPA and create a layer with print, but otherwise hidden and one that is not hidden (under Verfahren -> Planunterlagen und Planzeichnung -> Kartenebenen definieren).

![layers](https://user-images.githubusercontent.com/101879352/222078662-81a88dbb-03ff-4afc-87d1-512249a7a5af.png)

Then login as Privatperson and go to the public site of the procedure. You should be able to draw something in the map immediately without having to change the layers first. 



