### PR TITLE
Feat(refs:T322012): vue3 migration - usage of template tag/element

### DIFF
--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -41,26 +41,24 @@
           initCenter: false,
           procedureExtent: true
         }">
-        <template>
-          <dp-ol-map-layer-vector
-            class="u-mb-0_5"
-            v-if="hasPermission('area_procedure_adjustments_general_location') && procedureCoordinate"
-            :features="features.procedureCoordinate"
-            name="mapSettingsPreviewCoordinate" />
-          <dp-ol-map-layer-vector
-            v-if="initExtent"
-            class="u-mb-0_5"
-            :features="features.initExtent"
-            name="mapSettingsPreviewInitExtent"
-            zoom-to-drawing />
-          <dp-ol-map-layer-vector
-            v-if="territory"
-            class="u-mb-0_5"
-            :features="features.territory"
-            :draw-style="drawingStyles.territory"
-            name="mapSettingsPreviewTerritory" />
-        </template>
-      </dp-ol-map>
+        <dp-ol-map-layer-vector
+          class="u-mb-0_5"
+          v-if="hasPermission('area_procedure_adjustments_general_location') && procedureCoordinate"
+          :features="features.procedureCoordinate"
+          name="mapSettingsPreviewCoordinate" />
+        <dp-ol-map-layer-vector
+          v-if="initExtent"
+          class="u-mb-0_5"
+          :features="features.initExtent"
+          name="mapSettingsPreviewInitExtent"
+          zoom-to-drawing />
+        <dp-ol-map-layer-vector
+          v-if="territory"
+          class="u-mb-0_5"
+          :features="features.territory"
+          :draw-style="drawingStyles.territory"
+          name="mapSettingsPreviewTerritory" />
+    </dp-ol-map>
     </div><!--
  --><div class="layout__item u-1-of-2">
       <ul class="list-style-none">

--- a/client/js/components/procedure/SegmentsList/CustomSearch.vue
+++ b/client/js/components/procedure/SegmentsList/CustomSearch.vue
@@ -20,7 +20,7 @@
         class="u-top-0 u-right-0 position--absolute"
         :has-menu="false"
         :padded="false">
-        <template v-slot:trigger>
+        <template #trigger>
           <dp-icon
             :class="{ 'color-ui-highlight': selectedFields.length > 0 }"
             icon="settings" />

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -79,7 +79,7 @@
             class="display--inline-block"
             v-if="hasPermission('feature_read_source_statement_via_api')">
             <dp-flyout :disabled="isDisabledAttachmentFlyout">
-              <slot name="trigger">
+              <template #trigger>
                 <span>
                   {{ Translator.trans('attachments') }}
                   <span v-text="attachmentsAndOriginalPdfCount" />
@@ -87,7 +87,7 @@
                     class="fa fa-angle-down"
                     aria-hidden="true" />
                 </span>
-              </slot>
+              </template>
               <template v-if="statement">
                 <div class="overflow-x-scroll overflow-word-break max-height-500 max-width-600 width-max-content">
                   <span class="display--block weight--bold">{{ Translator.trans('original.pdf') }}</span>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -79,7 +79,7 @@
             class="display--inline-block"
             v-if="hasPermission('feature_read_source_statement_via_api')">
             <dp-flyout :disabled="isDisabledAttachmentFlyout">
-              <template slot="trigger">
+              <slot name="trigger">
                 <span>
                   {{ Translator.trans('attachments') }}
                   <span v-text="attachmentsAndOriginalPdfCount" />
@@ -87,7 +87,7 @@
                     class="fa fa-angle-down"
                     aria-hidden="true" />
                 </span>
-              </template>
+              </slot>
               <template v-if="statement">
                 <div class="overflow-x-scroll overflow-word-break max-height-500 max-width-600 width-max-content">
                   <span class="display--block weight--bold">{{ Translator.trans('original.pdf') }}</span>
@@ -111,7 +111,7 @@
             <dp-flyout
               ref="metadataFlyout"
               :has-menu="false">
-              <template v-slot:trigger>
+              <template #trigger>
                 <span>
                   {{ Translator.trans('statement.metadata') }}
                   <i

--- a/client/js/components/procedure/basicSettings/DpProcedureCoordinate.vue
+++ b/client/js/components/procedure/basicSettings/DpProcedureCoordinate.vue
@@ -27,15 +27,15 @@
         v-slot:controls
         v-if="editable">
         <dp-procedure-coordinate-input
+          v-if="hasPermission('feature_procedure_coordinate_alternative_input')"
           :class="prefixClass('u-mb-0_5')"
           :coordinate="coordinate"
-          v-if="hasPermission('feature_procedure_coordinate_alternative_input')"
           @input="updateFeatures" />
 
         <procedure-coordinate-geolocation
+          v-if="hasPermission('feature_procedures_located_by_maintenance_service')"
           :coordinate="coordinate"
-          :location="procedureLocation"
-          v-if="hasPermission('feature_procedures_located_by_maintenance_service')" />
+          :location="procedureLocation" />
 
         <div :class="prefixClass('display--inline-block')">
           <dp-ol-map-draw-point
@@ -51,13 +51,11 @@
         </div>
       </template>
 
-      <template>
-        <dp-ol-map-layer-vector
-          :features="featuresFromCoordinate"
-          ref="procedureCoordinateDrawer"
-          name="procedureCoordinateDrawer"
-          @layer:features:changed="updateProcedureCoordinate" />
-      </template>
+      <dp-ol-map-layer-vector
+        :features="featuresFromCoordinate"
+        ref="procedureCoordinateDrawer"
+        name="procedureCoordinateDrawer"
+        @layer:features:changed="updateProcedureCoordinate" />
     </dp-ol-map>
 
     <!-- If adding a location to procedures is enforced, the corresponding validation is added here via `data-dp-validate`.

--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -20,120 +20,118 @@
           :labels="selectElementLabels"
           @set-label="setLabel" />
         <dp-sticky-element>
-          <template>
-            <div class="u-ml width-300">
+          <div class="u-ml width-300">
+            <p
+              class="weight--bold">
+              {{ Translator.trans('tool.active') }}
+            </p>
+            <div>
+              <div class="annotator__button-wrapper is-first">
+                <button
+                  @click="setInteraction('select')"
+                  class="btn annotator__button annotator__button--toggle"
+                  :class="{'is-current': currentInteractionName === 'select'}"
+                  aria-labelledby="elementSelectLabel">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 10 17"
+                    style="width: 20px; height: 20px;">
+                    <defs>
+                      <clipPath id="selectIcon">
+                        <path d="M0 0h12v17H0z" />
+                      </clipPath>
+                    </defs>
+                    <g :clip-path="`url(#selectIcon)`">
+                      <path
+                        d="M0 0v17l4.849-4.973H12z"
+                        :fill="currentInteractionName === 'select' ? '#fff' : '#4d4d4d'" />
+                    </g>
+                  </svg>
+                </button>
+              </div>
+              <span
+                class="u-valign--middle u-ml-0_5"
+                id="elementSelectLabel">
+                {{ Translator.trans('select.or.edit') }}
+              </span>
+            </div>
+            <div>
+              <div class="annotator__button-wrapper is-last">
+                <button
+                  @click="setInteraction('draw')"
+                  class="btn annotator__button annotator__button--toggle"
+                  :class="{'is-current': currentInteractionName === 'draw'}"
+                  aria-labelledby="elementDrawLabel">
+                  <i class="fa fa-plus" />
+                </button>
+              </div>
+              <span
+                class="u-valign--middle u-ml-0_5"
+                id="elementDrawLabel">
+                {{ Translator.trans('element.add') }}
+              </span>
+            </div>
+            <div class="u-mt-2">
               <p
-                class="weight--bold">
-                {{ Translator.trans('tool.active') }}
+                class="weight--bold"
+                :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}">
+                {{ Translator.trans('element.selected') }}
+                <i
+                  :aria-label="Translator.trans('contextual.help')"
+                  v-tooltip="{
+                    content: Translator.trans('annotator.modify.explanation'),
+                    classes: 'u-z-super'
+                  }"
+                  class="fa fa-question-circle float--right u-mt-0_125" />
               </p>
               <div>
-                <div class="annotator__button-wrapper is-first">
-                  <button
-                    @click="setInteraction('select')"
-                    class="btn annotator__button annotator__button--toggle"
-                    :class="{'is-current': currentInteractionName === 'select'}"
-                    aria-labelledby="elementSelectLabel">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 10 17"
-                      style="width: 20px; height: 20px;">
-                      <defs>
-                        <clipPath id="selectIcon">
-                          <path d="M0 0h12v17H0z" />
-                        </clipPath>
-                      </defs>
-                      <g :clip-path="`url(#selectIcon)`">
-                        <path
-                          d="M0 0v17l4.849-4.973H12z"
-                          :fill="currentInteractionName === 'select' ? '#fff' : '#4d4d4d'" />
-                      </g>
-                    </svg>
-                  </button>
-                </div>
+                <button
+                  @click="deleteFeature(editingFeature)"
+                  class="annotator__button btn btn--warning btn--outline u-ml-0_25"
+                  :disabled="currentInteractionName !== 'select' || !editingFeature"
+                  aria-labelledby="elementDeleteLabel">
+                  <i class="fa fa-trash" />
+                </button>
                 <span
                   class="u-valign--middle u-ml-0_5"
-                  id="elementSelectLabel">
-                  {{ Translator.trans('select.or.edit') }}
+                  :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}"
+                  id="elementDeleteLabel">
+                  {{ Translator.trans('element.delete') }}
                 </span>
               </div>
               <div>
-                <div class="annotator__button-wrapper is-last">
-                  <button
-                    @click="setInteraction('draw')"
-                    class="btn annotator__button annotator__button--toggle"
-                    :class="{'is-current': currentInteractionName === 'draw'}"
-                    aria-labelledby="elementDrawLabel">
-                    <i class="fa fa-plus" />
-                  </button>
-                </div>
+                <button
+                  @click="$refs.labelModal.toggleModal(getFeatureLabel(editingFeature))"
+                  class="annotator__button btn btn--primary btn--outline u-ml-0_25"
+                  :disabled="currentInteractionName !== 'select' || !editingFeature"
+                  aria-labelledby="formatChangeLabel">
+                  <i class="fa fa-tag" />
+                </button>
                 <span
                   class="u-valign--middle u-ml-0_5"
-                  id="elementDrawLabel">
-                  {{ Translator.trans('element.add') }}
+                  :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}"
+                  id="formatChangeLabel">
+                  {{ Translator.trans('format.change') }}
                 </span>
               </div>
-              <div class="u-mt-2">
-                <p
-                  class="weight--bold"
-                  :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}">
-                  {{ Translator.trans('element.selected') }}
-                  <i
-                    :aria-label="Translator.trans('contextual.help')"
-                    v-tooltip="{
-                      content: Translator.trans('annotator.modify.explanation'),
-                      classes: 'u-z-super'
-                    }"
-                    class="fa fa-question-circle float--right u-mt-0_125" />
-                </p>
-                <div>
-                  <button
-                    @click="deleteFeature(editingFeature)"
-                    class="annotator__button btn btn--warning btn--outline u-ml-0_25"
-                    :disabled="currentInteractionName !== 'select' || !editingFeature"
-                    aria-labelledby="elementDeleteLabel">
-                    <i class="fa fa-trash" />
-                  </button>
-                  <span
-                    class="u-valign--middle u-ml-0_5"
-                    :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}"
-                    id="elementDeleteLabel">
-                    {{ Translator.trans('element.delete') }}
-                  </span>
-                </div>
-                <div>
-                  <button
-                    @click="$refs.labelModal.toggleModal(getFeatureLabel(editingFeature))"
-                    class="annotator__button btn btn--primary btn--outline u-ml-0_25"
-                    :disabled="currentInteractionName !== 'select' || !editingFeature"
-                    aria-labelledby="formatChangeLabel">
-                    <i class="fa fa-tag" />
-                  </button>
-                  <span
-                    class="u-valign--middle u-ml-0_5"
-                    :class="{'color--grey-light': currentInteractionName !== 'select' || !editingFeature}"
-                    id="formatChangeLabel">
-                    {{ Translator.trans('format.change') }}
-                  </span>
-                </div>
-              </div>
-              <div class="u-mt-2">
-                <p>{{ Translator.trans('pages.checked', { doneCount: donePagesCount, totalCount: documentLengthTotal }) }}</p>
-                <div>
-                  <dp-button
-                    :busy="isSaving"
-                    class="width-250 u-mb-0_25"
-                    :disabled="documentLengthTotal === 0"
-                    :text="buttonText"
-                    @click="save" />
-                  <dp-button
-                    class="width-250"
-                    color="secondary"
-                    :href="Routing.generate('DemosPlan_procedure_dashboard', { procedure: procedureId })"
-                    :text="Translator.trans('abort')" />
-                </div>
+            </div>
+            <div class="u-mt-2">
+              <p>{{ Translator.trans('pages.checked', { doneCount: donePagesCount, totalCount: documentLengthTotal }) }}</p>
+              <div>
+                <dp-button
+                  :busy="isSaving"
+                  class="width-250 u-mb-0_25"
+                  :disabled="documentLengthTotal === 0"
+                  :text="buttonText"
+                  @click="save" />
+                <dp-button
+                  class="width-250"
+                  color="secondary"
+                  :href="Routing.generate('DemosPlan_procedure_dashboard', { procedure: procedureId })"
+                  :text="Translator.trans('abort')" />
               </div>
             </div>
-          </template>
+          </div>
         </dp-sticky-element>
       </div>
     </template>

--- a/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
+++ b/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
@@ -7,30 +7,26 @@
   All rights reserved
 </license>
 
-<template>
-  <dp-modal
-    ref="labelModal"
-    content-classes="width-auto">
-    <template>
-      <h3>
-        {{ Translator.trans('format') }}
-      </h3>
-      <div class="flex space-inline-s">
-        <dp-select
-          v-model="selectedLabel"
-          classes="width-300"
-          name="labelSelect"
-          placeholder="-"
-          :options="labels" />
-        <button
-          @click="setLabel"
-          class="btn btn--primary">
-          {{ Translator.trans('accept') }}
-        </button>
-      </div>
-    </template>
-  </dp-modal>
-</template>
+<dp-modal
+  ref="labelModal"
+  content-classes="width-auto">
+    <h3>
+      {{ Translator.trans('format') }}
+    </h3>
+    <div class="flex space-inline-s">
+      <dp-select
+        v-model="selectedLabel"
+        classes="width-300"
+        name="labelSelect"
+        placeholder="-"
+        :options="labels" />
+      <button
+        @click="setLabel"
+        class="btn btn--primary">
+        {{ Translator.trans('accept') }}
+      </button>
+    </div>
+</dp-modal>
 
 <script>
 import { DpModal, DpSelect } from '@demos-europe/demosplan-ui'

--- a/client/js/components/procedure/splitStatement/SplitStatementView.vue
+++ b/client/js/components/procedure/splitStatement/SplitStatementView.vue
@@ -29,7 +29,7 @@
               <dp-flyout
                 ref="metadataFlyout"
                 :has-menu="false">
-                <template v-slot:trigger>
+                <template #trigger>
                   <span>
                     {{ Translator.trans('statement.information', { id: statementExternId }) }}
                     <i

--- a/client/js/components/statement/DpBoilerPlateModal.vue
+++ b/client/js/components/statement/DpBoilerPlateModal.vue
@@ -7,37 +7,33 @@
   All rights reserved
 </license>
 
-<template>
-  <dp-modal
-    ref="boilerPlateModal"
-    content-classes="u-1-of-2">
-    <template>
-      <h3>{{ Translator.trans('boilerplate.insert') }}</h3>
-      <dp-boiler-plate
-        :title="Translator.trans('boilerplates.category', { category: Translator.trans(boilerPlateType) })"
-        :boiler-plates="displayedBoilerplates"
-        ref="boilerplateDropdown"
-        group-values="boilerplates"
-        group-label="groupName"
-        :group-select="false"
-        @boilerplate-text-added="addBoilerplateText" />
-      <div class="flex flex-items-center u-mt">
-        <a
-          class="weight--bold font-size-small"
-          :href="Routing.generate('DemosPlan_procedure_boilerplate_list', { procedure: procedureId })">
-          {{ Translator.trans('boilerplates.edit') }} ({{ Translator.trans('view.leave.hint') }})
-        </a>
-        <dp-button-row
-          class="flex-item-end"
-          primary
-          :primary-text="Translator.trans('insert')"
-          secondary
-          @primary-action="insertBoilerPlate"
-          @secondary-action="resetAndClose" />
-      </div>
-    </template>
-  </dp-modal>
-</template>
+<dp-modal
+  ref="boilerPlateModal"
+  content-classes="u-1-of-2">
+<h3>{{ Translator.trans('boilerplate.insert') }}</h3>
+<dp-boiler-plate
+  :title="Translator.trans('boilerplates.category', { category: Translator.trans(boilerPlateType) })"
+  :boiler-plates="displayedBoilerplates"
+  ref="boilerplateDropdown"
+  group-values="boilerplates"
+  group-label="groupName"
+  :group-select="false"
+  @boilerplate-text-added="addBoilerplateText" />
+<div class="flex flex-items-center u-mt">
+  <a
+    class="weight--bold font-size-small"
+    :href="Routing.generate('DemosPlan_procedure_boilerplate_list', { procedure: procedureId })">
+    {{ Translator.trans('boilerplates.edit') }} ({{ Translator.trans('view.leave.hint') }})
+  </a>
+  <dp-button-row
+    class="flex-item-end"
+    primary
+    :primary-text="Translator.trans('insert')"
+    secondary
+    @primary-action="insertBoilerPlate"
+    @secondary-action="resetAndClose" />
+</div>
+</dp-modal>
 
 <script>
 import { DpButtonRow, DpModal } from '@demos-europe/demosplan-ui'

--- a/client/js/components/statement/assessmentTable/DpFilterModal.vue
+++ b/client/js/components/statement/assessmentTable/DpFilterModal.vue
@@ -45,169 +45,165 @@
       @modal:toggled="isOpen => resetUnsavedOptions(isOpen)">
       <dp-loading v-if="isLoading" />
 
-      <template v-else>
-        <!-- Show filters -->
-        <template v-if="false === saveFilterSetView">
-          <h2 class="u-mb">
-            {{ Translator.trans('filter.modalTitle') }}
-          </h2>
+      <!-- Show filters -->
+      <template v-else-if="false === saveFilterSetView">
+        <h2 class="u-mb">
+          {{ Translator.trans('filter.modalTitle') }}
+        </h2>
 
-          <!-- Select with saved filter sets -->
-          <div
-            v-if="userFilterSetSaveEnabled">
-            <dp-multiselect
-              v-model="selectedUserFilterSet"
-              id="userFilterSets"
-              :options="userFilterSets"
-              track-by="id"
-              :custom-label="nameFromAttributes">
-              <template v-slot:option="{ option }">
-                <a
-                  class="multiselect__option-extention"
-                  href="#"
-                  @click.prevent="deleteSavedFilterSet(option.id)">
-                  <i
-                    class="fa fa-trash"
-                    aria-hidden="true" />
-                </a>
-                {{ hasOwnProp(option, 'attributes') ? option.attributes.name : '' }}
-              </template>
-              <template v-slot:singleLabel="{ option }">
-                {{ hasOwnProp(option, 'attributes') ? option.attributes.name : '' }}
-              </template>
-            </dp-multiselect>
+        <!-- Select with saved filter sets -->
+        <div
+          v-if="userFilterSetSaveEnabled">
+          <dp-multiselect
+            v-model="selectedUserFilterSet"
+            id="userFilterSets"
+            :options="userFilterSets"
+            track-by="id"
+            :custom-label="nameFromAttributes">
+            <template v-slot:option="{ option }">
+              <a
+                class="multiselect__option-extention"
+                href="#"
+                @click.prevent="deleteSavedFilterSet(option.id)">
+                <i
+                  class="fa fa-trash"
+                  aria-hidden="true" />
+              </a>
+              {{ hasOwnProp(option, 'attributes') ? option.attributes.name : '' }}
+            </template>
+            <template v-slot:singleLabel="{ option }">
+              {{ hasOwnProp(option, 'attributes') ? option.attributes.name : '' }}
+            </template>
+          </dp-multiselect>
 
-            <div class="text--right u-mb u-pt-0_5">
-              <button
-                type="button"
-                class="btn btn--primary"
-                @click.prevent="loadUserFilterSet">
-                {{ Translator.trans('filter.saveFilterSet.load') }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Tabs with filters -->
-          <dp-tabs tab-size="medium">
-            <dp-tab
-              v-for="(filterGroup, index) in filterGroupsToBeDisplayed"
-              class="u-pt-0_5"
-              :key="index"
-              :id="filterGroup.label"
-              :label="Translator.trans(filterGroup.label)"
-              :suffix="createSelectedFiltersBadge(filterGroup)">
-              <dp-filter-modal-select-item
-                v-for="filterItem in filterByType(filterGroup.type)"
-                :key="filterItem.id"
-                :filter-item="filterItem"
-                :filter-group="filterGroup"
-                :applied-filter-options="appliedFilterOptions.filter(option => option.filterId === filterItem.id)"
-                @update-selected="updateSelectedOptions"
-                @updating-filters="disabledInteractions = true"
-                @updated-filters="disabledInteractions = false" />
-            </dp-tab>
-          </dp-tabs>
-
-          <!-- hidden selects so selected fields can be saved via form submit -->
-          <template>
-            <select
-              v-for="(option, optionKey) in allSelectedFilterOptionsWithFilterName"
-              :key="optionKey"
-              :id="option.name"
-              :name="option.name"
-              multiple
-              style="display: none">
-              <option
-                :key="optionKey"
-                :value="option.value"
-                selected>
-                {{ option.label }}
-              </option>
-            </select>
-          </template>
-
-          <!-- Checkbox to indicate user wants to save the current filter set -->
-          <template v-if="userFilterSetSaveEnabled">
-            <div class="layout__item u-1-of-3" /><!--
-         --><label
-            for="r_save_filter_set"
-            class="layout__item u-2-of-3 u-pt-0_5"
-            :class="{'color--grey': noFilterSelected}">
-            <input
-              id="r_save_filter_set"
-              type="checkbox"
-              name="r_save_filter_set"
-              :disabled="noFilterSelected"
-              data-cy="saveFilterSet"
-              v-model="saveFilterSet">
-            {{ Translator.trans('filter.saveFilterSet.label') }}
-          </label>
-          </template>
-
-          <!-- Button row -->
-          <div class="text--right space-inline-s">
-            <button
-              type="submit"
-              class="btn btn--primary"
-              :class="{'pointer-events-none':disabledInteractions}"
-              data-cy="submitOrNext"
-              @click.prevent="submitOrNext"
-              v-text="Translator.trans(saveFilterSet ? 'filter.saveFilterSet.next' : 'filter.apply')" />
+          <div class="text--right u-mb u-pt-0_5">
             <button
               type="button"
-              class="btn btn--secondary"
-              @click="reset"
-              v-text="Translator.trans('filter.reset')" />
+              class="btn btn--primary"
+              @click.prevent="loadUserFilterSet">
+              {{ Translator.trans('filter.saveFilterSet.load') }}
+            </button>
           </div>
-        </template>
+        </div>
 
-        <!-- Show UI to save filter set -->
-        <template v-else>
-          <h2>{{ Translator.trans('filter.saveFilterSet.title') }}</h2>
-
-          <label
-            for="r_save_filter_set_name"
-            class="u-pt-0_5">
-            {{ Translator.trans('filter.saveFilterSet.label') }}
-            <input
-              class="layout__item u-mt-0_5"
-              type="text"
-              id="r_save_filter_set_name"
-              name="r_save_filter_set_name"
-              data-cy="filterSetName"
-              :value="filterSetName">
-          </label>
-
-          <div
-            class="visuallyhidden"
+        <!-- Tabs with filters -->
+        <dp-tabs tab-size="medium">
+          <dp-tab
             v-for="(filterGroup, index) in filterGroupsToBeDisplayed"
-            :key="index">
+            class="u-pt-0_5"
+            :key="index"
+            :id="filterGroup.label"
+            :label="Translator.trans(filterGroup.label)"
+            :suffix="createSelectedFiltersBadge(filterGroup)">
             <dp-filter-modal-select-item
               v-for="filterItem in filterByType(filterGroup.type)"
               :key="filterItem.id"
               :filter-item="filterItem"
               :filter-group="filterGroup"
-              hidden />
-          </div>
+              :applied-filter-options="appliedFilterOptions.filter(option => option.filterId === filterItem.id)"
+              @update-selected="updateSelectedOptions"
+              @updating-filters="disabledInteractions = true"
+              @updated-filters="disabledInteractions = false" />
+          </dp-tab>
+        </dp-tabs>
 
-          <!-- Button row -->
-          <div class="text--right space-inline-s">
-            <button
-              class="btn btn--primary"
-              :class="{'pointer-events-none': disabledInteractions}"
-              type="submit"
-              data-cy="submitWithSave"
-              @click.stop="submitWithSave">
-              {{ Translator.trans('filter.saveFilterSet.submit') }}
-            </button>
-            <button
-              type="button"
-              class="btn btn--secondary"
-              @click="back">
-              {{ Translator.trans('filter.saveFilterSet.back') }}
-            </button>
-          </div>
+        <!-- hidden selects so selected fields can be saved via form submit -->
+        <select
+          v-for="(option, optionKey) in allSelectedFilterOptionsWithFilterName"
+          :key="optionKey"
+          :id="option.name"
+          :name="option.name"
+          multiple
+          style="display: none">
+          <option
+            :key="optionKey"
+            :value="option.value"
+            selected>
+            {{ option.label }}
+          </option>
+        </select>
+
+        <!-- Checkbox to indicate user wants to save the current filter set -->
+        <template v-if="userFilterSetSaveEnabled">
+          <div class="layout__item u-1-of-3" /><!--
+       --><label
+          for="r_save_filter_set"
+          class="layout__item u-2-of-3 u-pt-0_5"
+          :class="{'color--grey': noFilterSelected}">
+          <input
+            id="r_save_filter_set"
+            type="checkbox"
+            name="r_save_filter_set"
+            :disabled="noFilterSelected"
+            data-cy="saveFilterSet"
+            v-model="saveFilterSet">
+          {{ Translator.trans('filter.saveFilterSet.label') }}
+        </label>
         </template>
+
+        <!-- Button row -->
+        <div class="text--right space-inline-s">
+          <button
+            type="submit"
+            class="btn btn--primary"
+            :class="{'pointer-events-none':disabledInteractions}"
+            data-cy="submitOrNext"
+            @click.prevent="submitOrNext"
+            v-text="Translator.trans(saveFilterSet ? 'filter.saveFilterSet.next' : 'filter.apply')" />
+          <button
+            type="button"
+            class="btn btn--secondary"
+            @click="reset"
+            v-text="Translator.trans('filter.reset')" />
+        </div>
+      </template>
+
+      <!-- Show UI to save filter set -->
+      <template v-else>
+        <h2>{{ Translator.trans('filter.saveFilterSet.title') }}</h2>
+
+        <label
+          for="r_save_filter_set_name"
+          class="u-pt-0_5">
+          {{ Translator.trans('filter.saveFilterSet.label') }}
+          <input
+            class="layout__item u-mt-0_5"
+            type="text"
+            id="r_save_filter_set_name"
+            name="r_save_filter_set_name"
+            data-cy="filterSetName"
+            :value="filterSetName">
+        </label>
+
+        <div
+          class="visuallyhidden"
+          v-for="(filterGroup, index) in filterGroupsToBeDisplayed"
+          :key="index">
+          <dp-filter-modal-select-item
+            v-for="filterItem in filterByType(filterGroup.type)"
+            :key="filterItem.id"
+            :filter-item="filterItem"
+            :filter-group="filterGroup"
+            hidden />
+        </div>
+
+        <!-- Button row -->
+        <div class="text--right space-inline-s">
+          <button
+            class="btn btn--primary"
+            :class="{'pointer-events-none': disabledInteractions}"
+            type="submit"
+            data-cy="submitWithSave"
+            @click.stop="submitWithSave">
+            {{ Translator.trans('filter.saveFilterSet.submit') }}
+          </button>
+          <button
+            type="button"
+            class="btn btn--secondary"
+            @click="back">
+            {{ Translator.trans('filter.saveFilterSet.back') }}
+          </button>
+        </div>
       </template>
     </dp-modal>
   </div>

--- a/client/js/components/statement/assessmentTable/DpMapModal.vue
+++ b/client/js/components/statement/assessmentTable/DpMapModal.vue
@@ -7,34 +7,28 @@
   All rights reserved
 </license>
 
-<template>
-  <portal to="vueModals">
-    <dp-modal
-      ref="mapModal"
-      content-classes="u-1-of-2 u-pb"
-      @modal:toggled="(open) => {isModalOpen = open}">
-      <template>
-        <dp-ol-map
-          :class="prefixClass('u-mv-0_5')"
-          v-if="isModalOpen"
-          :procedure-id="procedureId"
-          :map-options-route="mapOptionsRoute"
-          ref="map"
-          :options="{
-            autoSuggest: false,
-            scaleSelect: false,
-            procedureExtent: false,
-          }">
-          <template>
-            <dp-ol-map-layer-vector
-              zoom-to-drawing
-              :features="drawing" />
-          </template>
-        </dp-ol-map>
-      </template>
-    </dp-modal>
-  </portal>
-</template>
+<portal to="vueModals">
+  <dp-modal
+    ref="mapModal"
+    content-classes="u-1-of-2 u-pb"
+    @modal:toggled="(open) => {isModalOpen = open}">
+    <dp-ol-map
+      :class="prefixClass('u-mv-0_5')"
+      v-if="isModalOpen"
+      :procedure-id="procedureId"
+      :map-options-route="mapOptionsRoute"
+      ref="map"
+      :options="{
+        autoSuggest: false,
+        scaleSelect: false,
+        procedureExtent: false,
+      }">
+      <dp-ol-map-layer-vector
+        zoom-to-drawing
+        :features="drawing" />
+    </dp-ol-map>
+  </dp-modal>
+</portal>
 
 <script>
 import { DpModal, prefixClassMixin } from '@demos-europe/demosplan-ui'

--- a/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
@@ -7,237 +7,233 @@
   All rights reserved
 </license>
 
-<template>
-  <dp-table-card
-    class="c-public-statement"
-    :open="isOpen">
-    <template v-slot:header="">
-      <div
-        class="c-public-statement__header"
-        :class="{'border--bottom': isOpen}">
-        <div class="layout__item u-11-of-12 u-1-of-4-desk-up u-valign--sub u-pl-0">
-          <div class="display--inline-block u-mr-0_5">
-            <input
-              v-if="showCheckbox"
-              type="checkbox"
-              :id="number"
-              name="item_check[]"
-              :value="id">
-            <label
-              :for="number"
-              data-cy="statementNumber"
-              class="display--inline u-mb-0 u-ml-0_25">{{ number || '' }}</label>
-          </div><!--
-       --><div class="display--inline-block">
-            <span
-              class="u-mr-0_25 c-public-statement__tooltip"
-              v-tooltip="renderTooltipContent(tooltipContent)">#</span>
-            <span>{{ headerContent }}</span>
+<dp-table-card
+  class="c-public-statement"
+  :open="isOpen">
+  <template v-slot:header="">
+    <div
+      class="c-public-statement__header"
+      :class="{'border--bottom': isOpen}">
+      <div class="layout__item u-11-of-12 u-1-of-4-desk-up u-valign--sub u-pl-0">
+        <div class="display--inline-block u-mr-0_5">
+          <input
+            v-if="showCheckbox"
+            type="checkbox"
+            :id="number"
+            name="item_check[]"
+            :value="id">
+          <label
+            :for="number"
+            data-cy="statementNumber"
+            class="display--inline u-mb-0 u-ml-0_25">{{ number || '' }}</label>
+        </div><!--
+     --><div class="display--inline-block">
+          <span
+            class="u-mr-0_25 c-public-statement__tooltip"
+            v-tooltip="renderTooltipContent(tooltipContent)">#</span>
+          <span>{{ headerContent }}</span>
+          <button
+            v-if="unsavedChangesItem"
+            v-bind="unsavedChangesItem.attrs"
+            :key="unsavedChangesItem.name"
+            class="btn--blank o-link--default"
+            @click.prevent.stop="(e) => typeof unsavedChangesItem.callback === 'function' ? unsavedChangesItem.callback(e, _self) : false">
+            <i
+              class="fa fa-exclamation-circle color-ui-highlight u-mr-0_5"
+              v-tooltip="Translator.trans('unsaved.changes')" />
+          </button>
+        </div>
+      </div><!--
+   --><div class="layout__item u-1-of-12 u-3-of-4-desk-up u-pl-0 text--right">
+        <div class="show-desk-up-i">
+          <div
+            v-for="item in menuItems"
+            :key="item.id"
+            class="display--inline u-mr-0_5">
             <button
-              v-if="unsavedChangesItem"
-              v-bind="unsavedChangesItem.attrs"
-              :key="unsavedChangesItem.name"
-              class="btn--blank o-link--default"
-              @click.prevent.stop="(e) => typeof unsavedChangesItem.callback === 'function' ? unsavedChangesItem.callback(e, _self) : false">
-              <i
-                class="fa fa-exclamation-circle color-ui-highlight u-mr-0_5"
-                v-tooltip="Translator.trans('unsaved.changes')" />
+              v-if="item.type === 'button'"
+              v-bind="item.attrs"
+              class="btn--blank o-link--default u-valign--middle"
+              @click="(e) => typeof item.callback === 'function' ? item.callback(e, _self) : false">
+              {{ item.text }}
             </button>
+            <a
+              v-else-if="item.type === 'link'"
+              v-bind="item.attrs"
+              class="o-link--default u-valign--middle"
+              :href="item.url">
+              {{ item.text }}
+            </a>
+            <h4
+              v-else-if="item.type === 'heading'"
+              v-bind="item.attrs"
+              class="color--grey u-mb-0 u-mt-0_25 font-size-small u-valign--middle">
+              {{ item.text }}
+            </h4>
           </div>
         </div><!--
-     --><div class="layout__item u-1-of-12 u-3-of-4-desk-up u-pl-0 text--right">
-          <div class="show-desk-up-i">
+     --><div class="hide-desk-up-i">
+          <dp-flyout>
             <div
               v-for="item in menuItems"
-              :key="item.id"
-              class="display--inline u-mr-0_5">
-              <button
-                v-if="item.type === 'button'"
-                v-bind="item.attrs"
-                class="btn--blank o-link--default u-valign--middle"
-                @click="(e) => typeof item.callback === 'function' ? item.callback(e, _self) : false">
-                {{ item.text }}
-              </button>
+              :key="item.id">
               <a
-                v-else-if="item.type === 'link'"
+                v-if="item.type === 'link'"
                 v-bind="item.attrs"
-                class="o-link--default u-valign--middle"
+                class="o-link--default"
                 :href="item.url">
                 {{ item.text }}
               </a>
-              <h4
-                v-else-if="item.type === 'heading'"
+              <button
+                v-if="item.type === 'button'"
                 v-bind="item.attrs"
-                class="color--grey u-mb-0 u-mt-0_25 font-size-small u-valign--middle">
+                class="btn--blank o-link--default"
+                @click="(e) => typeof item.callback === 'function' ? item.callback(e, _self) : false">
+                {{ item.text }}
+              </button>
+              <h4
+                v-if="item.type === 'heading'"
+                v-bind="item.attrs"
+                class="color--grey u-mb-0 u-mt-0_25 font-size-small">
                 {{ item.text }}
               </h4>
             </div>
-          </div><!--
-       --><div class="hide-desk-up-i">
-            <dp-flyout>
-              <div
-                v-for="item in menuItems"
-                :key="item.id">
-                <a
-                  v-if="item.type === 'link'"
-                  v-bind="item.attrs"
-                  class="o-link--default"
-                  :href="item.url">
-                  {{ item.text }}
-                </a>
-                <button
-                  v-if="item.type === 'button'"
-                  v-bind="item.attrs"
-                  class="btn--blank o-link--default"
-                  @click="(e) => typeof item.callback === 'function' ? item.callback(e, _self) : false">
-                  {{ item.text }}
-                </button>
-                <h4
-                  v-if="item.type === 'heading'"
-                  v-bind="item.attrs"
-                  class="color--grey u-mb-0 u-mt-0_25 font-size-small">
-                  {{ item.text }}
-                </h4>
-              </div>
-            </dp-flyout>
-          </div><!--
-       --><div class="display--inline">
-            <button
-              @click="isOpen = false === isOpen"
-              type="button"
-              class="btn--blank o-link--default u-pr-0_25 c-public-statement__toggle">
-              <i
-                class="fa"
-                :class="isOpen ? 'fa-angle-up': 'fa-angle-down'" />
-            </button>
-          </div>
+          </dp-flyout>
+        </div><!--
+     --><div class="display--inline">
+          <button
+            @click="isOpen = false === isOpen"
+            type="button"
+            class="btn--blank o-link--default u-pr-0_25 c-public-statement__toggle">
+            <i
+              class="fa"
+              :class="isOpen ? 'fa-angle-up': 'fa-angle-down'" />
+          </button>
         </div>
       </div>
-    </template>
+    </div>
+  </template>
 
-    <template>
-      <div class="u-1-of-2 u-1-of-1-palm c-public-statement__content-container">
-        <div class="u-1-of-1 c-public-statement__content-item">
-          <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-            {{ Translator.trans('organisation') }}
-          </div><!--
-       --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-            {{ organisation || '-' }}
-          </div>
-        </div><!--
-     --><div class="u-1-of-1 c-public-statement__content-item">
-          <div
-              v-if="showAuthor"
-              class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('authored.by') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ authoredBy }}
-        </div>
+<div class="u-1-of-2 u-1-of-1-palm c-public-statement__content-container">
+  <div class="u-1-of-1 c-public-statement__content-item">
+    <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+      {{ Translator.trans('organisation') }}
+    </div><!--
+  --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+      {{ organisation || '-' }}
+    </div>
+  </div><!--
+ --><div class="u-1-of-1 c-public-statement__content-item">
+    <div
+      v-if="showAuthor"
+      class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('authored.by') }}
       </div><!--
-   --><div class="u-1-of-1 c-public-statement__content-item">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('department') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ department || '-' }}
-        </div>
-      </div><!--
-   --><div class="u-1-of-1 c-public-statement__content-item">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('phase') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ phase || '-' }}
-        </div>
-      </div><!--
-   --><div class="u-1-of-1 c-public-statement__content-item">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('document') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ document }}
-        </div>
-      </div><!--
-   --><div
-        v-if="hasPermission('feature_documents_new_statement')"
-        class="u-1-of-1 c-public-statement__content-item">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('paragraph') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ paragraph }}
-        </div>
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ authoredBy }}
       </div>
+    </div><!--
+ --><div class="u-1-of-1 c-public-statement__content-item">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('department') }}
       </div><!--
- --><div class="u-1-of-2 u-1-of-1-palm c-public-statement__content-container">
-      <div class="u-1-of-1 c-public-statement__content-item">
-        <template v-if="hasPermission('field_statement_location')">
-          <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-            {{ Translator.trans('location') }}
-          </div>
-          <div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-            <button
-              v-if="Object.keys(polygon).length > 0"
-              class="btn--blank o-link--default"
-              type="button"
-              @click.prevent.stop="$emit('open-map-modal', polygon)"
-              :aria-label="`${Translator.trans('statement.map.drawing.show')} ${Translator.trans('statement')}: ${number}`">
-              {{ Translator.trans('see') }}
-            </button>
-            <span v-else>
-              -
-            </span>
-          </div>
-        </template>
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ department || '-' }}
+      </div>
+    </div><!--
+ --><div class="u-1-of-1 c-public-statement__content-item">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('phase') }}
       </div><!--
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ phase || '-' }}
+      </div>
+    </div><!--
+ --><div class="u-1-of-1 c-public-statement__content-item">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('document') }}
+      </div><!--
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ document }}
+      </div>
+    </div><!--
+ --><div
+      v-if="hasPermission('feature_documents_new_statement')"
+      class="u-1-of-1 c-public-statement__content-item">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('paragraph') }}
+      </div><!--
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ paragraph }}
+      </div>
+    </div>
+    </div><!--
+--><div class="u-1-of-2 u-1-of-1-palm c-public-statement__content-container">
+    <div class="u-1-of-1 c-public-statement__content-item">
+      <template v-if="hasPermission('field_statement_location')">
+        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+          {{ Translator.trans('location') }}
+        </div>
+        <div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+          <button
+            v-if="Object.keys(polygon).length > 0"
+            class="btn--blank o-link--default"
+            type="button"
+            @click.prevent.stop="$emit('open-map-modal', polygon)"
+            :aria-label="`${Translator.trans('statement.map.drawing.show')} ${Translator.trans('statement')}: ${number}`">
+            {{ Translator.trans('see') }}
+          </button>
+          <span v-else>
+            -
+          </span>
+        </div>
+      </template>
+    </div><!--
+ --><div
+      class="u-1-of-1 c-public-statement__content-item"
+      v-if="priorityAreas !== null">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('potential.areas') }}
+      </div><!--
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+        {{ renderPriorityAreas(priorityAreas) }}
+      </div>
+    </div><!--
    --><div
         class="u-1-of-1 c-public-statement__content-item"
-        v-if="priorityAreas !== null">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('potential.areas') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-          {{ renderPriorityAreas(priorityAreas) }}
-        </div>
+        v-if="county !== null">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('county') }}
       </div><!--
-     --><div
-          class="u-1-of-1 c-public-statement__content-item"
-          v-if="county !== null">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('county') }}
-        </div><!--
-     --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
-        {{ county }}
-        </div>
+   --><div class="display--inline-block u-2-of-3 u-1-of-1-palm">
+      {{ county }}
+      </div>
+    </div><!--
+ --><div class="u-1-of-1 c-public-statement__content-item">
+      <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
+        {{ Translator.trans('attachments') }}
       </div><!--
-   --><div class="u-1-of-1 c-public-statement__content-item">
-        <div class="display--inline-block u-1-of-3 u-1-of-1-palm u-pr c-public-statement__label">
-          {{ Translator.trans('attachments') }}
-        </div><!--
-     --><div
-          class="display--inline-block u-2-of-3 u-1-of-1-palm overflow-word-break"
-          v-cleanhtml="renderAttachments(attachments)" />
-        </div>
+   --><div
+        class="display--inline-block u-2-of-3 u-1-of-1-palm overflow-word-break"
+        v-cleanhtml="renderAttachments(attachments)" />
       </div>
-      <dp-inline-notification
-        v-if="rejectedReason"
-        class="u-mt"
-        type="info">
-        <div>{{ Translator.trans('statement.rejected.with.reason') }}:</div>
-        <div>{{ rejectedReason }}</div>
-      </dp-inline-notification>
-      <div class="u-1-of-1 u-mt">
-        <div class="c-public-statement__label">
-          {{ Translator.trans('statementtext') }}
-        </div>
-        <div
-          class="overflow-word-break"
-          v-cleanhtml="text" />
+    </div>
+    <dp-inline-notification
+      v-if="rejectedReason"
+      class="u-mt"
+      type="info">
+      <div>{{ Translator.trans('statement.rejected.with.reason') }}:</div>
+      <div>{{ rejectedReason }}</div>
+    </dp-inline-notification>
+    <div class="u-1-of-1 u-mt">
+      <div class="c-public-statement__label">
+        {{ Translator.trans('statementtext') }}
       </div>
-    </template>
-  </dp-table-card>
-</template>
+      <div
+        class="overflow-word-break"
+        v-cleanhtml="text" />
+    </div>
+</dp-table-card>
 
 <script>
 import { CleanHtml, DpFlyout, DpInlineNotification, DpTableCard } from '@demos-europe/demosplan-ui'

--- a/client/js/components/statement/segments/DpRecommendationModal.vue
+++ b/client/js/components/statement/segments/DpRecommendationModal.vue
@@ -7,62 +7,58 @@
   All rights reserved
 </license>
 
-<template>
-  <dp-modal
-    ref="recommendationModal"
-    content-classes="u-2-of-3">
-    <template>
-      <h3>{{ Translator.trans('segment.recommendation.insert.similar') }}</h3>
-      <div class="layout u-mb">
-        <div class="layout__item u-1-of-3">
-          <span class="display--block weight--bold">
-            {{ Translator.trans('segment.tags') }}
+<dp-modal
+  ref="recommendationModal"
+  content-classes="u-2-of-3">
+    <h3>{{ Translator.trans('segment.recommendation.insert.similar') }}</h3>
+    <div class="layout u-mb">
+      <div class="layout__item u-1-of-3">
+        <span class="display--block weight--bold">
+          {{ Translator.trans('segment.tags') }}
+        </span>
+        <div class="bg-color--grey-light-2 u-p-0_25">
+          <span
+            :key="id"
+            v-for="(id, idx) in tagIds">
+            {{ getTagTitle(id, idx) }}
           </span>
-          <div class="bg-color--grey-light-2 u-p-0_25">
-            <span
-              :key="id"
-              v-for="(id, idx) in tagIds">
-              {{ getTagTitle(id, idx) }}
-            </span>
-          </div>
-        </div><!--
-     --><div class="layout__item u-2-of-3">
-        <dp-label
-          :text="Translator.trans('search.text')"
-          for="searchField" />
-        <dp-search-field
-          @search="setSearchTerm"
-          @reset="setSearchTerm('')"
-          class="width--100p"
-          :placeholder="Translator.trans('search')" />
-      </div>
-      </div>
-
-      <dp-loading v-if="isLoading" />
-
-      <template v-else>
-        <ul
-          v-if="currentRecommendations.length > 0"
-          class="o-list space-stack-m u-pt-0_5 border--top height-50vh overflow-auto">
-          <dp-insertable-recommendation
-            class="o-list__item"
-            :from-other-procedure="recommendation.fromOtherProcedure"
-            :key="recommendation.id"
-            :procedure-name="recommendation.procedureName"
-            v-for="recommendation in currentRecommendations"
-            :search-term="searchTerm"
-            @insert-recommendation="toggleInsert(recommendation.attributes.recommendation)"
-            :recommendation="recommendation.attributes.recommendation" />
-        </ul>
-        <div
-          v-if="currentRecommendations.length === 0"
-          class="u-pt-0_5 border--top">
-          {{ Translator.trans('statement.list.empty') }}
         </div>
-      </template>
+      </div><!--
+   --><div class="layout__item u-2-of-3">
+      <dp-label
+        :text="Translator.trans('search.text')"
+        for="searchField" />
+      <dp-search-field
+        @search="setSearchTerm"
+        @reset="setSearchTerm('')"
+        class="width--100p"
+        :placeholder="Translator.trans('search')" />
+    </div>
+    </div>
+
+    <dp-loading v-if="isLoading" />
+
+    <template v-else>
+      <ul
+        v-if="currentRecommendations.length > 0"
+        class="o-list space-stack-m u-pt-0_5 border--top height-50vh overflow-auto">
+        <dp-insertable-recommendation
+          class="o-list__item"
+          :from-other-procedure="recommendation.fromOtherProcedure"
+          :key="recommendation.id"
+          :procedure-name="recommendation.procedureName"
+          v-for="recommendation in currentRecommendations"
+          :search-term="searchTerm"
+          @insert-recommendation="toggleInsert(recommendation.attributes.recommendation)"
+          :recommendation="recommendation.attributes.recommendation" />
+      </ul>
+      <div
+        v-else-if="currentRecommendations.length === 0"
+        class="u-pt-0_5 border--top">
+        {{ Translator.trans('statement.list.empty') }}
+      </div>
     </template>
-  </dp-modal>
-</template>
+</dp-modal>
 
 <script>
 import { dataTableSearch, dpApi, DpLabel, DpLoading, DpModal, DpSearchField } from '@demos-europe/demosplan-ui'

--- a/client/js/components/statement/statement/DpVersionHistory.vue
+++ b/client/js/components/statement/statement/DpVersionHistory.vue
@@ -25,7 +25,7 @@
       class="u-mt-1_5 u-ml" />
 
     <div
-      v-else-if="false === isLoading"
+      v-else
       class="c-slidebar__content overflow-y-auto"
       :class="{'u-mr': days.length === 0}"
       style="height: 88vh;">

--- a/client/js/components/statement/statement/DpVersionHistory.vue
+++ b/client/js/components/statement/statement/DpVersionHistory.vue
@@ -15,55 +15,53 @@
 
 <template>
   <div>
-    <template>
-      <h2 class="u-mb-0_75">
-        {{ versionHistoryHeading }}
-      </h2>
+    <h2 class="u-mb-0_75">
+      {{ versionHistoryHeading }}
+    </h2>
 
-      <dp-loading
-        v-if="isLoading"
-        data-cy="loadingSpinner"
-        class="u-mt-1_5 u-ml" />
+    <dp-loading
+      v-if="isLoading"
+      data-cy="loadingSpinner"
+      class="u-mt-1_5 u-ml" />
 
-      <div
-        v-else-if="false === isLoading"
-        class="c-slidebar__content overflow-y-auto"
-        :class="{'u-mr': days.length === 0}"
-        style="height: 88vh;">
-        <table class="u-mb">
-          <tr class="hide-visually">
-            <th>
-              {{ Translator.trans('history') }}
-            </th>
-          </tr>
-          <tr>
-            <!-- if history is empty -->
-            <td
-              v-if="days === null || typeof days === 'undefined' || days.length === 0"
-              data-cy="noEntries"
-              colspan="4"
-              class="u-mr">
-              <dp-inline-notification
-                type="info"
-                :message="Translator.trans('explanation.noentries')"
-              />
-            </td>
-          </tr>
-          <!-- if there are history items -->
-          <!-- for each day -->
-          <template v-if="days.length">
-            <dp-version-history-day
-              v-for="(day, idx) in days"
-              :procedure-id="procedureId"
-              :key="idx"
-              :date="day.attributes.day"
-              :day="day"
-              :all-times="times"
-              :entity="entity" />
-          </template>
-        </table>
-      </div>
-    </template>
+    <div
+      v-else-if="false === isLoading"
+      class="c-slidebar__content overflow-y-auto"
+      :class="{'u-mr': days.length === 0}"
+      style="height: 88vh;">
+      <table class="u-mb">
+        <tr class="hide-visually">
+          <th>
+            {{ Translator.trans('history') }}
+          </th>
+        </tr>
+        <tr>
+          <!-- if history is empty -->
+          <td
+            v-if="days === null || typeof days === 'undefined' || days.length === 0"
+            data-cy="noEntries"
+            colspan="4"
+            class="u-mr">
+            <dp-inline-notification
+              type="info"
+              :message="Translator.trans('explanation.noentries')"
+            />
+          </td>
+        </tr>
+        <!-- if there are history items -->
+        <!-- for each day -->
+        <template v-if="days.length">
+          <dp-version-history-day
+            v-for="(day, idx) in days"
+            :procedure-id="procedureId"
+            :key="idx"
+            :date="day.attributes.day"
+            :day="day"
+            :all-times="times"
+            :entity="entity" />
+        </template>
+      </table>
+    </div>
   </div>
 </template>
 

--- a/client/js/components/statement/statement/DpVersionHistoryDay.vue
+++ b/client/js/components/statement/statement/DpVersionHistoryDay.vue
@@ -43,15 +43,14 @@
         style="width: 5%" />
     </tr>
 
-    <template>
-      <dp-version-history-item
-        v-for="(time, idx) in filteredItems"
-        :key="idx"
-        :procedure-id="procedureId"
-        :day="day"
-        :time="time.attributes"
-        :entity="entity" />
-    </template>
+
+    <dp-version-history-item
+      v-for="(time, idx) in filteredItems"
+      :key="idx"
+      :procedure-id="procedureId"
+      :day="day"
+      :time="time.attributes"
+      :entity="entity" />
   </tbody>
 </template>
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32012#761740

### Description: 

- <template> tags with no special directives are now treated as plain elements and will result in a native <template>
 element instead of rendering its inner content
- remove <template> if no directives and not necessary any more
- in one commit there was a problem, that the template looks unnecessary because the slot name spelling, which shall reference to the slot of the template, was deprecated
- instead of `slot="name"` use `v-slot:name` or the more shortened way `#name` 

- ***this PR will be merged into the integration branch `f_vue3_compat_mode_setup`***

### Linked PRs

- https://github.com/demos-europe/demosplan-core/pull/1240

### PR Checklist

- [x] Link all relevant tickets
