### PR TITLE
F T32013 submitters of the same statement are not saved

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SimilarStatementSubmitterResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SimilarStatementSubmitterResourceType.php
@@ -94,7 +94,7 @@ final class SimilarStatementSubmitterResourceType extends DplanResourceType impl
 
     public function isDirectlyAccessible(): bool
     {
-        return false;
+        return true;
     }
 
     public function isReferencable(): bool
@@ -109,9 +109,9 @@ final class SimilarStatementSubmitterResourceType extends DplanResourceType impl
             return $this->conditionFactory->false();
         }
 
-        // As resources of this type ar not directly accessible but via relationships only,
-        // we can simply return true here.
-        return $this->conditionFactory->true();
+        $procedureId = $procedure->getId();
+
+        return $this->conditionFactory->propertyHasValue($procedureId, $this->procedure->id);
     }
 
     /**

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -831,8 +831,8 @@ class StatementService extends CoreService implements StatementServiceInterface
                 /** @var Statement $statement */
                 foreach ($similarStatements as $statement) {
                     $statement->getSimilarStatementSubmitters()->add($submitter);
-                    $change->addEntitiesToPersist($statement);
                 }
+                $change->addEntitiesToPersist($similarStatements->getValues());
             }
         );
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32013

Description: submitters of the same statement are not saved, the resourcetype had to be adjusted


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
