### PR TITLE
Fix(refs: T32450) make radio buttons reactive without clicking in the form

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -541,10 +541,16 @@ export default {
   },
 
   methods: {
+    logValue (val) {
+      console.log(val)
+    },
     setInitialValues () {
       this.values = { ...this.initValues }
       // Set default values to ensure reactivity.
-      if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0) {
+      if (typeof this.values.submitter !== 'undefined' && typeof this.values.submitter.institution === 'undefined') {
+        Vue.set(this.values.submitter, 'institution',  this.values.submitter.toeb)
+      }
+      if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0 ) {
         Vue.set(this.values, 'submitter', {})
         for (const [key, value] of Object.entries(submitterProperties)) {
           Vue.set(this.values.submitter, key === 'toeb' ? 'institution' : key, value)

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -553,7 +553,7 @@ export default {
       if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0 ) {
         Vue.set(this.values, 'submitter', {})
         for (const [key, value] of Object.entries(submitterProperties)) {
-          Vue.set(this.values.submitter, key === 'toeb' ? 'institution' : key, value)
+          Vue.set(this.values.submitter, key, value)
         }
       }
     },

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -548,8 +548,11 @@ export default {
       this.values = { ...this.initValues }
       // Set default values to ensure reactivity.
       if (typeof this.values.submitter !== 'undefined' && typeof this.values.submitter.institution === 'undefined') {
+        // Since Data sends us the key toeb instead of institution, we need to transform this for now but keep all init values
         Vue.set(this.values.submitter, 'institution',  this.values.submitter.toeb)
+        Vue.delete(this.values.submitter, 'toeb')
       }
+
       if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0 ) {
         Vue.set(this.values, 'submitter', {})
         for (const [key, value] of Object.entries(submitterProperties)) {

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -541,9 +541,6 @@ export default {
   },
 
   methods: {
-    logValue (val) {
-      console.log(val)
-    },
     setInitialValues () {
       this.values = { ...this.initValues }
       // Set default values to ensure reactivity.


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32450

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- Replace key `toeb` with `institution` but keep all other init values
- The key institution was not set correctly if there are init values. If there are, we need to keep all initial values but `toeb` which must be renamed to `institution`

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Navigate to convert pdf view (from overview eg)
- Click on institution and make sure it still works

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
