### PR TITLE
F related story issues

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -521,7 +521,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         if ($this->user->hasRole(Role::CUSTOMER_MASTER_USER)) {
             $this->enablePermissions([
                 'area_organisations',
-                'area_organisations_applications_manage',
                 'area_organisations_view_of_customer',
                 'area_preferences',  // Einstellungen
                 'feature_orga_edit',


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31959

Description: 

-  this pr fixes this issues (see the mentions Tickets ) related to the story T30530.
- the permission 'area_organisations_applications_manage' has to be removed from core permissions and enabled only in the projects where it is needed.

related prs:
blp : https://github.com/demos-europe/demosplan-project-blp/pull/36
regio: https://github.com/demos-europe/demosplan-project-regio/pull/27
diplanbau: https://github.com/demos-europe/demosplan-project-diplanbau/pull/74

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Tests updated/created
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
