### PR TITLE
chore: fix addon route path as it may be called differently

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonRoutingLoader.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonRoutingLoader.php
@@ -57,8 +57,8 @@ class AddonRoutingLoader extends AnnotationDirectoryLoader implements RouteLoade
     private function addControllers(mixed $addonInfo, RouteCollection $routeCollection): void
     {
         $controllerDir = $addonInfo->getInstallPath().self::PATH_TO_CONTROLLERS_FROM_ADDONROOT;
-        if ('' !== $addonInfo->getInstallPath() && is_dir($controllerDir)) {
-            $controllerPath = AddonPath::getRootPath($controllerDir);
+        $controllerPath = AddonPath::getRootPath($controllerDir);
+        if ('' !== $addonInfo->getInstallPath() && is_dir($controllerPath)) {
             $routeCollection->addCollection($this->load($controllerPath));
         }
     }


### PR DESCRIPTION
`pwd` might be different depending on how the code is triggered. This PR makes this a bit more robust

### How to review/test
Code review or try to call a addon route in browser directly after cache clear

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
