### PR TITLE
fix(refs:T31509): add space

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAdmin/statistics.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAdmin/statistics.html.twig
@@ -269,8 +269,8 @@
                     <td class="o-hellip--td">
                         {{- item.name -}}
                         <br>
-                        {{- 'from.date'|trans -}}
-                        {{- item.createdDate|default()|dplanDate -}}
+                        {{- 'from.date'|trans }}
+                        {{ item.createdDate|default()|dplanDate -}}
                     </td>
                     <td class="o-hellip--td">
                         {{- item.phaseName|default() -}}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31509

All spaces were removed from the template in an attempt to shrink html in case large amounts of entries are in the procedurelist. however that one space has to stay there.

The visual inconsistency within the header is not fixed by this PR.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
