### PR TITLE
fix (refs T32805): only send email to all users within one customer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -23,6 +23,7 @@ use demosplan\DemosPlanCoreBundle\ResourceTypes\CustomerResourceType;
 use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 use demosplan\DemosPlanUserBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanUserBundle\Logic\CustomerHandler;
+use demosplan\DemosPlanUserBundle\Logic\UserService;
 use demosplan\DemosPlanUserBundle\ValueObject\CustomerFormInput;
 use EDT\JsonApi\ResourceTypes\ResourceTypeInterface;
 use Exception;
@@ -138,16 +139,16 @@ class DemosPlanCustomerController extends BaseController
      * @throws MessageBagException
      */
     public function sendMailToAllCustomersAction(
+        CustomerHandler $customerHandler,
+        HTMLSanitizer $HTMLSanitizer,
+        MailService $mailService,
         Request $request,
         TranslatorInterface $translator,
-        MailService $mailService,
-        CustomerHandler $customerHandler,
-        HTMLSanitizer $HTMLSanitizer
+        UserService $userService
     ): Response {
         try {
             $currentCustomer = $customerHandler->getCurrentCustomer();
-            $emailAddresses = $currentCustomer->getEmailsOfUsersOfOrgas();
-
+            $emailAddresses = $userService->getEmailsOfUsersOfOrgas($currentCustomer);
             $templateVars['usersCount'] = count($emailAddresses);
             if ($request->isMethod('GET')) {
                 return $this->renderTemplate(

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
@@ -285,7 +285,12 @@ class Customer extends CoreEntity implements UuidEntityInterface
         $this->orgaStatuses = $orgaStatuses;
     }
 
-    public function getOrgas(): Collection
+    /**
+     * @param array<int,string> $statuses if null, all orga statuses will be returned
+     *                                    will be applied as or condition
+     * @return Collection<int, Orga>
+     */
+    public function getOrgas(array $statuses = []): Collection
     {
         $orgas = new ArrayCollection();
 
@@ -293,28 +298,14 @@ class Customer extends CoreEntity implements UuidEntityInterface
         foreach ($this->getOrgaStatuses() as $customerOrgaTypes) {
             $orga = $customerOrgaTypes->getOrga();
             if (!$orgas->contains($orga)) {
-                $orgas->add($orga);
+                // filter by status
+                if ([] === $statuses || in_array($customerOrgaTypes->getStatus(), $statuses, true)) {
+                    $orgas->add($orga);
+                }
             }
         }
 
         return $orgas;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getEmailsOfUsersOfOrgas(): array
-    {
-        $mailAddresses = [];
-        /** @var Orga $orga */
-        foreach ($this->getOrgas() as $orga) {
-            /** @var User $user */
-            foreach ($orga->getUsers() as $user) {
-                $mailAddresses[] = $user->getEmail();
-            }
-        }
-
-        return $mailAddresses;
     }
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32805

We need to check that any person is in current customer before sending an email as there are organizations like 'Privatperson' special organization that need to be in multiple customers. But not every user is registered in any of these customers.
Moreover, we should check whether the orga is accepted before we send emails to it.

### How to review/test
Register a new citizen in Customer A and send as platform administrator emails to all users of Customer B. The new citizen should not receive any email

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
