### PR TITLE
Fix: Remove double data property

### DIFF
--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -321,11 +321,6 @@ export default {
           checked: false,
           success: false
         },
-        assignPlace: {
-          selected: [],
-          checked: false,
-          success: false
-        },
         assignSegment: {
           selected: [],
           checked: false,


### PR DESCRIPTION
### Description: 

- Sonarcloud shows major issue because of double data propöerty
- just remove it to fix it, because it already exists

