### PR TITLE
feature (refs T31926): change method of EventSubscriber from private to public.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
@@ -10,9 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
-use Symfony\Component\HttpFoundation\Response;
 use DemosEurope\DemosplanAddon\Contracts\Events\ParameterProviderEventInterface;
 use demosplan\DemosPlanCoreBundle\Logic\ViewRenderer;
+use Symfony\Component\HttpFoundation\Response;
 
 class ParametersProviderSubscriber extends BaseEventSubscriber
 {

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ParametersProviderSubscriber.php
@@ -33,7 +33,7 @@ class ParametersProviderSubscriber extends BaseEventSubscriber
         ];
     }
 
-    private function processParameters(ParameterProviderEventInterface $event)
+    public function processParameters(ParameterProviderEventInterface $event)
     {
         $view = $event->getView();
         $parameters = $event->getParameters();


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T31926

Description:
change method of EventSubscriber from private to public.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
