### PR TITLE
Use distinct filenames for css entry points

### DIFF
--- a/config.webpack.js
+++ b/config.webpack.js
@@ -86,8 +86,8 @@ const bundlesConfig = merge(baseConfig, {
   name: 'main',
   entry: () => {
     return {
-      css: config.stylesEntryPoint,
-      publiccss: config.publicStylesEntryPoint,
+      style: config.stylesEntryPoint,
+      'style-public': config.publicStylesEntryPoint,
       ...bundleEntryPoints(config.clientBundleGlob)
     }
   },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -31,7 +31,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundle('css.css') }}
+            {{ webpackBundle('style.css') }}
         {% endblock stylesheets %}
 
         {% block component_header %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
@@ -28,7 +28,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundle('publiccss.css') }}
+            {{ webpackBundle('style-public.css') }}
         {% endblock stylesheets %}
 
         {% block component_header %}


### PR DESCRIPTION
Before, the getBundleAndRelatedChunkSplits always returned two entrypoins (css.css and publiccss.css) when being asked for css.css only. that led to those styles being included twice. The reason was that strpos('css.css', 'publiccss.css') returns true... well.

### How to review/test
After running `yarn dev:<project>` and then navigating into the planning area of demosPlan, the styles should not only look good (as they always do), but there should be only one css file included in the html.