### PR TITLE
chore: make the number of logfiles to keep configurable

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/packages/monolog.yaml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/packages/monolog.yaml
@@ -16,7 +16,7 @@ monolog:
     handlers:
         applog:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             level: error
             handler: file
         main:
@@ -37,61 +37,61 @@ monolog:
             channels: [php]
         file:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             level: "%symfony_loglevel%"
         console:
             type: console
             process_psr_3_messages: false
         dplan.main:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_main_logfile%"
             level: "%frontend_loglevel%"
             channels: ["dplan"]
         dplan.plugin:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_main_logfile%"
             level: "%frontend_loglevel%"
             channels: ["dplan_plugin"]
         dplan.gateway:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_call_logfile%"
             level: "%gatewayservice_loglevel%"
             channels: ["dplan_gateway"]
         dplan.request:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_request_logfile%"
             level: "%frontend_loglevel%"
             channels: ["dplan_request"]
         dplan.mail:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_mail_logfile%"
             level: "%mailservice_loglevel%"
             channels: ["dplan_mail"]
         dplan.maintenance:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/dplanmaintenance.log"
             level: "%frontend_loglevel%"
             channels: ["dplan_maintenance"]
         dplan.importer:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             level: "%importer_loglevel%"
             channels: ["dplan_importer"]
         dplan.404:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/404.log"
             level: "%frontend_loglevel%"
             channels: ["dplan_404"]
         dplan.csp:
             type: "%logging_strategy%"
-            max_files: 7
+            max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/csp.log"
             level: "notice"
             channels: ["dplan_csp"]

--- a/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/parameters_default.yml
@@ -7,6 +7,8 @@ parameters:
 
     # logging strategy for monolog, can be either "rotating_file" or "stream"
     logging_strategy: "rotating_file"
+    # maximum number of log files to keep (aka days to keep)
+    logging_max_files: 60
 
     # Projekttyp, mögliche Werte: portal, gateway
     # #refactor: this variable should be removed


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32438

The number of logfiles to keep before they are deleted should be configurable on server basis.

### How to review/test
code review is best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
