### PR TITLE
feat: add default map to prod fixtures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
@@ -44,6 +44,8 @@ class LoadCustomerData extends TestFixture
 
         $customerDemos = new Customer(self::DEMOS, 'demos');
         $customerDemos->setAccessibilityExplanation('Barrierefreiheitserklärung');
+        $customerDemos->setBaseLayerUrl('https://sgx.geodatenzentrum.de/wms_basemapde');
+        $customerDemos->setBaseLayerLayers('de_basemapde_web_raster_farbe');
         $manager->persist($customerDemos);
         $this->setReference(self::DEMOS, $customerDemos);
 


### PR DESCRIPTION
This PR adds basic map information to the production customer fixtures to avoid a blank map at the start page. 

### How to review/test
You may load prod fixtures, but code review might suffice

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
