### PR TITLE
fix (refs T31336): correct spelling of referenced service.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -76,7 +76,7 @@ services:
     DemosEurope\DemosplanAddon\Contracts\PercentageDistributionTransformerInterface:
         class: demosplan\DemosPlanCoreBundle\Transformers\PercentageDistributionTransformer
 
-    DemosEurope\DemosplanAddon\Contracts\PermissionsInterface: '@demosplan\DemosPlanCoreBundle\Permissions\permissions'
+    DemosEurope\DemosplanAddon\Contracts\PermissionsInterface: '@demosplan\DemosPlanCoreBundle\Permissions\Permissions'
 
     DemosEurope\DemosplanAddon\Contracts\Handler\StatementHandlerInterface:
         class: 'demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler'


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31336

Correct spelling of referenced service. It have to start with a capital letter.

### How to review/test
The error message should no longer arise: 'You have requested a non-existent service "demosplan\DemosPlanCoreBundle\Permissions\permissions".'

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
