### PR TITLE
feature (refs T31926): use new Response instance to prevent null value

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
+use Symfony\Component\HttpFoundation\Response;
 use DemosEurope\DemosplanAddon\Contracts\Events\ParameterProviderEventInterface;
 use demosplan\DemosPlanCoreBundle\Logic\ViewRenderer;
 
@@ -36,7 +37,7 @@ class ParametersProviderSubscriber extends BaseEventSubscriber
     {
         $view = $event->getView();
         $parameters = $event->getParameters();
-        $response = $event->getResponse();
+        $response = new Response();
         $this->viewRenderer->processRequestStatus();
         $parameters = $this->viewRenderer->processRequestParameters($view, $parameters, $response);
         $event->setParameters($parameters);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31926

Description:
use new Response instance for method processRequestParameters
instead of null

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
