### PR TITLE
Fix(refs:T31701): platform settings are not loading

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettings.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettings.vue
@@ -417,7 +417,7 @@ export default {
           }
         },
         fields: this.requestFields,
-        includes: this.requestIncludes.join(',')
+        include: this.requestIncludes.join(',')
       }
     },
 


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/T31701

Description: in the `getRequestPayload` in the return it should be `include` instead of `includes` otherwise there are no relationships in the payload and we get undefined for the requested attributes

### How to review/test
- login as support and go to the platform settings

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
