### PR TITLE
fix: Update the addon's code on reinstall

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -80,6 +80,8 @@ class AddonInstallFromZipCommand extends CoreCommand
     {
         $output = new SymfonyStyle($input, $output);
 
+        $reinstall = $input->getOption('reinstall');
+
         $this->setPaths($input->getArgument('path'));
         try {
             $this->initializeAddonsInfrastructure();
@@ -89,12 +91,12 @@ class AddonInstallFromZipCommand extends CoreCommand
             return Command::FAILURE;
         }
 
-        $this->copyAndUnzipFileIfNecessary($output);
+        $this->copyAndUnzipFileIfNecessary($output, $reinstall);
 
         try {
             $packageDefinition = $this->loadPackageDefinition();
 
-            $this->checkReinstall($packageDefinition, $input->getOption('reinstall'));
+            $this->checkReinstall($packageDefinition, $reinstall);
 
             $this->addAddonToComposerRequire($packageDefinition);
         } catch (JsonException $e) {
@@ -220,12 +222,12 @@ class AddonInstallFromZipCommand extends CoreCommand
     /**
      * This will try to copy and unzip the Repo if the path is correct and the repo is not already present in the cache.
      */
-    private function copyAndUnzipFileIfNecessary(OutputInterface $output): void
+    private function copyAndUnzipFileIfNecessary(OutputInterface $output, bool $reinstall): void
     {
         $doesFileExist = file_exists($this->zipSourcePath);
         $addonExistsInCache = file_exists($this->zipCachePath);
 
-        if ($doesFileExist && !$addonExistsInCache) {
+        if ($doesFileExist && (!$addonExistsInCache || $reinstall)) {
             $zipArchive = new ZipArchive();
             $open = $zipArchive->open($this->zipSourcePath);
             if ($open) {

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -226,8 +226,9 @@ class AddonInstallFromZipCommand extends CoreCommand
     {
         $doesFileExist = file_exists($this->zipSourcePath);
         $addonExistsInCache = file_exists($this->zipCachePath);
+        $shouldUnzip = !$addonExistsInCache || $reinstall;
 
-        if ($doesFileExist && (!$addonExistsInCache || $reinstall)) {
+        if ($doesFileExist && $shouldUnzip) {
             $zipArchive = new ZipArchive();
             $open = $zipArchive->open($this->zipSourcePath);
             if ($open) {


### PR DESCRIPTION
We previously skipped updating the actual code when an addon was marked for reinstallation. This should now happen as expected.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
