### PR TITLE
Show statement as text when not in edit mode

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -67,19 +67,28 @@
 
     <!-- if statement has no segments, display statement -->
     <template v-else-if="statement">
-      <dp-editor
-        hidden-input="statementText"
-        @input="updateStatementText"
-        :value="statement.attributes.fullText || ''"
-        :toolbar-items="{ linkButton: true }"
-        :readonly="!editable"
-        required />
-      <dp-button-row
-        class="u-mv"
-        primary
-        secondary
-        @primary-action="dpValidateAction('segmentsStatementForm', saveStatement, false)"
-        @secondary-action="resetStatement" />
+      <template v-if="editable">
+        <dp-editor
+          hidden-input="statementText"
+          @input="updateStatementText"
+          :value="statement.attributes.fullText || ''"
+          :toolbar-items="{ linkButton: true }"
+          required />
+        <dp-button-row
+          class="u-mv"
+          primary
+          secondary
+          @primary-action="dpValidateAction('segmentsStatementForm', saveStatement, false)"
+          @secondary-action="resetStatement" />
+      </template>
+      <div
+        v-else
+        class="border space-inset-s">
+        <p class="weight--bold">
+          {{ Translator.trans('statement.text.short') }}
+        </p>
+        <div v-cleanhtml="statement.attributes.fullText || ''" />
+      </div>
     </template>
   </div>
 </template>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -131,12 +131,11 @@
       </header>
     </dp-sticky-element>
 
-    <div>
+    <div class="u-mt-0_5">
       <!--Statement meta data -->
       <statement-meta
         v-if="showInfobox && statement"
         :attachments="filteredAttachments"
-        class="u-mt-0_5"
         :current-user-id="currentUser.id"
         :statement="statement"
         :submit-type-options="submitTypeOptions"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T28146

There is no reason to show a disabled editor, at all. It is more helpful to just show the text.

The border and padding is applied to add structure to the view. It borrows the style from the StatementMeta box.

### How to review/test
In ewm, go to the statement list and open a statement that is not segmented already. unassign it. The statement text should be rendered in a bordered box, without the editor ui.

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
