### PR TITLE
feature (refs T32200): avoid null for parameter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -69,6 +69,8 @@ services:
 
     DemosEurope\DemosplanAddon\Contracts\FileServiceInterface:
         class: demosplan\DemosPlanCoreBundle\Logic\FileService
+        arguments:
+            $client: '@old_sound_rabbit_mq.demos_plan_import_rpc'
 
     DemosEurope\DemosplanAddon\Contracts\CurrentProcedureServiceInterface:
         class: demosplan\DemosPlanProcedureBundle\Logic\CurrentProcedureService


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32200

Description:
avoid null for parameter client in FileService when injecting the fileServiceInterface.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
