### PR TITLE
feature (refs T30254): change SegmentRepository usage of SegmentsManager

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
@@ -76,7 +76,7 @@ class SegmentRepository extends CoreRepository
         $manager = $this->getEntityManager();
         $query = $manager->createQueryBuilder()
             ->select('segment.orderInProcedure')
-            ->from('SegmentsManager:Segment', 'segment')
+            ->from(Segment::class, 'segment')
             ->where('segment.orderInProcedure IS NOT NULL')
             ->andWhere('segment.procedure = :procedureId')->setParameter('procedureId', $procedureId)
             ->addOrderBy('segment.orderInProcedure', 'DESC')


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30254

Description:
change SegmentRepository usage of SegmentsManager to Segment::class instead
as the SegmentsManager does not exist anymore. Segments got included into the core. 


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
