### PR TITLE
Remove specific version for demosplan-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "0.0.19",
+    "@demos-europe/demosplan-ui": "^0",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.16.0",


### PR DESCRIPTION
Specific version is not needed anymore. 
