### PR TITLE
feat: create OpenAPI Data only on development builds

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
@@ -14,6 +14,7 @@ use cebe\openapi\spec\OpenApi;
 use cebe\openapi\Writer;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
 use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Logic\ApiDocumentation\JsApiResourceDefinitionBuilder;
@@ -136,7 +137,9 @@ class FrontendIntegratorCommand extends CoreCommand
             ->add('dplan:translations:dump')
             ->run();
 
-        $this->updateApiCodingSupport();
+        if (DemosPlanKernel::ENVIRONMENT_PROD !== $this->getApplication()->getKernel()->getEnvironment()) {
+            $this->updateApiCodingSupport();
+        }
     }
 
     /**


### PR DESCRIPTION
OpenAPT specification only needs to be created on development builds. This also may help in Problems with production asset dumps


### How to review/test
code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
