### PR TITLE
fix T32606 resrouce types interfaces have to be set public

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -99,15 +99,23 @@ services:
 
     DemosEurope\DemosplanAddon\Contracts\ResourceType\FileResourceTypeInterface:
         class: demosplan\DemosPlanCoreBundle\ResourceTypes\FileResourceType
+        public: true
 
     DemosEurope\DemosplanAddon\Contracts\ResourceType\ProcedureResourceTypeInterface:
         class: demosplan\DemosPlanCoreBundle\ResourceTypes\ProcedureResourceType
+        public: true
 
     DemosEurope\DemosplanAddon\Contracts\ResourceType\StatementResourceTypeInterface:
         class: demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType
+        public: true
 
     DemosEurope\DemosplanAddon\Contracts\ResourceType\UserResourceTypeInterface:
         class: demosplan\DemosPlanCoreBundle\ResourceTypes\UserResourceType
+        public: true
+
+    DemosEurope\DemosplanAddon\Contracts\ResourceType\OriginalStatementResourceTypeInterface:
+        class: demosplan\DemosPlanCoreBundle\ResourceTypes\OriginalStatementResourceType
+        public: true
 
     DemosEurope\DemosplanAddon\Contracts\ResourceType\ResourceTypeServiceInterface:
         class: demosplan\DemosPlanCoreBundle\Logic\ResourceTypeService
@@ -1204,6 +1212,7 @@ services:
 
     EDT\Wrapping\TypeProviders\PrefilledTypeProvider:
         alias: 'demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
+
 
     EDT\Wrapping\Utilities\TypeAccessors\AbstractProcessorConfig:
 

--- a/config/services_autowire.yml
+++ b/config/services_autowire.yml
@@ -41,6 +41,7 @@ services:
 
     demosplan\DemosPlanCoreBundle\ResourceTypes\:
         resource: '../demosplan/DemosPlanCoreBundle/ResourceTypes'
+        public: true
         autowire: true
         tags: ['dplan.resourceType']
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32606

Description: resrouce types interfaces have to be set public

