### PR TITLE
Fix unclaiming of statement

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -455,6 +455,7 @@ export default {
         .then(response => { checkResponse(response) })
         .then(() => {
           const dataToUpdate = this.setDataToUpdate(true)
+
           this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
           dplan.notify.notify('confirm', Translator.trans('confirm.statement.assignment.assigned'))
         })

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -587,6 +587,7 @@ export default {
     synchronizeAssignee (statement) {
       const oldAssignee = JSON.stringify(statement.relationships.assignee.data)
       const newAssignee = JSON.stringify(this.statement.relationships.assignee.data)
+
       if (oldAssignee !== newAssignee) {
         statement.relationships.assignee.data = this.statement.relationships.assignee.data
       }

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -638,6 +638,7 @@ export default {
         .then(response => checkResponse(response))
         .then(() => {
           const dataToUpdate = this.setDataToUpdate()
+
           this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
           dplan.notify.notify('confirm', Translator.trans('confirm.statement.assignment.unassigned'))
         })

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -539,6 +539,7 @@ export default {
     },
 
     saveStatement (statement) {
+      this.synchronizeAssignee(statement)
       this.synchronizeFullText(statement)
       // The key isManual is readonly, so we should remove it before saving
       delete statement.attributes.isManual
@@ -580,6 +581,20 @@ export default {
 
       const defaultAction = hasPermission('feature_segment_recommendation_edit') ? 'addRecommendation' : 'editText'
       this.currentAction = action || defaultAction
+    },
+
+    /**
+     * If `this.statement` has changed its assignee (which does not propagate to the
+     * localStatement in StatementMeta), it must be synced back before applying the
+     * StatementMeta data to `this.statement`.
+     * @param {object} statement - The local statement of StatementMeta.vue.
+     */
+    synchronizeAssignee (statement) {
+      const oldAssignee = JSON.stringify(statement.relationships.assignee.data)
+      const newAssignee = JSON.stringify(this.statement.relationships.assignee.data)
+      if (oldAssignee !== newAssignee) {
+        statement.relationships.assignee.data = this.statement.relationships.assignee.data
+      }
     },
 
     /**

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -436,9 +436,6 @@ export default {
      */
     claimStatement () {
       this.isLoading = true
-      const dataToUpdate = this.setDataToUpdate(true)
-      this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
-
       const payload = {
         data: {
           id: this.statement.id,
@@ -457,6 +454,8 @@ export default {
       return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'Statement', resourceId: this.statement.id }), {}, payload)
         .then(response => { checkResponse(response) })
         .then(() => {
+          const dataToUpdate = this.setDataToUpdate(true)
+          this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
           dplan.notify.notify('confirm', Translator.trans('confirm.statement.assignment.assigned'))
         })
         .catch((err) => {
@@ -622,8 +621,6 @@ export default {
 
     unclaimStatement () {
       this.isLoading = true
-      const dataToUpdate = this.setDataToUpdate()
-      this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
       const payload = {
         data: {
           type: 'Statement',
@@ -636,8 +633,11 @@ export default {
         }
       }
       return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'Statement', resourceId: this.statement.id }), {}, payload)
-        .then((response) => {
-          checkResponse(response)
+        .then((response) => checkResponse(response))
+        .then(() => {
+          const dataToUpdate = this.setDataToUpdate()
+          this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })
+          dplan.notify.notify('confirm', Translator.trans('confirm.statement.assignment.unassigned'))
         })
         .catch((err) => {
           this.restoreStatementAction(this.statement.id)

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -635,7 +635,7 @@ export default {
         }
       }
       return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'Statement', resourceId: this.statement.id }), {}, payload)
-        .then((response) => checkResponse(response))
+        .then(response => checkResponse(response))
         .then(() => {
           const dataToUpdate = this.setDataToUpdate()
           this.setStatement({ ...dataToUpdate, id: this.statement.id, group: null })

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -55,20 +55,16 @@
         </div>
         <ul class="float--right u-m-0 space-inline-s flex">
           <li class="display--inline-block">
-            <button
-              class="o-flyout__trigger btn--blank o-link--default u-ph-0_25 line-height--2 whitespace--nowrap"
-              @click="toggleClaimStatement">
-              <dp-claim
-                entity-type="statement"
-                :assigned-id="currentAssignee.id"
-                :assigned-name="currentAssignee.name"
-                :assigned-organisation="currentAssignee.orgaName"
-                :current-user-id="currentUser.id"
-                :is-loading="isLoading" />
-              <span
-                v-if="!isLoading"
-                v-text="Translator.trans(`${currentUser.id === currentAssignee.id ? 'assigned' : 'assign'}`)" />
-            </button>
+            <dp-claim
+              class="o-flyout__trigger u-ph-0_25 line-height--2"
+              entity-type="statement"
+              :assigned-id="currentAssignee.id"
+              :assigned-name="currentAssignee.name"
+              :assigned-organisation="currentAssignee.orgaName"
+              :current-user-id="currentUser.id"
+              :is-loading="isLoading"
+              :label="Translator.trans(`${currentUser.id === currentAssignee.id ? 'assigned' : 'assign'}`)"
+              @click="toggleClaimStatement" />
           </li>
           <li class="display--inline-block">
             <a

--- a/client/js/components/statement/DpClaim.vue
+++ b/client/js/components/statement/DpClaim.vue
@@ -41,7 +41,8 @@ the FB is ready with editing of fragments.
 
 <template>
   <!--data-assigned is needed for batch edit-->
-  <a
+  <button
+    class="flex flex-items-center space-inline-xs btn--blank o-link--default"
     :class="{'cursor--pointer' : false === isLoading}"
     :data-assigned="isAssignedToMe /* needed for checking checked elements*/"
     @click.prevent.stop="updateAssignment"
@@ -56,7 +57,10 @@ the FB is ready with editing of fragments.
       class="fa"
       :class="status.icon"
       aria-hidden="true" />
-  </a>
+    <span
+      v-if="label"
+      v-text="label" />
+  </button>
 </template>
 
 <script>
@@ -106,6 +110,12 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+
+    label: {
+      type: String,
+      required: false,
+      default: ''
     },
 
     lastClaimedUserId: {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32028

**Fixing the bug**
Inside StatementMeta, the statement obj persists its initial state, which it also bubbles back up onSave. So, when loading the view with unassigned statement, and then assigning it, the local statement in StatementMeta still has the unassigned state which is applied to the outer state then, leading to the buggy behavior.

To work around this, we can either only pass the data into StatementMeta which is actually needed by this component, or we can fix it afterwards (this version) - which is a little ugly but as most data is needed within StatementMeta, it is still the better choice.

**Button cleanup**
The claim component generates a link element. To wrap that within a button is not html5 conform, also the link is not really the correct element here. To still have the text label besides the icon, a new prop is used in DpClaim. Also, some flex classes are used to ensure vertical alignment also for the loading state.

**Remove "optimistic claiming"**
The optimistic behavior (that was implemented before) is not the standard behavior within demosPlan. Also, as we show a loading indicator on the claim button, the rest of the UI should be in sync with that. The alternative would have been to also remove the loading indicator, hence hiding the loading completely. However as we do not use this pattern at all, why should we use it here?

### How to review/test
- Best reviewed on a per-commit-basis. 
- The behavior described in the ticket (does only happen if you load the view in unclaimed state) should not persist.
- Before, the edit state of the StatementMeta box was shown as soon as users clicked the claim button. Now, the edit state should only show up after the request (which saves the claiming) resolves.

### PR Checklist
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
