### PR TITLE
feat (refs T31926): move ai api user to database

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230324132250 extends AbstractMigration
+{
+    private const PW_HASH = 'sha512';
+    private const FLAGS = 'a:7:{s:10:"newsletter";b:0;s:16:"access_confirmed";b:1;s:16:"profileCompleted";b:1;s:7:"noPiwik";b:0;s:17:"forumNotification";b:0;s:7:"newUser";b:0;s:24:"assignedTaskNotification";b:1;}';
+
+    public function getDescription(): string
+    {
+        return 'refs T31926: Insert the AiApiUser in the database.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql('SET foreign_key_checks = 0;');
+        $this->addSql('INSERT INTO _user SET
+              _u_id = UUID(),
+              _u_dm_id = NULL,
+              _u_gender = NULL,
+              _u_title = NULL,
+              _u_firstname = NULL,
+              _u_lastname = NULL,
+              _u_email = :login,
+              _u_login = :login,
+              _u_password = :password,
+              alternative_login_password = NULL,
+              _u_salt = NULL,
+              _u_language = NULL,
+              _u_created_date = NOW(),
+              _u_modified_date = NOW(),
+              _u_deleted = 0,
+              _u_gw_id = NULL,
+              flags = :flags,
+              last_login = NULL,
+              twin_user_id = NULL,
+              provided_by_identity_provider = 0;',
+            [
+                'login' => AiApiUser::AI_API_USER_LOGIN,
+                'password' => $this->generateNewRandomPassword(),
+                'flags' => self::FLAGS,
+            ]
+        );
+
+        $aiApiUserId = $this->getAiApiUserId();
+        $allCustomerIds = $this->getAllCustomerIds();
+        $roleId = $this->getRoleId();
+
+        foreach ($allCustomerIds as $customerId) {
+            $this->setRelationRoleUserCustomer($aiApiUserId, $roleId, $customerId['_c_id']);
+        }
+
+        $this->addSql('INSERT INTO _orga_users_doctrine SET
+                      _o_id = :orgaId,
+                      _u_id = :userId;',
+            [
+                'orgaId' => AiApiUser::ANONYMOUS_USER_ORGA_ID,
+                'userId' => $aiApiUserId,
+            ]
+        );
+
+        $this->addSql('INSERT INTO _department_users_doctrine SET
+                           _d_id = :departmentId,
+                           _u_id = :userId;',
+            [
+                'departmentId' => AiApiUser::ANONYMOUS_USER_DEPARTMENT_ID,
+                'userId' => $aiApiUserId,
+            ]
+        );
+        $this->addSql('SET foreign_key_checks = 1;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $aiApiUserId = $this->getAiApiUserId();
+        $this->addSql('SET foreign_key_checks = 0;');
+        $this->addSql('DELETE FROM _user WHERE _u_id = ?;', [$aiApiUserId]);
+        $this->addSql('DELETE FROM relation_role_user_customer WHERE user = ?;', [$aiApiUserId]);
+        $this->addSql('DELETE FROM _orga_users_doctrine WHERE _u_id = ?;', [$aiApiUserId]);
+        $this->addSql('DELETE FROM _department_users_doctrine WHERE _u_id = ?;', [$aiApiUserId]);
+        $this->addSql('SET foreign_key_checks = 1;');
+    }
+
+    private function setRelationRoleUserCustomer($userId, $roleId, $customerId)
+    {
+        $this->addSql('INSERT INTO relation_role_user_customer SET
+                        id = UUID(),
+                        user = :userId,
+                        role = :roleId,
+                        customer = :customerId;',
+            [
+                'userId' => $userId,
+                'roleId' => $roleId,
+                'customerId' => $customerId,
+            ]
+        );
+    }
+
+    private function getAiApiUserId()
+    {
+        return $this->connection->fetchOne('SELECT _u_id FROM _user
+             WHERE _u_login = :userLogin;', ['userLogin' => AiApiUser::AI_API_USER_LOGIN]);
+    }
+
+    private function getRoleId()
+    {
+        return $this->connection->fetchOne('SELECT _r_id FROM _role WHERE _r_code = "RAICOM";');
+    }
+
+    private function getAllCustomerIds()
+    {
+        return $this->connection->fetchAllAssociative('SELECT _c_id FROM customer;');
+    }
+
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+
+    /**
+     * Generate a new random password.
+     *
+     * WARNING: This is not a hashed password but the plain text variant
+     *
+     * This method should be used in places where we need to inform the user
+     * about their new password, e.g. when recovering from a password loss.
+     *
+     * @throws Exception
+     */
+    private function generateNewRandomPassword(): string
+    {
+        return substr(hash(self::PW_HASH, random_bytes(500)), 0, 10);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -43,9 +53,9 @@ class Version20230324132250 extends AbstractMigration
               twin_user_id = NULL,
               provided_by_identity_provider = 0;',
             [
-                'login' => AiApiUser::AI_API_USER_LOGIN,
+                'login'    => AiApiUser::AI_API_USER_LOGIN,
                 'password' => $this->generateNewRandomPassword(),
-                'flags' => self::FLAGS,
+                'flags'    => self::FLAGS,
             ]
         );
 
@@ -71,7 +81,7 @@ class Version20230324132250 extends AbstractMigration
                            _u_id = :userId;',
             [
                 'departmentId' => AiApiUser::ANONYMOUS_USER_DEPARTMENT_ID,
-                'userId' => $aiApiUserId,
+                'userId'       => $aiApiUserId,
             ]
         );
         $this->addSql('SET foreign_key_checks = 1;');
@@ -97,8 +107,8 @@ class Version20230324132250 extends AbstractMigration
                         role = :roleId,
                         customer = :customerId;',
             [
-                'userId' => $userId,
-                'roleId' => $roleId,
+                'userId'     => $userId,
+                'roleId'     => $roleId,
                 'customerId' => $customerId,
             ]
         );

--- a/demosplan/DemosPlanCoreBundle/Logic/JwtRouter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JwtRouter.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanProcedureBundle\Repository\ProcedureRepository;
+use demosplan\DemosPlanUserBundle\Logic\UserService;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -31,7 +32,7 @@ class JwtRouter extends Router
         JWTTokenManagerInterface $jwtManager,
         ProcedureRepository $procedureRepository,
         RouterInterface $router,
-        protected readonly CurrentContextProvider $contextProvider
+        protected readonly UserService $userService
     ) {
         $this->jwtManager = $jwtManager;
         parent::__construct($globalConfig, $procedureRepository, $router);
@@ -39,9 +40,8 @@ class JwtRouter extends Router
 
     public function generate($route, $parameters = [], $referenceType = self::ABSOLUTE_URL): string
     {
-        $customer = $this->contextProvider->getCurrentCustomer();
-
-        $apiAuthorization = $this->jwtManager->create(new AiApiUser($customer));
+        $aiApiUser = $this->userService->getValidUser(AiApiUser::AI_API_USER_LOGIN);
+        $apiAuthorization = $this->jwtManager->create($aiApiUser);
         if (!array_key_exists('jwt', $parameters)) {
             $parameters['jwt'] = $apiAuthorization;
         }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -10,8 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Provider;
 
-use DemosEurope\DemosplanAddon\Contracts\CurrentContextProviderInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
+use demosplan\DemosPlanUserBundle\Logic\UserService;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class AiApiUserProvider implements UserProviderInterface
 {
     public function __construct(
-        protected readonly CurrentContextProviderInterface $contextProvider
+        protected readonly UserService $userService
     ) {}
 
     /**
@@ -33,7 +33,7 @@ class AiApiUserProvider implements UserProviderInterface
             throw new UserNotFoundException('Invalid username');
         }
 
-        return new AiApiUser($this->contextProvider->getCurrentCustomer());
+        return $this->userService->getValidUser($username);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -20,7 +20,8 @@ class AiApiUserProvider implements UserProviderInterface
 {
     public function __construct(
         protected readonly UserService $userService
-    ) {}
+    ) {
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31926

The AiApiUser is currently created by constructor, but should not be persisted or stored in the database. However, the addon-specific permission evaluation checks properties that lead to persist problems when creating the user. To prevent this, it was decided to save the AiApiUser in the database via core migration. The user should now be fetched via the database and the addon-specific permission checks should hopefully work again.

Hint: The migrations are in the linked PR's

### How to review/test
You could run the migrations and check if they works.
But to test if the bug is fixed with this PR we have to install these changes on dev.

### Linked PRs (optional)

https://github.com/demos-europe/demosplan-project-ewm/pull/41 closed
https://github.com/demos-europe/demosplan-project-blp/pull/37 closed
https://github.com/demos-europe/demosplan-project-regio/pull/28 closed

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
