### PR TITLE
F_T31511 make statement splitting possible

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DependencyInjection/ServiceTagAutoconfigurator.php
+++ b/demosplan/DemosPlanCoreBundle/DependencyInjection/ServiceTagAutoconfigurator.php
@@ -14,7 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\DependencyInjection;
 
 use demosplan\DemosPlanCoreBundle\DataGenerator\DataGeneratorInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Deployment\StrategyInterface;
-use demosplan\DemosPlanCoreBundle\Logic\Rpc\RpcMethodSolverInterface;
+use DemosEurope\DemosplanAddon\Logic\Rpc\RpcMethodAddonSolverInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -46,7 +46,7 @@ final class ServiceTagAutoconfigurator
     private const CLASS_MAP = [
         self::DEPLOYMENT_STRATEGIES => StrategyInterface::class,
         self::FAKE_DATA_GENERATOR   => DataGeneratorInterface::class,
-        self::RPC_METHOD_SOLVERS    => RpcMethodSolverInterface::class,
+        self::RPC_METHOD_SOLVERS    => RpcMethodAddonSolverInterface::class,
     ];
 
     public static function configure(ContainerBuilder $containerBuilder): void

--- a/demosplan/DemosPlanCoreBundle/Logic/Rpc/RpcMethodSolverInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Rpc/RpcMethodSolverInterface.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Rpc;
 
+use DemosEurope\DemosplanAddon\Logic\Rpc\RpcMethodAddonSolverInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedException;
 use JsonSchema\Exception\InvalidSchemaException;
@@ -19,7 +20,7 @@ use JsonSchema\Exception\InvalidSchemaException;
 /**
  * Interface to be implemented by the classes that execute/solve RPC Methods.
  */
-interface RpcMethodSolverInterface
+interface RpcMethodSolverInterface extends RpcMethodAddonSolverInterface
 {
     public function supports(string $method): bool;
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31511

Description: use RpcMethodAddonSolverInterface instead RpcMethodSolverInterface to autoconfigurate services.


- [X] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
