### PR TITLE
F add parameters_test yaml

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_test.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_test.yml
@@ -1,0 +1,15 @@
+parameters:
+    database_name: 'any_name'
+    email_bounce_prefix: 'bobsh'
+    email_bounce_domain: 'bounces-qs.bob-sh.de'
+    email_system: 'testemail@mail.org'
+    avscan_enable: false
+    fileservice_filepath: "/tmp/uploads"
+    doctrine.dbal.connection_factory.class: Liip\TestFixturesBundle\Factory\ConnectionFactory
+    subdomain: 'hindsight'
+    subdomains_allowed:
+        - 'sh'
+        - 'hindsight'
+        - 'brandenburg'
+    project_prefix: 'dplan_test'
+    honeypot_disabled: true


### PR DESCRIPTION
Description: - this parameters yaml was by mistake moved to demospipes addon, the addon related parameters are moved from here. The Rest parameters should stay in core


