### PR TITLE
fix(refs T31998): restore setActiveTabId

### DIFF
--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -28,14 +28,16 @@
     </dp-tab>
   </dp-tabs>
 
-  <dp-loading v-else class="u-mv" />
+  <dp-loading
+    v-else
+    class="u-mv" />
 </template>
 
 <script>
+import { checkResponse, dpRpc, hasAnyPermissions } from '@demos-europe/demosplan-utils'
 import { DpLoading, DpTab, DpTabs } from '@demos-europe/demosplan-ui'
 import AdministrationImportNone from './AdministrationImportNone'
 import ExcelImport from './ExcelImport/ExcelImport'
-import { checkResponse, dpRpc, hasAnyPermissions } from '@demos-europe/demosplan-utils'
 import StatementFormImport from './StatementFormImport/StatementFormImport'
 
 export default {
@@ -173,6 +175,7 @@ export default {
     Promise.allSettled([this.loadComponents('import.tabs')])
       .then(() => {
         this.allComponentsLoaded = true
+        this.setActiveTabId()
       })
   }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31998

Somehow the invoking of setActiveTabId got lost
during the refactoring of the component. Anyhow,
here we go again.

### How to review/test
Go to import, craft a manual statement via "Direkteingabe" tab. Submit the form. After reloading the page, the same tab should be selected.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
