### PR TITLE
chore: Move NotifyContainer from demosplan-ui to core

### DIFF
--- a/client/js/InitVue.js
+++ b/client/js/InitVue.js
@@ -7,12 +7,13 @@
  * All rights reserved
  */
 
-import { DpAccordion, DpNotifyContainer, dpValidateMultiselectDirective, Tooltip } from '@demos-europe/demosplan-ui'
+import { DpAccordion, dpValidateMultiselectDirective, Tooltip } from '@demos-europe/demosplan-ui'
 import { initGlobalEventListener, ToggleSideMenu, touchFriendlyUserbox } from '@DpJs/lib/core/libs'
 import { bootstrap } from '@DpJs/bootstrap'
 import { initStore } from '@DpJs/store/core/initStore'
 import { loadLibs } from '@DpJs/lib/core/loadLibs'
 import NotificationStoreAdapter from '@DpJs/store/core/NotificationStoreAdapter'
+import NotifyContainer from '@DpJs/components/shared/NotifyContainer'
 
 function initialize (components = {}, storeModules = {}, apiStoreModules = [], presetStoreModules = {}) {
   bootstrap()
@@ -33,7 +34,7 @@ function initialize (components = {}, storeModules = {}, apiStoreModules = [], p
        * DpAccordion is registered globally here, because we need it for the sidemenu in sidemenu.html.twig and can't
        * register it locally there (special knp menu renderer, see https://github.com/KnpLabs/KnpMenu).
        */
-      components: { ...components, DpAccordion, DpNotifyContainer },
+      components: { ...components, DpAccordion, NotifyContainer },
       store: store,
       mounted () {
         window.dplan.notify = new NotificationStoreAdapter(this.$store)

--- a/client/js/components/shared/NotifyContainer.vue
+++ b/client/js/components/shared/NotifyContainer.vue
@@ -1,0 +1,96 @@
+<license>
+(c) 2010-present DEMOS E-Partizipation GmbH.
+
+This file is part of the package demosplan,
+for more information see the license file.
+
+All rights reserved
+</license>
+
+<!-- @improve check for a11y issues, see https://inclusive-components.design/notifications/ -->
+<template>
+  <div
+    :class="prefixClass('c-notify')"
+    :aria-live="liveState">
+    <transition-group
+      name="transition-slide-up"
+      tag="span">
+        <dp-notify-message
+          v-for="message in notificationMessages"
+          :key="message.uid"
+          :message="message"
+          @dp-notify-remove="removeMessage"
+          :role="messageRole" />
+    </transition-group>
+  </div>
+</template>
+
+<script>
+import { DpNotifyMessage, hasOwnProp, prefixClassMixin } from '@demos-europe/demosplan-ui'
+import { mapMutations, mapState } from 'vuex'
+export default {
+  name: 'NotifyContainer',
+  components: {
+    DpNotifyMessage
+  },
+  mixins: [prefixClassMixin],
+  props: {
+    notifications: {
+      type: [Object, Array],
+      required: false,
+      default: () => ([])
+    }
+  },
+  data () {
+    return {
+      isVisible: false
+    }
+  },
+  computed: {
+    ...mapState('notify', ['messages']),
+    liveState () {
+      return (this.isVisible) ? 'polite' : 'off'
+    },
+    messageRole () {
+      return (this.isVisible) ? 'message' : 'none'
+    },
+    notificationMessages () {
+      return this.messages
+    }
+  },
+  methods: {
+    ...mapMutations('notify', ['add', 'remove']),
+
+    init () {
+      for (const type in this.notifications) {
+        if (hasOwnProp(this.notifications, type)) {
+          const messages = this.notifications[type]
+          let i = 0
+          const l = messages.length
+          let message
+          for (; i < l; i++) {
+            message = messages[i]
+            // Support legacy messages
+            if (typeof message === 'string') {
+              message = { message: message }
+            }
+            this.add({
+              type,
+              text: message.message || '',
+              linkUrl: message.linkUrl || '',
+              linkText: message.linkText || ''
+            })
+          }
+        }
+      }
+      document.addEventListener('visibilitychange', () => { this.isVisible = !document.hidden })
+    },
+    removeMessage (message) {
+      this.remove(message)
+    }
+  },
+  created () {
+    this.init()
+  }
+}
+</script>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -186,7 +186,7 @@
             {% endblock base_footer %}
 
             {# Generic notification component (for cases where notifications are not handled in other Vue components) #}
-            <dp-notify-container :notifications="JSON.parse('{{ app.session.flashbag.all|json_encode|e('js') }}')"></dp-notify-container>
+            <notify-container :notifications="JSON.parse('{{ app.session.flashbag.all|json_encode|e('js') }}')"></notify-container>
 
             {# Vue Modals port their contents here #}
             <portal-target name="vueModals" multiple></portal-target>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
@@ -99,7 +99,7 @@
             {% endblock oeb %}
 
             {# Generic notification component (for cases where notifications are not handled in other Vue components) #}
-            <dp-notify-container :notifications="JSON.parse('{{ app.session.flashbag.all|json_encode|e('js') }}')"></dp-notify-container>
+            <notify-container :notifications="JSON.parse('{{ app.session.flashbag.all|json_encode|e('js') }}')"></notify-container>
 
             {# Vue Modals port their contents here #}
             <portal-target name="vueModals" multiple></portal-target>


### PR DESCRIPTION
we don't want to have the store logic in demosplan-ui. So I moved the notificationContainer here

The corresponding PR from demosplan-ui:
https://github.com/demos-europe/demosplan-ui/pull/146


:warning: 
DO NOT BEFORE https://github.com/demos-europe/demosplan-ui/pull/146 IS RELEASED
:warning: 