### PR TITLE
chore: update deprecated RouteCollectionBuilder

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 use function array_merge;
 use function file_exists;
@@ -105,12 +105,12 @@ class DemosPlanKernel extends Kernel
         yield from $addonBundleGenerator->registerBundles($this->environment);
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $coreConfigPath = DemosPlanPath::getConfigPath();
 
-        $routes->import($coreConfigPath.'/{routes}/'.$this->environment.'/*'.self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($coreConfigPath.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($coreConfigPath.'/{routes}/'.$this->environment.'/*'.self::CONFIG_EXTS, 'glob');
+        $routes->import($coreConfigPath.'/{routes}/*'.self::CONFIG_EXTS,  'glob');
 
         $routesConfig = DemosPlanPath::getProjectPath('app/config/routing.yml');
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27388

RouteCollectionBuilder was deprecated in favor of RoutingConfigurator

### How to review/test
Call any route, one deprecation should be gone

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
