### PR TITLE
fix (refs T31622, T16953): fix user id in report entry

### DIFF
--- a/demosplan/DemosPlanReportBundle/Logic/ProcedureReportEntryFactory.php
+++ b/demosplan/DemosPlanReportBundle/Logic/ProcedureReportEntryFactory.php
@@ -133,6 +133,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
         if ($user instanceof User) {
             $entry->setUser($user);
         } else {
+            $entry->setUserId('');
             $entry->setUserName($user);
         }
         $entry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_PROCEDURE);


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31622
**Ticket:** https://yaits.demos-deutschland.de/T16953

The user id is not nullable for report entries. So even if we don't really have a user and use the default fallback name, we still have to set the user id to at least empty string. This little fix should take care of both tickets.

### How to review/test
You can locally set the phases of a procedure to participation and the end date to yesterday. Then log out and call the URL for the maintenance task for the local project.
