### PR TITLE
Fix(refs:T32192): Remove unnecessary twig block

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
@@ -1,4 +1,4 @@
-<footer class="c-footer o-page__padded u-ml-0_75 u-mr-0_75 {{ cssClassesFooter|default }} cf" role="contentinfo">
+<footer class="c-footer o-page__padded {{ cssClassesFooter|default }} cf" role="contentinfo">
 
     <nav class="display--inline-block"
          aria-label="{{ 'menu.footer'|trans }}"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_footer.html.twig
@@ -1,4 +1,4 @@
-<footer class="c-footer o-page__padded {{ cssClassesFooter|default }} cf" role="contentinfo">
+<footer class="c-footer o-page__padded u-ml-0_75 u-mr-0_75 {{ cssClassesFooter|default }} cf" role="contentinfo">
 
     <nav class="display--inline-block"
          aria-label="{{ 'menu.footer'|trans }}"
@@ -65,8 +65,6 @@
 
         {% endapply %}
     </nav>
-
-    {% block copyright %}{% endblock copyright %}
 
     <div class=" version-number c-footer__version u-pt-0_25-palm u-pr-0_5 float--right"
          aria-label="{{ 'system.version_info'|trans }}">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32192

### Description: 

- the twig block for copyright can be removed

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-project-diplanbau/pull/87

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
