### PR TITLE
fix (refs T32046): simplify sidemenu item extras

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/MenuBuilder/MenuBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MenuBuilder/MenuBuilder.php
@@ -303,10 +303,10 @@ class MenuBuilder
         $processedExtras = [];
 
         if (isset($menuEntry['extras']) && is_array($menuEntry['extras'])) {
-            foreach ($menuEntry['extras'] as $extraKey => $extraValue) {
-                $processedExtras[$extraKey] = $extraValue;
-                if (isset($this->availableRouteParameters[$extraValue])) {
-                    $processedExtras[$extraKey] = $this->availableRouteParameters[$extraValue];
+            foreach ($menuEntry['extras'] as $extraKey) {
+                $processedExtras[$extraKey] = true;
+                if (isset($this->availableRouteParameters[$extraKey])) {
+                    $processedExtras[$extraKey] = $this->availableRouteParameters[$extraKey];
                 }
             }
         }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32046

We knew something like extras would be needed at some point, so we established it as an option. But at least for now, we can keep it a bit more simple which is exactly what this commit does.

This part of the new sidemenu was never used before.
