### PR TITLE
chore: reduce authenticator method visibility

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -124,7 +124,7 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
         $this->translator = $translator;
     }
 
-    abstract public function getCredentials(Request $request): Credentials;
+    abstract protected function getCredentials(Request $request): Credentials;
 
     public function authenticate(Request $request): Passport
     {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
@@ -37,7 +37,7 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
             && $request->isMethod('POST');
     }
 
-    public function getCredentials(Request $request): Credentials
+    protected function getCredentials(Request $request): Credentials
     {
         // check Honeypotfields
         try {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHAuthenticator.php
@@ -30,7 +30,7 @@ final class OsiHHAuthenticator extends OsiAuthenticator
             && $request->query->has('Token');
     }
 
-    public function getCredentials(Request $request): Credentials
+    protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('Token');
         $request->getSession()->set(Security::LAST_USERNAME, $osiToken);

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHStaticAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHStaticAuthenticator.php
@@ -31,7 +31,7 @@ final class OsiHHStaticAuthenticator extends OsiAuthenticator
             && 'bobhh' === $request->query->get('project');
     }
 
-    public function getCredentials(Request $request): Credentials
+    protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('TokenTest');
         $request->getSession()->set(Security::LAST_USERNAME, $osiToken);

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHAuthenticator.php
@@ -30,7 +30,7 @@ final class OsiSHAuthenticator extends OsiAuthenticator
             && $request->query->has('Token');
     }
 
-    public function getCredentials(Request $request): Credentials
+    protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('Token');
         $request->getSession()->set(Security::LAST_USERNAME, $osiToken);

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHStaticAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHStaticAuthenticator.php
@@ -30,7 +30,7 @@ final class OsiSHStaticAuthenticator extends OsiAuthenticator
             && $request->query->has('TokenTest');
     }
 
-    public function getCredentials(Request $request): Credentials
+    protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('TokenTest');
         $request->getSession()->set(Security::LAST_USERNAME, $osiToken);


### PR DESCRIPTION
The visibility of `getCredentials` may be tightened, as it is only used within class context

### How to review/test
code review should be best, phpstan can help

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
