### PR TITLE
bug(refs T31795): add slots for boilerplate

### DIFF
--- a/client/js/bundles/news/newsAdminEdit.js
+++ b/client/js/bundles/news/newsAdminEdit.js
@@ -11,15 +11,18 @@
  * This is the entrypoint for news_admin_edit.html.twig
  */
 
-import { DpChangeStateAtDate, DpEditor, DpUploadFiles } from '@demos-europe/demosplan-ui'
+import { DpChangeStateAtDate, DpEditor, DpLabel, DpUploadFiles } from '@demos-europe/demosplan-ui'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 import newsAdminInit from '@DpJs/lib/news/newsAdmin'
 
 const components = {
+  DpBoilerPlateModal,
   DpChangeStateAtDate,
   DpEditor,
+  DpLabel,
   DpUploadFiles
 }
 

--- a/client/js/bundles/news/newsAdminNew.js
+++ b/client/js/bundles/news/newsAdminNew.js
@@ -11,15 +11,18 @@
  * This is the entry point for news_admin_new.html.twig
  */
 
-import { DpChangeStateAtDate, DpEditor, DpUploadFiles } from '@demos-europe/demosplan-ui'
+import { DpChangeStateAtDate, DpEditor, DpLabel, DpUploadFiles } from '@demos-europe/demosplan-ui'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 import newsAdminInit from '@DpJs/lib/news/newsAdmin'
 
 const components = {
+  DpBoilerPlateModal,
   DpChangeStateAtDate,
   DpEditor,
+  DpLabel,
   DpUploadFiles
 }
 

--- a/client/js/bundles/procedure/administrationMemberEmail.js
+++ b/client/js/bundles/procedure/administrationMemberEmail.js
@@ -12,12 +12,14 @@
  */
 import { DpAccordion, DpEditor, DpInlineNotification, DpLabel } from '@demos-europe/demosplan-ui'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import DpEmailList from '@DpJs/components/procedure/basicSettings/DpEmailList'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 
 const components = {
   DpAccordion,
+  DpBoilerPlateModal,
   DpEditor,
   DpEmailList,
   DpInlineNotification,

--- a/client/js/bundles/procedure/administrationSendEmail.js
+++ b/client/js/bundles/procedure/administrationSendEmail.js
@@ -11,12 +11,13 @@
  * This is the entrypoint for administration_send_email.html.twig
  */
 
-import { DpCheckbox, DpEditor } from '@demos-europe/demosplan-ui'
+import { DpCheckbox, DpEditor, DpLabel } from '@demos-europe/demosplan-ui'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 
-const components = { DpCheckbox, DpEditor }
+const components = { DpBoilerPlateModal, DpCheckbox, DpEditor, DpLabel }
 
 const stores = {
   boilerplates: BoilerplatesStore

--- a/client/js/bundles/procedure/administrationUnregisteredPublicagencyEmail.js
+++ b/client/js/bundles/procedure/administrationUnregisteredPublicagencyEmail.js
@@ -10,12 +10,13 @@
 /**
  * This is the entrypoint for administration_unregistered_publicagency_email.html.twig
  */
-import { DpAccordion, DpEditor } from '@demos-europe/demosplan-ui'
+import { DpAccordion, DpEditor, DpLabel } from '@demos-europe/demosplan-ui'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 
-const components = { DpAccordion, DpEditor }
+const components = { DpAccordion, DpBoilerPlateModal, DpEditor, DpLabel }
 
 const stores = {
   boilerplates: BoilerplatesStore

--- a/client/js/bundles/statement/assessmentStatement.js
+++ b/client/js/bundles/statement/assessmentStatement.js
@@ -11,11 +11,12 @@
  * This is the entrypoint for assessment_statement.html.twig and cluster_detail.html.twig
  */
 
+import { DpEditor, DpLabel, DpUploadFiles } from '@demos-europe/demosplan-ui'
 import AssessmentStatement from '@DpJs/lib/statement/AssessmentStatement'
 import AssessmentTableStore from '@DpJs/store/statement/AssessmentTable'
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
 import DetailView from '@DpJs/components/statement/assessmentTable/DetailView/DetailView'
-import { DpUploadFiles } from '@demos-europe/demosplan-ui'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 import StatementStore from '@DpJs/store/statement/Statement'
@@ -30,6 +31,9 @@ const stores = {
 
 const components = {
   DetailView,
+  DpBoilerPlateModal,
+  DpEditor,
+  DpLabel,
   DpUploadFiles
 }
 

--- a/client/js/bundles/user/customersettingsmail.js
+++ b/client/js/bundles/user/customersettingsmail.js
@@ -11,10 +11,14 @@
  * This is the entrypoint for customer_settings_update_mail.html.twig
  */
 import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
+import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
+import { DpLabel } from '@demos-europe/demosplan-ui'
 import dpValidate from '@demos-europe/demosplan-utils/lib/validation/dpValidate'
 import { initialize } from '@DpJs/InitVue'
 
 const components = {
+  DpBoilerPlateModal,
+  DpLabel,
   DpEditor: async () => {
     const { DpEditor } = await import('@demos-europe/demosplan-ui')
     return DpEditor

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -118,7 +118,7 @@
             id="addRecommendationTipTap"
             v-model="actions.addRecommendations.text"
             editor-id="recommendationText"
-            :toolbar-items="{https://github.com/demos-europe/demosplan-core/pull/969
+            :toolbar-items="{
               fullscreenButton: true,
               linkButton: true
             }">

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -118,7 +118,7 @@
             id="addRecommendationTipTap"
             v-model="actions.addRecommendations.text"
             editor-id="recommendationText"
-            :toolbar-items="{
+            :toolbar-items="{https://github.com/demos-europe/demosplan-core/pull/969
               fullscreenButton: true,
               linkButton: true
             }">
@@ -128,7 +128,7 @@
                 boiler-plate-type="consideration"
                 editor-id="recommendationText"
                 :procedure-id="procedureId"
-                @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+                @insert="text => modalProps.handleInsertText(text)" />
             </template>
             <template v-slot:button>
               <button

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -112,7 +112,7 @@
               boiler-plate-type="consideration"
               editor-id="recommendationText"
               :procedure-id="procedureId"
-              @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+              @insert="text => modalProps.handleInsertText(text)" />
             <dp-recommendation-modal
               v-if="segment.hasRelationship('tags')"
               ref="recommendationModal"

--- a/client/js/components/statement/DpBoilerPlateModal.vue
+++ b/client/js/components/statement/DpBoilerPlateModal.vue
@@ -123,7 +123,7 @@ export default {
     },
 
     insertBoilerPlate () {
-      this.$emit('insertBoilerPlate', this.textToBeAdded)
+      this.$emit('insert', this.textToBeAdded)
       this.resetAndClose()
     },
 

--- a/client/js/components/statement/assessmentTable/DetailView/DetailViewFinalEmailBody.vue
+++ b/client/js/components/statement/assessmentTable/DetailView/DetailViewFinalEmailBody.vue
@@ -17,7 +17,7 @@
         ref="boilerPlateModal"
         boiler-plate-type="email"
         :procedure-id="procedureId"
-        @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+        @insert="text => modalProps.handleInsertText(text)" />
     </template>
     <template v-slot:button>
       <button

--- a/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
@@ -103,7 +103,7 @@
                 ref="boilerPlateModal"
                 boiler-plate-type="consideration"
                 :procedure-id="procedureId"
-                @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+                @insert="text => modalProps.handleInsertText(text)" />
             </template>
             <template v-slot:button>
               <button

--- a/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
@@ -100,7 +100,7 @@
                 ref="boilerPlateModal"
                 boiler-plate-type="consideration"
                 :procedure-id="procedureId"
-                @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+                @insert="text => modalProps.handleInsertText(text)" />
             </template>
             <template v-slot:button>
               <button

--- a/client/js/components/statement/assessmentTable/TiptapEditText.vue
+++ b/client/js/components/statement/assessmentTable/TiptapEditText.vue
@@ -46,7 +46,7 @@
             boiler-plate-type="consideration"
             :editor-id="editorId"
             :procedure-id="procedureId"
-            @insertBoilerPlate="text => modalProps.handleInsertText(text)" />
+            @insert="text => modalProps.handleInsertText(text)" />
         </template>
         <template v-slot:button>
           <button

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/shared/v1/assessment_statement_detail_statement_text.html.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/shared/v1/assessment_statement_detail_statement_text.html.twig
@@ -104,12 +104,28 @@
                                 editor-id="recommendationText"
                                 :entity-id="JSON.parse('{{ statement.id|json_encode|e('js') }}')"
                                 hidden-input="r_recommendation"
-                                procedure-id="{{ templateVars.table.procedure.ident }}"
                                 :toolbar-items="{
-                                    boilerPlate: 'consideration',
                                     linkButton: true
                                 }"
                                 v-model="currentRecommendation">
+                                <template v-slot:modal="modalProps">
+                                    <dp-boiler-plate-modal
+                                        ref="boilerPlateModal"
+                                        boiler-plate-type="consideration"
+                                        editor-id="recommendationText"
+                                        procedure-id="{{ templateVars.table.procedure.ident }}"
+                                        @insert="text => modalProps.handleInsertText(text)">
+                                    </dp-boiler-plate-modal>
+                                </template>
+                                <template v-slot:button>
+                                    <button
+                                        class="{{ 'menubar__button'|prefixClass }}"
+                                        type="button"
+                                        v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                                        @click.stop="$refs.boilerPlateModal.toggleModal()">
+                                        <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                                    </button>
+                                </template>
                             </dp-editor>
                         {% else %}
                             <span class="overflow-word-break">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -236,24 +236,40 @@
             ]
         }) }}
 
-        {{ uiComponent('form.row', {
-            elements: [
-                {
-                    label: { text: 'news.text'|trans },
-                    control: {
-                        value: news.text,
-                        procedureId: procedure,
-                        hiddenInput: 'r_text',
-                        linkButton: true,
-                        editorId: 'newsText',
-                        ref: 'r_text',
-                        boilerPlate: 'news.notes'
-                    },
-                    id: 'r_text',
-                    type: 'editor'
-                }
-            ]
-        }) }}
+        <div class="{{ 'u-mb-0_75'|prefixClass }}">
+            <dp-label
+                for="r_text"
+                text="{{ 'news.text'|trans }}">
+            </dp-label>
+            <dp-editor
+                id="r_text"
+                ref="r_text"
+                editor-id="newsText"
+                hidden-input="r_text"
+                :toolbar-items="{
+                    linkButton: true
+                }"
+                value="{{ news.text }}">
+                <template v-slot:modal="modalProps">
+                    <dp-boiler-plate-modal
+                        ref="boilerPlateModal"
+                        boiler-plate-type="news.notes"
+                        editor-id="newsText"
+                        procedure-id="{{ procedure }}"
+                        @insert="text => modalProps.handleInsertText(text)">
+                    </dp-boiler-plate-modal>
+                </template>
+                <template v-slot:button>
+                    <button
+                        class="{{ 'menubar__button'|prefixClass }}"
+                        type="button"
+                        v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                        @click.stop="$refs.boilerPlateModal.toggleModal()">
+                        <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                    </button>
+                </template>
+            </dp-editor>
+        </div>
 
         {% if news.picture is defined and news.picture != "" %}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_new.html.twig
@@ -193,24 +193,40 @@
             ]
         }) }}
 
-        {{ uiComponent('form.row', {
-            elements: [
-                {
-                    label: { text: 'news.text'|trans },
-                    control: {
-                        value: templateVars.prefill.r_text|default,
-                        procedureId: procedure,
-                        hiddenInput: 'r_text',
-                        linkButton: true,
-                        editorId: 'newsText',
-                        ref: 'r_text',
-                        boilerPlate: 'news.notes'
-                    },
-                    id: 'r_text',
-                    type: 'editor'
-                }
-            ]
-        }) }}
+        <div class="{{ 'u-mb-0_75'|prefixClass }}">
+            <dp-label
+                for="r_text"
+                text="{{ 'news.text'|trans }}">
+            </dp-label>
+            <dp-editor
+                id="r_text"
+                ref="r_text"
+                editor-id="newsText"
+                hidden-input="r_text"
+                :toolbar-items="{
+                    linkButton: true
+                }"
+                value="{{ templateVars.prefill.r_text|default }}">
+                <template v-slot:modal="modalProps">
+                    <dp-boiler-plate-modal
+                        ref="boilerPlateModal"
+                        boiler-plate-type="news.notes"
+                        editor-id="newsText"
+                        procedure-id="{{ procedure }}"
+                        @insert="text => modalProps.handleInsertText(text)">
+                    </dp-boiler-plate-modal>
+                </template>
+                <template v-slot:button>
+                    <button
+                        class="{{ 'menubar__button'|prefixClass }}"
+                        type="button"
+                        v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                        @click.stop="$refs.boilerPlateModal.toggleModal()">
+                        <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                    </button>
+                </template>
+            </dp-editor>
+        </div>
 
         {{
             fileupload(

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_member_email.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_member_email.html.twig
@@ -109,26 +109,40 @@
                 |json_encode|e('js', 'utf-8') }}')">
         </dp-email-list>
 
-
-        {{ uiComponent('form.row', {
-            elements: [
-                {
-                    label: { text: 'email.body'|trans },
-                    control: {
-                        value: templateVars.procedure.settings.emailText|default,
-                        boilerPlate: 'email',
-                        toolbarItems: { headings: [1, 2, 3] },
-                        hiddenInput: 'r_emailText',
-                        linkButton: true,
-                        procedureId: procedureId,
-                        ref: 'r_emailText'
-                    },
-                    type: 'editor',
-                    id: 'r_emailText',
-                    required: true
-                }
-            ]
-        }) }}
+        <div class="{{ 'u-mb-0_75'|prefixClass }}">
+            <dp-label
+                for="r_emailText"
+                text="{{ 'email.body'|trans }}">
+            </dp-label>
+            <dp-editor
+                id="r_emailText"
+                ref="r_emailText"
+                hidden-input="r_emailText"
+                :toolbar-items="{
+                    headings: [1, 2, 3],
+                    linkButton: true
+                }"
+                required
+                value="{{ templateVars.procedure.settings.emailText|default }}">
+                <template v-slot:modal="modalProps">
+                    <dp-boiler-plate-modal
+                        ref="boilerPlateModal"
+                        boiler-plate-type="email"
+                        procedure-id="{{ procedureId }}"
+                        @insert="text => modalProps.handleInsertText(text)">
+                    </dp-boiler-plate-modal>
+                </template>
+                <template v-slot:button>
+                    <button
+                        class="{{ 'menubar__button'|prefixClass }}"
+                        type="button"
+                        v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                        @click.stop="$refs.boilerPlateModal.toggleModal()">
+                        <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                    </button>
+                </template>
+            </dp-editor>
+        </div>
 
         <a
             href="{{ path('DemosPlan_procedure_member_index', {'procedure': procedureId}) }}"

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_send_email.html.twig
@@ -37,25 +37,40 @@
             ]
         }) }}
 
-        {{ uiComponent('form.row', {
-            elements: [
-                {
-                    label: { text: 'email.body'|trans },
-                    control: {
-                        name: 'r_email_body',
-                        boilerPlate: 'email',
-                        toolbarItems: { headings: [1,2,3] },
-                        hiddenInput: 'r_email_body',
-                        linkButton: true,
-                        procedureId: templateVars.procedureId
-                    },
-                    id: 'r_email_body',
-                    type: 'editor',
-                    required: true,
-                    value: templateVars.preparationMail.mailBody
-                }
-            ]
-        }) }}
+        <div class="{{ 'u-mb-0_75'|prefixClass }}">
+            <dp-label
+                for="r_email_body"
+                text="{{ 'email.body'|trans }}">
+            </dp-label>
+            <dp-editor
+                id="r_email_body"
+                ref="r_email_body"
+                hidden-input="r_email_body"
+                :toolbar-items="{
+                    headings: [1, 2, 3],
+                    linkButton: true
+                }"
+                required
+                value="{{ templateVars.preparationMail.mailBody }}">
+                <template v-slot:modal="modalProps">
+                    <dp-boiler-plate-modal
+                        ref="boilerPlateModal"
+                        boiler-plate-type="email"
+                        procedure-id="{{ templateVars.procedureId }}"
+                        @insert="text => modalProps.handleInsertText(text)">
+                    </dp-boiler-plate-modal>
+                </template>
+                <template v-slot:button>
+                    <button
+                        class="{{ 'menubar__button'|prefixClass }}"
+                        type="button"
+                        v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                        @click.stop="$refs.boilerPlateModal.toggleModal()">
+                        <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                    </button>
+                </template>
+            </dp-editor>
+        </div>
 
         <dp-checkbox
             id="r_email_address"

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
@@ -90,25 +90,40 @@
                 ]
             }) }}
 
-            {{ uiComponent('form.row', {
-                elements: [
-                    {
-                        label: { text: 'email.body'|trans },
-                        control: {
-                            value: templateVars.emailText|default,
-                            boilerPlate: 'email',
-                            toolbarItems: { headings: [1,2,3] },
-                            hiddenInput: 'r_emailText',
-                            linkButton: true,
-                            procedureId: procedureId,
-                            ref: 'r_emailText'
-                        },
-                        type: 'editor',
-                        id: 'r_emailText',
-                        required: true
-                    }
-                ]
-            }) }}
+            <div class="{{ 'u-mb-0_75'|prefixClass }}">
+                <dp-label
+                    for="r_emailText"
+                    text="{{ 'email.body'|trans }}">
+                </dp-label>
+                <dp-editor
+                    id="r_emailText"
+                    ref="r_emailText"
+                    hidden-input="r_emailText"
+                    required
+                    :toolbar-items="{
+                        headings: [1,2,3],
+                        linkButton: true
+                    }"
+                    value="{{ templateVars.emailText|default }}">
+                    <template v-slot:modal="modalProps">
+                        <dp-boiler-plate-modal
+                            ref="boilerPlateModal"
+                            boiler-plate-type="email"
+                            procedure-id="{{ procedureId }}"
+                            @insert="text => modalProps.handleInsertText(text)">
+                        </dp-boiler-plate-modal>
+                    </template>
+                    <template v-slot:button>
+                        <button
+                            class="{{ 'menubar__button'|prefixClass }}"
+                            type="button"
+                            v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                            @click.stop="$refs.boilerPlateModal.toggleModal()">
+                            <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                        </button>
+                    </template>
+                </dp-editor>
+            </div>
 
             <a
                 class="btn btn--secondary text--left u-mt-0_5"

--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/customer_settings_update_mail.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/customer_settings_update_mail.html.twig
@@ -32,26 +32,39 @@
                 ]
             }) }}
 
-            {{ uiComponent('form.row', {
-                elements: [
-                    {
-                        label: { text: 'email.body'|trans },
-                        control: {
-                            name: 'r_email_body',
-                            boilerPlate: 'email',
-                            headings: [1,2,3],
-                            hiddenInput: 'r_email_body',
-                            linkButton: true,
-                            required: true
-                        },
-                        id: 'r_email_body',
-                        type: 'editor',
-                        required: true,
-                        value: 'customer.settings.update.mail.default.text'|trans({ termsOfUseUrl: urlBase ~ path('DemosPlan_misccontent_static_terms'), dataProtectionUrl: urlBase ~ path('DemosPlan_misccontent_static_dataprotection') })
-                    }
-                ]
-            }) }}
-            </label>
+            <div class="{{ 'u-mb-0_75'|prefixClass }}">
+                <dp-label
+                    for="r_email_body"
+                    text="{{ 'email.body'|trans }}">
+                </dp-label>
+                <dp-editor
+                    id="r_email_body"
+                    hidden-input="r_email_body"
+                    :toolbar-items="{
+                        headings: [1,2,3],
+                        linkButton: true
+                    }"
+                    required
+                    value="{{ 'customer.settings.update.mail.default.text'|trans({ termsOfUseUrl: urlBase ~ path('DemosPlan_misccontent_static_terms'), dataProtectionUrl: urlBase ~ path('DemosPlan_misccontent_static_dataprotection') }) }}">
+                    <template v-slot:modal="modalProps">
+                        <dp-boiler-plate-modal
+                            ref="boilerPlateModal"
+                            boiler-plate-type="email"
+                            procedure-id="{{ procedure }}"
+                            @insert="text => modalProps.handleInsertText(text)">
+                        </dp-boiler-plate-modal>
+                    </template>
+                    <template v-slot:button>
+                        <button
+                            class="{{ 'menubar__button'|prefixClass }}"
+                            type="button"
+                            v-tooltip="'{{ 'boilerplate.insert'|trans }})'"
+                            @click.stop="$refs.boilerPlateModal.toggleModal()">
+                            <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
+                        </button>
+                    </template>
+                </dp-editor>
+            </div>
 
             {{ uiComponent('form.element', {
                 label: { text: 'customer.settings.update.mail.info'|trans({ count: templateVars.usersCount|default(0) }) },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31795

BoilerplateModal in DpEditor was replaced by slots and therefore the ui form rows in twig files were replaced directly with dpEditor and the needed slots. 
See also https://github.com/demos-europe/demosplan-core/pull/875

### How to review/test

