### PR TITLE
Fix(refs:32940): incorrect view by fullscreen

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -390,7 +390,6 @@ export default {
       const extent = view.getProjection().getExtent()
       const center = view.getCenter()
 
-      // Force a recalculation of the map viewport size. This should be called when third-party code changes the size of the map viewport.
       this.map.updateSize()
 
       view.fit(extent, {

--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -353,7 +353,6 @@ export default {
         document.addEventListener(event, () => {
           //  Toggle class `fullscreen-mode` on html element to change canvas size dynamically via CSS
           html.classList.toggle(this.prefixClass('fullscreen-mode'))
-          this.updateMapInstance()
         }, false)
       })
     },
@@ -391,6 +390,7 @@ export default {
       const extent = view.getProjection().getExtent()
       const center = view.getCenter()
 
+      // Force a recalculation of the map viewport size. This should be called when third-party code changes the size of the map viewport.
       this.map.updateSize()
 
       view.fit(extent, {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32940

### Description: 

- if you click to fullscreen the chosen scale view shall be shown in fullscreen
- the bug is that it shows always the full map content in fullscreen
- remove the function here, which contains a force of a recalculation of the map viewport, 
- so that the fullscreen view cannot be forced to show another view than the chosen view when fullscreen is not clicked

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
