### PR TITLE
feature (refs T32945): split multiPurposePermission into separate ones.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/permissions.yml
@@ -581,6 +581,10 @@ feature_admin_element_edit:
     label: 'Kategorien bearbeiten'
     loginRequired: true
     parent: feature_admin
+feature_admin_element_delete:
+    label: 'delete categories'
+    loginRequired: true
+    parent: feature_admin
 feature_admin_element_import:
     label: 'Kategorien und Dateien importieren'
     loginRequired: true

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/elements_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/elements_admin_edit.html.twig
@@ -299,7 +299,7 @@
                     <input type="hidden" name="r_ident" value="{{ element.ident|default() }}">
                     <input type="hidden" name="r_parent" value="{{ templateVars.parent|default('') }}">
 
-                    {% if hasPermission('feature_admin_element_edit')%}
+                    {% if hasPermission('feature_admin_element_delete')%}
                         <fieldset class="u-pb-0">
                             <legend>{{ "category.delete"|trans }}</legend>
                             <p>{{ "explanation.category.delete"|trans }}</p>


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32945

Description:
The permission feature_admin_element_edit is used for multiple purposes which we need to distinguish. Therefore a separate permission for deleting an element was introduced


### Linked PRs (optional)


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
