### PR TITLE
fix: avoid exception in uncalled listener

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
@@ -302,17 +302,17 @@ parameters:
 
     # SAML-related settings. These are set in config files in project folder
     # this is just an example to document the keys
-    saml_baseurl: ''
-    saml_idp_entityid: ''
-    saml_idp_slo_url: ''
-    saml_idp_sso_url: ''
-    saml_idp_x509_string: ''
-    saml_sp_acs_url: ''
-    saml_sp_entityid: ''
-    saml_sp_sls_url: ''
-    saml_sp_x509_private_string: ''
-    saml_sp_x509_string: ''
-    saml_registration_url: ''
+    saml_baseurl: 'http://localhost/'
+    saml_idp_entityid: 'id'
+    saml_idp_slo_url: 'http://localhost/'
+    saml_idp_sso_url: 'http://localhost/'
+    saml_idp_x509_string: 'secretString'
+    saml_sp_acs_url: 'http://localhost/'
+    saml_sp_entityid: 'id'
+    saml_sp_sls_url: 'http://localhost/'
+    saml_sp_x509_private_string: 'secretString'
+    saml_sp_x509_string: 'secretString'
+    saml_registration_url: 'http://localhost/'
 
     # Set users with permissions to alter Database
     database_install_user: ""


### PR DESCRIPTION
When no SAML is configured the default configuration needs to meet some basic requirements. These are set so that the exception would not be thrown anymore.

### How to review/test
clear cache and find no info about the exception in an uncalled listener any more

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
