### PR TITLE
refs T32414: add csrf token to registration

### DIFF
--- a/client/js/components/user/citizenRegisterForm/CitizenRegisterForm.vue
+++ b/client/js/components/user/citizenRegisterForm/CitizenRegisterForm.vue
@@ -65,6 +65,11 @@
             name="gdpr_consent"
             required
             value="on" />
+          <dp-input
+            id="_csrf_token"
+            name="_csrf_token"
+            type="hidden"
+            :value="csrfToken"/>
           <dp-button
             :class="prefixClass('u-mt-0_5 u-mb-0_25')"
             data-cy="submit"
@@ -123,6 +128,12 @@ export default {
     },
 
     samlLoginPath: {
+      type: String,
+      required: true,
+      default: ''
+    },
+
+    csrfToken: {
       type: String,
       required: true,
       default: ''

--- a/client/js/components/user/citizenRegisterForm/CitizenRegisterForm.vue
+++ b/client/js/components/user/citizenRegisterForm/CitizenRegisterForm.vue
@@ -135,8 +135,7 @@ export default {
 
     csrfToken: {
       type: String,
-      required: true,
-      default: ''
+      required: true
     }
   }
 }

--- a/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
+++ b/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
@@ -196,8 +196,7 @@ export default {
     },
     csrfToken: {
       type: String,
-      required: true,
-      default: ''
+      required: true
     }
   }
 

--- a/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
+++ b/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
@@ -127,10 +127,11 @@
             required
             value-to-send="on" />
 
-          <input
-            type="hidden"
+          <dp-input
+            id="_csrf_token"
             name="_csrf_token"
-            :value="csrfToken">
+            type="hidden"
+            :value="csrfToken"/>
 
           <dp-button
             :class="prefixClass('u-mt-0_5 u-mb-0_25')"

--- a/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
+++ b/client/js/components/user/orgaRegisterForm/OrgaRegisterForm.vue
@@ -126,6 +126,12 @@
             name="gdpr_consent"
             required
             value-to-send="on" />
+
+          <input
+            type="hidden"
+            name="_csrf_token"
+            :value="csrfToken">
+
           <dp-button
             :class="prefixClass('u-mt-0_5 u-mb-0_25')"
             data-cy="submit"
@@ -186,6 +192,11 @@ export default {
     customer: {
       type: String,
       required: true
+    },
+    csrfToken: {
+      type: String,
+      required: true,
+      default: ''
     }
   }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/SessionHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/SessionHandler.php
@@ -96,12 +96,6 @@ class SessionHandler extends PdoSessionHandler
     public function initialize(array $context = null): void
     {
         try {
-            // Migrate session to avoid blocking parallel requests due to session file locks.
-            // Session values are not used to persist data between requests (apart from userId)
-            // so concurrent requests could not overwrite data.
-            // This bloats the amount of session files but these could well be garbage collected
-            $this->request->getSession()->migrate();
-
             $user = $this->currentUser->getUser();
 
             // Die Berechtigungen und das Menühighlighting initialisieren und in der Session ablegen.

--- a/demosplan/DemosPlanUserBundle/Logic/UserHandler.php
+++ b/demosplan/DemosPlanUserBundle/Logic/UserHandler.php
@@ -275,14 +275,14 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
      * @throws LoginNameInUseException
      * @throws Exception
      */
-    public function createCitizen(ParameterBag $data, ParameterBagInterface $parameterBag): User
+    public function createCitizen(ParameterBag $data): User
     {
         $firstname = $data->get('r_firstname');
         $lastname = $data->get('r_lastname');
         $emailAddress = $data->get('r_email');
 
-        $fieldsExpected = 4;
-        if (!$parameterBag->get('honeypot_disabled')) {
+        $fieldsExpected = 5;
+        if ($data->has('r_loadtime')) {
             $fieldsExpected += 2;
         }
 
@@ -291,7 +291,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
             || null === $emailAddress
             || !is_string($firstname)
             || !is_string($lastname)
-            // there are only six values expected. Three "real" values + 1 checkbox + eventually 2 Honeypot values
+            // there are only seven values expected. Three "real" values + 1 checkbox + 1 csrf token + eventually 2 Honeypot values
             || $fieldsExpected !== $data->count()) {
             throw new InvalidArgumentException('Invalid request');
         }

--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/citizen_register_form.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/citizen_register_form.html.twig
@@ -6,7 +6,10 @@
         content_heading: 'register'|trans
     }%}
         {% block content %}
-            <citizen-register-form :is-saml="{{ useSaml|json_encode }}" :saml-login-path="{{ path('saml_login')|json_encode }}">
+            <citizen-register-form
+                :is-saml="{{ useSaml|json_encode }}"
+                :saml-login-path="{{ path('saml_login')|json_encode }}"
+                :csrf-token="{{ csrf_token('register-user')|json_encode }}">
                 {{ extensionPointMarkup('formExtraFields')|raw }}
             </citizen-register-form>
         {% endblock content %}

--- a/templates/bundles/DemosPlanUserBundle/DemosPlanUser/orga_register_form.html.twig
+++ b/templates/bundles/DemosPlanUserBundle/DemosPlanUser/orga_register_form.html.twig
@@ -6,7 +6,8 @@
     }%}
         {% block content %}
             <orga-register-form
-                customer="{{ templateVars.customerName|default }}">
+                customer="{{ templateVars.customerName|default }}"
+                :csrf-token="{{ csrf_token('register-orga')|json_encode }}">
                 {{ extensionPointMarkup('formExtraFields')|raw }}
             </orga-register-form>
         {% endblock content %}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3702,6 +3702,7 @@ user.password.recovery_vague: "Falls die eingegebene E-Mail-Adresse {email} eine
 user.password.set: "Ihr Passwort wurde erfolgreich gesetzt."
 user.registration.completed: "Registrierung abgeschlossen"
 user.registration.fail: "Registrierung fehlgeschlagen."
+user.registration.invalid.csrf: "Das Formular war ungültig. Bitte versuchen Sie es erneut."
 user.registration.confirmed: "Zugangsdaten gesendet"
 user.registration.invitation.outstanding: "Nutzer*in wurde noch nicht per E-Mail eingeladen!"
 user.registration.invitation.sent: "Nutzer*in per E-Mail eingeladen"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32414

This PR adds a csrf token to citizen and organization registration to avoid forms being misused for spam

### How to review/test
register an organization and replay post request via browser or curl. With this patch no new organization should be added 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
