### PR TITLE
bug(refs T32785): Add css selector to savelist

### DIFF
--- a/client/fe/config/config.js
+++ b/client/fe/config/config.js
@@ -78,6 +78,9 @@ class Config {
           /color-ui-.+/,
           /tabs-component.*/
         ],
+        deep: [
+          /split-statement/
+        ],
         greedy: [
           /tooltip/
         ]


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32785

The components for this css were moved to an addon, but the styles are still in core and need to be loaded. Safelist.deep includes the selector's children.

### How to review/test
Split a statement and see if the styles were loaded. 
