### PR TITLE
Hide button row

### DIFF
--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/edit_orga.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/edit_orga.html.twig
@@ -25,11 +25,6 @@
             >
 
             {% include '@DemosPlanUser/DemosPlanUser/orga_data_entry.html.twig' %}
-
-            {{ uiComponent('button-row', {
-                primary: uiComponent('button', { type: 'submit' }),
-                secondary: uiComponent('button', { color: 'secondary', type: 'reset' })
-            }) }}
         </form>
 
         {% endblock content %}

--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/orga_data_entry.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/orga_data_entry.html.twig
@@ -351,3 +351,11 @@
         {% endblock %}
     </fieldset>
 {% endif %}
+
+
+{% block buttonRow %}
+    {{ uiComponent('button-row', {
+        primary: uiComponent('button', { type: 'submit' }),
+        secondary: uiComponent('button', { color: 'secondary', type: 'reset' })
+    }) }}
+{% endblock buttonRow %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31858

There is no practical way of hiding the buttonRow based on permissions - the appearance of form elements is already controlled by twig project overrides. So, to hide the buttonRow for ewm, it is moved within the inner template. Here, it can then be hidden via block, too.

### How to review/test
Nothing should change except for EWM. There should be no buttons anymore when visiting the "Daten der Orga" view anymore.

### Linked PRs
https://github.com/demos-europe/demosplan-project-ewm/pull/44

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
