### PR TITLE
feature (refs T30254): move service tag of emailAddressRepositoryInterface over to services_repositories.yml

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -1271,8 +1271,6 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener, event: postLoad, entity: demosplan\DemosPlanCoreBundle\Entity\User\User, lazy: true }
 
-    DemosEurope\DemosplanAddon\Contracts\Repositories\EmailAddressRepositoryInterface:
-        class: 'demosplan\DemosPlanCoreBundle\Repository\EmailAddressRepository'
 
     EDT\Wrapping\TypeProviders\PrefilledTypeProvider:
         alias: 'demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'

--- a/demosplan/DemosPlanCoreBundle/Resources/config/services_repositories.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services_repositories.yml
@@ -257,3 +257,5 @@ services:
     DemosEurope\DemosplanAddon\Contracts\Repositories\GisLayerCategoryRepositoryInterface: '@demosplan\DemosPlanMapBundle\Repository\GisLayerCategoryRepository'
 
     DemosEurope\DemosplanAddon\Contracts\Repositories\MapRepositoryInterface: '@demosplan\DemosPlanMapBundle\Repository\MapRepository'
+
+    DemosEurope\DemosplanAddon\Contracts\Repositories\EmailAddressRepositoryInterface: '@demosplan\DemosPlanCoreBundle\Repository\EmailAddressRepository'


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30254

Description:
move the service tag of the emailAddressRepositoryInterface over to the services_repositories.yml
as it needs to be there in order to work.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
