### PR TITLE
F T32871 new map layer cannot be created

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Maps/GetCapabilitesRpcMethodSolver.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Maps/GetCapabilitesRpcMethodSolver.php
@@ -83,7 +83,7 @@ class GetCapabilitesRpcMethodSolver implements RpcMethodSolverInterface
 
         $this->jsonSchemaValidator->validate(
             Json::encode($rpcRequest, JSON_THROW_ON_ERROR),
-            DemosPlanPath::getConfigPath('config/json-schema/rpc-map-get-capbilities-schema.json')
+            DemosPlanPath::getConfigPath('json-schema/rpc-map-get-capbilities-schema.json')
         );
     }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32871

Description: The rpc-map-get-capbilities-schema.json path was wrong und had to be adjusted


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
