### PR TITLE
feature (refs T32008): get OrgaName of dataInputUser who caused the reportEntry instead of STN-author

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
@@ -144,7 +144,7 @@ class ReportEntryResourceType extends DplanResourceType
                 return false;
             }),
             $this->createAttribute($this->orgaName)->readable(true, function (ReportEntry $entry): string {
-                return $this->messageConverter->extractOrgaNameFromReportEntryMessage($entry);
+                return $this->userHandler->getSingleUser($entry->getUserId())?->getOrga()?->getName() ?? '';
             }),
         ];
     }

--- a/demosplan/DemosPlanReportBundle/Logic/ReportMessageConverter.php
+++ b/demosplan/DemosPlanReportBundle/Logic/ReportMessageConverter.php
@@ -72,17 +72,6 @@ class ReportMessageConverter
         $this->translator = $translator;
     }
 
-    public function extractOrgaNameFromReportEntryMessage(ReportEntry $reportEntry): string
-    {
-        $orgaName = '';
-        $reportEntryMessage = $reportEntry->getMessageDecoded(true);
-        if (array_key_exists('oName', $reportEntryMessage)) {
-            $orgaName = $reportEntryMessage['oName'];
-        }
-
-        return $orgaName;
-    }
-
     public function convertMessage(ReportEntry $reportEntry): string
     {
         $message = '';


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32008

Description:
When the cause for a report entry is a user with role
PROCEDURE_DATA_INPUT the name should be
replaced by his OrgaName. Prior to this change
the orgaName of the STN author was used to replace the name.

Other Prs:
This change is needed in ewm_release. https://github.com/demos-europe/demosplan-core/pull/1185

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
