### PR TITLE
Feat(refs:T31666): Dont show globalnews title and section if no news exists

### DIFF
--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
@@ -1,90 +1,93 @@
 <section class="{{ 'o-page__padded--spaced o-page__news u-pt'|prefixClass }}">
+    {% if templateVars.list.newslist is not empty %}
 
-    <header>
-        <h2 class="{{ 'layout__item u-1-of-2 u-pl-0'|prefixClass }}">
-            {{ "news.announcements"|trans }}
-        </h2>
-        <a class="{{ 'layout__item u-1-of-2 text--right u-mb-0_5 u-pl-0'|prefixClass }}" href="{{ path('DemosPlan_globalnews_news') }}">
-            <span>
-                {{ "news.see.all"|trans }}
-            </span>
-            <i class="{{ 'fa fa-angle-right'|prefixClass }}" aria-hidden="true"></i>
-        </a>
-    </header>
+        <header>
+            <h2 class="{{ 'layout__item u-1-of-2 u-pl-0'|prefixClass }}">
+                {{ "news.announcements"|trans }}
+            </h2>
+            <a class="{{ 'layout__item u-1-of-2 text--right u-mb-0_5 u-pl-0'|prefixClass }}" href="{{ path('DemosPlan_globalnews_news') }}">
+                <span>
+                    {{ "news.see.all"|trans }}
+                </span>
+                <i class="{{ 'fa fa-angle-right'|prefixClass }}" aria-hidden="true"></i>
+            </a>
+        </header>
 
-    <div class="{{ 'layout'|prefixClass }}">
-        {% set cols = templateVars.list.newslist|length %}
-        {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm o-page__news-item' %}
-        {% for newsItem in templateVars.list.newslist %}
+        <div class="{{ 'layout'|prefixClass }}">
+            {% set cols = templateVars.list.newslist|length %}
+            {% set classes = 'u-1-of-' ~ cols ~ ' layout__item u-1-of-1-palm u-mb-0_5-palm o-page__news-item' %}
+            {% for newsItem in templateVars.list.newslist %}
 
-            <div class="{{ classes|prefixClass }}">
+                <div class="{{ classes|prefixClass }}">
 
-                {# title #}
-                <h3 class="{{ 'font-size-h3 u-mb-0'|prefixClass }}">
-                    <a title="{{ newsItem.title|default( "news"|trans ) }} lesen" href="{{ path('DemosPlan_globalnews_news_detail',{'newsID':newsItem.ident}) }}">
-                      {{ newsItem.title }}
-                   </a>
-                </h3>
+                    {# title #}
+                    <h3 class="{{ 'font-size-h3 u-mb-0'|prefixClass }}">
+                        <a title="{{ newsItem.title|default( "news"|trans ) }} lesen" href="{{ path('DemosPlan_globalnews_news_detail',{'newsID':newsItem.ident}) }}">
+                          {{ newsItem.title }}
+                       </a>
+                    </h3>
 
-                {# meta #}
-                <div class="{{ 'cf u-mb-0_25'|prefixClass }}">
+                    {# meta #}
+                    <div class="{{ 'cf u-mb-0_25'|prefixClass }}">
 
-                    {# creation date #}
-                    {% if newsItem.createDate is defined %}
-                        <span class="{{ 'font-size-smaller'|prefixClass }}">
-                            {{ newsItem.createDate|default()|dplanDate }}
-                        </span>
-                    {% endif %}
-
-                    {# label 'press' if press category found #}
-                    {% if newsItem.categories is defined and newsItem.categories[0] is defined %}
-                        {% if 'press' == newsItem.categories[0].name %}
-                            <span class="{{ 'font-size-smaller u-ml-0_25'|prefixClass }}">
-                               Pressebericht
+                        {# creation date #}
+                        {% if newsItem.createDate is defined %}
+                            <span class="{{ 'font-size-smaller'|prefixClass }}">
+                                {{ newsItem.createDate|default()|dplanDate }}
                             </span>
                         {% endif %}
-                    {% endif %}
 
-                    {# pdf attachment #}
-                    {% if newsItem.pdf is defined and newsItem.pdf != '' %}
-                        <a
-                            class="{{ 'font-size-smaller u-ml-0_25'|prefixClass }}"
-                            target="_blank"
-                            rel="noopener"
-                            href="{{ path("core_file", { 'hash': newsItem.pdf|getFile('hash') }) }}"
-                            title="Download {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }} {% if (newsItem.pdf|getFile('size')|length > 0 or newsItem.pdf|getFile('mimeType')|length > 0 ) %} ({{- newsItem.pdf|getFile('size') }} {{ newsItem.pdf|getFile('mimeType') -}}){% endif %}">
-                            <i class="{{ 'fa fa-file'|prefixClass }}" aria-hidden="true"></i>
-                            {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }}
-                        </a>
-                    {% endif %}
+                        {# label 'press' if press category found #}
+                        {% if newsItem.categories is defined and newsItem.categories[0] is defined %}
+                            {% if 'press' == newsItem.categories[0].name %}
+                                <span class="{{ 'font-size-smaller u-ml-0_25'|prefixClass }}">
+                                   Pressebericht
+                                </span>
+                            {% endif %}
+                        {% endif %}
 
-                </div>
+                        {# pdf attachment #}
+                        {% if newsItem.pdf is defined and newsItem.pdf != '' %}
+                            <a
+                                class="{{ 'font-size-smaller u-ml-0_25'|prefixClass }}"
+                                target="_blank"
+                                rel="noopener"
+                                href="{{ path("core_file", { 'hash': newsItem.pdf|getFile('hash') }) }}"
+                                title="Download {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }} {% if (newsItem.pdf|getFile('size')|length > 0 or newsItem.pdf|getFile('mimeType')|length > 0 ) %} ({{- newsItem.pdf|getFile('size') }} {{ newsItem.pdf|getFile('mimeType') -}}){% endif %}">
+                                <i class="{{ 'fa fa-file'|prefixClass }}" aria-hidden="true"></i>
+                                {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }}
+                            </a>
+                        {% endif %}
 
-                {# wrap floating content elements in clearfix #}
-                <div class="{{ 'cf position--relative'|prefixClass }}">
-
-                    {# image is represented as css background image to keep square proportions in fluid context #}
-                    {% if newsItem.picture is defined and newsItem.picture != "" %}
-                        <div class="{{ 'o-box__thumbnail'|prefixClass }}"
-                            style="background-image: url( {{ path("core_logo", { 'hash': newsItem.picture|getFile('hash') }) }} );">
-                        </div>
-                    {% endif %}
-
-                    {# full text #}
-                    <div class="{{ 'o-box__text-truncated'|prefixClass }}">
-                        {{ newsItem.description|wysiwyg }}
                     </div>
 
-                    {# readmore link #}
-                    <a title="{{ newsItem.title|default( "news"|trans ) }} lesen" class="{{ 'o-box__link'|prefixClass }}" href="{{ path('DemosPlan_globalnews_news_detail',{'newsID':newsItem.ident}) }}">
-                        {{ "readon"|trans }}&hellip;
-                    </a>
+                    {# wrap floating content elements in clearfix #}
+                    <div class="{{ 'cf position--relative'|prefixClass }}">
+
+                        {# image is represented as css background image to keep square proportions in fluid context #}
+                        {% if newsItem.picture is defined and newsItem.picture != "" %}
+                            <div class="{{ 'o-box__thumbnail'|prefixClass }}"
+                                style="background-image: url( {{ path("core_logo", { 'hash': newsItem.picture|getFile('hash') }) }} );">
+                            </div>
+                        {% endif %}
+
+                        {# full text #}
+                        <div class="{{ 'o-box__text-truncated'|prefixClass }}">
+                            {{ newsItem.description|wysiwyg }}
+                        </div>
+
+                        {# readmore link #}
+                        <a title="{{ newsItem.title|default( "news"|trans ) }} lesen" class="{{ 'o-box__link'|prefixClass }}" href="{{ path('DemosPlan_globalnews_news_detail',{'newsID':newsItem.ident}) }}">
+                            {{ "readon"|trans }}&hellip;
+                        </a>
+
+                    </div>
 
                 </div>
 
-            </div>
+            {% endfor %}
+        </div>
 
-        {% endfor %}
-    </div>
-
+    {% endif %}
 </section>
+

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_index_globalnewslist.html.twig
@@ -53,7 +53,10 @@
                                 target="_blank"
                                 rel="noopener"
                                 href="{{ path("core_file", { 'hash': newsItem.pdf|getFile('hash') }) }}"
-                                title="Download {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }} {% if (newsItem.pdf|getFile('size')|length > 0 or newsItem.pdf|getFile('mimeType')|length > 0 ) %} ({{- newsItem.pdf|getFile('size') }} {{ newsItem.pdf|getFile('mimeType') -}}){% endif %}">
+                                title="Download {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }}
+                                {% if (newsItem.pdf|getFile('size')|length > 0 or newsItem.pdf|getFile('mimeType')|length > 0 ) %}
+                                ({{- newsItem.pdf|getFile('size') }} {{ newsItem.pdf|getFile('mimeType') -}})
+                                {% endif %}">
                                 <i class="{{ 'fa fa-file'|prefixClass }}" aria-hidden="true"></i>
                                 {{ newsItem.pdftitle|default(newsItem.pdf|getFile('name')) }}
                             </a>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31666

### Description: 

- the globalnews section shouldnt be shown if there no news exist

### How to review/test

- go to `Startseite`
- look to the globalnews section with `Aktuelle Meldungen` and `Alle Meldungen` , if there are no any news
- if there are existing news, login as `Redakteur` (or new role in DiplanBau `Mandanten-Aministration`) and deactivate the status of the news in `Verwalten` -> `Portal-Mitteilungen` -> `Portal-Mitteilungen verwalten`

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
