### PR TITLE
fix(T32010): solve issue by creating a new organisation

### DIFF
--- a/client/js/components/user/DpCreateItem.vue
+++ b/client/js/components/user/DpCreateItem.vue
@@ -210,6 +210,39 @@ export default {
       createUser: 'create'
     }),
 
+    changeTypeToPascalCase (payload) {
+      const newPayload = {
+        ...payload,
+        attributes: {
+          ...payload.attributes
+        },
+        relationships: {
+          customers: {
+            data: payload.customers?.data[0].id
+              ? payload.customers.data.map(el => {
+                return {
+                  ...el,
+                  type: 'Customer'
+                }
+              })
+              : null
+          },
+          departments: {
+            data: payload.departments?.data[0].id
+              ? payload.departments.data.map(el => {
+                return {
+                  ...el,
+                  type: 'Department'
+                }
+              })
+              : null
+          }
+        }
+      }
+
+      return newPayload
+    },
+
     reset () {
       this.isOpen = false
       this.item = {}
@@ -242,7 +275,9 @@ export default {
           if (this.item.attributes.registrationStatuses.length === 0) {
             this.$refs.formFields.saveNewRegistrationStatus()
           }
-          this.createOrganisation(this.itemResource)
+          // The Types for relationships should be sent as PascalCase
+          const payload = this.changeTypeToPascalCase(this.itemResource)
+          this.createOrganisation(payload)
             .then(() => {
               if (this.itemResource.attributes.registrationStatuses.find(el => el.status === 'pending')) {
                 this.$root.$emit('get-items')

--- a/client/js/components/user/DpOrganisationFormFields.vue
+++ b/client/js/components/user/DpOrganisationFormFields.vue
@@ -822,19 +822,17 @@ export default {
     customers () {
       if (hasOwnProp(this.organisation.relationships, 'customers') === false) {
         return ''
+      } else if (Object.keys(this.organisation.relationships.customers.data).length && this.organisation.relationships.customers.data[0].id !== '') {
+        const allCustomers = Object.values(this.organisation.relationships.customers.list())
+        const names = []
+        allCustomers.forEach(el => {
+          if (typeof el !== 'undefined') {
+            names.push(el.attributes.name)
+          }
+        })
+        return names.join(', ')
       } else {
-        if (Object.keys(this.organisation.relationships.customers.data).length) {
-          const allCustomers = Object.values(this.organisation.relationships.customers.list())
-          const names = []
-          allCustomers.forEach(el => {
-            if (typeof el !== 'undefined') {
-              names.push(el.attributes.name)
-            }
-          })
-          return names.join(', ')
-        } else {
-          return ''
-        }
+        return ''
       }
     },
 
@@ -844,7 +842,15 @@ export default {
      * @return {string}
      */
     organisationSlug () {
-      return Object.keys(this.organisation.relationships.currentSlug.data).length ? this.organisation.relationships.currentSlug.get().attributes.name : ''
+      let organisationSlug
+
+      if (hasOwnProp(this.organisation.relationships, 'currentSlug') && this.organisation.relationships.currentSlug.data?.id !== '') {
+        organisationSlug = this.organisation.relationships.currentSlug.get().attributes.name
+      } else {
+        organisationSlug = ''
+      }
+
+      return organisationSlug
     },
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -332,7 +332,7 @@ class DemosPlanOrganisationAPIController extends APIController
             $newOrga = $userHandler->addOrga($orgaDataArray);
 
             // Fehlermeldung, Pflichtfelder
-            if (array_key_exists('mandatoryfieldwarning', $newOrga)) {
+            if (is_array($newOrga) && array_key_exists('mandatoryfieldwarning', $newOrga)) {
                 $this->messageBag->add('error', 'error.mandatoryfields');
                 throw new InvalidArgumentException('Can\'t create orga since mandatory fields are missing.');
             }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32010

**Description:** This PR handles different return types of `UserHandler::addOrga()`. It returns Orga Entity by success or an array if the MissingMandatoryFields is true.

As well as resolve some other issues:
- add method which changes the case of types in relationships (to prevent some warnings)
`ResourcefulApi.js:60 --> The Resource with type 'customer' is sent in lower camel case. Please send as upper camel case.
`
- add additional check when customer id is an empty string (to prevent issues in VUEX store)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
