### PR TITLE
T31993 fix statement exporter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -19,9 +19,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
 use demosplan\DemosPlanStatementBundle\Exception\HandlerException;
 use demosplan\DemosPlanStatementBundle\Logic\AssessmentTableExporter\AssessmentTableXlsExporter;
-use demosplan\DemosPlanStatementBundle\Logic\StatementService;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use PhpOffice\PhpWord\Element\Section;
@@ -39,21 +39,18 @@ class SegmentsByStatementsExporter extends SegmentsExporter
      * @var AssessmentTableXlsExporter
      */
     private $assessmentTableXlsExporter;
-    /**
-     * @var StatementService
-     */
-    private $statementService;
+    private EntityHelper $entityHelper;
 
     public function __construct(
         AssessmentTableXlsExporter $assessmentTableXlsExporter,
         CurrentUserInterface $currentUser,
+        EntityHelper $entityHelper,
         Slugify $slugify,
-        StatementService $statementService,
         TranslatorInterface $translator
     ) {
         parent::__construct($currentUser, $slugify, $translator);
         $this->assessmentTableXlsExporter = $assessmentTableXlsExporter;
-        $this->statementService = $statementService;
+        $this->entityHelper = $entityHelper;
     }
 
     public function getSynopseFileName(Procedure $procedure, string $suffix): string
@@ -274,8 +271,8 @@ class SegmentsByStatementsExporter extends SegmentsExporter
      */
     private function covertIntoExportableArray(SegmentInterface $segmentOrStatement): array
     {
-        $exportData = $this->statementService->toArray($segmentOrStatement);
-        $exportData['meta'] = $this->statementService->toArray($exportData['meta']);
+        $exportData = $this->entityHelper->toArray($segmentOrStatement);
+        $exportData['meta'] = $this->entityHelper->toArray($exportData['meta']);
         $exportData['submitDateString'] = $segmentOrStatement->getSubmitDateString();
         $exportData['countyNames'] = $segmentOrStatement->getCountyNames();
 
@@ -297,7 +294,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
             $exportData['fileNames'] = $segmentOrStatement->getParentStatementOfSegment()->getFileNames();
         }
         $exportData['tagNames'] = $segmentOrStatement->getTagNames();
-        $exportData['tags'] = array_map([$this->statementService, 'toArray'], $exportData['tags']->toArray());
+        $exportData['tags'] = array_map([$this->entityHelper, 'toArray'], $exportData['tags']->toArray());
         foreach ($exportData['tags'] as $key => $tag) {
             $exportData['tags'][$key]['topicTitle'] = $tag['topic']->getTitle();
         }

--- a/demosplan/DemosPlanStatementBundle/Logic/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -414,6 +414,9 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
                 $isUsingDotNotation = str_contains($attributeKey, '.');
                 $isSortable = false;
                 if (!$isUsingDotNotation) {
+                    if(!array_key_exists($attributeKey, $statement)) {
+                        continue;
+                    }
                     $isNotEmptyArray = is_array($statement[$attributeKey]) && 0 < count($statement[$attributeKey]);
                     $isCausingNewLine = $attributeKeysWhichCauseNewLine->contains($attributeKey);
                     $isSortable = $isNotEmptyArray && $isCausingNewLine;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31993

Statement exporter relied on non existing methods. Moreover, access to not defined keys in an array might occur.

### How to review/test
export statements as xlsx

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
