### PR TITLE
Feat(refs:T31920): Use the existing padding css for version number

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
@@ -68,7 +68,7 @@
 
     {% block copyright %}{% endblock copyright %}
 
-    <div class=" version-number c-footer__version u-pt-0_25-palm float--right"
+    <div class=" version-number c-footer__version u-pt-0_25-palm u-pr-0_5 float--right"
          aria-label="{{ 'system.version_info'|trans }}">
           v{{ projectVersion }}
     </div>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31920

### Description: 

- the version number shall have a little padding to the right

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-project-diplanbau/pull/83


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
