### PR TITLE
F T28477 incorrect display of the title when exporting statements

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -1036,7 +1036,7 @@ class DocxExporter
         $frontPageSection->addTextBreak(3);
 
         //Verfahrensname
-        $frontPageSection->addText(htmlspecialchars($procedure->getName()), $coverHeadingStyle, $coverParagraphStyle);
+        $frontPageSection->addText(htmlspecialchars($procedure->getName(), ENT_NOQUOTES), $coverHeadingStyle, $coverParagraphStyle);
 
         //Verfahrensschritt
         $phaseName = $procedure->getPhaseName();
@@ -1821,7 +1821,8 @@ class DocxExporter
             $cell->addText(
                 htmlspecialchars(
                     $this->getTranslator()->trans($transKey)
-                    .$delimiter.$concatValue
+                    .$delimiter.$concatValue,
+                    ENT_NOQUOTES
                 ),
                 $fStyle,
                 $pStyle);

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/ProcedureExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/ProcedureExtension.php
@@ -12,6 +12,12 @@ namespace demosplan\DemosPlanCoreBundle\Twig\Extension;
 
 use Carbon\Carbon;
 use DateTime;
+use Exception;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\TwigFunction;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
@@ -20,11 +26,6 @@ use demosplan\DemosPlanCoreBundle\Permissions\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfigInterface;
 use demosplan\DemosPlanProcedureBundle\Logic\ProcedureService;
 use demosplan\DemosPlanUserBundle\Logic\CurrentUserInterface;
-use Exception;
-use Psr\Container\ContainerInterface;
-use RuntimeException;
-use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\TwigFunction;
 
 /**
  * Procedure specific functions.
@@ -55,10 +56,16 @@ class ProcedureExtension extends ExtensionBase
      */
     private $currentUser;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
         ContainerInterface $container,
         CurrentUserInterface $currentUser,
         GlobalConfigInterface $globalConfig,
+        LoggerInterface       $logger,
         PermissionsInterface $permissions,
         ProcedureService $procedureService,
         TranslatorInterface $translator)
@@ -69,6 +76,7 @@ class ProcedureExtension extends ExtensionBase
         $this->procedureService = $procedureService;
         $this->translator = $translator;
         $this->currentUser = $currentUser;
+        $this->logger       = $logger;
     }
 
     public function getFunctions(): array

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/ProcedureExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/ProcedureExtension.php
@@ -303,6 +303,8 @@ class ProcedureExtension extends ExtensionBase
         try {
             $procedure = $this->getProcedureObject($procedure);
         } catch (Exception $exception) {
+            $this->logger->error('Could not get procedure object', [$exception]);
+
             return '';
         }
 

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export.tex.twig
@@ -1,7 +1,7 @@
 {% extends '@DemosPlanCore/DemosPlanCore/pdfexport.tex.twig' %}
 
 {% block demosplanbundlecontent %}
-	\section*{{ '{' }}{{title}}{{ '}' }}
+	\section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
     {% if templateVars.table.entries is defined
        and templateVars.table.entries.total is defined and templateVars.table.entries.total > 0 %}
         {% for statement in templateVars.table.entries.statements %}

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_anonymous.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_anonymous.tex.twig
@@ -1,7 +1,7 @@
 {% extends '@DemosPlanCore/DemosPlanCore/pdfexport.tex.twig' %}
 
 {% block demosplanbundlecontent %}
-	\section*{{ '{' }}{{title}}{{ '}' }}
+	\section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
 	{% if templateVars.table.entries is defined and templateVars.table.entries.statements is defined %}
 		{% if templateVars.table.entries.total is defined %}
 			{% if templateVars.table.entries.total > 0 %}

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_condensed.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_condensed.tex.twig
@@ -2,6 +2,6 @@
 
 {% block demosplanbundlecontent %}
 	% Überschrift
-	\section*{{ '{' }}{{title}}{{ '}' }}
+	\section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
 		{% if templateVars.table.entries is defined %}{% if templateVars.table.entries.total is defined %}{% if templateVars.table.entries.total > 0 %}{% for statement in templateVars.table.entries.statements %}{% include '@DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_condensed.tex.twig' %}{% endfor %}{% endif %}{% endif %}{% endif %}
 {% endblock %}

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_condensed_anonymous.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_condensed_anonymous.tex.twig
@@ -2,6 +2,6 @@
 
 {% block demosplanbundlecontent %}
 	% Überschrift
-	\section*{{ '{' }}{{title}}{{ '}' }}
+	\section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
 		{% if templateVars.table.entries is defined %}{% if templateVars.table.entries.total is defined %}{% if templateVars.table.entries.total > 0 %}{% for statement in templateVars.table.entries.statements %}{% include '@DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_anonymous_condensed.tex.twig' %}{% endfor %}{% endif %}{% endif %}{% endif %}
 {% endblock %}

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_fragments_anonymous.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_fragments_anonymous.tex.twig
@@ -2,7 +2,7 @@
 
 {% import '@DemosPlanAssessmentTable/DemosPlan/statement_macros.tex.twig' as statement_macros %}
 {% block demosplanbundlecontent %}
-    \section*{{ '{' }}{{title}}{{ '}' }}
+    \section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
     {% if templateVars.table.entries is defined and templateVars.table.entries.total is defined and templateVars.table.entries.total > 0 and templateVars.table.entries.statements is defined %}
         {% for statement in templateVars.table.entries.statements %}
             {% include '@DemosPlanAssessmentTable/DemosPlan/snipped_statement_head.tex.twig' %}

--- a/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_original.tex.twig
+++ b/templates/bundles/DemosPlanAssessmentTableBundle/DemosPlan/export_original.tex.twig
@@ -2,6 +2,6 @@
 
 {% block demosplanbundlecontent %}
 	% Überschrift
-	\section*{{ '{' }}{{title}}{{ '}' }}
+	\section*{{ '{' }}{{title|latex|raw}}{{ '}' }}
 		{% if templateVars.table.entries is defined %}{% if templateVars.table.entries.total is defined %}{% if templateVars.table.entries.total > 0 %}{% for statement in templateVars.table.entries.statements %}{% include '@DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig' %}{% endfor %}{% endif %}{% endif %}{% endif %}
 {% endblock %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T28477

Description: 
In the pdf and the doc export, the procedure name is incorrect displayed. Twigs filters are added to display it correctly in the pdf export. 

For the docx export, the quotes conversion while retrieving procedure name is disabled. The htmlspecialchars method has now ENT_NOQUOTES as flag parameter which prevent to encode quotes

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
