### PR TITLE
bug(refs T28356): Software components with no url

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatic/components_entry.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatic/components_entry.html.twig
@@ -1,4 +1,6 @@
-<table class="c-table u-mv">
+<table
+    class="c-table u-mv"
+    aria-label="{{ 'misc.softwarecomponents'|trans({}, "page-title") }}">
     <thead>
         <tr>
             <th>Komponente</th>
@@ -9,7 +11,7 @@
     {% for component in components %}
         <tr>
             <td>
-                {% if component.website is defined and component.website|length > 0 %}
+                {% if component.website is defined and component.website|length > 0  and component.website != "Unknown" %}
                     <a
                         class="o-link--external"
                         target="_blank"


### PR DESCRIPTION
 **Ticket:** https://yaits.demos-deutschland.de/T28356

The website for some software components is unknown. There should be no link displayed then.

### How to review/test
Go to Impressum -> Lizenzhinweise -> hier and check if the components with unknown websites have no link. 

