### PR TITLE
fix(refs T32449): remove access to segments for ahb

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -12,7 +12,7 @@
     <dp-loading v-if="isLoading" />
 
     <!-- if statement has segments and user has the permission, display segments -->
-    <template v-else-if="hasSegments && hasPermission('area_statement_segmentation')">
+    <template v-else-if="hasSegments">
       <div
         v-for="segment in segments"
         :key="segment.id"
@@ -177,7 +177,7 @@ export default {
     },
 
     hasSegments () {
-      return Object.keys(this.segments).length > 0
+      return Object.keys(this.segments).length > 0 && hasPermission('area_statement_segmentation')
     },
 
     statement () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -375,6 +375,9 @@ export default {
             this.scrollToSegment()
           })
         })
+        .finally(() => {
+          this.isLoading = false
+        })
     }
   },
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -348,7 +348,7 @@ export default {
   },
 
   mounted () {
-    if (Object.keys(this.segments).length === 0) {
+    if (Object.keys(this.segments).length === 0 && hasPermission('area_statement_segmentation')) {
       this.isLoading = true
       this.listSegments({
         include: ['assignee', 'comments', 'place', 'tags', 'assignee.orga', 'comments.submitter', 'comments.place'].join(),
@@ -379,7 +379,7 @@ export default {
   },
 
   beforeDestroy () {
-    if (this.editingSegmentIds.length > 0) {
+    if (this.editingSegmentIds.length > 0 && hasPermission('area_statement_segmentation')) {
       this.editingSegmentIds.forEach(segment => this.reset(segment.id))
     }
     if (this.hasSegments === false && this.segment) {


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32034

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Also the fetching of segments data should only be fired, when the current user has the permission for segments. Otherwise the response would throw an console error. And also the loading state would not been set to false which prevented the statement text to be rendered instead. To make this component more resilient a finally block has also been added to the fetch function for segments

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
