### PR TITLE
fix(refs T31929): Optimize addon loading

### DIFF
--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -9,6 +9,7 @@
 
 <template>
   <dp-tabs
+    v-if="allComponentsLoaded"
     :active-id="activeTabId"
     use-url-fragment
     @change="setActiveTabId">
@@ -26,10 +27,12 @@
       </slot>
     </dp-tab>
   </dp-tabs>
+
+  <dp-loading v-else class="u-mv" />
 </template>
 
 <script>
-import { DpTab, DpTabs } from '@demos-europe/demosplan-ui'
+import { DpLoading, DpTab, DpTabs } from '@demos-europe/demosplan-ui'
 import AdministrationImportNone from './AdministrationImportNone'
 import ExcelImport from './ExcelImport/ExcelImport'
 import { checkResponse, dpRpc, hasAnyPermissions } from '@demos-europe/demosplan-utils'
@@ -40,6 +43,7 @@ export default {
 
   components: {
     AdministrationImportNone,
+    DpLoading,
     DpTab,
     DpTabs,
     ExcelImport,
@@ -96,6 +100,7 @@ export default {
   data () {
     return {
       activeTabId: '',
+      allComponentsLoaded: false,
       asyncComponents: []
     }
   },
@@ -136,7 +141,7 @@ export default {
         hookName: hookName
       }
 
-      dpRpc('addons.assets.load', params)
+      return dpRpc('addons.assets.load', params)
         .then(response => checkResponse(response))
         .then(response => {
           const result = response[0].result
@@ -160,12 +165,17 @@ export default {
               title: addon.options.title
             })
           }
-      })
-    },
+        })
+    }
   },
 
   mounted () {
-    this.loadComponents('import.tabs')
+    const loadComponents = this.loadComponents('import.tabs')
+
+    Promise.allSettled([loadComponents])
+      .then(() => {
+        this.allComponentsLoaded = true
+      })
   }
 }
 </script>

--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -170,9 +170,7 @@ export default {
   },
 
   mounted () {
-    const loadComponents = this.loadComponents('import.tabs')
-
-    Promise.allSettled([loadComponents])
+    Promise.allSettled([this.loadComponents('import.tabs')])
       .then(() => {
         this.allComponentsLoaded = true
       })

--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -170,7 +170,7 @@ export default {
   },
 
   mounted () {
-    Promise.allSettled([this.loadComponents('import.tabs')])
+        Promise.allSettled([this.loadComponents('import.tabs')])
       .then(() => {
         this.allComponentsLoaded = true
       })

--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -170,7 +170,7 @@ export default {
   },
 
   mounted () {
-        Promise.allSettled([this.loadComponents('import.tabs')])
+    Promise.allSettled([this.loadComponents('import.tabs')])
       .then(() => {
         this.allComponentsLoaded = true
       })


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31929

Loading the '"default" Tabs/Components on the import page and then add some addons later on triggered a rerendering of the already loaded components, which broke the dpDatepicker and had potential to brake other things aswell.
To prevent that now the Tabs only get rendered after the addon-request is fulfilled. In premature obedience, to make it scalable, I already added a promisall resolving...  


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test

As FPA goto
/verfahren/<procedure-id>/import#StatementFormImport

check if the Datepicker for Einreichungsdatum/Verfassungsdatum works

<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
