### PR TITLE
F_T31959 adjust core permissions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -510,7 +510,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         if ($this->user->hasRole(Role::CUSTOMER_MASTER_USER)) {
             $this->enablePermissions([
                 'area_organisations',
-                'area_organisations_applications_manage',
                 'area_organisations_view_of_customer',
                 'area_preferences',  // Einstellungen
                 'feature_orga_edit',


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31959

Description: adjust core permissions
    - remove area_organisations_applications_manage from core. This permission will be enabled for the CUSTOMER_MASTER_USER only in the projects where it is allowed


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Tests updated/created
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly