### PR TITLE
Use correct button label

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -200,6 +200,7 @@
         class="u-mt-0_5"
         primary
         secondary
+        :secondary-text="Translator.trans('discard.changes')"
         @primary-action="dpValidateAction('statementMetaData', save, false)"
         @secondary-action="reset" />
     </div>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -78,6 +78,7 @@
           class="u-mv"
           primary
           secondary
+          :secondary-text="Translator.trans('discard.changes')"
           @primary-action="dpValidateAction('segmentsStatementForm', saveStatement, false)"
           @secondary-action="resetStatement" />
       </template>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30572

The secondary button actually resets the form fields to the value that was last saved, it discards unsaved changes.

To reflect this, instead of "Abbrechen" the new label "Änderungen verwerfen" is applied. It has been chosen because:

- it explicitly says what the button is doing
- it is already used in similar places within demosPlan

Even if "Verwerfen" is shorter, there is a chance that users might assume the whole texts to be removed when clicking the button.

### How to review/test
In the statement detail view in ewm, both below the metabox fields and below the editor of the (not already segmented) statement text, the secondary button should read "Änderungen verwerfen".

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
