### PR TITLE
F t32562 fix deletion of statements with similar

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -18,12 +18,29 @@ class LoadProcedurePersonData extends TestFixture implements DependentFixtureInt
         /** @var Statement $testStatement */
         $testStatement = $this->getReference('testStatement');
 
+        /** @var Statement $testStatement2 */
+        $testStatement2 = $this->getReference('testFixtureStatement');
+
         /** @var Procedure $testProcedure */
         $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
         $procedurePerson1 = new ProcedurePerson('Max Mustermann', $testProcedure);
         $procedurePerson1->addSimilarForeignStatement($testStatement);
         $manager->persist($procedurePerson1);
         $this->setReference('testProcedurePerson1', $procedurePerson1);
+
+        /** @var Procedure $testProcedure */
+        $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
+        $procedurePerson2 = new ProcedurePerson('Malia Musterfrau', $testProcedure);
+        $procedurePerson2->addSimilarForeignStatement($testStatement2);
+        $manager->persist($procedurePerson2);
+        $this->setReference('testProcedurePerson2', $procedurePerson2);
+
+        /** @var Procedure $testProcedure */
+        $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
+        $procedurePerson3 = new ProcedurePerson('Oliver Groß', $testProcedure);
+        $procedurePerson3->addSimilarForeignStatement($testStatement);
+        $manager->persist($procedurePerson3);
+        $this->setReference('testprocedurePerson3', $procedurePerson3);
 
         $manager->flush();
     }

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+
+namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
+
+
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+class LoadProcedurePersonData extends TestFixture implements DependentFixtureInterface
+{
+
+    public function load(ObjectManager $manager)
+    {
+        /** @var Procedure $testProcedure */
+        $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
+        $procedurePerson1 = new ProcedurePerson('Max Mustermann', $testProcedure);
+        $manager->persist($procedurePerson1);
+        $this->setReference('testProcedurePerson1', $procedurePerson1);
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return [
+            LoadProcedureData::class,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -7,17 +7,21 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 class LoadProcedurePersonData extends TestFixture implements DependentFixtureInterface
 {
-
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
+        /** @var Statement $testStatement */
+        $testStatement = $this->getReference('testStatement');
+
         /** @var Procedure $testProcedure */
         $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
         $procedurePerson1 = new ProcedurePerson('Max Mustermann', $testProcedure);
+        $procedurePerson1->addSimilarForeignStatement($testStatement);
         $manager->persist($procedurePerson1);
         $this->setReference('testProcedurePerson1', $procedurePerson1);
 
@@ -28,6 +32,7 @@ class LoadProcedurePersonData extends TestFixture implements DependentFixtureInt
     {
         return [
             LoadProcedureData::class,
+            LoadStatementData::class,
         ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -15,30 +15,21 @@ class LoadProcedurePersonData extends TestFixture implements DependentFixtureInt
 {
     public function load(ObjectManager $manager): void
     {
-        /** @var Statement $testStatement */
-        $testStatement = $this->getReference('testStatement');
-
-        /** @var Statement $testStatement2 */
-        $testStatement2 = $this->getReference('testFixtureStatement');
-
         /** @var Procedure $testProcedure */
         $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
         $procedurePerson1 = new ProcedurePerson('Max Mustermann', $testProcedure);
-        $procedurePerson1->addSimilarForeignStatement($testStatement);
         $manager->persist($procedurePerson1);
         $this->setReference('testProcedurePerson1', $procedurePerson1);
 
         /** @var Procedure $testProcedure */
         $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
         $procedurePerson2 = new ProcedurePerson('Malia Musterfrau', $testProcedure);
-        $procedurePerson2->addSimilarForeignStatement($testStatement2);
         $manager->persist($procedurePerson2);
         $this->setReference('testProcedurePerson2', $procedurePerson2);
 
         /** @var Procedure $testProcedure */
         $testProcedure = $this->getReference(LoadProcedureData::TESTPROCEDURE);
         $procedurePerson3 = new ProcedurePerson('Oliver Groß', $testProcedure);
-        $procedurePerson3->addSimilarForeignStatement($testStatement);
         $manager->persist($procedurePerson3);
         $this->setReference('testprocedurePerson3', $procedurePerson3);
 
@@ -49,7 +40,6 @@ class LoadProcedurePersonData extends TestFixture implements DependentFixtureInt
     {
         return [
             LoadProcedureData::class,
-            LoadStatementData::class,
         ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
@@ -27,6 +27,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementVersionField;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanStatementBundle\Exception\InvalidDataException;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
@@ -295,6 +296,13 @@ class LoadStatementData extends TestFixture implements DependentFixtureInterface
         $statement5->setText('Ich bin der Text für ein weiteres Statement');
         $statement5->setTitle('oneMoreStatement');
         $statement5->setUser($testUser);
+        $statement5->setSimilarStatementSubmitters(
+            new ArrayCollection([
+                $this->getReference('testProcedurePerson1'),
+                $this->getReference('testProcedurePerson2'),
+                ]
+            )
+        );
 
         $this->setReference('testFixtureStatement', $statement5);
         $manager->persist($statement5);
@@ -322,6 +330,8 @@ class LoadStatementData extends TestFixture implements DependentFixtureInterface
         $statement2->setText('Ich bin der Text für das Statement, gleiche Orga, anderer User');
         $statement2->setTitle('Statement Orga');
         $statement2->setUser($this->getReference('testUserPlanningOffice'));
+        $statement2->setSimilarStatementSubmitter($this->getReference('testProcedurePerson1'));
+
 
         /** @var User $submitter */
         $submitter = $this->getReference('testUserDataInput1');
@@ -952,6 +962,7 @@ class LoadStatementData extends TestFixture implements DependentFixtureInterface
             LoadProcedureData::class,
             LoadTagData::class,
             LoadUserData::class,
+            LoadProcedurePersonData::class,
         ];
     }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -222,7 +222,7 @@ class ProcedurePerson implements UuidEntityInterface
     {
         if ($this->similarForeignStatements->contains($similarForeignStatement)) {
             $this->similarForeignStatements->removeElement($similarForeignStatement);
-            $similarForeignStatement->removeSimilarStatementSubmitters($this);
+            $similarForeignStatement->removeSimilarStatementSubmitter($this);
         }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -114,6 +114,7 @@ class ProcedurePerson implements UuidEntityInterface
     {
         $this->fullName = $fullName;
         $this->procedure = $procedure;
+        $this->similarForeignStatements = new ArrayCollection();
     }
 
     public function getId(): ?string

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Entity\Procedure;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -90,7 +91,6 @@ class ProcedurePerson implements UuidEntityInterface
      */
     private $emailAddress;
 
-
     /**
      * Each item in this collection references a statement for which this person has submitted a similar statement.
      * However, the latter one is unknown and may or may not have been entered into the application.
@@ -100,7 +100,8 @@ class ProcedurePerson implements UuidEntityInterface
      * @ORM\ManyToMany(
      *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement",
      *     mappedBy="similarStatementSubmitters",
-     *     orphanRemoval: true
+     *     cascade={"persist"},
+     *     orphanRemoval = true
      * )
      * @ORM\JoinTable(
      *     name="similar_statement_submitter",
@@ -197,5 +198,28 @@ class ProcedurePerson implements UuidEntityInterface
     public function getEmailAddress(): ?string
     {
         return $this->emailAddress;
+    }
+
+    public function getSimilarForeignStatements(): Collection
+    {
+        return $this->similarForeignStatements;
+    }
+
+    /**
+     * Adds the given statement to the similarForeignStatements if not already containing.
+     */
+    public function addSimilarForeignStatements(Statement $similarForeignStatement): void
+    {
+        if (!$this->similarForeignStatements->contains($similarForeignStatement)) {
+            $this->similarForeignStatements->add($similarForeignStatement);
+        }
+    }
+
+    public function removeSimilarForeignStatement(Statement $similarForeignStatement): void
+    {
+        if ($this->similarForeignStatements->contains($similarForeignStatement)) {
+            $this->similarForeignStatements->removeElement($similarForeignStatement);
+            $similarForeignStatement->removeSimilarStatementSubmitters($this);
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -101,7 +101,6 @@ class ProcedurePerson implements UuidEntityInterface
      *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement",
      *     mappedBy="similarStatementSubmitters",
      *     cascade={"persist"},
-     *     orphanRemoval = true
      * )
      * @ORM\JoinTable(
      *     name="similar_statement_submitter",
@@ -208,10 +207,14 @@ class ProcedurePerson implements UuidEntityInterface
     /**
      * Adds the given statement to the similarForeignStatements if not already containing.
      */
-    public function addSimilarForeignStatements(Statement $similarForeignStatement): void
+    public function addSimilarForeignStatement(Statement $similarForeignStatement): void
     {
         if (!$this->similarForeignStatements->contains($similarForeignStatement)) {
             $this->similarForeignStatements->add($similarForeignStatement);
+        }
+
+        if (!$similarForeignStatement->getSimilarStatementSubmitters()->contains($this)) {
+            $similarForeignStatement->addSimilarStatementSubmitter($this);
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -99,17 +99,16 @@ class ProcedurePerson implements UuidEntityInterface
      *
      * @ORM\ManyToMany(
      *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement",
-     *     mappedBy="similarStatementSubmitters"
+     *     mappedBy="similarStatementSubmitters",
+     *     orphanRemoval: true
      * )
      * @ORM\JoinTable(
      *     name="similar_statement_submitter",
      *     joinColumns={@ORM\JoinColumn(name="_st_id", referencedColumnName="statement_id")},
      *     inverseJoinColumns={@ORM\JoinColumn(name="id", referencedColumnName="submitter_id")}
      * )
-     *
-     * todo: orphan removal by doctrine
      */
-    private $similarForeignStatements;
+    private Collection $similarForeignStatements;
 
     public function __construct(string $fullName, Procedure $procedure)
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Entity\Procedure;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -87,6 +89,27 @@ class ProcedurePerson implements UuidEntityInterface
      * @Assert\Email()
      */
     private $emailAddress;
+
+
+    /**
+     * Each item in this collection references a statement for which this person has submitted a similar statement.
+     * However, the latter one is unknown and may or may not have been entered into the application.
+     *
+     * @var Collection<int, Statement>
+     *
+     * @ORM\ManyToMany(
+     *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement",
+     *     mappedBy="similarStatementSubmitters"
+     * )
+     * @ORM\JoinTable(
+     *     name="similar_statement_submitter",
+     *     joinColumns={@ORM\JoinColumn(name="_st_id", referencedColumnName="statement_id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="id", referencedColumnName="submitter_id")}
+     * )
+     *
+     * todo: orphan removal by doctrine
+     */
+    private $similarForeignStatements;
 
     public function __construct(string $fullName, Procedure $procedure)
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -983,18 +983,25 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
     private $piSegmentsProposalResourceUrl;
 
     /**
+     * This is modelled as ManyToMany, because intentionally it should be possible, that one ProcedurePersons is
+     * related to many Statements, as well as many Statements are related to one ProcedurePerson.
+     * Actually this is used as OneToMany, because one Statement can be related to many ProcedurePersons, but a
+     * ProcedurePerson will only have one related Statement. That means, we can use cascade remove on this site,
+     * to ensure related ProcedurePersons will be deleted in case of this Statement will be deleted.
+     *
      * @var Collection<int, ProcedurePerson>
      *
      * @ORM\ManyToMany(
      *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson",
      *     inversedBy="similarForeignStatements",
-     *     cascade={"persist"},
+     *     cascade={"persist", "remove"},
      *     orphanRemoval = true
      * )
      * @ORM\JoinTable(name="similar_statement_submitter",
      *      joinColumns={@ORM\JoinColumn(name="statement_id", referencedColumnName="_st_id")},
      *      inverseJoinColumns={@ORM\JoinColumn(name="submitter_id", referencedColumnName="id")}
      * )
+     * remove orphan submitters by using orphanRemoval=true here
      */
     private Collection $similarStatementSubmitters;
 
@@ -4133,7 +4140,6 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
 //            $this->similarStatementSubmitters->add($submitter);
         }
 
-
         $this->similarStatementSubmitters = $similarStatementSubmitters;
 
         return $this;
@@ -4157,5 +4163,9 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
         $this->anonymous = $anonymous;
 
         return $this;
+    }
+    public function setSimilarStatementSubmitter(ProcedurePerson $similarStatementSubmitter): void
+    {
+        $this->similarStatementSubmitters = new ArrayCollection([$similarStatementSubmitter]);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -4139,7 +4139,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
         return $this;
     }
 
-    public function removeSimilarStatementSubmitters(ProcedurePerson $procedurePerson): void
+    public function removeSimilarStatementSubmitter(ProcedurePerson $procedurePerson): void
     {
         if ($this->similarStatementSubmitters->contains($procedurePerson)) {
             $this->similarStatementSubmitters->removeElement($procedurePerson);

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -987,6 +987,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      *
      * @ORM\ManyToMany(
      *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson",
+     *     inversedBy="similarForeignStatements",
      *     cascade={"persist"}
      * )
      * @ORM\JoinTable(name="similar_statement_submitter",
@@ -4101,6 +4102,14 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
         $this->similarStatementSubmitters = $similarStatementSubmitters;
 
         return $this;
+    }
+
+    public function removeSimilarStatementSubmitters(ProcedurePerson $procedurePerson): void
+    {
+        if ($this->similarStatementSubmitters->contains($procedurePerson)) {
+            $this->similarStatementSubmitters->removeElement($procedurePerson);
+            $procedurePerson->removeSimilarForeignStatement($this);
+        }
     }
 
     public function isAnonymous(): bool

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -4097,7 +4097,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
 
     public function addSimilarStatementSubmitter(ProcedurePerson $similarStatementSubmitter): void
     {
-        if ($this->similarStatementSubmitters->contains($similarStatementSubmitter)) {
+        if (!$this->similarStatementSubmitters->contains($similarStatementSubmitter)) {
             $this->similarStatementSubmitters->add($similarStatementSubmitter);
         }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -985,7 +985,10 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
     /**
      * @var Collection<int, ProcedurePerson>
      *
-     * @ORM\ManyToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson", cascade={"persist", "remove"})
+     * @ORM\ManyToMany(
+     *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson",
+     *     cascade={"persist"}
+     * )
      * @ORM\JoinTable(name="similar_statement_submitter",
      *      joinColumns={@ORM\JoinColumn(name="statement_id", referencedColumnName="_st_id")},
      *      inverseJoinColumns={@ORM\JoinColumn(name="submitter_id", referencedColumnName="id")}

--- a/tests/backend/base/FunctionalTestCase.php
+++ b/tests/backend/base/FunctionalTestCase.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureBehaviorDefinition;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
@@ -604,6 +605,11 @@ class FunctionalTestCase extends WebTestCase
     }
 
     protected function getProcedureBehaviorDefinitionReference(string $name): ProcedureBehaviorDefinition
+    {
+        return $this->getReference($name);
+    }
+
+    protected function getProcedurePersonReference(string $name): ProcedurePerson
     {
         return $this->getReference($name);
     }

--- a/tests/backend/core/Statement/Functional/SimiliarStatementSubmitterTest.php
+++ b/tests/backend/core/Statement/Functional/SimiliarStatementSubmitterTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanStatementBundle\Logic\StatementService;
+use Doctrine\Common\Collections\ArrayCollection;
+use Tests\Base\FunctionalTestCase;
+
+/**
+ *
+ */
+class SimiliarStatementSubmitterTest extends FunctionalTestCase
+{
+    /** @var StatementService System under Test */
+    protected $sut;
+
+    //protected StatementService $statementService;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = $this->getContainer()->get(StatementService::class);
+       // $this->statementService = $this->getContainer()->get(StatementService::class);
+    }
+
+    public function test123()
+    {
+        $this->loginTestUser();
+        $testStatementWithToken1 = $this->getStatementReference('testStatement');
+        $testProcedurePerson1 = $this->getProcedurePersonReference('testProcedurePerson1');
+        static::assertInstanceOf(Statement::class, $testStatementWithToken1);
+        static::assertInstanceOf(ProcedurePerson::class, $testProcedurePerson1);
+
+        //$testSimilarStatementSubmitters = new ArrayCollection([$testProcedurePerson1]);
+        //static::assertCount(0, $testStatementWithToken1->getSimilarStatementSubmitters());
+       // $testStatementWithToken1->setSimilarStatementSubmitters($testSimilarStatementSubmitters);
+       // $updatedStatement1 = $this->sut->updateStatementObject($testStatementWithToken1);
+        //static::assertCount(1, $updatedStatement1->getSimilarStatementSubmitters());
+        $deleted = $this->sut->deleteStatement($testStatementWithToken1->getId(), true);
+        static::assertTrue($deleted);
+    }
+}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32562

On deleting a Statement, the related ProcedurePerson (SimilarStatementSubmitter) has to be handled too.


### How to review/test
Try to delete a Statement with a similar statement submitter.


### PR Checklist
- [x] Tests updated/created
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
