### PR TITLE
f implement split statement view with dynamic props

### DIFF
--- a/client/js/bundles/procedure/administrationSplitStatement.js
+++ b/client/js/bundles/procedure/administrationSplitStatement.js
@@ -11,11 +11,15 @@
  * This is the entrypoint for administration_split_statement.html.twig
  */
 
+import AddonWrapper from "@DpJs/components/addon/AddonWrapper"
 import { initialize } from '@DpJs/InitVue'
 import SplitStatementStore from '@DpJs/store/procedure/SplitStatementStore'
 import SplitStatementView from '@DpJs/components/procedure/splitStatement/SplitStatementView'
 
-const components = { SplitStatementView }
+const components = {
+  AddonWrapper,
+  SplitStatementView
+}
 const stores = {
   splitstatement: SplitStatementStore
 }

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_split_statement.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_split_statement.html.twig
@@ -7,6 +7,19 @@
         {% set submitTypeOptions = submitTypeOptions|merge([{ label: label, value: value }]) %}
     {% endfor %}
 
+    {% set addonProps = {
+        'procedureId': procedure,
+        'statementId': statementId,
+        'statementExternId': statementExternId,
+        'procedureId': procedure,
+        'procedureName': procedureName,
+        'title': title
+        }
+    %}
+    <addon-wrapper
+        hook-name="split.statements"
+        :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">
+    </addon-wrapper>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T31759

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### Can only be tested after demospipes addon was installed
- Since we need the split statement view for enabling the demospipes addon, this commit adds the addon wrapper to load the split statement view
- Also passing the required props via twig into the addon
- Adds AddonWrapper to entrypoint

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
