### PR TITLE
feat (refs T32782): simplify WeakPassword check

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -44,29 +44,14 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
     use TargetPathTrait;
 
     /**
-     * @var GlobalConfigInterface
-     */
-    protected $globalConfig;
-
-    /**
      * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * @var RequestStack
-     */
-    protected $requestStack;
-
-    /**
      * @var UrlGeneratorInterface
      */
     protected $urlGenerator;
-
-    /**
-     * @var UserPasswordHasherInterface
-     */
-    protected $passwordHasher;
 
     /**
      * @var UserMapperInterface
@@ -91,39 +76,20 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
      */
     protected $messageBag;
 
-    /**
-     * @var ValidatorInterface
-     */
-    protected $passwordValidator;
-
-    /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
 
     public function __construct(
         private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider,
         UserMapperInterface $authenticator,
-        GlobalConfigInterface $globalConfig,
         LoggerInterface $logger,
         MessageBagInterface $messageBag,
-        PasswordValidator $passwordValidator,
-        RequestStack $requestStack,
         TraceableEventDispatcher $eventDispatcher,
-        TranslatorInterface $translator,
         UrlGeneratorInterface $urlGenerator,
-        UserPasswordHasherInterface $passwordHasher
     ) {
         $this->userMapper = $authenticator;
         $this->eventDispatcher = $eventDispatcher;
-        $this->globalConfig = $globalConfig;
         $this->logger = $logger;
-        $this->passwordHasher = $passwordHasher;
-        $this->passwordValidator = $passwordValidator;
-        $this->requestStack = $requestStack;
         $this->urlGenerator = $urlGenerator;
         $this->messageBag = $messageBag;
-        $this->translator = $translator;
     }
 
     abstract protected function getCredentials(Request $request): Credentials;
@@ -149,8 +115,7 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
 
     /**
      * This Hook might be used to validate Requirements to the credentials
-     * that are specific to a distinct authentication like rules for
-     * password strength.
+     * that are specific to a distinct authentication method.
      */
     public function validateCredentials(Credentials $credentials): void
     {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
 use demosplan\DemosPlanCoreBundle\Event\RequestValidationWeakEvent;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -61,25 +60,6 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
         return $credentialsVO;
     }
 
-    public function validateCredentials(Credentials $credentials): void
-    {
-        // check for password strength and warn if it is too weak
-        $violations = $this->passwordValidator->validate($credentials->getPassword());
-        if (0 < $violations->count()) {
-            $linkChangeText = $this->translator->trans('password.change');
-            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
-                'warning',
-                'warning.password.weak',
-                [],
-                'DemosPlan_user_portal',
-                [],
-                $linkChangeText)
-            );
-        }
-
-        parent::validateCredentials($credentials);
-    }
-
     protected function getPassport(Credentials $credentials): Passport
     {
         $user = $this->userMapper->getValidUser($credentials);
@@ -89,6 +69,7 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
             new PasswordCredentials($credentials->getPassword()),
             [
                 new PasswordUpgradeBadge($credentials->getPassword()),
+                new WeakPasswordCheckerBadge($credentials->getPassword()),
                 new CsrfTokenBadge('authenticate', $credentials->getToken()),
             ]
         );
@@ -97,6 +78,7 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $this->messageBag->add('warning', 'warning.login.failed');
+        $this->logger->info('Login failed', [$exception]);
 
         return new RedirectResponse($this->urlGenerator->generate('DemosPlan_user_login_alternative'));
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/WeakPasswordCheckerBadge.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/WeakPasswordCheckerBadge.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
+
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+
+class WeakPasswordCheckerBadge implements BadgeInterface
+{
+
+    public function __construct(private readonly string $password)
+    {
+
+    }
+
+    public function isResolved(): bool
+    {
+        return true;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
+++ b/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Security\HTTP\EventListener;
+
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
+use demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\WeakPasswordCheckerBadge;
+use demosplan\DemosPlanCoreBundle\Validator\PasswordValidator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class WeakPasswordCheckerEventListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly PasswordValidator $passwordValidator,
+        private readonly TranslatorInterface $translator,
+        private readonly MessageBagInterface $messageBag
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [CheckPassportEvent::class => ['checkPassport']];
+    }
+
+    public function checkPassport(CheckPassportEvent $event): void
+    {
+        $passport = $event->getPassport();
+        if (!$passport->hasBadge(WeakPasswordCheckerBadge::class)) {
+            return;
+        }
+
+        /** @var WeakPasswordCheckerBadge $badge */
+        $badge = $passport->getBadge(WeakPasswordCheckerBadge::class);
+
+        // check for password strength and warn if it is too weak
+        $violations = $this->passwordValidator->validate($badge->getPassword());
+        if (0 < $violations->count()) {
+            $linkChangeText = $this->translator->trans('password.change');
+            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
+                'warning',
+                'warning.password.weak',
+                [],
+                'DemosPlan_user_portal',
+                [],
+                $linkChangeText)
+            );
+        }
+    }
+}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32782

Check password only when authentication is valid. Otherwise a notification may be shown even on invalid password. The password is now validated by using symfonys UserBadge system.

### How to review/test
Code review or try to login with existing user but invalid, too short password like `wer` 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
