### PR TITLE
chore: fix extract unknown role logic

### DIFF
--- a/demosplan/DemosPlanUserBundle/Logic/UserMapperDataportGateway.php
+++ b/demosplan/DemosPlanUserBundle/Logic/UserMapperDataportGateway.php
@@ -392,8 +392,7 @@ abstract class UserMapperDataportGateway implements UserMapperInterface
         foreach ($this->data['roles'] as $role) {
             $rolesFound = $this->findRole($role['ROLENAME']);
             if (0 === $rolesFound->count()) {
-                $roleFound = $rolesFound->first();
-                $roles[] = $roleFound['role'];
+                $roles[] = $role['ROLENAME'];
                 $this->logger->debug('Unknown Role found', [$role['ROLENAME']]);
             }
         }


### PR DESCRIPTION
This PR fixes a small logic error. When no role could be found there is no first item

### How to review/test
code review or you may login with a user from `UserMapperDataportGatewayHHStatic` 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
