### PR TITLE
fix request format for extra email addresses

### DIFF
--- a/client/js/components/procedure/basicSettings/DpAllowedSenderEmailList.vue
+++ b/client/js/components/procedure/basicSettings/DpAllowedSenderEmailList.vue
@@ -85,7 +85,7 @@ export default {
       const payload = {
         type: 'MaillaneConnection',
         attributes: {
-          allowedSenderEmailAddresses: emailAddress
+          allowedSenderEmailAddresses: [emailAddress]
         },
         procedureId: this.procedureId
       }
@@ -97,7 +97,7 @@ export default {
       const payload = {
         type: 'MaillaneConnection',
         attributes: {
-          allowedSenderEmailAddresses: extraEmailAddress
+          allowedSenderEmailAddresses: [extraEmailAddress]
         },
         procedureId: this.procedureId
       }


### PR DESCRIPTION
- The BE needs the allowedSenderAddresses as array not as a string hence this has been adjusted so.

