### PR TITLE
chore (refs T27388): upgrade request header deprecation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/TrustedProxiesSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/TrustedProxiesSubscriber.php
@@ -39,7 +39,10 @@ class TrustedProxiesSubscriber implements EventSubscriberInterface
         if (0 < count($this->globalConfig->getProxyTrusted())) {
             $request::setTrustedProxies(
                 array_merge($request::getTrustedProxies(), $this->globalConfig->getProxyTrusted()),
-                Request::HEADER_X_FORWARDED_ALL
+                Request::HEADER_X_FORWARDED_FOR
+                | Request::HEADER_X_FORWARDED_HOST
+                | Request::HEADER_X_FORWARDED_PORT
+                | Request::HEADER_X_FORWARDED_PROTO
             );
         }
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27388

Request::HEADER_X_FORWARDED_ALL has been deprecated and needs to be replaced by the single constants it merged so far

### How to review/test
code review

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
