### PR TITLE
Empty internId on delete last child statement.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -1898,7 +1898,7 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * Löschen eines Statements.
+     * Deleting a draftstatement.
      *
      * @param string $_route
      * @param string $procedure

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementResourceTypeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementResourceTypeService.php
@@ -19,6 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PropertiesUpdater;
 use demosplan\DemosPlanCoreBundle\Logic\ResourceTypeService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
 use demosplan\DemosPlanStatementBundle\Exception\DuplicateInternIdException;
+use demosplan\DemosPlanStatementBundle\Logic\StatementDeleter;
 use demosplan\DemosPlanStatementBundle\Logic\StatementService;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
 use Exception;
@@ -41,14 +42,18 @@ class StatementResourceTypeService extends ResourceTypeService
      */
     private $statementService;
 
+    private StatementDeleter $statementDeleter;
+
     public function __construct(
         ValidatorInterface $validator,
         CurrentUserInterface $currentUser,
         ResourceTypeService $resourceTypeService,
-        StatementService $statementService
+        StatementService $statementService,
+        StatementDeleter $statementDeleter
     ) {
         $this->currentUser = $currentUser;
         $this->statementService = $statementService;
+        $this->statementDeleter = $statementDeleter;
         $this->resourceTypeService = $resourceTypeService;
         parent::__construct($validator);
     }
@@ -118,6 +123,6 @@ class StatementResourceTypeService extends ResourceTypeService
 
     public function deleteStatement(Statement $statement): bool
     {
-        return $this->statementService->deleteStatementObject($statement);
+        return $this->statementDeleter->deleteStatementObject($statement);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -2706,6 +2706,11 @@ feature_read_source_statement_via_api:
     label: ' used in : Statement list and segment list '
     expose: true
     loginRequired: true
-
-
+feature_auto_delete_original_statement:
+    description: |
+        On delete the last child of an original statement, the related originalstatement will be automatically
+        deleted too.
+    label: 'Automatically delete related original statement, in case of last child was deleted.'
+    expose: false
+    loginRequired: true
 

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementDeleter.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementDeleter.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+
+namespace demosplan\DemosPlanStatementBundle\Logic;
+
+
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
+use demosplan\DemosPlanCoreBundle\Exception\DemosException;
+use demosplan\DemosPlanCoreBundle\Logic\Consultation\ConsultationTokenService;
+use demosplan\DemosPlanCoreBundle\Logic\CoreService;
+use demosplan\DemosPlanCoreBundle\Logic\EntityContentChangeService;
+use demosplan\DemosPlanCoreBundle\Logic\SearchIndexTaskService;
+use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
+use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
+use demosplan\DemosPlanReportBundle\Logic\ReportService;
+use demosplan\DemosPlanReportBundle\Logic\StatementReportEntryFactory;
+use demosplan\DemosPlanStatementBundle\Exception\StatementNotFoundException;
+use demosplan\DemosPlanStatementBundle\Repository\StatementRepository;
+use demosplan\DemosPlanUserBundle\Exception\UserNotFoundException;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+
+class StatementDeleter extends CoreService
+{
+    protected AssignService $assignService;
+    protected PermissionsInterface $permissions;
+    protected StatementFragmentService $statementFragmentService;
+    protected ConsultationTokenService $consultationTokenService;
+    protected StatementAttachmentService $statementAttachmentService;
+    private SearchIndexTaskService $searchIndexTaskService;
+    private StatementRepository $statementRepository;
+    private StatementReportEntryFactory $statementReportEntryFactory;
+    private ReportService $reportService;
+    private MessageBagInterface $messageBag;
+    private EntityContentChangeService $entityContentChangeService;
+    private StatementService $statementService;
+
+    public function __construct(
+        AssignService $assignService,
+        PermissionsInterface $permissions,
+        StatementFragmentService $statementFragmentService,
+        ConsultationTokenService $consultationTokenService,
+        StatementAttachmentService $statementAttachmentService,
+        SearchIndexTaskService $searchIndexTaskService,
+        StatementRepository $statementRepository,
+        StatementReportEntryFactory $statementReportEntryFactory,
+        ReportService $reportService,
+        MessageBagInterface $messageBag,
+        EntityContentChangeService $entityContentChangeService,
+        StatementService $statementService
+    ) {
+        $this->assignService = $assignService;
+        $this->permissions = $permissions;
+        $this->statementFragmentService = $statementFragmentService;
+        $this->consultationTokenService = $consultationTokenService;
+        $this->statementAttachmentService = $statementAttachmentService;
+        $this->searchIndexTaskService = $searchIndexTaskService;
+        $this->statementRepository = $statementRepository;
+        $this->statementReportEntryFactory = $statementReportEntryFactory;
+        $this->reportService = $reportService;
+        $this->messageBag = $messageBag;
+        $this->entityContentChangeService = $entityContentChangeService;
+        $this->statementService = $statementService;
+    }
+
+    /**
+     * $ignoreOriginal is never used as true as far as i can see
+     *
+     * @param Statement $statement
+     * @param bool      $ignoreAssignment
+     * @param bool      $ignoreOriginal
+     *
+     * @return bool
+     * @throws UserNotFoundException
+     * @throws ORMException
+     * @throws OptimisticLockException|Exception
+     */
+    public function deleteStatementObject(
+        Statement $statement,
+        bool $ignoreAssignment = false,
+        bool $ignoreOriginal = false
+    ): bool {
+
+        /** @var Connection $doctrineConnection */
+        $doctrineConnection = $this->getDoctrine()->getConnection();
+        try {
+            $success = false;
+            $statementId = $statement->getId();
+            $relatedOriginalStatementId = $statement->getOriginalId();
+
+            // if the corresponding permission is disabled, the Statement can be deleted anyway
+            $ignoreAssignment =
+                $ignoreAssignment
+                || false === $this->permissions->hasPermission('feature_statement_assignment');
+
+            $noAssignee = null === $statement->getAssignee();
+            $assignedToCurrentUser = $this->assignService->isStatementObjectAssignedToCurrentUser($statement);
+            // T5136:
+            $lockedByAssignment = !($ignoreAssignment || $noAssignee || $assignedToCurrentUser);
+
+            $lockedByAssignmentOfRelatedFragments =
+                !$this->statementFragmentService->areAllFragmentsClaimedByCurrentUser($statementId);
+
+            $lockedByCluster = $statement->isInCluster();
+            // placeholders (even originalSTN) are allowed to delete:
+            $lockedBecauseOfOriginal = $statement->isOriginal() && !$ignoreOriginal;
+
+            $allowedToDelete =
+                !$lockedByAssignmentOfRelatedFragments
+                && !$lockedByAssignment
+                && !$lockedByCluster
+                && !$lockedBecauseOfOriginal;
+
+            if ($allowedToDelete) {
+                try {
+                    // Prohibit deletion if a consultation token exists for this statement
+                    if (null !== $this->consultationTokenService->getTokenForStatement($statement)) {
+                        throw new DemosException(
+                            'error.delete.statement.consultation.token',
+                            'Statement '.DemosPlanTools::varExport($statementId, true).' has an associated consultation token.');
+                    }
+
+                    $doctrineConnection->beginTransaction();
+                    $forReport = clone $statement;
+
+                    $attachedFileIdents = \collect($statement->getAttachments())
+                        ->map(static fn(StatementAttachment $attachment): string => $attachment->getFile()->getIdent());
+
+                    $this->statementAttachmentService->deleteStatementAttachments($statement->getAttachments()->getValues());
+
+                    // remove placeholderstatement from index if exists
+                    if ($statement->wasMoved()) {
+                        $this->searchIndexTaskService->deleteFromIndexTask(
+                            Statement::class,
+                            $statement->getPlaceholderStatement()->getId()
+                        );
+                    }
+                    $deleted = $this->statementRepository->delete($statementId);
+                    // add report:
+                    try {
+                        if (true === $deleted) {
+                            $this->emptyInternIdOfOriginalInCaseOfDeleteLastChild($statement);
+                            $entry = $this->statementReportEntryFactory->createDeletionEntry($forReport);
+                            $this->reportService->persistAndFlushReportEntries($entry);
+                            $this->logger->info('generate report of deleteStatement(). ReportID: ', ['identifier' => $entry->getIdentifier()]);
+                        }
+                    } catch (Exception $e) {
+                        $this->getLogger()->warning('Add Report in deleteStatement() failed Message: ', [$e]);
+                    }
+                    $doctrineConnection->commit();
+                    // remove Statement from Elasticsearch Index
+                    $this->searchIndexTaskService->deleteFromIndexTask(
+                        Statement::class,
+                        $statementId
+                    );
+
+                    $this->entityContentChangeService->deleteByEntityIds([$statementId]);
+                    $success = true;
+                } catch (DemosException $demosException) {
+                    $this->getLogger()->error('Fehler beim Löschen eines Statements: ', [$demosException]);
+                    $this->messageBag->add(
+                        'warning',
+                        $demosException->getUserMsg()
+                    );
+                    $success = false;
+                } catch (Exception $e) {
+                    $this->getLogger()->error('Fehler beim Löschen eines Statements: ', [$e]);
+                    $doctrineConnection->rollBack();
+                    $success = false;
+                }
+            } else {
+                if ($lockedByAssignmentOfRelatedFragments) {
+                    $this->getLogger()->warning("Statement {$statementId} was not deleted, because of related fragments are locked by assignment");
+                    $this->messageBag->add(
+                        'warning',
+                        'warning.delete.statement.because.of.fragments.not.claimed.by.current.user',
+                        ['externId' => $statement->getExternId()]
+                    );
+                }
+
+                if ($lockedByAssignment) {
+                    $this->getLogger()
+                        ->warning("Statement {$statementId} was not deleted, because of locked by assignment");
+                    $this->messageBag->add(
+                        'warning', 'warning.delete.statement.because.of.assignment',
+                        ['externId' => $statement->getExternId()]
+                    );
+                }
+
+                if ($lockedByCluster) {
+                    $this->getLogger()
+                        ->warning("Statement {$statementId} was not deleted, because of locked by cluster");
+                    $this->messageBag->add(
+                        'warning', 'error.statement.clustered.in',
+                        ['headStatementId' => $statement->getExternId()]
+                    );
+                }
+
+                if ($lockedBecauseOfOriginal) {
+                    $this->getLogger()
+                        ->warning("Statement {$statementId} was not deleted, because it is a undeletable original-Statement");
+                    $this->messageBag->add(
+                        'warning', 'warning.delete.statement.original',
+                        ['externId' => $statement->getExternId()]
+                    );
+                }
+            }
+
+            return $success;
+        } catch (Exception $e) {
+            $this->getLogger()->warning('Fehler beim Löschen eines Statements: ', [$e]);
+            $doctrineConnection->rollBack();
+
+            return false;
+        }
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function emptyInternIdOfOriginalInCaseOfDeleteLastChild(Statement $statement): void
+    {
+        if ($this->permissions->hasPermission('feature_auto_delete_original_statement')) {
+            $original = $statement->getOriginal();
+            if (0 === $original->getChildren()->count()) {
+                $original->setInternId(null);
+                $this->statementService->updateStatementObject($original);
+            }
+        }
+    }
+}

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementHandler.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementHandler.php
@@ -282,6 +282,8 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
      */
     private $globalConfig;
 
+    private StatementDeleter $statementDeleter;
+
     public function __construct(
         ArrayHelper $arrayHelper,
         AssignService $assignService,
@@ -323,7 +325,8 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         TranslatorInterface $translator,
         UserService $userService,
         StatementCopier $statementCopier,
-        ValidatorInterface $validator
+        ValidatorInterface $validator,
+        StatementDeleter $statementDeleter
     ) {
         parent::__construct($messageBag);
 
@@ -367,6 +370,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         $this->userService = $userService;
         $this->validator = $validator;
         $this->globalConfig = $globalConfig;
+        $this->statementDeleter = $statementDeleter;
     }
 
     /**
@@ -3875,7 +3879,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
                     $headStatementId = $headStatement->getExternId();
 
                     // will also check for 'feature_statement_assignment' & 'feature_statement_cluster':
-                    $status = $this->statementService->deleteStatementObject($headStatement);
+                    $status = $this->statementDeleter->deleteStatementObject($headStatement);
 
                     if ($status) {
                         $this->getMessageBag()->add(
@@ -3953,7 +3957,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         if (0 === $notDetachedStatements->count()) {
             $this->getLogger()->info("All statements of Cluster {$headStatement->getId()} are successfully detached.");
             // will also check for assignment but not for clustered!
-            $successful = $statementService->deleteStatementObject($headStatement, true);
+            $successful = $this->statementDeleter->deleteStatementObject($headStatement, true);
         } else {
             $this->getLogger()->error("Some statements of Cluster {$headStatement->getId()} are not detached.");
             $this->getMessageBag()->add(
@@ -4613,7 +4617,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
             return $newClusterStatement;
         } catch (Exception $e) {
             if (isset($newClusterStatement) && $newClusterStatement instanceof Statement) {
-                $this->statementService->deleteStatementObject($newClusterStatement);
+                $this->statementDeleter->deleteStatementObject($newClusterStatement);
             }
             throw $e;
         }

--- a/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
+++ b/demosplan/DemosPlanStatementBundle/Logic/StatementService.php
@@ -364,6 +364,7 @@ class StatementService extends CoreService implements StatementServiceInterface
      * @var GlobalConfigInterface
      */
     private $globalConfig;
+    private StatementDeleter $statementDeleter;
 
     public function __construct(
         AssignService $assignService,
@@ -415,7 +416,8 @@ class StatementService extends CoreService implements StatementServiceInterface
         TagTopicRepository $tagTopicRepository,
         TranslatorInterface $translator,
         UserRepository $userRepository,
-        UserService $userService
+        UserService $userService,
+        StatementDeleter $statementDeleter
     ) {
         $this->assignService = $assignService;
         $this->conditionFactory = $conditionFactory;
@@ -467,6 +469,7 @@ class StatementService extends CoreService implements StatementServiceInterface
         $this->userRepository = $userRepository;
         $this->userService = $userService;
         $this->globalConfig = $globalConfig;
+        $this->statementDeleter = $statementDeleter;
     }
 
     /**
@@ -1996,6 +1999,12 @@ class StatementService extends CoreService implements StatementServiceInterface
 
     /**
      * Löscht eine Stellungnahme nur wenn diese keinem Anwender zugewiesen ist.
+     *
+     * @return bool
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws UserNotFoundException
+     * @throws \Doctrine\DBAL\Exception
      */
     public function deleteStatement(string $statementId, bool $ignoreAssignment = false, bool $ignoreOriginal = false): bool
     {
@@ -2006,136 +2015,7 @@ class StatementService extends CoreService implements StatementServiceInterface
             return false;
         }
 
-        return $this->deleteStatementObject($statement, $ignoreAssignment, $ignoreOriginal);
-    }
-
-    public function deleteStatementObject(Statement $statement, bool $ignoreAssignment = false, bool $ignoreOriginal = false): bool
-    {
-        $doctrineConnection = $this->getDoctrine()->getConnection();
-
-        try {
-            $success = false;
-            $statementId = $statement->getId();
-
-            // if the corresponding permission is disabled, the Statement can be deleted anyway
-            $ignoreAssignment = $ignoreAssignment || (false === $this->permissions->hasPermission('feature_statement_assignment'));
-            $noAssignee = null === $statement->getAssignee();
-            $assignedToCurrentUser = $this->assignService->isStatementObjectAssignedToCurrentUser($statement);
-            // T5136:
-            $lockedByAssignment = !($ignoreAssignment || $noAssignee || $assignedToCurrentUser);
-            $lockedByAssignmentOfRelatedFragments = !$this->statementFragmentService->areAllFragmentsClaimedByCurrentUser($statementId);
-            $lockedByCluster = $statement->isInCluster();
-            // placeholders (even originalSTN) are allowed to delete:
-            $lockedBecauseOfOriginal = $statement->isOriginal() && !$ignoreOriginal;
-
-            $allowedToDelete = (
-                !$lockedByAssignmentOfRelatedFragments
-                && !$lockedByAssignment
-                && !$lockedByCluster
-                && !$lockedBecauseOfOriginal
-            );
-
-            if ($allowedToDelete) {
-                try {
-                    // Prohibit deletion if a consultation token exists for this statement
-                    if (null !== $this->consultationTokenService->getTokenForStatement($statement)) {
-                        throw new DemosException('error.delete.statement.consultation.token', 'Statement '.DemosPlanTools::varExport($statementId, true).' has an associated consultation token.');
-                    }
-
-                    $doctrineConnection->beginTransaction();
-                    $forReport = clone $statement;
-
-                    $attachedFileIdents = \collect($statement->getAttachments())
-                        ->map(static function (StatementAttachment $attachment): string {
-                            return $attachment->getFile()->getIdent();
-                        });
-
-                    $this->statementAttachmentService->deleteStatementAttachments($statement->getAttachments()->getValues());
-
-                    // remove placeholderstatement from index if exists
-                    if ($statement->wasMoved()) {
-                        $this->searchIndexTaskService->deleteFromIndexTask(
-                            Statement::class,
-                            $statement->getPlaceholderStatement()->getId()
-                        );
-                    }
-                    $deleted = $this->statementRepository->delete($statementId);
-                    // add report:
-                    try {
-                        if (true === $deleted) {
-                            $entry = $this->statementReportEntryFactory->createDeletionEntry($forReport);
-                            $this->reportService->persistAndFlushReportEntries($entry);
-                            $this->logger->info('generate report of deleteStatement(). ReportID: ', ['identifier' => $entry->getIdentifier()]);
-                        }
-                    } catch (Exception $e) {
-                        $this->getLogger()->warning('Add Report in deleteStatement() failed Message: ', [$e]);
-                    }
-                    $doctrineConnection->commit();
-                    // remove Statement from Elasticsearch Index
-                    $this->searchIndexTaskService->deleteFromIndexTask(
-                        Statement::class,
-                        $statementId
-                    );
-
-                    $this->getEntityContentChangeService()->deleteByEntityIds([$statementId]);
-                    $success = true;
-                } catch (DemosException $demosException) {
-                    $this->getLogger()->error('Fehler beim Löschen eines Statements: ', [$demosException]);
-                    $this->messageBag->add(
-                        'warning',
-                        $demosException->getUserMsg()
-                    );
-                    $success = false;
-                } catch (Exception $e) {
-                    $this->getLogger()->error('Fehler beim Löschen eines Statements: ', [$e]);
-                    $doctrineConnection->rollBack();
-                    $success = false;
-                }
-            } else {
-                if ($lockedByAssignmentOfRelatedFragments) {
-                    $this->getLogger()->warning("Statement {$statementId} was not deleted, because of related fragments are locked by assignment");
-                    $this->messageBag->add(
-                        'warning',
-                        'warning.delete.statement.because.of.fragments.not.claimed.by.current.user',
-                        ['externId' => $statement->getExternId()]
-                    );
-                }
-
-                if ($lockedByAssignment) {
-                    $this->getLogger()
-                        ->warning("Statement {$statementId} was not deleted, because of locked by assignment");
-                    $this->messageBag->add(
-                        'warning', 'warning.delete.statement.because.of.assignment',
-                        ['externId' => $statement->getExternId()]
-                    );
-                }
-
-                if ($lockedByCluster) {
-                    $this->getLogger()
-                        ->warning("Statement {$statementId} was not deleted, because of locked by cluster");
-                    $this->messageBag->add(
-                        'warning', 'error.statement.clustered.in',
-                        ['headStatementId' => $statement->getExternId()]
-                    );
-                }
-
-                if ($lockedBecauseOfOriginal) {
-                    $this->getLogger()
-                        ->warning("Statement {$statementId} was not deleted, because it is a undeletable original-Statement");
-                    $this->messageBag->add(
-                        'warning', 'warning.delete.statement.original',
-                        ['externId' => $statement->getExternId()]
-                    );
-                }
-            }
-
-            return $success;
-        } catch (Exception $e) {
-            $this->getLogger()->warning('Fehler beim Löschen eines Statements: ', [$e]);
-            $doctrineConnection->rollBack();
-
-            return false;
-        }
+        return $this->statementDeleter->deleteStatementObject($statement, $ignoreAssignment, $ignoreOriginal);
     }
 
     /**

--- a/tests/backend/core/Statement/Functional/StatementDeleterTest.php
+++ b/tests/backend/core/Statement/Functional/StatementDeleterTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\Core\Statement\Functional;
+
+
+use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementMeta;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Tag;
+use Tests\Base\FunctionalTestCase;
+
+class StatementDeleterTest extends FunctionalTestCase
+{
+    public function testEmtpyInternIdOfOriginalInCaseOfDeleteLastChild()
+    {
+        //get statement with OSTN (with set internID) with only one child
+        //delete statement
+        //check if related original stn has null as internid
+
+
+        $testTag1 = $this->getTagReference('testFixtureTag_1');
+        $testStatement2 = $this->getStatementReference('testStatement2');
+        static::assertInstanceOf(StatementMeta::class, $testStatement2->getMeta());
+
+        $amountOfMetasBefore = $this->countEntries(StatementMeta::class);
+
+        $amountOfTagsBefore = count($testStatement2->getTags());
+        $entireAmountOfTagsBefore = count($this->getEntries(Tag::class));
+
+        $initialAmountOfStatementsOfTag1 = count($testTag1->getStatements());
+        $this->sut->addTagToStatement($testTag1, $testStatement2);
+
+        // total amount of tags in DB has not changed
+        static::assertCount($entireAmountOfTagsBefore, $this->getEntries(Tag::class));
+        static::assertCount($initialAmountOfStatementsOfTag1 + 1, $testTag1->getStatements());
+        static::assertContains($testStatement2, $testTag1->getStatements());
+        static::assertContains($testTag1, $testStatement2->getTags());
+        $tags = $testStatement2->getTags();
+        static::assertCount($amountOfTagsBefore + 1, $tags);
+
+        // the actually deletion:
+        $result = $this->sut->deleteStatement($testStatement2->getId());
+
+        static::assertTrue($result);
+        static::assertCount($initialAmountOfStatementsOfTag1, $testTag1->getStatements());
+        static::assertNotContains($testStatement2, $testTag1->getStatements());
+        // total amount of tags in DB has still not changed
+        static::assertCount($entireAmountOfTagsBefore, $this->getEntries(Tag::class));
+
+        // total amount of StatementMeta in DB is decremeted
+        static::assertSame(
+            $amountOfMetasBefore - 1,
+            $this->countEntries(StatementMeta::class)
+        );
+    }
+}


### PR DESCRIPTION
Empty internId of original statement in case of last chlid (normal statement) will be deleted.

**Ticket:** https://yaits.demos-deutschland.de/T22439

To "free" the previous given internId and allow to use them again. Extract deleteStatementObject() into own servcie to avoid making the StatementService even bigger. Add new permission to decide if the internId of the related originalSTN should be nulled. This is also the first step do acutally automatically delete the related original statement in case of deleting the last child statement.


### How to review/test
Delete the last child statement of a original-statement with a set internId.
After successful deletion of the child-statement, the interId of the related originalSTN should be emtpy and therefore should be givable to another STN as well.


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
