### PR TITLE
bug(refs T32505): center map

### DIFF
--- a/client/js/components/map/map/DpOlMapDrawFeature.vue
+++ b/client/js/components/map/map/DpOlMapDrawFeature.vue
@@ -307,6 +307,10 @@ export default {
       }
     },
 
+    getExtent () {
+      return this.drawingExtent
+    },
+
     toggle () {
       if (this.currentlyActive === false) {
         this.$root.$emit('setDrawingActive', this.name)

--- a/client/js/components/map/map/DpOlMapEditFeature.vue
+++ b/client/js/components/map/map/DpOlMapEditFeature.vue
@@ -130,7 +130,10 @@ export default {
 
   data () {
     return {
-      selectInteraction: new Select({ wrapX: false }),
+      selectInteraction: new Select({
+        hitTolerance: 10,
+        wrapX: false
+      }),
       modifyInteraction: null,
       currentlyActive: this.initActive,
       selectedFeatureId: [],

--- a/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
@@ -97,6 +97,7 @@ import { DpButtonRow } from '@demos-europe/demosplan-ui'
 import DpOlMap from '@DpJs/components/map/map/DpOlMap'
 import DpOlMapDrawFeature from '@DpJs/components/map/map/DpOlMapDrawFeature'
 import DpOlMapEditFeature from '@DpJs/components/map/map/DpOlMapEditFeature'
+import { extend } from 'ol/extent'
 
 export default {
   name: 'SegmentLocationMap',
@@ -182,6 +183,9 @@ export default {
     segmentId (newVal) {
       if (newVal) {
         this.setInitDrawings()
+        this.$nextTick(() => {
+          this.setCenterAndExtent()
+        })
       }
     }
   },
@@ -231,6 +235,23 @@ export default {
         .catch(() => {
           dplan.notify.error(Translator.trans('error.changes.not.saved'))
         })
+    },
+
+    /*
+     * Center the map around all drawings and zoom to the combined extent.
+     */
+    setCenterAndExtent () {
+      const extentPolygon = this.$refs.drawPolygon.getExtent()
+      const extentPoint = this.$refs.drawPoint.getExtent()
+      const extentLine = this.$refs.drawLine.getExtent()
+
+      let completeExtend = extend(extentPolygon, extentPoint)
+      completeExtend = extend(completeExtend, extentLine)
+
+      this.$refs.map.map.updateSize()
+      this.$nextTick(() => {
+        this.$refs.map.map.getView().fit(completeExtend, { size: this.$refs.map.map.getSize() })
+      })
     },
 
     setInitDrawings () {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32505

Center the map around all drawings and zoom to the combined extent. For that, first we need to get the extent from each layer and then combine them into one extent. After that the map can be fitted to the combined extent.

### How to review/test
Go to Verfahren -> Abschnitte -> Erwiderungen verfassen and click on the "Ortsbezug" button. Make some drawings (line, point, polygon), close it and open it again. The map should be centered around the drawings and zooming in (all drawings should be seen). 
