### PR TITLE
feature (refs T32200): avoid null as param client in FileService in addonContext

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -73,11 +73,6 @@ class FileService extends CoreService implements FileServiceInterface
     protected $fileString;
 
     /**
-     * @var RpcClient
-     */
-    protected $client;
-
-    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -134,7 +129,8 @@ class FileService extends CoreService implements FileServiceInterface
         MessageBagInterface $messageBag,
         RequestStack $requestStack,
         SingleDocumentRepository $singleDocumentRepository,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        protected RpcClient $rpcClient
     ) {
         $this->currentProcedureService = $currentProcedureService;
         $this->entityManager = $entityManager;

--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -395,9 +395,11 @@ services:
         lazy: true
         parent: demosplan\DemosPlanCoreBundle\Logic\CoreService
 
+    OldSound\RabbitMqBundle\RabbitMq\RpcClient: '@old_sound_rabbit_mq.demos_plan_import_rpc'
+
     demosplan\DemosPlanCoreBundle\Logic\FileService:
-        calls:
-            - [ 'setClient', [ '@old_sound_rabbit_mq.demos_plan_import_rpc' ]]
+        arguments:
+            $rpcClient: '@old_sound_rabbit_mq.demos_plan_import_rpc'
         lazy: true
         parent: demosplan\DemosPlanCoreBundle\Logic\CoreService
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32200

Description:
Sentry pointed to a method call on null regarding the FileService::client property.
These changes hopefully help to initialize the client when used in an addon context.

Sentry log: File could not be saved
`
Call to a member function addRequest() on null #0 /data/app/bobhh/demosplan/DemosPlanCoreBundle/Logic/FileService.php(478): demosplan\DemosPlanCoreBundle\Logic\FileService->virusCheck(Object(Symfony\Component\HttpFoundation\File\File)) #1 /data/app/bobhh/demosplan/DemosPlanCoreBundle/Logic/FileService.php(432): demosplan\DemosPlanCoreBundle\Logic\FileService->saveFile(Object(demosplan\DemosPlanCoreBundle\Entity\File), Object(Symfony\Component\HttpFoundation\File\File), true) #2 /data/app/bobhh/addons/vendor/demos-europe/demosplan-addon-xbauleitplanung/src/Logic/XtaProcedureCommonFeatures.php(198): demosplan\DemosPlanCoreBundle\Logic\FileService->saveTemporaryFile('/tmp/null_ID_5e...', 'null_ID_5e907bb...', '415fd2f4-cb04-1...', 'f82f5a5b-953b-4...') #3 /data/app/bobhh/addons/vendor/demos-europe/demosplan-addon-xbauleitplanung/src/Logic/XtaProcedureCreator.php(57): DemosEurope\DemosplanAddon\XBauleitplanung\Logic\XtaProcedureCommonFeatures->createFileEntity('/tmp/null_ID_5e...', '415fd2f4-cb04-1...', 'f82f5a5b-953b-4...')
`

### How to review/test
unfortunately this can only be tested on suse when receiving a XtaProcedureMessage

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
