### PR TITLE
Fix(refs:T31512): Replace consideration with considerationadvice

### DIFF
--- a/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
@@ -82,7 +82,7 @@
         <label
           for="r_consideration"
           class="display--inline-block">
-          {{ Translator.trans('considerationadvice.add') }}
+          {{ Translator.trans('consideration.text.add') }}
         </label>
         <div
           v-if="options.consideration.checked"
@@ -91,7 +91,7 @@
             for="r_consideration_value"
             class="u-mb-0_25  u-n-mt-0_5" /><!--
           --><p class="lbl__hint u-mb-0_5">
-          {{ Translator.trans('considerationadvice.add.explanation') }}
+          {{ Translator.trans('consideration.text.add.explanation') }}
         </p>
 
           <dp-editor

--- a/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
@@ -82,7 +82,7 @@
         <label
           for="r_consideration"
           class="display--inline-block">
-          {{ Translator.trans('consideration.text.add') }}
+          {{ Translator.trans('considerationadvice.add') }}
         </label>
         <div
           v-if="options.consideration.checked"
@@ -91,7 +91,7 @@
             for="r_consideration_value"
             class="u-mb-0_25  u-n-mt-0_5" /><!--
           --><p class="lbl__hint u-mb-0_5">
-          {{ Translator.trans('consideration.text.add.explanation') }}
+          {{ Translator.trans('considerationadvice.add.explanation') }}
         </p>
 
           <dp-editor

--- a/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
@@ -83,13 +83,13 @@
         <label
           for="r_recommendation"
           class="display--inline-block">
-          {{ Translator.trans('consideration.text.add') }}
+          {{ Translator.trans('considerationadvice.text.add') }}
         </label>
         <div
           v-if="options.recommendation.checked"
           class="u-ml">
           <p class="lbl__hint u-mb-0_5">
-            {{ Translator.trans('consideration.text.add.explanation') }}
+            {{ Translator.trans('considerationadvice.text.add.explanation') }}
           </p>
           <dp-editor
             :value="options.recommendation.value"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -649,8 +649,8 @@ consideration.versions: "Ältere Versionen der Abwägung / Empfehlung"
 considerationadvice.fpf: "Empfehlung der Fachbehörde oder des Planungsbüros"
 # this should only be used when referring to the field on fragments. statements use 'recommendation'
 considerationadvice: "Abwägung / Empfehlung"
-considerationadvice.add: "Abwägung / Empfehlung ergänzen"
-considerationadvice.add.explanation: "Der Text wird bei einer evtl. bestehenden Abwägung / Empfehlung ans Textende angehängt."
+considerationadvice.text.add: "Abwägung / Empfehlung ergänzen"
+considerationadvice.text.add.explanation: "Der Text wird bei einer evtl. bestehenden Abwägung / Empfehlung ans Textende angehängt."
 considerationtable.back: "Zurück zur Abwägungstabelle"
 # deliberation table?
 considerationtable: "Abwägungstabelle"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -649,6 +649,8 @@ consideration.versions: "Ältere Versionen der Abwägung / Empfehlung"
 considerationadvice.fpf: "Empfehlung der Fachbehörde oder des Planungsbüros"
 # this should only be used when referring to the field on fragments. statements use 'recommendation'
 considerationadvice: "Abwägung / Empfehlung"
+considerationadvice.add: "Abwägung / Empfehlung ergänzen"
+considerationadvice.add.explanation: "Der Text wird bei einer evtl. bestehenden Abwägung / Empfehlung ans Textende angehängt."
 considerationtable.back: "Zurück zur Abwägungstabelle"
 # deliberation table?
 considerationtable: "Abwägungstabelle"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31512

Description: if you would like to edit the considerationadvice in AT, it says in the edit part consideration and this is confusing

### How to review/test
- go to AT, click a checkbox of a statement, go to `Bearbeiten`


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
