### PR TITLE
fix: Adjust path to Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@
  * All rights reserved
  */
 
-const config = require('./client/setup/config').config
+const config = require('./client/fe/config/config').config
 const webpackConfig = require('./config.webpack')
 
 const aliases = webpackConfig[0].resolve.alias


### PR DESCRIPTION
After moving the config.js (part of the webpack config) we forgot to adjust the path from the jest.config.

see https://github.com/demos-europe/demosplan-core/pull/890

