### PR TITLE
feat: remove rollup migration preparation code

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
@@ -57,14 +57,6 @@ class MigrateCommand extends CoreCommand
         $migrationsConfigurationPath = DemosPlanPath::getProjectPath('app/config/project_migrations.yml');
         $migrationsSyncCommand = 'doctrine:migrations:sync-metadata-storage --configuration ';
         $migrationsCommand = 'doctrine:migrations:migrate --configuration ';
-        $lastRollupMigration = 'app/Resources/DemosPlanCoreBundle/DoctrineMigrations/2022/09/Version20220914133419.php';
-
-        // ensure that rollup migrations are applied before core migrations are performed
-        if (file_exists(DemosPlanPath::getProjectPath($lastRollupMigration))) {
-            $commands[] = $migrationsSyncCommand.$migrationsConfigurationPath." {$db} --env={$env}";
-            $commands[] = $migrationsCommand.$migrationsConfigurationPath.
-                    ' Application\Migrations\Version20220914133419'." {$db} --env={$env}";
-        }
 
         $commands[] = "doctrine:migrations:migrate {$db} --env={$env}";
         $commands[] = $migrationsSyncCommand.$migrationsConfigurationPath." {$db} --env={$env}";


### PR DESCRIPTION
Before performing the database rollup in core demosplan we needed to make sure that the database is in any project in a consistent state. This is not necessary anymore. In fact, on every migration any project migrations later than the rollup migration was downmigrated and after the core migrations reapplied. This PR sets an end to this, as rollup is already performed in most of the existing projects.

### How to review/test
Perform `dplan:migrate -vvv` and notice that no project migrations are down migrated

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
