### PR TITLE
fix(refs T29882): require claiming before going to split statement view

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -145,13 +145,14 @@
         </template>
         <template v-slot:flyout="{ assignee, id, originalPdf, segmentsCount, synchronized }">
           <dp-flyout>
-            <a
+            <button
               v-if="hasPermission('area_statement_segmentation')"
-              :class="{'is-disabled': segmentsCount > 0 && segmentsCount !== '-' && (assignee.id !== '' && assignee.id !== currentUserId)}"
-              :href="Routing.generate('dplan_drafts_list_edit', { statementId: id, procedureId: procedureId })"
+              :class="`${(segmentsCount > 0 && segmentsCount !== '-') ? 'is-disabled' : '' } btn--blank o-link--default`"
+              :disabled="segmentsCount > 0 && segmentsCount !== '-'"
+              @click.prevent="handleStatementSegmentation(id, assignee, segmentsCount)"
               rel="noopener">
               {{ Translator.trans('split') }}
-            </a>
+            </button>
             <a
               :href="Routing.generate('dplan_statement_segments_list', { statementId: id, procedureId: procedureId })"
               :class="{'is-disabled': synchronized }"
@@ -486,6 +487,54 @@ export default {
       }
     },
 
+    /**
+     * If statement already has segments, do nothing
+     * If statement is not claimed, silently assign it to the current user and go to split statement view
+     * If statement is claimed by current user, go to split statement view
+     * If statement is claimed by another user, ask the current user to claim it and, after they confirm, assign it to
+     * the current user, then go to split statement view. If the user doesn't confirm, do nothing.
+     * @param statementId {string}
+     * @param assignee {object} { data: { id: string, type: string }}
+     * @param segmentsCount {number || string} can be a number or '-'
+     */
+    handleStatementSegmentation (statementId, assignee, segmentsCount) {
+      const isStatementSegmented = segmentsCount > 0 && segmentsCount !== '-'
+      const isStatementClaimedByCurrentUser = assignee.id === this.currentUserId
+      const isStatementClaimed = assignee.id !== ''
+      const isStatementClaimedByOtherUser = isStatementClaimed && !isStatementClaimedByCurrentUser
+
+      if (isStatementSegmented) {
+        return
+      }
+
+      if (isStatementClaimedByCurrentUser) {
+        window.location.href = Routing.generate('dplan_drafts_list_edit', { statementId: statementId, procedureId: this.procedureId })
+      }
+
+      if (!isStatementClaimed) {
+        // claim silently
+        this.claimStatement(statementId)
+          .then(() => {
+            window.location.href = Routing.generate('dplan_drafts_list_edit', { statementId: statementId, procedureId: this.procedureId })
+          })
+          .catch(err => {
+            console.error(err)
+          })
+      }
+
+      if (isStatementClaimedByOtherUser && dpconfirm(Translator.trans('warning.statement.needLock.generic'))) {
+        this.claimStatement(statementId)
+          .then(() => {
+            window.location.href = Routing.generate('dplan_drafts_list_edit', { statementId: statementId, procedureId: this.procedureId })
+          })
+          .catch(err => {
+            console.error(err)
+          })
+      }
+
+      // window.location.href = Routing.generate('dplan_drafts_list_edit', { statementId: statementId, procedureId: this.procedureId })
+    },
+
     applySearch (term, selectedFields) {
       this.searchValue = term
       this.searchFieldsSelected = selectedFields
@@ -524,9 +573,11 @@ export default {
         return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'Statement', resourceId: statementId }), {}, payload)
           .then(response => {
             checkResponse(response)
+            return response
           })
-          .then(() => {
+          .then((response) => {
             dplan.notify.notify('confirm', Translator.trans('confirm.statement.assignment.assigned'))
+            return response
           })
           .catch((err) => {
             console.error(err)


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29882 :red_circle: 

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

If a user wants to segment a statement that is claimed by another user, they are now asked to claim it first.

The following behavior is implemented for the "Aufteilen" button in the flyout menu:
- If statement already has segments, do nothing
- If statement is not claimed, silently assign it to the current user and go to split statement view
- If statement is claimed by current user, go to split statement view
- If statement is claimed by another user, ask the current user to claim it and, after they confirm, assign it to  the current user, then go to split statement view. If the user doesn't confirm, do nothing.

### PR Checklist
<!-- Reminders for handling PRs -->

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
