### PR TITLE
fix (refs T31926): adjust ai api user migration

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/03/Version20230324132250.php
@@ -16,6 +16,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use Faker\Provider\Uuid;
 
 class Version20230324132250 extends AbstractMigration
 {
@@ -31,8 +32,9 @@ class Version20230324132250 extends AbstractMigration
     {
         $this->abortIfNotMysql();
         $this->addSql('SET foreign_key_checks = 0;');
+        $aiApiUserId = Uuid::uuid();
         $this->addSql('INSERT INTO _user SET
-              _u_id = UUID(),
+              _u_id = :user_id,
               _u_dm_id = NULL,
               _u_gender = NULL,
               _u_title = NULL,
@@ -53,13 +55,12 @@ class Version20230324132250 extends AbstractMigration
               twin_user_id = NULL,
               provided_by_identity_provider = 0;',
             [
+                'user_id'  => $aiApiUserId,
                 'login'    => AiApiUser::AI_API_USER_LOGIN,
                 'password' => $this->generateNewRandomPassword(),
                 'flags'    => self::FLAGS,
             ]
         );
-
-        $aiApiUserId = $this->getAiApiUserId();
         $allCustomerIds = $this->getAllCustomerIds();
         $roleId = $this->getRoleId();
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31926

Adjust the migration that brings the AiApiUser to the database. Generate the uuid which reference the user first, then it can be used for relations.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
