### PR TITLE
bug(refs: T31984): prevent unintentional deletion of editor text

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -538,10 +538,27 @@ export default {
       this.setContent({ prop: 'slidebar', val: { isOpen: false, showTab: '', segmentId: '' } })
     },
 
+    /**
+     * This prevents the user from unintentionally deleting an unsaved text by synchronizing the local
+     * statement in StatementMeta.vue (which also emits the local statement when saving only metadata)
+     * with the statements from store. The editor automatically updates the state of statements in the
+     * store when registering an input. This only occurs when a statement has not been segmented already.
+     *
+     * @param {object} statement - The local statement of StatementMeta.vue.
+     */
+    canUpdateStatementAttributeFullText (statement) {
+      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
+        statement.attributes.fullText = this.statement.attributes.fullText
+      }
+    },
+
     saveStatement (statement) {
+      this.$on('save', this.canUpdateStatementAttributeFullText(statement))
+
       // The key isManual is readonly, so we should remove it before saving
       delete statement.attributes.isManual
       this.setStatement({ ...statement, id: statement.id })
+
       this.saveStatementAction(statement.id)
         .then(() => {
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -420,20 +420,6 @@ export default {
       'toggleSlidebarContent'
     ]),
 
-    /**
-     * This prevents the user from unintentionally deleting an unsaved text by synchronizing the local
-     * statement in StatementMeta.vue (which also emits the local statement when saving only metadata)
-     * with the statements from store. The editor automatically updates the state of statements in the
-     * store when registering an input. This only occurs when a statement has not been segmented already.
-     *
-     * @param {object} statement - The local statement of StatementMeta.vue.
-     */
-    canUpdateStatementAttributesFullText (statement) {
-      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
-        statement.attributes.fullText = this.statement.attributes.fullText
-      }
-    },
-
     checkStatementClaim () {
       if (this.statementClaimChecked === false) {
         this.statementClaimChecked = true
@@ -553,7 +539,7 @@ export default {
     },
 
     saveStatement (statement) {
-      this.$on('save', this.canUpdateStatementAttributesFullText(statement))
+      this.synchronizeFullText(statement)
       // The key isManual is readonly, so we should remove it before saving
       delete statement.attributes.isManual
       this.setStatement({ ...statement, id: statement.id })
@@ -594,6 +580,20 @@ export default {
 
       const defaultAction = hasPermission('feature_segment_recommendation_edit') ? 'addRecommendation' : 'editText'
       this.currentAction = action || defaultAction
+    },
+
+    /**
+     * This prevents the user from unintentionally deleting an unsaved text by synchronizing the local
+     * statement in StatementMeta.vue (which also emits the local statement when saving only metadata)
+     * with the statements from store. The editor automatically updates the state of statements in the
+     * store when registering an input. This only occurs when a statement has not been segmented already.
+     *
+     * @param {object} statement - The local statement of StatementMeta.vue.
+     */
+    synchronizeFullText (statement) {
+      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
+        statement.attributes.fullText = this.statement.attributes.fullText
+      }
     },
 
     toggleClaimStatement () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -420,6 +420,20 @@ export default {
       'toggleSlidebarContent'
     ]),
 
+    /**
+     * This prevents the user from unintentionally deleting an unsaved text by synchronizing the local
+     * statement in StatementMeta.vue (which also emits the local statement when saving only metadata)
+     * with the statements from store. The editor automatically updates the state of statements in the
+     * store when registering an input. This only occurs when a statement has not been segmented already.
+     *
+     * @param {object} statement - The local statement of StatementMeta.vue.
+     */
+    canUpdateStatementAttributesFullText (statement) {
+      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
+        statement.attributes.fullText = this.statement.attributes.fullText
+      }
+    },
+
     checkStatementClaim () {
       if (this.statementClaimChecked === false) {
         this.statementClaimChecked = true
@@ -538,23 +552,8 @@ export default {
       this.setContent({ prop: 'slidebar', val: { isOpen: false, showTab: '', segmentId: '' } })
     },
 
-    /**
-     * This prevents the user from unintentionally deleting an unsaved text by synchronizing the local
-     * statement in StatementMeta.vue (which also emits the local statement when saving only metadata)
-     * with the statements from store. The editor automatically updates the state of statements in the
-     * store when registering an input. This only occurs when a statement has not been segmented already.
-     *
-     * @param {object} statement - The local statement of StatementMeta.vue.
-     */
-    canUpdateStatementAttributeFullText (statement) {
-      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
-        statement.attributes.fullText = this.statement.attributes.fullText
-      }
-    },
-
     saveStatement (statement) {
-      this.$on('save', this.canUpdateStatementAttributeFullText(statement))
-
+      this.$on('save', this.canUpdateStatementAttributesFullText(statement))
       // The key isManual is readonly, so we should remove it before saving
       delete statement.attributes.isManual
       this.setStatement({ ...statement, id: statement.id })

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -591,7 +591,7 @@ export default {
      * @param {object} statement - The local statement of StatementMeta.vue.
      */
     synchronizeFullText (statement) {
-      if (statement.attributes.fullText !== this.statement.attributes.fullText && dpConfirm(Translator.trans('statement.save.recommendation'))) {
+      if (statement.attributes.fullText !== this.statement.attributes.fullText && dpConfirm(Translator.trans('statement.save.text'))) {
         statement.attributes.fullText = this.statement.attributes.fullText
       }
     },

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -591,7 +591,7 @@ export default {
      * @param {object} statement - The local statement of StatementMeta.vue.
      */
     synchronizeFullText (statement) {
-      if (statement.attributes.fullText !== this.statement.attributes.fullText) {
+      if (statement.attributes.fullText !== this.statement.attributes.fullText && dpConfirm(Translator.trans('statement.save.recommendation'))) {
         statement.attributes.fullText = this.statement.attributes.fullText
       }
     },

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3213,7 +3213,7 @@ statement.representation.creation: "Die Stellungnahme im Namen folgender Institu
 statement.save.altered: "Stellungnahme verändert speichern"
 statement.save.as.draft: "Stellungnahme als Entwurf speichern"
 statement.save.immediate: "Stellungnahme direkt einreichen"
-statement.save.recommendation: "Möchten Sie die Erwiederung der Stellungnahmen ebenfalls abspeichern?"
+statement.save.recommendation: "Möchten Sie die Erwiederung der Stellungnahme ebenfalls abspeichern?"
 statement.send.email: "Stellungnahme per E-Mail versenden"
 statement.send.email.label: "Sende unten stehende Stellungnahme an"
 statement.send: "Stellungnahme versenden"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3213,6 +3213,7 @@ statement.representation.creation: "Die Stellungnahme im Namen folgender Institu
 statement.save.altered: "Stellungnahme verändert speichern"
 statement.save.as.draft: "Stellungnahme als Entwurf speichern"
 statement.save.immediate: "Stellungnahme direkt einreichen"
+statement.save.recommendation: "Möchten Sie die Erwiederung der Stellungnahmen ebenfalls abspeichern?"
 statement.send.email: "Stellungnahme per E-Mail versenden"
 statement.send.email.label: "Sende unten stehende Stellungnahme an"
 statement.send: "Stellungnahme versenden"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3213,7 +3213,7 @@ statement.representation.creation: "Die Stellungnahme im Namen folgender Institu
 statement.save.altered: "Stellungnahme verändert speichern"
 statement.save.as.draft: "Stellungnahme als Entwurf speichern"
 statement.save.immediate: "Stellungnahme direkt einreichen"
-statement.save.recommendation: "Möchten Sie die Erwiederung der Stellungnahme ebenfalls abspeichern?"
+statement.save.text: "Sie haben Änderungen am Text der Stellungnahme vorgenommen. Wenn Sie fortfahren, werden diese ebenfalls gespeichert."
 statement.send.email: "Stellungnahme per E-Mail versenden"
 statement.send.email.label: "Sende unten stehende Stellungnahme an"
 statement.send: "Stellungnahme versenden"


### PR DESCRIPTION
[Ticket](https://yaits.demos-deutschland.de/T31984)

This PR prevents the user from unintentionally deleting an unsaved text by synchronizing the local statement in `StatementMeta.vue` (which also emits the local statement when saving only metadata) with the statements from store. The editor automatically updates the state of statements in the store when registering an input. This only occurs when a statement has not been segmented already.

### How to review/test
- navigate to detail view of statement
- select statement without segments
- click edit and claim statement
- edit the text of the editor
- use the upper save button for metadata
- reload page and confirm that the text in the editor was saved too
- check if a statement with segments still works like before 

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
