### PR TITLE
feat: provide link to external identity provider

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -26,9 +26,6 @@ use demosplan\DemosPlanUserBundle\Logic\UserHasher;
 use demosplan\DemosPlanUserBundle\Logic\UserService;
 use demosplan\DemosPlanUserBundle\Repository\UserRepository;
 use Exception;
-
-use function in_array;
-
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -41,6 +38,8 @@ use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Throwable;
+
+use function in_array;
 
 /**
  * Class DemosPlanAuthenticationController.
@@ -77,6 +76,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     path="/password/change",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_mydata_password")
      *
      * @return Response
@@ -107,6 +107,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     name="DemosPlan_user_change_email_request",
      *     path="/email/change"
      * )
+     *
      * @DplanPermissions("feature_change_own_email")
      *
      * @return RedirectResponse|Response
@@ -135,6 +136,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     name="DemosPlan_user_doubleoptin_change_email",
      *     path="email/change/doubleoptin/{uId}/{key}"
      * )
+     *
      * @DplanPermissions("feature_change_own_email")
      */
     public function changeEmailConfirmationAction(string $uId, string $key): RedirectResponse
@@ -167,6 +169,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     path="/password/recover",
      *     options={"expose": true}
      * )
+     *
      *  @DplanPermissions({"area_demosplan","feature_password_recovery"})
      *
      * @return RedirectResponse|Response
@@ -234,6 +237,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     path="/dplan/login",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_demosplan")
      *
      * @return Response
@@ -275,7 +279,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
             // add access to test external identity provider
             // do not display link when it targets same site
             $gatewayUrl = $parameterBag->get('gateway_url');
-            $useIdp = '' !== $gatewayUrl && !str_contains($gatewayUrl, $request->getPathInfo()) ;
+            $useIdp = '' !== $gatewayUrl && !str_contains($gatewayUrl, $request->getPathInfo());
         }
 
         if (true === $parameterBag->get('alternative_login_use_testuser_osi')) {
@@ -323,6 +327,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     path="/user/logout/gateway",
      *     defaults={"toGateway": true}
      * )
+     *
      * @DplanPermissions("area_demosplan")
      *
      * @param bool $toGateway
@@ -367,6 +372,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     name="DemosPlan_user_logout_success",
      *     path="/user/logout/success"
      * )
+     *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
@@ -391,6 +397,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     name="DemosPlan_user_doubleoptin_invite_confirmation",
      *     path="/doubleoptin/{uId}/{token}"
      * )
+     *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
@@ -421,6 +428,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *     path="/user/{uId}/setpass/{token}",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response

--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/alternative_login.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/alternative_login.html.twig
@@ -16,6 +16,10 @@
         {% endblock content %}
     {% endembed %}
 
+    {% if loginList.useIdp %}
+        <p>Login with <a href="{{ gatewayURL }}">external provider</a></p>
+    {% endif %}
+
     {# Login lists (platform, simulated osi login) that are available during testing #}
     {% if loginList.enabled %}
         <div class="{{ 'u-m u-mt-0'|prefixClass }}">


### PR DESCRIPTION
This PR adds a possibility to login via external identity provider in development environments on top on login via form.

### How to review/test
set `gateway_url` to something like `/connect/keycloak_ozg` and find a (unstyled) link to the external idp

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
