### PR TITLE
fix (refs T32244 & T32245): Remove old use statements of moved bundles.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -86,17 +86,6 @@ use demosplan\DemosPlanProcedureBundle\Repository\NotificationReceiverRepository
 use demosplan\DemosPlanProcedureBundle\ValueObject\BoilerplateGroupVO;
 use demosplan\DemosPlanProcedureBundle\ValueObject\BoilerplateVO;
 use demosplan\DemosPlanProcedureBundle\ValueObject\ProcedureFormData;
-use demosplan\DemosPlanStatementBundle\Exception\GdprConsentRequiredException;
-use demosplan\DemosPlanStatementBundle\Logic\AssessmentHandler;
-use demosplan\DemosPlanStatementBundle\Logic\CountyService;
-use demosplan\DemosPlanStatementBundle\Logic\DraftStatementHandler;
-use demosplan\DemosPlanStatementBundle\Logic\DraftStatementService;
-use demosplan\DemosPlanStatementBundle\Logic\GdprConsentRevokeTokenService;
-use demosplan\DemosPlanStatementBundle\Logic\StatementFragmentService;
-use demosplan\DemosPlanStatementBundle\Logic\StatementHandler;
-use demosplan\DemosPlanStatementBundle\Logic\StatementService;
-use demosplan\DemosPlanSurveyBundle\Logic\SurveyService;
-use demosplan\DemosPlanSurveyBundle\Logic\SurveyShowHandler;
 use demosplan\DemosPlanUserBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanUserBundle\Exception\DuplicateSlugException;
 use demosplan\DemosPlanUserBundle\Logic\AddressBookEntryService;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32244 & https://yaits.demos-deutschland.de/T32245 

The DemosPlanStatementBundle and DemosPlanSurveyBundle was moved to core. This PR removes some leftover use cases.

### How to review/test
code review

### Linked PRs (optional)

https://github.com/demos-europe/demosplan-core/pull/1217
https://github.com/demos-europe/demosplan-core/pull/1197

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
