### PR TITLE
Remove pattern validation for city

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -144,8 +144,7 @@
                     name="r_orga_city"
                     :label="{
                       text: Translator.trans('city')
-                    }"
-                    pattern="^[A-Za-zÄäÜüÖöß -]+$" />
+                    }" />
                 </div>
               </div><!--
 

--- a/client/js/components/procedure/admin/AuthorizedUsersList.vue
+++ b/client/js/components/procedure/admin/AuthorizedUsersList.vue
@@ -73,8 +73,7 @@
               class="o-form__group-item"
               :label="{
                 text: Translator.trans('city')
-              }"
-              pattern="^[A-Za-zÄäÜüÖöß -]+$" />
+              }" />
           </div>
         </div><!--
 

--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -313,8 +313,7 @@ export default {
               field: 'city',
               name: 'r_orga_city',
               width: 'u-4-of-12',
-              type: 'text',
-              pattern: '^[A-Za-zÄäÜüÖöß -]+$'
+              type: 'text'
             }
           ]
         }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31969

This PR removes the pattern validation for all "city" form input fields. It was once introduced in DpAutofillSubmitterData without overthinking ux aspects, and has since spread into other form
fields that ask for a city.

It does not add value for users to restrict the input for the "city" field based on assumptions that can prove wrong anytime. It will do little harm to remove the restriction (which will eventually lead to a typo going unnoticed) but it will cause massive trouble for users failing for a too-restrictive validation.

### How to review/test
It should be possible to input all characters into the "city" field.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
