### PR TITLE
fix (refs T32858): Allow overwriting filenames on tus upload

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
@@ -82,7 +82,8 @@ class TusUploadEventSubscriber implements EventSubscriberInterface
             $filePathParts[] = $filename;
             $sanitizedPath = implode('/', $filePathParts);
             // rename uploaded file and update reference in uploaded file
-            $fs->rename($file->getFilePath(), $sanitizedPath);
+            // in order to avoid dangling file data is prevented renaming, simply allow overwriting.
+            $fs->rename($file->getFilePath(), $sanitizedPath, true);
             $file->setFilePath($sanitizedPath);
         }
 

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 /**
  * This file is part of the package demosplan.
  *
- * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
-use TusPhp\File;
 use demosplan\DemosPlanCoreBundle\Application\Header;
 use demosplan\DemosPlanCoreBundle\Exception\VirusFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
@@ -22,6 +21,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Throwable;
 use TusPhp\Cache\FileStore;
 use TusPhp\Events\UploadComplete;
+use TusPhp\File;
 
 /**
  * Hook into the Tus events for upload processing.


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32858

In order to avoid dangling file data is prevented renaming, simply allow overwriting.

### How to review/test
Test to upload a csv, especially the one described in the ticket.


Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
