### PR TITLE
Feat(refs:32012): Remove prop and native modifier - migration to vue3

### DIFF
--- a/client/js/components/statement/assessmentTable/ConsolidateModal.vue
+++ b/client/js/components/statement/assessmentTable/ConsolidateModal.vue
@@ -59,7 +59,7 @@
           <div class="u-ml">
             <p
               class="u-mb-0"
-              :inner-html.prop="Translator.trans('warning.consolidate.only.clusters.selected')" />
+              :inner-html="Translator.trans('warning.consolidate.only.clusters.selected')" />
           </div>
         </div>
         <!-- display if the user has selected group statements -->
@@ -72,7 +72,7 @@
           <div class="u-ml">
             <p
               class="u-mb-0"
-              :inner-html.prop="Translator.trans('warning.statement.cluster.resolve')" />
+              :inner-html="Translator.trans('warning.statement.cluster.resolve')" />
           </div>
         </div>
       </fieldset>

--- a/client/js/components/statement/assessmentTable/CopyStatementModal.vue
+++ b/client/js/components/statement/assessmentTable/CopyStatementModal.vue
@@ -32,7 +32,7 @@
             <div class="u-ml">
               <p
                 class="u-mb-0"
-                :inner-html.prop="Translator.trans('statement.copy.to.procedure.fragments.not.claimed.warning')" />
+                :inner-html="Translator.trans('statement.copy.to.procedure.fragments.not.claimed.warning')" />
             </div>
           </div>
 

--- a/client/js/components/statement/assessmentTable/DpMoveStatementModal.vue
+++ b/client/js/components/statement/assessmentTable/DpMoveStatementModal.vue
@@ -29,11 +29,11 @@
             <div class="u-ml">
               <p
                 :class="{'u-mb-0': false === hasPermission('feature_statement_move_to_foreign_procedure')}"
-                :inner-html.prop="Translator.trans('statement.moveto.procedure.description')" />
+                :inner-html="Translator.trans('statement.moveto.procedure.description')" />
               <p
                 class="u-mb-0"
                 v-if="hasPermission('feature_statement_move_to_foreign_procedure')"
-                :inner-html.prop="Translator.trans('statement.moveto.procedure.description.foreignProcedures')" />
+                :inner-html="Translator.trans('statement.moveto.procedure.description.foreignProcedures')" />
             </div>
           </div>
 
@@ -45,7 +45,7 @@
             <div class="u-ml">
               <p
                 class="u-mb-0"
-                :inner-html.prop="Translator.trans('statement.moveto.procedure.fragments.not.claimed.warning')" />
+                :inner-html="Translator.trans('statement.moveto.procedure.fragments.not.claimed.warning')" />
             </div>
           </div>
 

--- a/client/js/components/statement/assessmentTable/TiptapEditText.vue
+++ b/client/js/components/statement/assessmentTable/TiptapEditText.vue
@@ -85,7 +85,7 @@
           :element="editLabel"
           :is-shortened="isShortened"
           @heightLimit:toggle="update"
-          @click.native="toggleEditMode" />
+          @click="toggleEditMode" />
         <button
           type="button"
           :disabled="!editable"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32012


### Description: 

- vue3 removed the modifier prop and native
- these can be removed without any problem
***- this PR will be merged into the integration branch `f_vue3_compat_mode_setup`***

### PR Checklist

- [x] Link all relevant tickets
