### PR TITLE
feat: show list even when some data is invalid

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Map\MapService;
 use proj4php\Point;
 use proj4php\Proj;
 use proj4php\Proj4php;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -32,7 +33,7 @@ class WerDenktWasAPIController extends BaseController
      *
      * @DplanPermissions("area_public_participation")
      */
-    public function procedureListGeoJSONAction(TranslatorInterface $translator): ?JsonResponse
+    public function procedureListGeoJSONAction(TranslatorInterface $translator, LoggerInterface $logger): ?JsonResponse
     {
         $searchProceduresResponse = $this->forward(
             '\demosplan\DemosPlanCoreBundle\Controller\Procedure\DemosPlanProcedureAPIController::searchProceduresAjaxAction',
@@ -54,47 +55,55 @@ class WerDenktWasAPIController extends BaseController
         $targetProjection = new Proj(MapService::EPSG_4326_PROJECTION_LABEL, $projection);
 
         foreach ($data['data'] as $procedureInfo) {
-            $feature = [
-                'type' => 'Feature',
-            ];
+            try {
+                $feature = [
+                    'type' => 'Feature',
+                ];
 
-            $coordinates = array_map(static function ($coordinate) {
-                return (float) $coordinate;
-            }, explode(',', $procedureInfo['attributes']['coordinate']));
+                $coordinates = array_map(static function ($coordinate) {
+                    return (float) $coordinate;
+                }, explode(',', $procedureInfo['attributes']['coordinate']));
 
-            // skip procedures without coordinates (should not happen on production)
-            if ([0.0] === $coordinates) {
+                // skip procedures without coordinates (should not happen on production)
+                if ([0.0] === $coordinates) {
+                    continue;
+                }
+
+                $sourcePoint = new Point($coordinates[0], $coordinates[1], $sourceProjection);
+                $targetPoint = $projection->transform($targetProjection, $sourcePoint);
+                $feature['geometry'] = [
+                    'type'        => 'Point',
+                    'coordinates' => [$targetPoint->toArray()[0], $targetPoint->toArray()[1]],
+                ];
+
+                $feature['properties'] = [
+                    'description'   => $procedureInfo['attributes']['externalDescription'],
+                    'organisation'  => $procedureInfo['attributes']['owningOrganisationName'],
+                    'name'          => $procedureInfo['attributes']['externalName'] ?? '',
+                    'participation' => [
+                        'start' => Carbon::createFromTimeString(
+                            $procedureInfo['attributes']['externalStartDate'] ?? ''
+                        )->toIso8601String(),
+                        'end'   => Carbon::createFromTimeString(
+                            $procedureInfo['attributes']['externalEndDate'] ?? ''
+                        )->toIso8601String(),
+                        'phase' => $translator->trans($procedureInfo['attributes']['externalPhaseTranslationKey'] ?? ''),
+                    ],
+                    'url'           => $this->generateUrl(
+                        'DemosPlan_procedure_public_detail',
+                        ['procedure' => $procedureInfo['id']],
+                        UrlGeneratorInterface::ABSOLUTE_URL
+                    ),
+                ];
+
+                $geojson['features'][] = $feature;
+            } catch (\Throwable $e) {
+                $logger->warning('Could not add procedure to GeoJSON', [
+                    'procedure' => $procedureInfo,
+                    'exception' => $e,
+                ]);
                 continue;
             }
-
-            $sourcePoint = new Point($coordinates[0], $coordinates[1], $sourceProjection);
-            $targetPoint = $projection->transform($targetProjection, $sourcePoint);
-            $feature['geometry'] = [
-                'type'        => 'Point',
-                'coordinates' => [$targetPoint->toArray()[0], $targetPoint->toArray()[1]],
-            ];
-
-            $feature['properties'] = [
-                'description'   => $procedureInfo['attributes']['externalDescription'],
-                'organisation'  => $procedureInfo['attributes']['owningOrganisationName'],
-                'name'          => $procedureInfo['attributes']['externalName'] ?? '',
-                'participation' => [
-                    'start' => Carbon::createFromTimeString(
-                        $procedureInfo['attributes']['externalStartDate'] ?? ''
-                    )->toIso8601String(),
-                    'end'   => Carbon::createFromTimeString(
-                        $procedureInfo['attributes']['externalEndDate'] ?? ''
-                    )->toIso8601String(),
-                    'phase' => $translator->trans($procedureInfo['attributes']['externalPhaseTranslationKey'] ?? ''),
-                ],
-                'url'           => $this->generateUrl(
-                    'DemosPlan_procedure_public_detail',
-                    ['procedure' => $procedureInfo['id']],
-                    UrlGeneratorInterface::ABSOLUTE_URL
-                ),
-            ];
-
-            $geojson['features'][] = $feature;
         }
 
         $response = new JsonResponse($geojson);


### PR DESCRIPTION
Some data in a procedure may be invalid which should not lead to a complete blank procedure list but exclude this data from the result and log it.

### How to review/test
code review or call the route and tamper with procedure data

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
