### PR TITLE
feat (refs T32606): Adjust services.yml for UserResourceTypeInterface

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/services.yml
@@ -135,6 +135,9 @@ services:
 #    DemosEurope\DemosplanAddon\Contracts\ResourceType\UpdatableDqlResourceTypeInterface:
 #        class:
 
+    DemosEurope\DemosplanAddon\Contracts\ResourceType\UserResourceTypeInterface:
+        class: demosplan\DemosPlanCoreBundle\ResourceTypes\UserResourceType
+
 #    DemosEurope\DemosplanAddon\Contracts\ResourceType\CreatableDqlResourceTypeInterface:
 #        class:
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32606

This error raises after some changes for a fix in an addon: there are no class that implements DemosEurope\DemosplanAddon\Contracts\ResourceType\UserResourceTypeInterface
In the code this UserResourceTypeInterface is already implemented by the UserResourceType.

I'm not sure with this, but I hope the adjustment in the services.yml to map UserResourceTypeInterface with UserResourceType fixes this error.

### How to review/test
code review

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
