### PR TITLE
fix (refs T32124): Always show published documents to owning orga

### DIFF
--- a/demosplan/DemosPlanDocumentBundle/Logic/DocumentHandler.php
+++ b/demosplan/DemosPlanDocumentBundle/Logic/DocumentHandler.php
@@ -391,9 +391,11 @@ class DocumentHandler extends CoreHandler
      */
     public function hasProcedureElements(string $procedureId, $userOrgaId): bool
     {
+        $procedure = $this->procedureService->getProcedure($procedureId);
         $outputResultElementList = $this->elementsService->getElementsListObjects(
             $procedureId,
-            $userOrgaId
+            $userOrgaId,
+            $userOrgaId === $procedure->getOrgaId()
         );
 
         $hasProcedureElements = false;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32124

Planners may not be able to view published documents in the case when only specific organisations are allowed to view documents

### How to review/test
You need to have only categories published that are also only allowed to be accessed by specific organisations

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
