### PR TITLE
fix(refs T32450): make radio buttons reactive when initial data is set

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -547,7 +547,7 @@ export default {
       if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0) {
         Vue.set(this.values, 'submitter', {})
         for (const [key, value] of Object.entries(submitterProperties)) {
-          Vue.set(this.values.submitter, key, value)
+          Vue.set(this.values.submitter, key === 'toeb' ? 'institution' : key, value)
         }
       }
     },


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32450

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- We are receiving a wrong key from data
- To make the radio buttons toggle the rendering of the institution form fields it was necessary to check for the key `toeb`
- Data send us the key `toeb` but this is outdated. The new term is `institution` hence the key must be checked and adjusted in case it is `toeb`
- This is needed to make the usually read-only props reactive to determine if the statement belongs to an institution or not

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- finish the import of a pdf via the overview page
- confirm the additional form fields are displayed when selected institution (radio button)

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
