### PR TITLE
chore: only add addon controllers if addons have them

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonRoutingLoader.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonRoutingLoader.php
@@ -34,12 +34,7 @@ class AddonRoutingLoader extends AnnotationDirectoryLoader implements RouteLoade
     {
         $routeCollection = new RouteCollection();
         foreach ($this->addonRegistry->getAddonInfos() as $addonInfo) {
-            if ('' !== $addonInfo->getInstallPath()) {
-                $controllerPath = AddonPath::getRootPath(
-                    $addonInfo->getInstallPath().self::PATH_TO_CONTROLLERS_FROM_ADDONROOT
-                );
-                $routeCollection->addCollection($this->load($controllerPath));
-            }
+            $this->addControllers($addonInfo, $routeCollection);
         }
 
         return $routeCollection;
@@ -51,6 +46,18 @@ class AddonRoutingLoader extends AnnotationDirectoryLoader implements RouteLoade
             $route->setDefault('_controller', $class->getName());
         } else {
             $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+        }
+    }
+
+    /**
+     * Add controllers from addon to route collection if they exist.
+     */
+    private function addControllers(mixed $addonInfo, RouteCollection $routeCollection): void
+    {
+        $controllerDir = $addonInfo->getInstallPath() . self::PATH_TO_CONTROLLERS_FROM_ADDONROOT;
+        if ('' !== $addonInfo->getInstallPath() && is_dir($controllerDir)) {
+            $controllerPath = AddonPath::getRootPath($controllerDir);
+            $routeCollection->addCollection($this->load($controllerPath));
         }
     }
 }


### PR DESCRIPTION
Avoid error when addons do not have Controllers folder

### How to review/test
install an addon without the folder or review code

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
