### PR TITLE
F_remove unnecessary interface defintion

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -136,9 +136,6 @@ services:
     DemosEurope\DemosplanAddon\Contracts\Events\GetPropertiesEventInterface:
         class: demosplan\DemosPlanCoreBundle\Logic\ApiRequest\GetPropertiesEvent
 
-    DemosEurope\DemosplanAddon\Contracts\Events\ParameterProviderEventInterface:
-        class: DemosEurope\DemosplanAddon\DemosPipes\Event\ParameterProviderEvent
-
     DemosEurope\DemosplanAddon\Contracts\Events\DailyMaintenanceEventInterface:
         class: demosplan\DemosPlanCoreBundle\Event\DailyMaintenanceEvent
 


### PR DESCRIPTION
Description:  

there are no need to add a defintion to this interface in the services yaml. 
