### PR TITLE
fix (refs T32003): disable permissions for institution tagging

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -341,17 +341,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 'feature_user_list',
                 'field_statement_recommendation',
             ]);
-
-            if ($this->isMemberOfPlanningOrganisation()) {
-                $this->enablePermissions([
-                    'area_institution_tag_manage',
-                    'feature_institution_tag_assign',
-                    'feature_institution_tag_create',
-                    'feature_institution_tag_delete',
-                    'feature_institution_tag_read',
-                    'feature_institution_tag_update',
-                ]);
-            }
         }
 
         if ($this->user->hasRole(Role::PLANNING_AGENCY_ADMIN)) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32003

The permissions for "Institutionen verschlagworten" should only enabled for diplanbau.

### How to review/test
You could check if you can tagging institutions only in DiPlanBau.

### Linked PRs (optional)

### PR Checklist
<!-- Reminders for handling PRs -->
https://github.com/demos-europe/demosplan-project-diplanbau/pull/77

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
