### PR TITLE
fix(refs T32449): load statement text instead if permission is not granted for segments

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -11,8 +11,8 @@
   <div data-dp-validate="segmentsStatementForm">
     <dp-loading v-if="isLoading" />
 
-    <!-- if statement has segments, display segments -->
-    <template v-else-if="hasSegments">
+    <!-- if statement has segments and user has the permission, display segments -->
+    <template v-else-if="hasSegments && hasPermission('area_statement_segmentation')">
       <div
         v-for="segment in segments"
         :key="segment.id"


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32449

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This is the frontend part for https://github.com/demos-europe/demosplan-project-ewm/pull/55. This PR adds a permission check in the StatementSegmentsList to render the statement text if the permission `area_statement_segmentation` is not granted to the current user.

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-project-ewm/pull/55



Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets

