### PR TITLE
Fix (refs: T32452) attachments in stn detail view not accessable

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -56,6 +56,7 @@
         <ul class="float--right u-m-0 space-inline-s flex">
           <li class="display--inline-block">
             <dp-claim
+              v-if="!statement.attributes.synchronized"
               class="o-flyout__trigger u-ph-0_25 line-height--2"
               entity-type="statement"
               :assigned-id="currentAssignee.id"
@@ -501,7 +502,8 @@ export default {
             'submitDate',
             'submitName',
             'submitType',
-            'submitterEmailAddress'
+            'submitterEmailAddress',
+            'synchronized'
           ].join(),
           SimilarStatementSubmitter: [
             'city',

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -92,11 +92,12 @@
         :translations="{ lockedForSelection: Translator.trans('item.lockedForSelection.sharedStatement') }"
         @select-all="handleSelectAll"
         @items-toggled="handleToggleItem">
-        <template v-slot:externId="{ assignee, externId, id: statementId }">
+        <template v-slot:externId="{ assignee, externId, id: statementId, synchronized }">
           <span
             class="weight--bold"
             v-text="externId" />
           <dp-claim
+            v-if="!synchronized"
             entity-type="statement"
             :assigned-id="assignee.id || ''"
             :assigned-name="assignee.name || ''"
@@ -155,7 +156,6 @@
             </button>
             <a
               :href="Routing.generate('dplan_statement_segments_list', { statementId: id, procedureId: procedureId })"
-              :class="{'is-disabled': synchronized }"
               rel="noopener">
               {{ Translator.trans('statement.details_and_recommendation') }}
             </a>

--- a/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanStatementBundle/DemosPlanStatement/list_statements.html.twig
@@ -19,7 +19,7 @@
     <list-statements
         class="u-mv-0_5"
         current-user-id="{{ currentUser.ident }}"
-        :is-source-and-coupled-procedure="{{ templateVars.isSourceAndCoupledProcedure|default('false') }}"
+        :is-source-and-coupled-procedure="{{ templateVars.isSourceAndCoupledProcedure == 1 ? 'true' : 'false' }}"
         procedure-id="{{ procedure }}"
         :submit-type-options="JSON.parse('{{ submitTypesOptions|json_encode|e('js', 'utf-8') }}')"
     ></list-statements>


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32452

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- since the claiming or the editing of an already synchronized stn is not allowed we can disable the claiming completely if this is the case
- if a statement is in synchronized status, the claiming elements in the statement list and 
statement detail views have been disabled/will not be rendered
- `templateVars.isSourceAndCoupledProcedure|default('false')` raises console errors since twig passes `1` or `0` as `true` or `false` values but the prop is defined as `Booleans` hence has been adjusted accordingly to `templateVars.isSourceAndCoupledProcedure == 1 ? 'true' : 'false'.`

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly