### PR TITLE
feature (refs T30254): Make PercentageDistribution value object availabe in addons

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/PercentageDistributionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/PercentageDistributionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Factory;
+
+use DemosEurope\DemosplanAddon\Contracts\Factory\PercentageDistributionFactoryInterface;
+use DemosEurope\DemosplanAddon\Contracts\ValueObject\PercentageDistributionInterface;
+use demosplan\DemosPlanCoreBundle\ValueObject\PercentageDistribution;
+
+class PercentageDistributionFactory implements PercentageDistributionFactoryInterface
+{
+    public function createPercentageDistribution(int $total, array $absolutes): PercentageDistributionInterface
+    {
+        return new PercentageDistribution($total, $absolutes);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -25,6 +25,9 @@ services:
 
     DemosEurope\DemosplanAddon\Contracts\Factory\GisLayerFactoryInterface: '@demosplan\DemosPlanCoreBundle\Logic\Factory\GisLayerFactory'
 
+    DemosEurope\DemosplanAddon\Contracts\Factory\PercentageDistributionFactoryInterface:
+        class: 'demosplan\DemosPlanCoreBundle\Logic\Factory\PercentageDistributionFactory'
+
     DemosEurope\DemosplanAddon\Contracts\Services\ServiceStorageInterface:
         class: 'demosplan\DemosPlanProcedureBundle\Logic\ServiceStorage'
 

--- a/demosplan/DemosPlanCoreBundle/ValueObject/PercentageDistribution.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/PercentageDistribution.php
@@ -10,12 +10,14 @@
 
 namespace demosplan\DemosPlanCoreBundle\ValueObject;
 
+use DemosEurope\DemosplanAddon\Contracts\ValueObject\PercentageDistributionInterface;
+
 /**
  * @method int   getTotal()
  * @method array getPercentages()
  * @method array getAbsolutes()
  */
-class PercentageDistribution extends ValueObject
+class PercentageDistribution extends ValueObject implements PercentageDistributionInterface
 {
     /** @var array<string,float> */
     protected $percentages;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30254

Description: Added a PercentageDistributionFactory and implement the PercentageDistributionInterface on PercentageDistribution.php to make the PercentageDistribution value object accessible and creatable in addons.

### Linked PRs
- Other PR #{https://github.com/demos-europe/demosplan-core/pull/958}


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
