### PR TITLE
feat(refs T32601): automatically use dates in pdf import confirmation view

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -492,7 +492,7 @@ export default {
       isLoading: false,
       isSaving: false,
       values: {
-        authoredDate: this.initialAuthoredDate,
+        authoredDate: this.values.submitter.date ? this.values.submitter.date : '',
         memo: '',
         submittedDate: '',
         tags: [],
@@ -506,10 +506,6 @@ export default {
     escapedUsedInternIds () {
       const specialCharEscaper = /\[|\\|\^|\$|\.|\||\?|\*|\+|\(|\)|\//g
       return this.usedInternIds.map(id => id.replace(specialCharEscaper, (specialChar) => `\\${specialChar}`))
-    },
-
-    initialAuthoredDate () {
-      return this.values.submitter.date ? this.values.submitter.date : ''
     },
 
     internIdsPattern () {
@@ -568,7 +564,7 @@ export default {
      */
     setInstitutionValue (val) {
       this.$nextTick(() => {
-        this.$set(this.values.submitter, 'institution',  val)
+        this.$set(this.values.submitter, 'institution', val)
       })
     },
 

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -492,7 +492,7 @@ export default {
       isLoading: false,
       isSaving: false,
       values: {
-        authoredDate: '',
+        authoredDate: this.initialAuthoredDate,
         memo: '',
         submittedDate: '',
         tags: [],
@@ -503,6 +503,15 @@ export default {
   },
 
   computed: {
+    escapedUsedInternIds () {
+      const specialCharEscaper = /\[|\\|\^|\$|\.|\||\?|\*|\+|\(|\)|\//g
+      return this.usedInternIds.map(id => id.replace(specialCharEscaper, (specialChar) => `\\${specialChar}`))
+    },
+
+    initialAuthoredDate () {
+      return this.values.submitter.date ? this.values.submitter.date : ''
+    },
+
     internIdsPattern () {
       let pattern = ''
       if (this.escapedUsedInternIds.length > 0) {
@@ -510,11 +519,6 @@ export default {
       }
       pattern = pattern + '[0-9a-zA-Z-_ /().?!,+*#äüöß]{1,}$'
       return pattern
-    },
-
-    escapedUsedInternIds () {
-      const specialCharEscaper = /\[|\\|\^|\$|\.|\||\?|\*|\+|\(|\)|\//g
-      return this.usedInternIds.map(id => id.replace(specialCharEscaper, (specialChar) => `\\${specialChar}`))
     },
 
     nowDate () {

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -41,7 +41,7 @@
                 text: Translator.trans('citizen')
               }"
               :checked="values.submitter.institution === false || values.submitter.institution === undefined"
-              @change="values.submitter.institution = false" />
+              @change="setInstitutionValue(false)" />
             <dp-radio
               name="r_role"
               value="1"
@@ -50,7 +50,7 @@
                 text: Translator.trans('institution')
               }"
               :checked="values.submitter.institution === true"
-              @change="values.submitter.institution = true" />
+              @change="setInstitutionValue(true)" />
           </div>
 
           <div class="space-stack-s">
@@ -71,7 +71,7 @@
                 v-model="values.submitter.department"
                 :class="{ 'layout__item u-1-of-2': !fieldsFullWidth }"
                 :label="{
-                  text: Translator.trans('department'),
+                  text: Translator.trans('department')
                 }"
                 name="r_orga_department_name" />
             </div>
@@ -546,16 +546,26 @@ export default {
       // Set default values to ensure reactivity.
       if (typeof this.values.submitter !== 'undefined' && typeof this.values.submitter.institution === 'undefined') {
         // Since Data sends us the key toeb instead of institution, we need to transform this for now but keep all init values
-        Vue.set(this.values.submitter, 'institution',  this.values.submitter.toeb)
-        Vue.delete(this.values.submitter, 'toeb')
+        this.$set(this.values.submitter, 'institution',  this.values.submitter.toeb)
+        this.$delete(this.values.submitter, 'toeb')
       }
 
       if (typeof this.values.submitter === 'undefined' || Object.keys(this.values.submitter).length === 0 ) {
-        Vue.set(this.values, 'submitter', {})
+        this.$set(this.values, 'submitter', {})
         for (const [key, value] of Object.entries(submitterProperties)) {
-          Vue.set(this.values.submitter, key, value)
+          this.$set(this.values.submitter, key, value)
         }
       }
+    },
+
+    /**
+     * @param { Boolean } val
+     * To ensure the reactivity the state of 'values.submitter.institution'.
+     */
+    setInstitutionValue (val) {
+      this.$nextTick(() => {
+        this.$set(this.values.submitter, 'institution',  val)
+      })
     },
 
     sortSelected (property) {

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -65,7 +65,6 @@
 
 <script>
 import { dpApi, DpLoading } from '@demos-europe/demosplan-ui'
-import dayjs from 'dayjs'
 import DpSendBeacon from './DpSendBeacon'
 import DpSimplifiedNewStatementForm from '@DpJs/components/procedure/DpSimplifiedNewStatementForm'
 

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -65,6 +65,7 @@
 
 <script>
 import { dpApi, DpLoading } from '@demos-europe/demosplan-ui'
+import dayjs from 'dayjs'
 import DpSendBeacon from './DpSendBeacon'
 import DpSimplifiedNewStatementForm from '@DpJs/components/procedure/DpSimplifiedNewStatementForm'
 
@@ -196,6 +197,8 @@ export default {
       this.document = documentResponse.data.data.find(el => el.type === 'AnnotatedStatementPdf')
       this.formValues = { ...this.formValues, text: this.document.attributes.text }
       this.pages = documentResponse.data.included.filter(el => el.type === 'AnnotatedStatementPdfPage')
+      const file = documentResponse.data.included.filter(el => el.type === 'File')[0]
+      this.formValues.submittedDate = dayjs(file.attributes.created).format('DD.MM.YYYY')
       this.isLoading = false
     },
 
@@ -236,9 +239,6 @@ export default {
 
   mounted () {
     this.getInitialData()
-      .then(response => {
-        this.submittedDate = response.included[0].attributes.created ? response.included[0].attributes.created : ''
-      })
   }
 }
 </script>

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -236,6 +236,9 @@ export default {
 
   mounted () {
     this.getInitialData()
+      .then(response => {
+        this.submittedDate = response.included[0].attributes.created ? response.included[0].attributes.created : ''
+      })
   }
 }
 </script>

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -197,8 +197,6 @@ export default {
       this.document = documentResponse.data.data.find(el => el.type === 'AnnotatedStatementPdf')
       this.formValues = { ...this.formValues, text: this.document.attributes.text }
       this.pages = documentResponse.data.included.filter(el => el.type === 'AnnotatedStatementPdfPage')
-      const file = documentResponse.data.included.filter(el => el.type === 'File')[0]
-      this.formValues.submittedDate = dayjs(file.attributes.created).format('DD.MM.YYYY')
       this.isLoading = false
     },
 


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32601

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR is part of EWM 3.1

- The simplified new statement form component was updated in an addon and must be synced here with the state.
This is mainly intended to reduce the maintenance efforts because the simplified statement form had to be duplicated in addons
- The `values.submitter.date` prop will be passed from data to FE if existant (correct box recognition setup) hence we can use this value to automatically fill in the form field value when confirming the pdf import

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
#### THIS IS NOT LOCALLY TESTABLE EVEN WITH LOCAL DATA PIPELINE ENABLED (because the local pipeline is outdated compared to the dev pipeline and we will not receive the date locally)

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
