### PR TITLE
bug(refs T32572): fix special characters appearing at the end of stri…

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -135,7 +135,7 @@
             <div
               v-tooltip="internId"
               class="o-hellip--nowrap text--right"
-              dir="rtl"
+              dir="auto"
               v-text="internId" />
           </div>
         </template>

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -135,7 +135,6 @@
             <div
               v-tooltip="internId"
               class="o-hellip--nowrap text--right"
-              dir="auto"
               v-text="internId" />
           </div>
         </template>


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32572

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
The value `rtl` of the `dir` attribute was the reason that special characters appear at the end of the string even if the input was special characters first.

Relating to https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir?retiredLocale=de, the auto value should be used for data with an unknown directionality, like data coming from user input, eventually stored in a database. Since this is the case here, the attribute's value has been set accordingly to `auto`.

#### This PR belongs to EWM 3.1 

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
