### PR TITLE
feat: make split statement button in list statements available again

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -146,8 +146,8 @@
         <template v-slot:flyout="{ assignee, id, originalPdf, segmentsCount, synchronized }">
           <dp-flyout>
             <a
-              class="is-disabled"
               v-if="hasPermission('area_statement_segmentation')"
+              :class="{'is-disabled': segmentsCount > 0 && segmentsCount !== '-' && (assignee.id !== '' && assignee.id !== currentUserId)}"
               :href="Routing.generate('dplan_drafts_list_edit', { statementId: id, procedureId: procedureId })"
               rel="noopener">
               {{ Translator.trans('split') }}


### PR DESCRIPTION
- Basically this reverts the changes of this commit #b9ffea39025c8de05645060b10b9fd90e26db75b
- Since split statements is addonized now, we need to make the button in the list statement view available again

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as FPA
- go to list statement view
- make sure unsegmented statements can be segmented via the flyout button
- if already has segments button should be disabled