### PR TITLE
fix(refs:T31922): expose permission for frontend

### DIFF
--- a/client/js/components/procedure/admin/DpNewProcedure/CoupleTokenInput.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/CoupleTokenInput.vue
@@ -8,7 +8,7 @@
 </license>
 
 <template>
-  <div>
+  <div class="space-stack-s">
     <dp-input
       aria-labelledby="token-notification"
       id="procedureCoupleToken"
@@ -22,6 +22,7 @@
       @input="validateToken" />
     <dp-inline-notification
       v-if="notification"
+      class="u-mb-0"
       id="token-notification"
       :message="notification.text"
       :type="notification.type" />

--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -161,8 +161,7 @@
           end-name="r_enddate"
           :required="hasPermission('feature_auto_switch_to_procedure_end_phase')"
           :calendars-after="2"
-          enforce-plausible-dates>
-        </dp-date-range-picker>
+          enforce-plausible-dates />
 
         <p
           v-if="hasPermission('feature_use_plis')"
@@ -170,19 +169,21 @@
           id="js__statusBox" />
       </div>
 
-      <template v-if="hasPermission('feature_procedure_couple_by_token')">
+      <div
+        v-if="hasPermission('feature_procedure_couple_by_token')"
+        class="u-mb-0_75">
         <h3
           class="weight--normal color--grey u-mt-1_5"
           v-text="Translator.trans('procedure.couple_token.vht.title')" />
+
         <div v-text="Translator.trans('procedure.couple_token.vht.info')" />
 
         <dp-inline-notification
           :message="Translator.trans('procedure.couple_token.vht.inline_notification')"
           type="warning" />
 
-        <couple-token-input
-          :token-length="tokenLength" />
-      </template>
+        <couple-token-input :token-length="tokenLength" />
+      </div>
 
       <div class="space-inline-s text--right">
         <dp-button

--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -1338,7 +1338,7 @@ feature_procedure_couple_by_token:
         Allows to enter a couple-token (feature_procedure_couple_token_autocreate) when creating a procedure
         and view it afterwards in that procedure.
         This permission is not a child of feature_procedure_couple_token_autocreate, instead it describes the opposite function.
-    expose: false
+    expose: true
     label: 'Allows to enter a token (feature_procedure_couple_token_autocreate) when creating a procedure.'
     loginRequired: true
 feature_procedure_couple_token_autocreate:


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31922

When refactoring the view to Vue [sic!] that was obviously overlooked. 

Also, some minor spacing tweaks are added (this should do nothing but add the correct and same space between the save/abort button and the preceeding ui elements, with or without the second notification.

### How to review/test
After logging into ewm as Fachplanung-Admin, when creating a new procedure it should be possible to input a token.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
