### PR TITLE
chore: avoid error when elasticsearch has some issues

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
@@ -550,7 +550,7 @@ class ElasticSearchService extends CoreService
         $resultSet->setResult($list);
         $resultSet->setFilterSet($filterSet);
         $resultSet->setSortingSet($sortingSet);
-        $resultSet->setTotal(count($elasticsearchResult->getHits()['hits']));
+        $resultSet->setTotal(count($elasticsearchResult->getHits()['hits'] ?? []));
         $resultSet->setSearchFields($elasticsearchResult->getSearchFields());
         $resultSet->setSearch($search ?? '');
         $resultSet->setPager($elasticsearchResult->getPager());


### PR DESCRIPTION
When elasticsearch is in an ivalid state count of null triggered an php error

### How to review/test
code review might be best. Otherwise stop eleasticsearch and call a procedure

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
