### PR TITLE
chore (refs T27388): fix simple and safe return type deprecations

### DIFF
--- a/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableViewMode.php
+++ b/demosplan/DemosPlanAssessmentTableBundle/Logic/AssessmentTableViewMode.php
@@ -77,7 +77,7 @@ final class AssessmentTableViewMode implements JsonSerializable
         return $this->viewMode;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'viewMode' => $this->viewMode,

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -37,7 +37,7 @@ class AddonBuildFrontendCommand extends CoreCommand
         $this->addArgument('addon-name', InputArgument::REQUIRED, 'Addon name, du\'h.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("Building frontend assets for {$input->getArgument('addon-name')}");
 

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DataProviderCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DataProviderCommand.php
@@ -28,7 +28,7 @@ abstract class DataProviderCommand extends CoreCommand
      */
     protected $output;
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = new SymfonyStyle($input, $output);

--- a/demosplan/DemosPlanCoreBundle/Constraint/ClaimConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ClaimConstraint.php
@@ -25,7 +25,7 @@ class ClaimConstraint extends Constraint
         return ClaimConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/ConsistentOriginalStatementConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ConsistentOriginalStatementConstraint.php
@@ -27,7 +27,7 @@ class ConsistentOriginalStatementConstraint extends Constraint
         return ConsistentOriginalStatementConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/CorrectDateOrderConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/CorrectDateOrderConstraint.php
@@ -27,7 +27,7 @@ class CorrectDateOrderConstraint extends Constraint
         return CorrectDateOrderConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/FormDefinitionConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/FormDefinitionConstraint.php
@@ -27,7 +27,7 @@ class FormDefinitionConstraint extends Constraint
         return FormDefinitionConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/MatchingFieldValueInSegments.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/MatchingFieldValueInSegments.php
@@ -66,7 +66,7 @@ class MatchingFieldValueInSegments extends Constraint
         return MatchingStatementIdValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/MatchingSubmitTypesConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/MatchingSubmitTypesConstraint.php
@@ -27,7 +27,7 @@ class MatchingSubmitTypesConstraint extends Constraint
         return MatchingSubmitTypesConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/OriginalReferenceConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/OriginalReferenceConstraint.php
@@ -25,7 +25,7 @@ class OriginalReferenceConstraint extends Constraint
         return OriginalReferenceConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/PrePersistUniqueInternIdConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/PrePersistUniqueInternIdConstraint.php
@@ -33,7 +33,7 @@ class PrePersistUniqueInternIdConstraint extends Constraint
         return PrePersistUniqueInternIdConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/ProcedureAllowedSegmentsConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ProcedureAllowedSegmentsConstraint.php
@@ -27,7 +27,7 @@ class ProcedureAllowedSegmentsConstraint extends Constraint
         return ProcedureAllowedSegmentsConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/ProcedureInCoupleAlreadyUsedConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ProcedureInCoupleAlreadyUsedConstraint.php
@@ -42,7 +42,7 @@ class ProcedureInCoupleAlreadyUsedConstraint extends Constraint
         return ProcedureInCoupleAlreadyUsedConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/ProcedureMasterTemplateConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ProcedureMasterTemplateConstraint.php
@@ -27,7 +27,7 @@ class ProcedureMasterTemplateConstraint extends Constraint
         return ProcedureMasterTemplateConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/ProcedureTemplateConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/ProcedureTemplateConstraint.php
@@ -27,7 +27,7 @@ class ProcedureTemplateConstraint extends Constraint
         return ProcedureTemplateConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/SimilarStatementSubmittersSameProcedureConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/SimilarStatementSubmittersSameProcedureConstraint.php
@@ -30,7 +30,7 @@ class SimilarStatementSubmittersSameProcedureConstraint extends Constraint
         return SimilarStatementSubmittersSameProcedureConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/Constraint/UserWithMatchingDepartmentInOrgaConstraint.php
+++ b/demosplan/DemosPlanCoreBundle/Constraint/UserWithMatchingDepartmentInOrgaConstraint.php
@@ -26,7 +26,7 @@ class UserWithMatchingDepartmentInOrgaConstraint extends Constraint
         return UserWithMatchingDepartmentInOrgaConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanCoreBundle/DependencyInjection/Configuration/MenusTreeBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/DependencyInjection/Configuration/MenusTreeBuilder.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class MenusTreeBuilder implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('menus');
 

--- a/demosplan/DemosPlanCoreBundle/Doctrine/Generator/UuidV4Generator.php
+++ b/demosplan/DemosPlanCoreBundle/Doctrine/Generator/UuidV4Generator.php
@@ -22,7 +22,7 @@ use Ramsey\Uuid\Uuid;
  */
 class UuidV4Generator extends AbstractIdGenerator
 {
-    public function generateId(EntityManagerInterface $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity): string
     {
         return Uuid::uuid4()->toString();
     }

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/NonAuthorizedAssignRemoveSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/NonAuthorizedAssignRemoveSubscriber.php
@@ -28,7 +28,7 @@ class NonAuthorizedAssignRemoveSubscriber implements EventSubscriberInterface
         $this->assignRemover = $assignRemover;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcedureEditedEvent::class => 'removeNonAuthorizedAssignees',

--- a/demosplan/DemosPlanCoreBundle/Logic/Logger/ApiLogger.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Logger/ApiLogger.php
@@ -44,7 +44,7 @@ class ApiLogger implements LoggerInterface
         $this->environment = $globalConfig->getKernelEnvironment();
     }
 
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $message = "Faulty API request: $message";
 
@@ -56,42 +56,42 @@ class ApiLogger implements LoggerInterface
         }
     }
 
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->logger->emergency($message, $context);
     }
 
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->logger->alert($message, $context);
     }
 
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->logger->critical($message, $context);
     }
 
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->logger->error($message, $context);
     }
 
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->logger->notice($message, $context);
     }
 
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->logger->info($message, $context);
     }
 
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->logger->debug($message, $context);
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->logger->log($level, $message, $context);
     }

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
@@ -234,7 +234,7 @@ class Permission implements ArrayAccess
         return in_array($offset, self::FIELDS, true);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->$offset;
     }

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
@@ -593,7 +593,7 @@ class GlobalConfig implements GlobalConfigInterface
         $this->setParams($params, $translator);
     }
 
-    public function setParams(ParameterBagInterface $parameterBag, TranslatorInterface $translator)
+    public function setParams(ParameterBagInterface $parameterBag, TranslatorInterface $translator): void
     {
         /*
          * Project configurations

--- a/demosplan/DemosPlanProcedureBundle/Constraint/ExclusiveProcedureOrProcedureTypeConstraint.php
+++ b/demosplan/DemosPlanProcedureBundle/Constraint/ExclusiveProcedureOrProcedureTypeConstraint.php
@@ -33,7 +33,7 @@ class ExclusiveProcedureOrProcedureTypeConstraint extends Constraint
         return ExclusiveProcedureOrProcedureTypeConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanProcedureBundle/Constraint/ProcedureTypeConstraint.php
+++ b/demosplan/DemosPlanProcedureBundle/Constraint/ProcedureTypeConstraint.php
@@ -59,7 +59,7 @@ class ProcedureTypeConstraint extends Constraint
         return ProcedureTypeConstraintValidator::class;
     }
 
-    public function getTargets()
+    public function getTargets(): array|string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/demosplan/DemosPlanStatementBundle/ValueObject/DraftStatementListFilters.php
+++ b/demosplan/DemosPlanStatementBundle/ValueObject/DraftStatementListFilters.php
@@ -166,7 +166,7 @@ class DraftStatementListFilters extends ValueObject implements ParameterBagInter
         throw new NotYetImplementedException('Not implemented yet.');
     }
 
-    public function unescapeValue($value)
+    public function unescapeValue($value): mixed
     {
         throw new NotYetImplementedException('Not implemented yet.');
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27388

This PR fixes some  simple and safe to apply return type deprecations

### How to review/test
Load any page and see the amount of deprecations drop in the symfony toolbar

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
