### PR TITLE
bug(refs T32938): fix dropdown does not show correct value

### DIFF
--- a/client/js/components/map/map/DpOlMapScaleSelect.vue
+++ b/client/js/components/map/map/DpOlMapScaleSelect.vue
@@ -46,16 +46,6 @@ export default {
     }
   },
 
-  /*
-   * Refactor watcher
-   * should not be necessary
-   */
-  watch: {
-    olMapState () {
-      this.init()
-    }
-  },
-
   methods: {
     init () {
       const map = this.olMapState.map

--- a/client/js/components/map/map/DpOlMapScaleSelect.vue
+++ b/client/js/components/map/map/DpOlMapScaleSelect.vue
@@ -46,6 +46,16 @@ export default {
     }
   },
 
+  /*
+   * Refactor watcher
+   * should not be necessary
+   */
+  watch: {
+    olMapState () {
+      this.init()
+    }
+  },
+
   methods: {
     init () {
       const map = this.olMapState.map

--- a/client/js/components/map/map/DpOlMapScaleSelect.vue
+++ b/client/js/components/map/map/DpOlMapScaleSelect.vue
@@ -61,28 +61,14 @@ export default {
       const map = this.olMapState.map
       const view = this.view = map.getView()
       const resolutions = view.getResolutions()
-      const currentResolution = this.view.getResolution()
       const units = this.units = view.getProjection().getUnits()
 
       //  Translate map resolutions to scales to display in select
       this.scales = getScalesAndResolutions(resolutions, units)
 
-      //  Get initial scale
-      this.currentScale = getScaleFromResolution(currentResolution, this.units)
-
-      //  Attach event listeners to OpenLayers events to determine if resolution has changed and update selected option
-      map.on('movestart', () => {
-        let newResolution
-        const resolution = newResolution = this.view.getResolution()
-
-        map.once('moveend', () => {
-          newResolution = this.view.getResolution()
-
-          //  Fire only if resolution changed (movestart & moveend is triggered by several other interactions as well)
-          if (resolution !== newResolution) {
-            this.currentScale = getScaleFromResolution(newResolution, this.units)
-          }
-        })
+      // Set current scale after map data has loaded completely. This also triggers when changing the scale.
+      map.on('loadend', () => {
+        this.currentScale = getScaleFromResolution(this.view.getResolution(), this.units)
       })
     },
 

--- a/client/js/components/map/map/DpOlMapScaleSelect.vue
+++ b/client/js/components/map/map/DpOlMapScaleSelect.vue
@@ -70,6 +70,9 @@ export default {
       map.on('loadend', () => {
         this.currentScale = getScaleFromResolution(this.view.getResolution(), this.units)
       })
+      map.on('moveend', () => {
+        this.currentScale = getScaleFromResolution(this.view.getResolution(), this.units)
+      })
     },
 
     setScale (evt) {


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T32938

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- This is a refactoring of this component combined with a bugfix.
- The dropdown didn't show the map's current scale when a map with another scale has been opened before
- To solve this the current scale value will not be set after zooming in or out of the map but when a map has been openend and the data of the current view is finished loading. This means everytime we zoom in or out or even just open the map in the sidemenu, the current scale will be evaluated by using the `loadend` OL event

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
-> Naivagate to statement details -> open map component and make sure the correct scale is visible in the dropdown -> open another map and make also the the scale updates (if needed)

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
![Screenshot 2023-05-26 at 15-29-08 Erwiderungen verfassen Releasetest 14 04  - Ronja Einwendungsmanagement Online](https://github.com/demos-europe/demosplan-core/assets/91727189/032398bd-e64a-4057-a91d-6b01eed77b6c)


