### PR TITLE
fix(refs T32259): AddonWrapper needs to be imported in DpBasicSettings

### DIFF
--- a/client/js/bundles/procedure/administrationEdit.js
+++ b/client/js/bundles/procedure/administrationEdit.js
@@ -10,7 +10,6 @@
 /**
  * This is the entry point for administration_edit.html.twig
  */
-import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import AdministrationMaster from '@DpJs/lib/procedure/AdministrationMaster'
 import DpBasicSettings from '@DpJs/components/procedure/basicSettings/DpBasicSettings'
 // Import this separately because Planfest has a separate twig template which does not use DpBasicSettings
@@ -21,7 +20,7 @@ import DPWizard from '@DpJs/lib/procedure/DPWizard'
 import { initialize } from '@DpJs/InitVue'
 import UrlPreview from '@DpJs/lib/shared/UrlPreview'
 
-const components = { AddonWrapper, DpBasicSettings, DpEmailList, DpDateRangePicker }
+const components = { DpBasicSettings, DpEmailList, DpDateRangePicker }
 
 initialize(components).then(() => {
   UrlPreview()

--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -10,6 +10,7 @@
 <script>
 import { dpApi, sortAlphabetically } from '@demos-europe/demosplan-utils'
 import { DpButton, DpDateRangePicker, DpDatetimePicker, DpEditor, DpInlineNotification, DpInput, DpMultiselect } from '@demos-europe/demosplan-ui'
+import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import DpEmailList from './DpEmailList'
 import ExportSettings from './ExportSettings'
 
@@ -17,6 +18,7 @@ export default {
   name: 'DpBasicSettings',
 
   components: {
+    AddonWrapper,
     AutoSwitchProcedurePhaseForm: () => import(/* webpackChunkName: "auto-switch-procedure-phase-form" */ '@DpJs/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm'),
     DpButton,
     DpDateRangePicker,


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32259

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

AddonWrapper needs to be imported in DpBasicSettings.vue and not in the entrypoint.

### Related PRs:
https://github.com/demos-europe/demosplan-addon-maillane/pull/25

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
