### PR TITLE
fix (refs T30866): Permissions needs to be available by exposing them.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -2300,6 +2300,7 @@ field_data_protection_text_customized_edit_customer:
 field_data_protection_text_customized_edit_orga:
     description: 'See parent for longer description.'
     label: 'Edit customized data protection text for orga'
+    expose: true
     parent: feature_data_protection_text_customized_view
 field_fragment_status:
     description: 'Set and show the status of fragment (new, assigned, editing etc).'
@@ -2319,6 +2320,7 @@ field_imprint_text_customized_edit_orga:
     description: 'See parent for longer description.'
     label: 'Edit customized imprint text for orga'
     parent: feature_imprint_text_customized_view
+    expose: true
 field_municipality_list:
     label: 'betroffene Vorranggebiete'
     loginRequired: true


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32219
Fix for **Ticket:** https://yaits.demos-deutschland.de/T30866

Needed Permissions are not exposed for using in FE.

Fields should be available an editable for customer master user now.

Story PR: https://github.com/demos-europe/demosplan-core/pull/1102