### PR TITLE
bug (refs T31604): fix occurrences of "Web-Atlas" in blueprints by replacing them with "basemap"

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
@@ -38,7 +38,7 @@ class Version20230301094921 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-        //color
+        // color
         $this->addSql(
             'UPDATE _gis AS g
             INNER JOIN _procedure AS p ON g._p_id = p._p_id
@@ -50,15 +50,15 @@ class Version20230301094921 extends AbstractMigration
             AND g._g_url NOT LIKE :oldGisUrlGray
             AND p._p_master = 1 AND p._p_deleted = 0',
             [
-                'gisName'     => self::NEW_GIS_NAME,
-                'gisLayer'    => self::NEW_GIS_LAYER_COLOR,
-                'newGisUrl'   => self::NEW_GIS_URL,
-                'oldGisUrl'   => self::OLD_GIS_URL,
+                'gisName'         => self::NEW_GIS_NAME,
+                'gisLayer'        => self::NEW_GIS_LAYER_COLOR,
+                'newGisUrl'       => self::NEW_GIS_URL,
+                'oldGisUrl'       => self::OLD_GIS_URL,
                 'oldGisUrlGray'   => self::OLD_GIS_URL_GRAY,
             ]
         );
 
-        //grey
+        // grey
         $this->addSql(
             'UPDATE _gis AS g
             INNER JOIN _procedure AS p ON g._p_id = p._p_id
@@ -69,9 +69,9 @@ class Version20230301094921 extends AbstractMigration
             WHERE g._g_url LIKE :oldGisUrlGray
             AND p._p_master = 1 AND p._p_deleted = 0',
             [
-                'gisName'     => self::NEW_GIS_NAME,
-                'gisLayer'    => self::NEW_GIS_LAYER_GRAY,
-                'newGisUrl'   => self::NEW_GIS_URL,
+                'gisName'         => self::NEW_GIS_NAME,
+                'gisLayer'        => self::NEW_GIS_LAYER_GRAY,
+                'newGisUrl'       => self::NEW_GIS_URL,
                 'oldGisUrlGray'   => self::OLD_GIS_URL_GRAY,
             ]
         );

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230301094921 extends AbstractMigration
+{
+    private const NEW_GIS_NAME = 'basemap';
+    private const NEW_GIS_LAYER = 'de_basemapde_web_raster_farbe';
+    private const NEW_GIS_URL = 'https://sgx.geodatenzentrum.de/wms_basemapde';
+
+    private const OLD_GIS_URL = '%webatlas%';
+
+    public function getDescription(): string
+    {
+        return 'refs T31604: Replace every occurrences of "Web-Atlas" by basemap only for procedure templates.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        // Replace all Web-Atlas Entries by basemap (only for procedure templates).
+        $this->addSql(
+            'UPDATE _gis AS g
+            INNER JOIN _procedure AS p ON g._p_id = p._p_id
+            SET
+                g._g_name = :gisName,
+                g._g_layers = :gisLayer,
+                g._g_url = :newGisUrl
+            WHERE g._g_url LIKE :oldGisUrl AND p._p_master = 1 AND p._p_deleted = 0',
+            [
+                'gisName'     => self::NEW_GIS_NAME,
+                'gisLayer'    => self::NEW_GIS_LAYER,
+                'newGisUrl'   => self::NEW_GIS_URL,
+                'oldGisUrl'   => self::OLD_GIS_URL,
+            ]
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        // This migration is not reversible because we can't
+        // be sure the Web-Atlas was already replaced by basemap.
+        $this->abortIfNotMysql();
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230301094921.php
@@ -19,10 +19,12 @@ use Doctrine\Migrations\AbstractMigration;
 class Version20230301094921 extends AbstractMigration
 {
     private const NEW_GIS_NAME = 'basemap';
-    private const NEW_GIS_LAYER = 'de_basemapde_web_raster_farbe';
+    private const NEW_GIS_LAYER_COLOR = 'de_basemapde_web_raster_farbe';
+    private const NEW_GIS_LAYER_GRAY = 'de_basemapde_web_raster_grau';
     private const NEW_GIS_URL = 'https://sgx.geodatenzentrum.de/wms_basemapde';
 
-    private const OLD_GIS_URL = '%webatlas%';
+    private const OLD_GIS_URL = 'https://sg.geodatenzentrum.de/wms_webatlasde%';
+    private const OLD_GIS_URL_GRAY = 'https://sg.geodatenzentrum.de/wms_webatlasde_grau%';
 
     public function getDescription(): string
     {
@@ -36,7 +38,7 @@ class Version20230301094921 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-        // Replace all Web-Atlas Entries by basemap (only for procedure templates).
+        //color
         $this->addSql(
             'UPDATE _gis AS g
             INNER JOIN _procedure AS p ON g._p_id = p._p_id
@@ -44,12 +46,33 @@ class Version20230301094921 extends AbstractMigration
                 g._g_name = :gisName,
                 g._g_layers = :gisLayer,
                 g._g_url = :newGisUrl
-            WHERE g._g_url LIKE :oldGisUrl AND p._p_master = 1 AND p._p_deleted = 0',
+            WHERE g._g_url LIKE :oldGisUrl
+            AND g._g_url NOT LIKE :oldGisUrlGray
+            AND p._p_master = 1 AND p._p_deleted = 0',
             [
                 'gisName'     => self::NEW_GIS_NAME,
-                'gisLayer'    => self::NEW_GIS_LAYER,
+                'gisLayer'    => self::NEW_GIS_LAYER_COLOR,
                 'newGisUrl'   => self::NEW_GIS_URL,
                 'oldGisUrl'   => self::OLD_GIS_URL,
+                'oldGisUrlGray'   => self::OLD_GIS_URL_GRAY,
+            ]
+        );
+
+        //grey
+        $this->addSql(
+            'UPDATE _gis AS g
+            INNER JOIN _procedure AS p ON g._p_id = p._p_id
+            SET
+                g._g_name = :gisName,
+                g._g_layers = :gisLayer,
+                g._g_url = :newGisUrl
+            WHERE g._g_url LIKE :oldGisUrlGray
+            AND p._p_master = 1 AND p._p_deleted = 0',
+            [
+                'gisName'     => self::NEW_GIS_NAME,
+                'gisLayer'    => self::NEW_GIS_LAYER_GRAY,
+                'newGisUrl'   => self::NEW_GIS_URL,
+                'oldGisUrlGray'   => self::OLD_GIS_URL_GRAY,
             ]
         );
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31604

Description: "Web Atlas" was not replaced with "basemap" in all procedure templates. 
 This was due to the fact that different urls are used for "Web Atlas", but only one was checked in https://github.com/demos-europe/demosplan-core/pull/578.
 Anyway, this PR should catch every url with "webatlas" in it.

### How to review/test
First: Find a older procedure template with a "Web-Atlas" as map (hint: not all have the name "Web-Atlas", so check if the url contains "webatlas".)
Then execute the migration.
And finally check the founded procedure template again. You should don't find any occurrences of "webaltas" in other procedure templates.

You could also check the database. In the ticket is a statement to find occurrences.


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
