### PR TITLE
fix (refs T32922): Fix versioning by fix getting user on creation of …

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
@@ -865,13 +865,19 @@ class EntityContentChangeService extends CoreService
      */
     protected function determineChanger(bool $isReviewer): ?object
     {
+        $user = null;
         $token = $this->getTokenStorage()->getToken();
 
+        // If possible, get the User via the SecurityUser
         if ($token instanceof TokenInterface) {
             $user = $this->userFromSecurityUserProvider->fromToken($token);
-            if ($user instanceof User) {
-                return $isReviewer ? $user->getDepartment() : $user;
-            }
+
+            // If not found yet, use fallback to get user directly
+            $user = $user instanceof User ? $user : $token->getUser();
+        }
+
+        if ($user instanceof User) {
+            return $isReviewer ? $user->getDepartment() : $user;
         }
 
         return null;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32922

Actually some times $this->userFromSecurityUserProvider->fromToken($token); can't find a user.
To cover this, we getting the user the old way, in case it was not found.

### How to review/test
Create a new version by changing working person or step.

### PR Checklist

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
