### PR TITLE
feat: Clear cache out of band

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -136,7 +136,7 @@ class AddonInstallFromZipCommand extends CoreCommand
             $activeProject = $this->getApplication()->getKernel()->getActiveProject();
 
             $batchReturn = Batch::create($this->getApplication(), $output)
-                ->add('cache:clear')
+                ->addShell(["bin/{$activeProject}", 'cache:clear'])
                 ->addShell(["bin/{$activeProject}", 'dplan:addon:build-frontend', $name])
                 ->run();
 


### PR DESCRIPTION
Clearing the cache in-process vs clearing the cache out-of-process yields slightly different results for the next command. In the latter way, the current application state does not affect the cache state.

Changing this is a bit of a gamble as I have seen varying results but it seems that it makes the cache state for the frontend asset build a little more reliable and thus reduces the friction during addon installation.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
