### PR TITLE
fix: remove DpAllowedSenderEmailList.vue from DpBasicSettings

### DIFF
--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -10,7 +10,6 @@
 <script>
 import { dpApi, sortAlphabetically } from '@demos-europe/demosplan-utils'
 import { DpButton, DpDateRangePicker, DpDatetimePicker, DpEditor, DpInlineNotification, DpInput, DpMultiselect } from '@demos-europe/demosplan-ui'
-import DpAllowedSenderEmailList from './DpAllowedSenderEmailList'
 import DpEmailList from './DpEmailList'
 import ExportSettings from './ExportSettings'
 
@@ -19,7 +18,6 @@ export default {
 
   components: {
     AutoSwitchProcedurePhaseForm: () => import(/* webpackChunkName: "auto-switch-procedure-phase-form" */ '@DpJs/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm'),
-    DpAllowedSenderEmailList,
     DpButton,
     DpDateRangePicker,
     DpDatetimePicker,


### PR DESCRIPTION
### Description
- This is now an addon component and therefore should be removed from the core also this is throwing an error since the component does not exist anymore in the core

### Related
This was overseen in https://github.com/demos-europe/demosplan-core/pull/1179 and hence the import was removed in this PR from the basic settings