### PR TITLE
Add styles to fix layout jump

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_card.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_card.scss
@@ -31,9 +31,11 @@
     }
 
     &.is-expanded {
+        position: relative; // Force the element above other elements to show the box shadow
         border-left: 2px solid $dp-color-neutral-base;
         width: 100%;
-        margin: 8px 0;
+        margin: 0 0 0 -2px;
+        padding-right: 11px;
         box-shadow: $dp-token-box-shadow-1;
 
         + li {


### PR DESCRIPTION
Instead of adding a margin to the expanded item to show its box shadow (which otherwise is overlapped from following items), positioning it relative solves this problem, too. The negative left margin and reduced right padding ensure the item stays within its vertical axis even with added box-shadow.

### How to review/test
 Login as a support user in projects that use `DpTableCard`, and click on a card. It should stay in place also in expalded state.