### PR TITLE
feat (refs T32954): Do not save user object in session

### DIFF
--- a/demosplan/DemosPlanUserBundle/Logic/UserMapperDataportGatewayHH.php
+++ b/demosplan/DemosPlanUserBundle/Logic/UserMapperDataportGatewayHH.php
@@ -476,7 +476,7 @@ class UserMapperDataportGatewayHH extends UserMapperDataportGateway
                     $publicAgencyUser->setTwinUser($user);
                     $this->userService->updateUserObject($publicAgencyUser);
 
-                    $request->getSession()->set('session2User', $publicAgencyUser);
+                    $request->getSession()->set('session2UserId', $publicAgencyUser->getId());
                 }
             }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32954

User object of the second user should not be saved in session as it leads to excessively large database entries.

### How to review/test
Login as a simulated osi fhhnet toeb and planner user and switch orgas. You should not be logged out

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
