### PR TITLE
rector (refs T27388) apply rector SymfonyLevelSetList::UP_TO_SYMFONY_54

### DIFF
--- a/config/routing_core.yml
+++ b/config/routing_core.yml
@@ -1,3 +1,6 @@
+imports:
+    resource: routes/*
+
 csp_report:
     path: /nelmio/csp/report
     methods: [POST]

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Application;
 
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use demosplan\DemosPlanCoreBundle\Addon\AddonBundleGenerator;
 use demosplan\DemosPlanCoreBundle\Addon\LoadAddonInfoCompilerPass;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler\DeploymentStrategyLoaderPass;
@@ -105,7 +106,7 @@ class DemosPlanKernel extends Kernel
         yield from $addonBundleGenerator->registerBundles($this->environment);
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $coreConfigPath = DemosPlanPath::getConfigPath();
 
@@ -274,11 +275,11 @@ class DemosPlanKernel extends Kernel
             );
         }
 
-        $container->addCompilerPass(new DeploymentStrategyLoaderPass());
-        $container->addCompilerPass(new RpcMethodSolverPass());
-        $container->addCompilerPass(new MenusLoaderPass());
-        $container->addCompilerPass(new OptionsLoaderPass(), PassConfig::TYPE_AFTER_REMOVING);
-        $container->addCompilerPass(new LoadAddonInfoCompilerPass());
+        $container->addCompilerPass(new DeploymentStrategyLoaderPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+        $container->addCompilerPass(new RpcMethodSolverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+        $container->addCompilerPass(new MenusLoaderPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+        $container->addCompilerPass(new OptionsLoaderPass(), PassConfig::TYPE_AFTER_REMOVING, 0);
+        $container->addCompilerPass(new LoadAddonInfoCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
     }
 
     public function getActiveProject(): string

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class AddonBuildFrontendCommand extends CoreCommand
 {
     protected static $defaultName = 'dplan:addon:build-frontend';
+    protected static $defaultDescription = 'Build frontend assets for an addon';
 
     private AddonRegistry $registry;
 
@@ -33,7 +34,6 @@ class AddonBuildFrontendCommand extends CoreCommand
 
     protected function configure()
     {
-        $this->setDescription('Build frontend assets for an addon');
         $this->addArgument('addon-name', InputArgument::REQUIRED, 'Addon name, du\'h.');
     }
 

--- a/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Logic\DemosFilesystem;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
@@ -62,7 +63,7 @@ class CacheClearCommand extends CoreCommand
         } catch (Exception $e) {
             $output->error('Failed to clear CLI APCu and OpCache, aborting');
 
-            return 1;
+            return (int) Command::FAILURE;
         }
 
         if ('test' !== $this->getApplication()->getKernel()->getEnvironment()) {
@@ -73,7 +74,7 @@ class CacheClearCommand extends CoreCommand
             $this->handleAppCacheClear($input, $output);
         }
 
-        return 0;
+        return (int) Command::SUCCESS;
     }
 
     private function scheduleWebApcuClear(SymfonyStyle $output): void

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
@@ -82,7 +82,7 @@ class GenerateCustomerCommand extends CoreCommand
     /**
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = $input->getOption(self::OPTION_NAME);
         if (null === $name) {

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ModifyTestuserDefaultPasswordCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ModifyTestuserDefaultPasswordCommand.php
@@ -47,7 +47,7 @@ class ModifyTestuserDefaultPasswordCommand extends CoreCommand
         $this->userService = $userService;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $defaultPassword = $this->askDefaultPassword($input, $output);
         $passwordToSet = $this->askNewDefaultPassword($input, $output);

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ModifyUserCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ModifyUserCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -46,7 +47,7 @@ class ModifyUserCommand extends CoreCommand
         if ('' === trim($this->standardPassword)) {
             $output->writeln('Standard-password needs to be defined configuration');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         /** @var array<int, string> $organisationsIds */
@@ -57,19 +58,19 @@ class ModifyUserCommand extends CoreCommand
         } catch (Exception $e) {
             $output->writeln('Reset password for users of specific organisations failed.');
 
-            return 1;
+            return Command::FAILURE;
         }
         try {
             $this->resetPasswordOfUsersPerRole(3, $users);
         } catch (Exception $e) {
             $output->writeln('Reset password for users of each role failed.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $output->writeln('Updated users to login with');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
@@ -76,7 +76,7 @@ class RegisterUserForCustomerCommand extends CoreCommand
         $this->helpers = $helpers;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $userToRegister = $this->askUserLogin($input, $output);
         if (null === $userToRegister) {

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Command\Command;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\EmailAddress;
@@ -158,7 +159,7 @@ class RemoveUserDataCommand extends CoreCommand
             // in case of this command should be workable for HH too.
             // _master_toeb
             // _master_toeb_versions
-            return 1;
+            return (int) Command::FAILURE;
         }
 
         // #1: independent::
@@ -196,7 +197,7 @@ class RemoveUserDataCommand extends CoreCommand
         // depended on draftstatements:
         $this->removeUserDataFromDraftStatementVersions();
 
-        return 0;
+        return (int) Command::SUCCESS;
     }
 
     protected function removeUserDataFromUsers(): void

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ReplaceFilesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ReplaceFilesCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\DataGenerator\DataGeneratorInterface;
 use demosplan\DemosPlanCoreBundle\DataGenerator\FakeDataGeneratorFactory;
@@ -104,7 +105,7 @@ class ReplaceFilesCommand extends CoreCommand
             $this->generateDummyForFile($file, $slot, $output, $dryRun, $directory);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/Db/DumpCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/DumpCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Command\Command;
 use Exception;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,7 +51,7 @@ class DumpCommand extends DatabaseManagementCommand
         } catch (Exception $e) {
             $output->error("Cannot write to {$file}");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $databaseName = $this->getDatabaseName($input);
@@ -82,6 +83,6 @@ class DumpCommand extends DatabaseManagementCommand
 
         $output->success('Done.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Db/RestoreCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/RestoreCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,14 +47,7 @@ class RestoreCommand extends DatabaseManagementCommand
         $databaseHost = $this->getDatabaseHost($input);
         $databasePassword = $this->getDatabasePassword($input);
 
-        $cmd = sprintf(
-            'mysql --user %s --host %s --password=%s %s < %s',
-            $databaseUser,
-            $databaseHost,
-            '' === $databasePassword ? '""' : $databasePassword,
-            $databaseName,
-            $file
-        );
+        $cmd = ['mysql', '--user', $databaseUser, '--host', $databaseHost, '--password=%s', '' === $databasePassword ? '""' : $databasePassword, '<', $databaseName];
 
         $mysql = new Process($cmd);
         $mysql->setTimeout(null);
@@ -64,6 +58,6 @@ class RestoreCommand extends DatabaseManagementCommand
 
         $output->success('Done.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Debug/DplanProcedureTypeFieldsCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Debug/DplanProcedureTypeFieldsCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Debug;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType;
 use demosplan\DemosPlanProcedureBundle\Logic\ProcedureTypeService;
@@ -85,7 +86,7 @@ class DplanProcedureTypeFieldsCommand extends CoreCommand
             return -1;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/DeployCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/DeployCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Logic\Deployment\StrategyLoader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -67,6 +68,6 @@ class DeployCommand extends CoreCommand
         $strategy->setGitReference($input->getOption('reference'));
         $strategy->execute($input, $output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Documentation;
 
+use Symfony\Component\Console\Command\Command;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
@@ -49,10 +50,10 @@ class PermissionListCommand extends CoreCommand
         } catch (JsonException $e) {
             $output->writeln('{"error": "Permission export failed."}');
 
-            return 1;
+            return (int) Command::FAILURE;
         }
 
-        return 0;
+        return (int) Command::SUCCESS;
     }
 
     protected function loadGlobalPermissions(): Collection

--- a/demosplan/DemosPlanCoreBundle/Command/ElasticsearchPopulateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ElasticsearchPopulateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use RuntimeException;
@@ -94,7 +95,7 @@ class ElasticsearchPopulateCommand extends CoreCommand
         $this->stopWorkers($output);
         $output->writeln('Elasticsearch populate finished');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function startIndexWorker(): void

--- a/demosplan/DemosPlanCoreBundle/Command/FrontendBuildinfoCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendBuildinfoCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -38,7 +39,7 @@ class FrontendBuildinfoCommand extends CoreCommand
             $output->writeln('Error: Additional data load failed');
             $output->writeln($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         try {
@@ -46,10 +47,10 @@ class FrontendBuildinfoCommand extends CoreCommand
         } catch (JsonException $e) {
             $output->writeln('Error: Parameter dump failed');
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getParameters(): array

--- a/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\Writer;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
@@ -95,7 +96,7 @@ class FrontendIntegratorCommand extends CoreCommand
             $output->writeln('Error: Additional data load failed');
             $output->writeln($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         try {
@@ -103,10 +104,10 @@ class FrontendIntegratorCommand extends CoreCommand
         } catch (JsonException $e) {
             $output->writeln('Error: Parameter dump failed');
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getParameters(): array

--- a/demosplan/DemosPlanCoreBundle/Command/LocationUpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/LocationUpdateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Logic\LocationUpdateService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -53,6 +54,6 @@ class LocationUpdateCommand extends CoreCommand
 
         $this->locationUpdate->repopulateDatabase($includeOnly);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Bazinga\GeocoderBundle\ProviderFactory\NominatimFactory;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\AddonMaintenanceEventInterface;
@@ -205,7 +206,7 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
      *
      * @throws ShutdownEndlessCommandException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Tell the user what we're going to do.
         // This will be silenced by Symfony if the user doesn't want any output at all,
@@ -249,7 +250,7 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
         // Tell the user we're done
         $output->writeln('done');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/PermissionFixCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PermissionFixCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Symfony\Component\Console\Input\InputInterface;
@@ -121,6 +122,6 @@ class PermissionFixCommand extends CoreCommand
             $output->warning('You need to run `composer update` because you chose to force me to delete things');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/PhpStanCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PhpStanCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -61,14 +62,14 @@ class PhpStanCommand extends CoreCommand
         $configSavePath = $this->writeConfig($input);
 
         if ($input->getOption('only-dump-config')) {
-            return 0;
+            return Command::SUCCESS;
         }
 
         $path = $input->getArgument('path');
 
         $level = (int) $input->getOption('level');
 
-        return $this->doRunPhpStan($input, $output, $configSavePath, $path, $level);
+        return (int) $this->doRunPhpStan($input, $output, $configSavePath, $path, $level);
     }
 
     protected function writeConfig(InputInterface $input): string

--- a/demosplan/DemosPlanCoreBundle/Command/PreflightCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PreflightCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,6 +62,6 @@ class PreflightCommand extends CoreCommand
          * - git checkout -- .
          * - git
          */
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/PsalmCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PsalmCommand.php
@@ -69,7 +69,7 @@ class PsalmCommand extends CoreCommand
     /**
      * @return int|null
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $configFilePath = DemosPlanPath::getTemporaryPath(uniqid('', true).'psalm.xml');
 
@@ -123,6 +123,6 @@ class PsalmCommand extends CoreCommand
             $output->write($process->getOutput());
         }
 
-        return $process->getExitCode();
+        return (int) $process->getExitCode();
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/TranslationsDumpCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/TranslationsDumpCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
@@ -36,7 +37,7 @@ class TranslationsDumpCommand extends CoreCommand
      *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tempDir = DemosPlanPath::getTemporaryPath(uniqid('dplan_translations', true));
 
@@ -95,6 +96,6 @@ class TranslationsDumpCommand extends CoreCommand
 
         DemosPlanPath::recursiveRemovePath($tempDir);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Carbon\Carbon;
 use demosplan\DemosPlanCoreBundle\Exception\UpdateException;
 use demosplan\DemosPlanCoreBundle\Logic\DemosFilesystem;
@@ -76,7 +77,7 @@ EOT
             && $this->getApplication()->getKernel()->isLocalContainer()) {
             $output->writeln('Will not run in your container to prevent damage.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         // setup log filename
@@ -173,7 +174,7 @@ EOT
 
         $this->clearUpdateLock($fs, $updateLockFile);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\User;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
@@ -63,7 +64,7 @@ class UserCreateCommand extends CoreCommand
         $this->helpers = $helpers;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $firstName = $this->askFirstname($input, $output);
         $lastName = $this->askLastname($input, $output);
@@ -94,7 +95,7 @@ class UserCreateCommand extends CoreCommand
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
-            return 0;
+            return Command::SUCCESS;
         } catch (Exception $e) {
             // Print Exception
             $output->writeln(
@@ -102,7 +103,7 @@ class UserCreateCommand extends CoreCommand
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserListCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\User;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -86,7 +87,7 @@ class UserListCommand extends CoreCommand
             $this->outputDataAsTextTable($output, $headers, $data);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function outputDataAsHTMLTable(OutputInterface $output, array $headers, Collection $data)

--- a/demosplan/DemosPlanCoreBundle/Command/VendorlistUpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/VendorlistUpdateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Carbon\Carbon;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
@@ -61,7 +62,7 @@ class VendorlistUpdateCommand extends CoreCommand
         $this->fetchPHPDependencyLicenses();
         $this->fetchNodeDependencyLicenses();
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function fetchPHPDependencyLicenses(): void

--- a/demosplan/DemosPlanCoreBundle/Command/WebfolderCreateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/WebfolderCreateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use demosplan\DemosPlanCoreBundle\Logic\DemosFilesystem;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Exception;
@@ -90,7 +91,7 @@ EOT
             $this->copyStaticCss($projectWebsource, $projectWebfolderTarget);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
@@ -31,16 +31,6 @@ class DemosPlanAdminController extends BaseController
     /**
      * Generiert die HTML Seite für die Statistik.
      *
-     * @Route(
-     *     name="DemosPlan_statistics",
-     *     path="/statistik",
-     *     defaults={"format": "html", "part": "all"},
-     * )
-     * @Route(
-     *     name="DemosPlan_statistics_csv",
-     *     path="/statistik/{part}/csv",
-     *     defaults={"format": "csv"},
-     * )
      *
      * @DplanPermissions("area_statistics")
      *
@@ -51,6 +41,8 @@ class DemosPlanAdminController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statistics', path: '/statistik', defaults: ['format' => 'html', 'part' => 'all'])]
+    #[Route(name: 'DemosPlan_statistics_csv', path: '/statistik/{part}/csv', defaults: ['format' => 'csv'])]
     public function generateStatisticsAction(
         Environment $twig,
         OrgaService $orgaService,

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -149,23 +149,14 @@ class DemosPlanAssessmentTableController extends BaseController
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
-     * @Route(
-     *     name="dplan_assessmenttable_view_table",
-     *     path="/verfahren/abwaegung/view/{procedureId}/{filterHash}",
-     *     defaults={
-     *          "filterHash": null,
-     *          "original": false,
-     *     },
-     *     options={"expose": true}
-     * )
      *
      * @param AssessmentExportOptions $exportOptions Object that holds logic about export options in normal and original view
      * @param string|null             $filterHash
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_assessmenttable_view_table', path: '/verfahren/abwaegung/view/{procedureId}/{filterHash}', defaults: ['filterHash' => null, 'original' => false], options: ['expose' => true])]
     public function viewTableAction(
         AssessmentExportOptions $exportOptions,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -359,23 +350,14 @@ class DemosPlanAssessmentTableController extends BaseController
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
-     * @Route(
-     *     name="dplan_assessmenttable_view_original_table",
-     *     path="/verfahren/original/{procedureId}/{filterHash}",
-     *     defaults={
-     *          "filterHash": null,
-     *          "original": true,
-     *     },
-     *     options={"expose": true}
-     * )
      *
      * @param AssessmentExportOptions $exportOptions Object that holds logic about export options in normal and original view
      * @param string|null             $filterHash
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_assessmenttable_view_original_table', path: '/verfahren/original/{procedureId}/{filterHash}', defaults: ['filterHash' => null, 'original' => true], options: ['expose' => true])]
     public function viewOriginalTableAction(
         AssessmentExportOptions $exportOptions,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -647,22 +629,9 @@ class DemosPlanAssessmentTableController extends BaseController
     }
 
     // @improve T13718
-
     /**
      * Abwaegungstabelle - Detailseite.
      *
-     * @Route(
-     *     name="DemosPlan_cluster_view",
-     *     path="/verfahren/{procedureId}/cluster/{statement}",
-     *     defaults={"title": "assessment.table.cluster.detail", "isCluster": true},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="dm_plan_assessment_single_view",
-     *     path="/verfahren/{procedureId}/abwaegung/sview/{statement}",
-     *     defaults={"title": "assessment.table.statement.detail"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
@@ -672,6 +641,8 @@ class DemosPlanAssessmentTableController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_cluster_view', path: '/verfahren/{procedureId}/cluster/{statement}', defaults: ['title' => 'assessment.table.cluster.detail', 'isCluster' => true], options: ['expose' => true])]
+    #[Route(name: 'dm_plan_assessment_single_view', path: '/verfahren/{procedureId}/abwaegung/sview/{statement}', defaults: ['title' => 'assessment.table.statement.detail'], options: ['expose' => true])]
     public function viewSingleAction(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -831,15 +802,11 @@ class DemosPlanAssessmentTableController extends BaseController
     /**
      * Kopieren einer einzelnen Stellungnahme.
      *
-     * @Route(
-     *     name="dm_plan_assessment_single_copy",
-     *     path="/verfahren/{procedure}/abwaegung/copy/{statement}"
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @throws Exception
      */
+    #[Route(name: 'dm_plan_assessment_single_copy', path: '/verfahren/{procedure}/abwaegung/copy/{statement}')]
     public function copySingleStatementAction(StatementService $statementService, string $procedure, string $statement): RedirectResponse
     {
         try {
@@ -866,20 +833,15 @@ class DemosPlanAssessmentTableController extends BaseController
      * This action is used to fill out the votum-form when assigning
      * tags to them.
      *
-     * @Route(
-     *     name="dm_plan_assessment_get_boilerplates_ajax",
-     *     path="/boilerplatetext/{procedure}/{tag}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_boilerplates")
      *
      * @param string $tag
      *
      * @return JsonResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'dm_plan_assessment_get_boilerplates_ajax', path: '/boilerplatetext/{procedure}/{tag}', options: ['expose' => true])]
     public function getBoilerplateAjaxAction(TagService $tagService, TranslatorInterface $translator, $tag)
     {
         try {
@@ -916,11 +878,6 @@ class DemosPlanAssessmentTableController extends BaseController
     /**
      * Get complete text of a statement to be displayed in a <dp-height-limit> component.
      *
-     * @Route(
-     *     name="dm_plan_assessment_get_statement_ajax",
-     *     path="/_ajax/statement/{statementId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
@@ -930,9 +887,9 @@ class DemosPlanAssessmentTableController extends BaseController
      * @param string $statementId
      *
      * @return JsonResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'dm_plan_assessment_get_statement_ajax', path: '/_ajax/statement/{statementId}', options: ['expose' => true])]
     public function getStatementRemainderAjaxAction(Request $request, StatementService $statementService, $statementId)
     {
         try {
@@ -962,20 +919,15 @@ class DemosPlanAssessmentTableController extends BaseController
      * Optionally pass `includeShortened=true` as get parameter to include
      * shortened fragment.
      *
-     * @Route(
-     *     name="dm_plan_assessment_get_recommendation_ajax",
-     *     path="/_ajax/recommendation/{statementId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_admin_assessmenttable", "field_statement_recommendation"})
      *
      * @param string $statementId
      *
      * @return JsonResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'dm_plan_assessment_get_recommendation_ajax', path: '/_ajax/recommendation/{statementId}', options: ['expose' => true])]
     public function getRecommendationRemainderAjaxAction(Request $request, StatementService $statementService, $statementId)
     {
         try {
@@ -1003,18 +955,6 @@ class DemosPlanAssessmentTableController extends BaseController
     /**
      * Return all versions of considerations of a fragment.
      *
-     * @Route(
-     *     name="dplan_assessment_fragment_get_consideration_versions",
-     *     path="/_ajax/assessment/{ident}/fragment/{fragmentId}/get",
-     *     defaults={"isReviewer": false},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="dplan_assessment_fragment_get_consideration_versions_reviewer",
-     *     path="/_ajax/fragment/{fragmentId}/get",
-     *     defaults={"isReviewer": true},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statements_fragment_edit")
      *
@@ -1025,6 +965,8 @@ class DemosPlanAssessmentTableController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'dplan_assessment_fragment_get_consideration_versions', path: '/_ajax/assessment/{ident}/fragment/{fragmentId}/get', defaults: ['isReviewer' => false], options: ['expose' => true])]
+    #[Route(name: 'dplan_assessment_fragment_get_consideration_versions_reviewer', path: '/_ajax/fragment/{fragmentId}/get', defaults: ['isReviewer' => true], options: ['expose' => true])]
     public function getFragmentConsiderationVersionsAjaxAction(CurrentUserInterface $currentUser, $isReviewer, $fragmentId)
     {
         try {
@@ -1049,17 +991,12 @@ class DemosPlanAssessmentTableController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_assessment_table_assessment_table_statement_bulk_edit_action",
-     *     path="/verfahren/{procedureId}/bulk-edit",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @param string      $procedureId
      * @param array       $rParams
      * @param string|null $filterHash
      */
+    #[Route(name: 'dplan_assessment_table_assessment_table_statement_bulk_edit_action', path: '/verfahren/{procedureId}/bulk-edit', methods: ['GET'], options: ['expose' => true])]
     public function prepareHashListWithDefaults(Request $request, $procedureId, string $type, $rParams, $filterHash = null): void
     {
         $hashList = $request->getSession()->get('hashList', []);
@@ -1095,19 +1032,13 @@ class DemosPlanAssessmentTableController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_assessment_table_assessment_table_statement_bulk_edit_action",
-     *     path="/verfahren/{procedureId}/bulk-edit",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_admin_assessmenttable", "feature_statement_bulk_edit"})
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_assessment_table_assessment_table_statement_bulk_edit_action', path: '/verfahren/{procedureId}/bulk-edit', methods: ['GET'], options: ['expose' => true])]
     public function statementBulkEditAction(FormFactoryInterface $formFactory, Request $request, string $procedureId)
     {
         // get authorized users
@@ -1135,21 +1066,15 @@ class DemosPlanAssessmentTableController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_assessment_table_assessment_table_statement_fragment_bulk_edit",
-     *     path="/verfahren/{procedureId}/fragment-bulk-edit",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_admin_assessmenttable", "feature_statement_fragment_bulk_edit"})
      *
      * @param string $procedureId
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_assessment_table_assessment_table_statement_fragment_bulk_edit', path: '/verfahren/{procedureId}/fragment-bulk-edit', methods: ['GET'], options: ['expose' => true])]
     public function statementFragmentBulkEditAction(Request $request, $procedureId)
     {
         // get authorized users

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
@@ -36,10 +36,6 @@ class DemosPlanStatementFragmentUpdateAPIController extends APIController
     /**
      * Accepts a new statement-fragment-update resource.
      *
-     * @Route(path="/api/1.0/statement-fragment-update/",
-     *        methods={"POST"},
-     *        name="dplan_api_assessment_table_statement_fragment_update_create",
-     *        options={"expose": true})
      *
      * @DplanPermissions({"area_admin_assessmenttable", "feature_statements_fragment_edit", "feature_statement_fragment_bulk_edit"})
      *
@@ -47,9 +43,9 @@ class DemosPlanStatementFragmentUpdateAPIController extends APIController
      * Will create a StatementFragmentUpdate which data is given in $request.
      *
      * @return EmptyResponse|APIResponse
-     *
      * @throws Exception
      */
+    #[Route(path: '/api/1.0/statement-fragment-update/', methods: ['POST'], name: 'dplan_api_assessment_table_statement_fragment_update_create', options: ['expose' => true])]
     public function createAction(
         CurrentProcedureService $currentProcedureService,
         StatementFragmentService $statementFragmentService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
@@ -22,9 +22,8 @@ class APIDocumentationController extends BaseController
 {
     /**
      * @DplanPermissions("area_demosplan")
-     *
-     * @Route(path="/api/", methods={"GET", "HEAD"})
      */
+    #[Route(path: '/api/', methods: ['GET', 'HEAD'])]
     public function indexAction(): Response
     {
         if ('dev' !== $this->globalConfig->getKernelEnvironment()) {
@@ -36,10 +35,8 @@ class APIDocumentationController extends BaseController
 
     /**
      * @DplanPermissions("area_demosplan")
-     *
-     * @Route(path="/api/openapi.json", methods={"GET", "HEAD"}, options={"expose": true},
-     *                                  name="dplan_api_openapi_json")
      */
+    #[Route(path: '/api/openapi.json', methods: ['GET', 'HEAD'], options: ['expose' => true], name: 'dplan_api_openapi_json')]
     public function jsonAction(OpenAPISchemaGenerator $apiDocumentationGenerator): Response
     {
         if ('dev' !== $this->globalConfig->getKernelEnvironment()) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
@@ -91,9 +92,8 @@ abstract class BaseController extends AbstractController
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setGlobalConfig(GlobalConfigInterface $globalConfig): void
     {
         $this->globalConfig = $globalConfig;
@@ -101,9 +101,8 @@ abstract class BaseController extends AbstractController
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
@@ -111,9 +110,8 @@ abstract class BaseController extends AbstractController
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setMessageBag(MessageBagInterface $messageBag): void
     {
         $this->messageBag = $messageBag;
@@ -121,9 +119,8 @@ abstract class BaseController extends AbstractController
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setViewRenderer(ViewRenderer $viewRenderer): void
     {
         $this->viewRenderer = $viewRenderer;
@@ -131,9 +128,8 @@ abstract class BaseController extends AbstractController
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setInitializeService(InitializeService $initializeService): void
     {
         $this->initializeService = $initializeService;

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -118,10 +118,6 @@ class DemosPlanDocumentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_plandocument_administration_element",
-     *     path="/verfahren/{procedure}/verwalten/element/{elementId}",
-     * )
      *
      * @DplanPermissions("area_admin_paragraphed_document")
      *
@@ -129,9 +125,9 @@ class DemosPlanDocumentController extends BaseController
      * @param string $elementId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_plandocument_administration_element', path: '/verfahren/{procedure}/verwalten/element/{elementId}')]
     public function paragraphAdminSaveAction(
         DocumentHandler $documentHandler,
         ElementHandler $elementHandler,
@@ -287,10 +283,6 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Absatz Edit.
      *
-     * @Route(
-     *     name="DemosPlan_plandocument_administration_paragraph_edit",
-     *     path="/verfahren/{procedure}/verwalten/paragraph/{documentID}",
-     * )
      *
      * @DplanPermissions("area_admin_paragraphed_document")
      *
@@ -298,9 +290,9 @@ class DemosPlanDocumentController extends BaseController
      * @param string $documentID
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_plandocument_administration_paragraph_edit', path: '/verfahren/{procedure}/verwalten/paragraph/{documentID}')]
     public function paragraphAdminEditAction(
         Breadcrumb $breadcrumb,
         DocumentHandler $documentHandler,
@@ -393,10 +385,6 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Absatz - Neu.
      *
-     * @Route(
-     *     name="DemosPlan_plandocument_administration_paragraph_new",
-     *     path="/verfahren/{procedure}/verwalten/paragraph/neu/{elementId}",
-     * )
      *
      * @DplanPermissions("area_admin_paragraphed_document")
      *
@@ -404,9 +392,9 @@ class DemosPlanDocumentController extends BaseController
      * @param string $elementId
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_plandocument_administration_paragraph_new', path: '/verfahren/{procedure}/verwalten/paragraph/neu/{elementId}')]
     public function paragraphAdminNewAction(
         Breadcrumb $breadcrumb,
         DocumentHandler $documentHandler,
@@ -482,10 +470,6 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Einzeldokument Neu.
      *
-     * @Route(
-     *     name="DemosPlan_singledocument_administration_new",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen/dokument/{elementId}/neu/{category}"
-     * )
      *
      * @DplanPermissions("area_admin_single_document")
      *
@@ -494,9 +478,9 @@ class DemosPlanDocumentController extends BaseController
      * @param string $category
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_singledocument_administration_new', path: '/verfahren/{procedure}/verwalten/planunterlagen/dokument/{elementId}/neu/{category}')]
     public function singleDocumentAdminNewAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -560,11 +544,6 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Einzeldokument Edit.
      *
-     * @Route(
-     *     name="DemosPlan_singledocument_administration_edit",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen/dokument/{documentID}/edit",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_single_document")
      *
@@ -572,9 +551,9 @@ class DemosPlanDocumentController extends BaseController
      * @param string $documentID
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_singledocument_administration_edit', path: '/verfahren/{procedure}/verwalten/planunterlagen/dokument/{documentID}/edit', options: ['expose' => true])]
     public function singleDocumentAdminEditAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -676,20 +655,15 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Kategorie Adminliste.
      *
-     * @Route(
-     *     name="DemosPlan_element_administration",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_single_document")
      *
      * @param string $procedure
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_element_administration', path: '/verfahren/{procedure}/verwalten/planunterlagen', options: ['expose' => true])]
     public function elementAdminListAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
@@ -792,19 +766,15 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Importer für die Planungsdokumentenkategorien und Dateien.
      *
-     * @Route(
-     *     name="DemosPlan_element_import",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen/import"
-     * )
      *
      * @DplanPermissions({"area_admin_single_document","feature_admin_element_import"})
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_element_import', path: '/verfahren/{procedure}/verwalten/planunterlagen/import')]
     public function elementAdminImportAction(
         CurrentUserInterface $currentUser,
         CurrentProcedureService $currentProcedureService,
@@ -1075,18 +1045,13 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Planunterlagen Kategorie Admin-Edit.
      *
-     * @Route(
-     *     name="DemosPlan_elements_administration_edit",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen/{elementId}/edit",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_single_document")
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_elements_administration_edit', path: '/verfahren/{procedure}/verwalten/planunterlagen/{elementId}/edit', options: ['expose' => true])]
     public function elementAdminEditAction(
         Breadcrumb $breadcrumb,
         CurrentProcedureService $currentProcedureService,
@@ -1236,19 +1201,15 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Neue Kategorien anlegen.
      *
-     * @Route(
-     *     name="DemosPlan_elements_administration_new",
-     *     path="/verfahren/{procedure}/verwalten/planunterlagen/new"
-     * )
      *
      * @DplanPermissions({"area_admin_single_document","feature_admin_element_edit"})
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_elements_administration_new', path: '/verfahren/{procedure}/verwalten/planunterlagen/new')]
     public function elementAdminNewAction(
         Breadcrumb $breadcrumb,
         ElementHandler $elementHandler,
@@ -1360,12 +1321,6 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Anzeige der Begründung/Verordnung in der Beteiligungsebene.
      *
-     * @Route(
-     *     name="DemosPlan_public_plandocument_paragraph",
-     *     path="/verfahren/{procedure}/public/paragraph/{elementId}",
-     *     defaults={"category": "paragraph", "type": "all"},
-     *     options={"expose": true},
-     * )
      *
      * @param string $procedure
      * @param string $elementId
@@ -1374,9 +1329,9 @@ class DemosPlanDocumentController extends BaseController
      * @return RedirectResponse|Response
      *
      * @DplanPermissions("area_public_participation")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_public_plandocument_paragraph', path: '/verfahren/{procedure}/public/paragraph/{elementId}', defaults: ['category' => 'paragraph', 'type' => 'all'], options: ['expose' => true])]
     public function publicParagraphListAction(
         BrandingService $brandingService,
         CountyService $countyService,
@@ -1860,18 +1815,13 @@ class DemosPlanDocumentController extends BaseController
     /**
      * Receives an array of File entity ids, zips the correspondent files and starts the download of the zip file.
      *
-     * @Route(
-     *     name="DemosPlan_document_zip_files",
-     *     path="/verfahren/{procedureId}/planunterlagen/zipfiles",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("feature_element_export")
      *
      * @return RedirectResponse|StreamedResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_document_zip_files', path: '/verfahren/{procedureId}/planunterlagen/zipfiles', options: ['expose' => true])]
     public function zipFilesAction(Request $request, TranslatorInterface $translator, string $procedureId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
@@ -71,15 +71,11 @@ class DemosPlanDocumentDashboardAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/documents/{procedureId}/dashboard",
-     *        methods={"GET"},
-     *        name="dp_api_documents_dashboard_get",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_admin")
-     *
      * Manages the display of the dashboard on load.
      */
+    #[Route(path: '/api/1.0/documents/{procedureId}/dashboard', methods: ['GET'], name: 'dp_api_documents_dashboard_get', options: ['expose' => true])]
     public function showDashboardAction(
         ElementHandler $elementHandler,
         ElementsService $elementsService,
@@ -136,15 +132,11 @@ class DemosPlanDocumentDashboardAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/documents/{procedureId}/dashboard",
-     *        methods={"PATCH"},
-     *        name="dp_api_documents_dashboard_update",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_admin")
-     *
      * Manages some updates performed from the dashboard.
      */
+    #[Route(path: '/api/1.0/documents/{procedureId}/dashboard', methods: ['PATCH'], name: 'dp_api_documents_dashboard_update', options: ['expose' => true])]
     public function updateDashboardAction(
         PermissionsInterface $permissions,
         ProcedureService $procedureService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsAPIController.php
@@ -27,13 +27,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class DemosPlanElementsAPIController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/documents/{procedureId}/elements/{elementsId}",
-     *        methods={"PATCH"},
-     *        name="dp_api_documents_elements_update",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("area_admin")
      */
+    #[Route(path: '/api/1.0/documents/{procedureId}/elements/{elementsId}', methods: ['PATCH'], name: 'dp_api_documents_elements_update', options: ['expose' => true])]
     public function updateElementsAction(ElementsService $elementsService, PermissionsInterface $permissions, $procedureId, string $elementsId): Response
     {
         $elementsToUpdate = $elementsService->getElementObject($elementsId);
@@ -63,13 +59,10 @@ class DemosPlanElementsAPIController extends APIController
     /**
      * @DplanPermissions("area_demosplan")
      *
-     * @Route(path="/api/1.0/element/{elementId}",
-     *        methods={"GET"},
-     *        name="dp_api_elements_get",
-     *        options={"expose": true})
      *
      * @return APIResponse|JsonResponse
      */
+    #[Route(path: '/api/1.0/element/{elementId}', methods: ['GET'], name: 'dp_api_elements_get', options: ['expose' => true])]
     public function getAction(
         ApiResourceService $apiResourceService,
         ElementHandler $elementHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsBulkEditController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsBulkEditController.php
@@ -21,17 +21,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class DemosPlanElementsBulkEditController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_elements_bulk_edit",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/planunterlagen/kategorien-bearbeiten",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_admin_element_edit")
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_elements_bulk_edit', methods: 'GET', path: '/verfahren/{procedureId}/planunterlagen/kategorien-bearbeiten', options: ['expose' => true])]
     public function showFormAction(string $procedureId): Response
     {
         return $this->renderTemplate(

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqApiController.php
@@ -22,15 +22,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class FaqApiController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/faq/{faqId}",
-     *        methods={"PATCH"},
-     *        name="dp_api_admin_faq_update",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_admin_faq")
-     *
      * @deprecated use `api_resource_update` route instead
      */
+    #[Route(path: '/api/1.0/faq/{faqId}', methods: ['PATCH'], name: 'dp_api_admin_faq_update', options: ['expose' => true])]
     public function updateAction(ApiLogger $apiLogger, string $faqId): Response
     {
         try {
@@ -49,13 +45,9 @@ class FaqApiController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/faq/{faqId}",
-     *        methods={"DELETE"},
-     *        name="dp_api_admin_faq_delete",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("area_admin_faq")
      */
+    #[Route(path: '/api/1.0/faq/{faqId}', methods: ['DELETE'], name: 'dp_api_admin_faq_delete', options: ['expose' => true])]
     public function deleteAction(string $faqId, FaqHandler $faqHandler): APIResponse
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
@@ -22,13 +22,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class FaqCategoryApiController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/faq-category/",
-     *        methods={"GET"},
-     *        name="dp_api_faq_category_list",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("area_admin_faq")
      */
+    #[Route(path: '/api/1.0/faq-category/', methods: ['GET'], name: 'dp_api_faq_category_list', options: ['expose' => true])]
     public function listAction(FaqHandler $faqHandler): APIResponse
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqController.php
@@ -42,18 +42,11 @@ class FaqController extends BaseController
      *
      * @throws Exception
      *
-     * @Route(
-     *     path="/faq",
-     *     name="DemosPlan_faq",
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     path="/haeufigefragen",
-     *     name="DemosPlan_haeufigefragen"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(path: '/faq', name: 'DemosPlan_faq', options: ['expose' => true])]
+    #[Route(path: '/haeufigefragen', name: 'DemosPlan_haeufigefragen')]
     public function faqListAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
@@ -86,16 +79,6 @@ class FaqController extends BaseController
     /**
      * Displays a list of Faq Articles visible to the current user (only one category, based on route).
      *
-     * @Route(
-     *     path="/faq/bauleitplanung",
-     *     name="DemosPlan_faq_public_planning",
-     *     defaults={"type": "oeb_bauleitplanung"}
-     * )
-     * @Route(
-     *     path="/faq/projekt",
-     *     name="DemosPlan_faq_public_project",
-     *     defaults={"type": "oeb_bob"}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
@@ -105,6 +88,8 @@ class FaqController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(path: '/faq/bauleitplanung', name: 'DemosPlan_faq_public_planning', defaults: ['type' => 'oeb_bauleitplanung'])]
+    #[Route(path: '/faq/projekt', name: 'DemosPlan_faq_public_project', defaults: ['type' => 'oeb_bob'])]
     public function faqPublicListAction(
         CurrentUserService $currentUserService,
         FaqHandler $faqHandler,
@@ -143,14 +128,10 @@ class FaqController extends BaseController
      *
      * @throws Exception
      *
-     * @Route(
-     *     path="/faq/verwalten",
-     *     name="DemosPlan_faq_administration_faq",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_faq")
      */
+    #[Route(path: '/faq/verwalten', name: 'DemosPlan_faq_administration_faq', options: ['expose' => true])]
     public function faqAdminListAction(
         Request $request,
         FaqHandler $faqHandler,
@@ -202,14 +183,10 @@ class FaqController extends BaseController
      *
      * @throws Exception
      *
-     * @Route(
-     *     path="/faq/{faqID}/edit",
-     *     name="DemosPlan_faq_administration_faq_edit",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_faq")
      */
+    #[Route(path: '/faq/{faqID}/edit', name: 'DemosPlan_faq_administration_faq_edit', options: ['expose' => true])]
     public function faqAdminEditAction(
         Breadcrumb $breadcrumb,
         GlobalConfig $globalConfig,
@@ -277,14 +254,10 @@ class FaqController extends BaseController
      * @throws MessageBagException
      * @throws CustomerNotFoundException
      *
-     * @Route(
-     *     path="/faq/neu",
-     *     name="DemosPlan_faq_administration_faq_new",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_faq")
      */
+    #[Route(path: '/faq/neu', name: 'DemosPlan_faq_administration_faq_new', options: ['expose' => true])]
     public function faqAdminNewAction(
         Breadcrumb $breadcrumb,
         FaqHandler $faqHandler,
@@ -398,16 +371,6 @@ class FaqController extends BaseController
     /**
      * @DplanPermissions("area_admin_faq")
      *
-     * @Route(
-     *     path="/category/new",
-     *     name="DemosPlan_faq_administration_category_new",
-     *     options={"expose": true},
-     * )
-     * @Route(
-     *     path="/category/{categoryId}/edit",
-     *     name="DemosPlan_faq_administration_category_edit",
-     *     options={"expose": true},
-     * )
      *
      * @param string $categoryId
      * @param string $action
@@ -419,6 +382,8 @@ class FaqController extends BaseController
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '/category/new', name: 'DemosPlan_faq_administration_category_new', options: ['expose' => true])]
+    #[Route(path: '/category/{categoryId}/edit', name: 'DemosPlan_faq_administration_category_edit', options: ['expose' => true])]
     public function faqCategoryEditAction(
         Breadcrumb $breadcrumb,
         FaqHandler $faqHandler,
@@ -491,16 +456,11 @@ class FaqController extends BaseController
     /**
      * @DplanPermissions("area_admin_faq")
      *
-     * @Route(
-     *     path="/category/{categoryId}/delete",
-     *     name="DemosPlan_faq_administration_category_delete",
-     *     options={"expose": true, "action": "delete"},
-     * )
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(path: '/category/{categoryId}/delete', name: 'DemosPlan_faq_administration_category_delete', options: ['expose' => true, 'action' => 'delete'])]
     public function faqCategoryDeleteAction(FaqHandler $faqHandler, string $categoryId): Response
     {
         $administrateFaq = 'DemosPlan_faq_administration_faq';

--- a/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
@@ -32,17 +32,13 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Index-Seite für Weiterentwicklungsbereich.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development",
-     *     path="/development"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_forum_development', path: '/development')]
     public function developmentIndexAction(Breadcrumb $breadcrumb, TranslatorInterface $translator)
     {
         $templateVars = [];
@@ -82,15 +78,11 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Ein Release anlegen.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_new",
-     *     path="/development/release/new"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_release_edit")
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_release_new', path: '/development/release/new')]
     public function newReleaseAction(Request $request)
     {
         // Anlegen eines neuen release
@@ -126,17 +118,13 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Update of a Release.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_edit",
-     *     path="/development/{releaseId}/edit"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @param string $releaseId
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_release_edit', path: '/development/{releaseId}/edit')]
     public function editReleaseAction(Request $request, $releaseId)
     {
         // Anlegen eines neuen release
@@ -173,18 +161,14 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Delete a release.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_delete",
-     *     path="/development/delete/{releaseId}/{token}"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_release_edit")
      *
      * @param string $releaseId
      * @param string $token
-     *
      * @return RedirectResponse
      */
+    #[Route(name: 'DemosPlan_forum_development_release_delete', path: '/development/delete/{releaseId}/{token}')]
     public function deleteReleaseAction($releaseId, $token)
     {
         // Token zum Überprüfen erstellen
@@ -212,15 +196,11 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Get a list oof all releases.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_list",
-     *     path="/development/release/list"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_release_edit")
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_release_list', path: '/development/release/list')]
     public function releaseListAction()
     {
         $storageResult = $this->forumHandler->getReleases();
@@ -245,19 +225,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Get all infos and user stories of a release.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_detail",
-     *     path="/development/{releaseId}"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @param string $releaseId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_forum_development_release_detail', path: '/development/{releaseId}')]
     public function releaseDetailAction(CurrentUserInterface $currentUser, $releaseId)
     {
         $storageResult = $this->forumHandler->getUserStoriesForRelease($releaseId);
@@ -305,19 +281,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Save votes for user stories by release.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_voting",
-     *     path="/development/{releaseId}/voting"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @param string $releaseId
      *
      * @return RedirectResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_forum_development_release_voting', path: '/development/{releaseId}/voting')]
     public function saveVotesForUserStoriesAction(
         Request $request,
         TranslatorInterface $translator,
@@ -394,17 +366,13 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Save new user story.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_new",
-     *     path="/development/{releaseId}/story/new"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_new', path: '/development/{releaseId}/story/new')]
     public function newUserStoryAction(Request $request, $releaseId)
     {
         // Anlegen eines neuen release
@@ -439,18 +407,14 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Update of an user story.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_edit",
-     *     path="/development/{releaseId}/story/edit/{storyId}"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
      * @param string $storyId
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_edit', path: '/development/{releaseId}/story/edit/{storyId}')]
     public function editUserStoryAction(Request $request, $releaseId, $storyId)
     {
         // Anlegen eines neuen release
@@ -493,19 +457,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Lösche eine User Story.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_delete",
-     *     path="/development/{releaseId}/story/delete/{storyId}/{token}"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_story_edit")
      *
      * @param string $releaseId
      * @param string $storyId
      * @param string $token
-     *
      * @return RedirectResponse
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_delete', path: '/development/{releaseId}/story/delete/{storyId}/{token}')]
     public function deleteUserStoryAction($releaseId, $storyId, $token)
     {
         // Token zum Überprüfen erstellen
@@ -528,19 +488,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Gebe die Details zu einer UserStory aus.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_detail",
-     *     path="/development/story/{storyId}"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_detail', path: '/development/story/{storyId}')]
     public function userStoryDetailAction(CurrentUserInterface $currentUser, $storyId)
     {
         $userId = $currentUser->getUser()->getId();
@@ -609,19 +565,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Save a new threadEntry for an userStory.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_threadentry_new",
-     *     path="/development/{storyId}/entry/new"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_threadentry_new', path: '/development/{storyId}/entry/new')]
     public function newThreadEntryForUserStoryAction(
         Request $request,
         TranslatorInterface $translator,
@@ -674,10 +626,6 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * update a threadEntry of user story thread.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_threadentry_edit",
-     *     path="/development/{storyId}/entry/{threadEntryId}/edit"
-     * )
      *
      * @DplanPermissions("area_development")
      *
@@ -685,9 +633,9 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
      * @param string $threadEntryId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_threadentry_edit', path: '/development/{storyId}/entry/{threadEntryId}/edit')]
     public function editThreadEntryOfUserStoryAction(
         CurrentUserInterface $currentUser,
         FileUploadService $fileUploadService,
@@ -780,19 +728,15 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Delete a threadEntry of an user story thread.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_userstory_threadentry_delete",
-     *     path="/development/{storyId}/entry/{threadEntryId}/delete/{token}"
-     * )
      *
      * @DplanPermissions("area_development")
      *
      * @param string $storyId
      * @param string $threadEntryId
      * @param string $token
-     *
      * @return RedirectResponse
      */
+    #[Route(name: 'DemosPlan_forum_development_userstory_threadentry_delete', path: '/development/{storyId}/entry/{threadEntryId}/delete/{token}')]
     public function deleteThreadEntryOfUserStoryAction(CurrentUserInterface $currentUser, PermissionsInterface $permissions, $storyId, $threadEntryId, $token)
     {
         $storageResult = [];
@@ -839,15 +783,11 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
     /**
      * Exportiere alle Infos zu einem Release im CSV-Format.
      *
-     * @Route(
-     *     name="DemosPlan_forum_development_release_export",
-     *     path="/development/{releaseId}/export"
-     * )
      *
      * @DplanPermissions("feature_forum_dev_release_edit")
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_forum_development_release_export', path: '/development/{releaseId}/export')]
     public function exportReleaseAction(Environment $twig, string $releaseId)
     {
         $storageResult = $this->forumHandler->getUserStoriesForRelease($releaseId);

--- a/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
@@ -20,14 +20,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class GenericApiController extends APIController
 {
     /**
-     * @Route(path="/api/2.0/{resourceType}",
-     *        methods={"GET"},
-     *        name="api_resource_list",
-     *        options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_json_api_list")
      */
+    #[Route(path: '/api/2.0/{resourceType}', methods: ['GET'], name: 'api_resource_list', options: ['expose' => true])]
     public function listAction(
         JsonApiActionService $resourceService,
         string $resourceType
@@ -38,14 +33,9 @@ class GenericApiController extends APIController
     }
 
     /**
-     * @Route(path="/api/2.0/{resourceType}/{resourceId}",
-     *        methods={"PATCH"},
-     *        name="api_resource_update",
-     *        options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_json_api_update")
      */
+    #[Route(path: '/api/2.0/{resourceType}/{resourceId}', methods: ['PATCH'], name: 'api_resource_update', options: ['expose' => true])]
     public function updateAction(
         JsonApiActionService $resourceService,
         string $resourceType,
@@ -62,14 +52,9 @@ class GenericApiController extends APIController
     }
 
     /**
-     * @Route(path="/api/2.0/{resourceType}",
-     *        methods={"POST"},
-     *        name="api_resource_create",
-     *        options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_json_api_create")
      */
+    #[Route(path: '/api/2.0/{resourceType}', methods: ['POST'], name: 'api_resource_create', options: ['expose' => true])]
     public function createAction(string $resourceType, JsonApiActionService $resourceService): Response
     {
         $requestJson = $this->getRequestJson();
@@ -83,16 +68,11 @@ class GenericApiController extends APIController
     }
 
     /**
-     * @Route(path="/api/2.0/{resourceType}/{resourceId}",
-     *        methods={"DELETE"},
-     *        name="api_resource_delete",
-     *        options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_json_api_delete")
-     *
      * @return APIResponse
      */
+    #[Route(path: '/api/2.0/{resourceType}/{resourceId}', methods: ['DELETE'], name: 'api_resource_delete', options: ['expose' => true])]
     public function deleteAction(
         JsonApiActionService $resourceService,
         string $resourceType,
@@ -104,15 +84,9 @@ class GenericApiController extends APIController
     }
 
     /**
-     * @Route(
-     *     "/api/2.0/{resourceType}/{resourceId}",
-     *     name="api_resource_get",
-     *     options={"expose": true},
-     *     methods={"GET"}
-     * )
-     *
      * @DplanPermissions("feature_json_api_get")
      */
+    #[Route(path: '/api/2.0/{resourceType}/{resourceId}', name: 'api_resource_get', options: ['expose' => true], methods: ['GET'])]
     public function getAction(
         JsonApiActionService $resourceService,
         string $resourceType,

--- a/demosplan/DemosPlanCoreBundle/Controller/GenericRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/GenericRpcController.php
@@ -28,13 +28,8 @@ class GenericRpcController extends BaseController
 {
     /**
      * @DplanPermissions("feature_json_rpc_post")
-     *
-     * @Route(path="/rpc/2.0/",
-     *        methods={"POST"},
-     *        name="rpc_generic_post",
-     *        options={"expose": true}
-     * )
      */
+    #[Route(path: '/rpc/2.0/', methods: ['POST'], name: 'rpc_generic_post', options: ['expose' => true])]
     public function postAction(
         CurrentProcedureService $currentProcedureService,
         Request $request,

--- a/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
@@ -27,17 +27,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanHelpController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_contextual_help_list",
-     *     methods="GET|POST",
-     *     path="/contextualHelp")
      *
      * @return RedirectResponse|Response
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_contextual_help_edit")
      */
+    #[Route(name: 'dplan_contextual_help_list', methods: 'GET|POST', path: '/contextualHelp')]
     public function listAction(
         Request $request,
         HelpHandler $helpHandler
@@ -65,17 +61,13 @@ class DemosPlanHelpController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_contextual_help_new",
-     *     methods="GET",
-     *     path="/contextualHelp/new")
      *
      * @return RedirectResponse|Response
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_contextual_help_edit")
      */
+    #[Route(name: 'dplan_contextual_help_new', methods: 'GET', path: '/contextualHelp/new')]
     public function newAction(
         Breadcrumb $breadcrumb,
         TranslatorInterface $translator
@@ -98,18 +90,14 @@ class DemosPlanHelpController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_contextual_help_create",
-     *     methods="POST",
-     *     path="/contextualHelp/create")
      *
      * @return RedirectResponse|Response
      *
      * @throws MessageBagException
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_contextual_help_edit")
      */
+    #[Route(name: 'dplan_contextual_help_create', methods: 'POST', path: '/contextualHelp/create')]
     public function createAction(
         HelpHandler $helpHandler,
         Request $request
@@ -127,19 +115,15 @@ class DemosPlanHelpController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_contextual_help_edit",
-     *     methods="GET",
-     *     path="/contextualHelp/{contextualHelpId}")
      *
      * @param string|null $contextualHelpId
      *
      * @return RedirectResponse|Response
      *
      * @throws MessageBagException
-     *
      * @DplanPermissions("area_admin_contextual_help_edit")
      */
+    #[Route(name: 'dplan_contextual_help_edit', methods: 'GET', path: '/contextualHelp/{contextualHelpId}')]
     public function editAction(
         Breadcrumb $breadcrumb,
         HelpHandler $helpHandler,
@@ -171,18 +155,14 @@ class DemosPlanHelpController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_contextual_help_update",
-     *     methods="POST",
-     *     path="/contextualHelp/{contextualHelpId}")
      *
      * @return RedirectResponse|Response
      *
      * @throws MessageBagException
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_contextual_help_edit")
      */
+    #[Route(name: 'dplan_contextual_help_update', methods: 'POST', path: '/contextualHelp/{contextualHelpId}')]
     public function updateAction(
         Request $request,
         HelpHandler $helpHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapApiController.php
@@ -21,15 +21,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class DemosPlanMapApiController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/map/options/admin/{procedureId}",
-     *        methods={"GET"},
-     *        name="dplan_api_map_options_admin",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_admin")
-     *
      * @throws Exception
      */
+    #[Route(path: '/api/1.0/map/options/admin/{procedureId}', methods: ['GET'], name: 'dplan_api_map_options_admin', options: ['expose' => true])]
     public function optionsAdminAction(MapService $mapService, string $procedureId): APIResponse
     {
         // @improve T14122
@@ -39,15 +35,11 @@ class DemosPlanMapApiController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/map/options/public/{procedureId}",
-     *        methods={"GET"},
-     *        name="dplan_api_map_options_public",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_demosplan")
-     *
      * @throws Exception
      */
+    #[Route(path: '/api/1.0/map/options/public/{procedureId}', methods: ['GET'], name: 'dplan_api_map_options_public', options: ['expose' => true])]
     public function optionsPublicAction(MapService $mapService, string $procedureId): APIResponse
     {
         // @improve T14122

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -54,20 +54,15 @@ class DemosPlanMapController extends BaseController
      * //improve T12925
      * Karte zum Verwalten der Karteneigenschaften wie BoundingBox & Startkartenausschnitt.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_map",
-     *     path="/verfahren/{procedureId}/verwalten/globaleGisEinstellungen",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_map")
      *
      * @param string $procedureId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_map_administration_map', path: '/verfahren/{procedureId}/verwalten/globaleGisEinstellungen', options: ['expose' => true])]
     public function mapAdminAction(
         ProcedureServiceStorage $procedureServiceStorage,
         Breadcrumb $breadcrumb,
@@ -146,19 +141,15 @@ class DemosPlanMapController extends BaseController
      * Warning: This action needs to be situated in front of DemosPlan_map_administration_gislayer_edit
      * otherwise "/neu" would be interpreted as "/{gislayerID}"
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_new",
-     *     path="/verfahren/{procedure}/verwalten/gislayer/neu"
-     * )
      *
      * @DplanPermissions("area_admin_map")
      *
      * @param string $procedure
      *
      * @return Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_new', path: '/verfahren/{procedure}/verwalten/gislayer/neu')]
     public function mapAdminGislayerNewAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -228,11 +219,6 @@ class DemosPlanMapController extends BaseController
     /**
      * Anzeige des Layer-Editformulars.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_edit",
-     *     path="/verfahren/{procedure}/verwalten/gislayer/{gislayerID}",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_map")
      *
@@ -240,9 +226,9 @@ class DemosPlanMapController extends BaseController
      * @param string $gislayerID
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_edit', path: '/verfahren/{procedure}/verwalten/gislayer/{gislayerID}', options: ['expose' => true])]
     public function mapAdminGislayerEditAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -317,10 +303,6 @@ class DemosPlanMapController extends BaseController
     /**
      * Anzeige des LayerCategory-Newformulars.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_category_new",
-     *     path="/verfahren/{procedureId}/verwalten/gislayergroup/new-category"
-     * )
      *
      *  @DplanPermissions({"area_admin_map","feature_map_category"})
      *
@@ -331,6 +313,7 @@ class DemosPlanMapController extends BaseController
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_category_new', path: '/verfahren/{procedureId}/verwalten/gislayergroup/new-category')]
     public function mapAdminGislayerCategoryNewAction(MapHandler $mapHandler, Request $request, $procedureId)
     {
         $request = $request->request->all();
@@ -388,11 +371,6 @@ class DemosPlanMapController extends BaseController
     /**
      * Anzeige des Layer-Kagetorie-Editformulars.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_category_edit",
-     *     path="/verfahren/{procedureId}/verwalten/gislayergroup/{gislayerCategoryId}/edit",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions({"area_admin_map","feature_map_category"})
      *
@@ -404,6 +382,7 @@ class DemosPlanMapController extends BaseController
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_category_edit', path: '/verfahren/{procedureId}/verwalten/gislayergroup/{gislayerCategoryId}/edit', options: ['expose' => true])]
     public function mapAdminGisLayerCategoryEditAction(MapHandler $mapHandler, Request $request, $procedureId, $gislayerCategoryId)
     {
         try {
@@ -458,20 +437,15 @@ class DemosPlanMapController extends BaseController
      * //improve T12925
      * Planzeichnung verwalten.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer",
-     *     path="/verfahren/{procedureId}/verwalten/gislayer",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_map")
      *
      * @param string $procedureId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer', path: '/verfahren/{procedureId}/verwalten/gislayer', options: ['expose' => true])]
     public function mapAdminGislayerAction(
         Breadcrumb $breadcrumb,
         CurrentProcedureService $currentProcedureService,
@@ -586,17 +560,13 @@ class DemosPlanMapController extends BaseController
     /**
      * Globale GIS-Layer vwewalten.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_global",
-     *     path="/gislayer"
-     * )
      *
      * @DplanPermissions("area_admin_gislayer_global_edit")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_global', path: '/gislayer')]
     public function mapAdminGislayerGlobalAction(
         GetFeatureInfo $getFeatureInfo,
         Request $request,
@@ -650,16 +620,6 @@ class DemosPlanMapController extends BaseController
     /**
      * Globale GIS-Layer bearbeiten.
      *
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_global_new",
-     *     path="/gislayer/neu",
-     *     defaults={"type": "new"},
-     * )
-     * @Route(
-     *     name="DemosPlan_map_administration_gislayer_global_edit",
-     *     path="/gislayer/{gislayerID}",
-     *     defaults={"type": "edit"},
-     * )
      *
      * @DplanPermissions("area_admin_gislayer_global_edit")
      *
@@ -670,6 +630,8 @@ class DemosPlanMapController extends BaseController
      *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_map_administration_gislayer_global_new', path: '/gislayer/neu', defaults: ['type' => 'new'])]
+    #[Route(name: 'DemosPlan_map_administration_gislayer_global_edit', path: '/gislayer/{gislayerID}', defaults: ['type' => 'edit'])]
     public function mapAdminGislayerGlobalEditAction(
         MapService $mapService,
         Request $request,
@@ -748,16 +710,11 @@ class DemosPlanMapController extends BaseController
      * Rufe die Sachdateninformationen ab.
      * Via Controller, weil per JavaScript nicht auf andere Domains zugegriffen werden darf.
      *
-     * @Route(
-     *     name="DemosPlan_map_get_feature_info",
-     *     path="/getFeatureInfo/{procedure}",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_map_participation_area")
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_map_get_feature_info', path: '/getFeatureInfo/{procedure}', options: ['expose' => true])]
     public function getFeatureInfoAjaxAction(GetFeatureInfo $getFeatureInfo, Request $request)
     {
         try {
@@ -800,18 +757,13 @@ class DemosPlanMapController extends BaseController
      * Get procedure by procedureType and clicked coordinate
      * proxy request through controller to avoid cors issues.
      *
-     * @Route(
-     *     name="DemosPlan_map_get_planning_area",
-     *     path="/getPlanningArea/{procedure}",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("feature_procedure_planning_area_match")
      *
      * @param string $procedure
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_map_get_planning_area', path: '/getPlanningArea/{procedure}', options: ['expose' => true])]
     public function getPlanningAreaAjaxAction(GetFeatureInfo $getFeatureInfo, ProcedureHandler $procedureHandler, Request $request, TranslatorInterface $translator, $procedure)
     {
         try {
@@ -904,18 +856,13 @@ class DemosPlanMapController extends BaseController
     /**
      * Rufe die getCapabilities eines lokal gespeicherten Layers ab.
      *
-     * @Route(
-     *     name="DemosPlan_map_get_capabilities_local",
-     *     path="/getCapabilitiesLocal/{layerId}",
-     *     options={"expose": true},
-     * )
      *
      * @deprecated Is this route used any more?
      *
      * @param string $layerId
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_map_get_capabilities_local', path: '/getCapabilitiesLocal/{layerId}', options: ['expose' => true])]
     public function getCapabilitiesLocalAjaxAction(CacheInterface $cache, MapCapabilitiesLoader $capabilitiesLoader, MapService $mapService, $layerId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanXplanboxController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanXplanboxController.php
@@ -25,19 +25,13 @@ class DemosPlanXplanboxController extends BaseController
     /**
      * Gib den Startkartenausschnitt zu einem Verfahren aus.
      *
-     * @Route(
-     *     name="DemosPlan_xplanbox_get_bounds",
-     *     path="/xplanbox/getBounds/{procedureName}",
-     *     requirements={"procedureName"=".+"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("feature_use_xplanbox")
      *
      * @param string $procedureName
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_xplanbox_get_bounds', path: '/xplanbox/getBounds/{procedureName}', requirements: ['procedureName' => '.+'], options: ['expose' => true])]
     public function getLgvXplanboxBoundsAction(Xplanbox $xplanbox, $procedureName)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/MiscContent/DemosPlanMiscContentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/MiscContent/DemosPlanMiscContentController.php
@@ -42,15 +42,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanMiscContentController extends BaseController
 {
     /**
-     * @Route(path="/barrierefreiheit",
-     *     name="DemosPlan_misccontent_static_accessibility_explanation"
-     * )
      *
      * @DplanPermissions("area_accessibility_explanation")
      *
      * @throws MessageBagException
      * @throws CustomerNotFoundException
      */
+    #[Route(path: '/barrierefreiheit', name: 'DemosPlan_misccontent_static_accessibility_explanation')]
     public function showAccessibilityExplanationAction(CustomerService $customerService): Response
     {
         $accessibilityExplanation = $customerService->getCurrentCustomer()->getAccessibilityExplanation();
@@ -67,15 +65,11 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_sign_language",
-     *     path="/gebaerdensprache",
-     * )
      *
      * @DplanPermissions("area_sign_language_overview_video")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_sign_language', path: '/gebaerdensprache')]
     public function showSignLanguagePageAction(CustomerService $customerService): Response
     {
         $templateVars['customer'] = $customerService->getCurrentCustomer();
@@ -90,18 +84,13 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_imprint",
-     *     path="/impressum",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_misccontent_static_imprint', path: '/impressum', options: ['expose' => true])]
     public function imprintAction(
         CustomerService $customerService,
         OrgaHandler $orgaHandler
@@ -132,18 +121,13 @@ class DemosPlanMiscContentController extends BaseController
     /**
      * Display dataprotection page.
      *
-     * @Route(
-     *     name="DemosPlan_misccontent_static_dataprotection",
-     *     path="/datenschutz",
-     *     options={"expose": "true"},
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_dataprotection', path: '/datenschutz', options: ['expose' => true])]
     public function dataProtectionAction(CustomerService $customerService, OrgaHandler $orgaHandler)
     {
         $templateVars = [
@@ -172,15 +156,11 @@ class DemosPlanMiscContentController extends BaseController
     /**
      * Infoseite zu Anmeldungsprocedere.
      *
-     * @Route(
-     *     name="DemosPlan_misccontent_static_how_to_login",
-     *     path="/anmeldung",
-     * )
      *
      * @DplanPermissions("area_demosplan")
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_misccontent_static_how_to_login', path: '/anmeldung')]
     public function howToLoginAction()
     {
         return $this->renderTemplate(
@@ -194,17 +174,13 @@ class DemosPlanMiscContentController extends BaseController
     /**
      * Kontaktformular.
      *
-     * @Route(
-     *     name="DemosPlan_misccontent_static_contact",
-     *     path="/kontakt"
-     * )
      *
      * @DplanPermissions("area_main_contact")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_misccontent_static_contact', path: '/kontakt')]
     public function contactAction(
         MessageBagInterface $messageBag,
         Request $request,
@@ -287,19 +263,15 @@ class DemosPlanMiscContentController extends BaseController
      *   php app/console dplan:vendorlist:update
      * ```
      *
-     * @Route(
-     *     name="DemosPlan_misccontent_static_softwarecomponents",
-     *     path="/software"
-     * )
      *
      * which generates licenses files for our php and js vendors
      *
      * @DplanPermissions("area_software_licenses")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_softwarecomponents', path: '/software')]
     public function softwareComponentsAction()
     {
         $templateVars = [];
@@ -344,18 +316,13 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_terms",
-     *     path="/nutzungsbedingungen",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_terms_of_use")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_misccontent_static_terms', path: '/nutzungsbedingungen', options: ['expose' => true])]
     public function termsAction(CustomerService $customerService, TranslatorInterface $translator)
     {
         $customer = $customerService->getCurrentCustomer();
@@ -371,17 +338,13 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_xplanung",
-     *     path="/xplanung"
-     * )
      *
      * @DplanPermissions("area_main_xplanning")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_xplanung', path: '/xplanung')]
     public function xplanAction(CustomerService $customerService)
     {
         $templateVars = [];
@@ -398,18 +361,13 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_terms_of_use",
-     *     path="/informationen/nutzungsbedingungen",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_terms_of_use', path: '/informationen/nutzungsbedingungen', options: ['expose' => true])]
     public function termsOfUseAction()
     {
         $templateVars = [];
@@ -425,15 +383,11 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_documents",
-     *     path="/unterlagen"
-     * )
      *
      * @DplanPermissions("area_demosplan")
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_misccontent_static_documents', path: '/unterlagen')]
     public function documentsAction(Breadcrumb $breadcrumb, TranslatorInterface $translator): Response
     {
         $templateVars = [];
@@ -456,17 +410,13 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_information",
-     *     path="/informationen"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_information', path: '/informationen')]
     public function informationAction(CurrentUserInterface $userProvider, FaqHandler $faqHandler): Response
     {
         $categories = $faqHandler->getCustomFaqCategoriesByNamesOrCustom(FaqCategory::FAQ_CATEGORY_TYPES_MANDATORY);
@@ -484,15 +434,11 @@ class DemosPlanMiscContentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_misccontent_static_simple_language",
-     *     path="/leichte-sprache",
-     * )
      *
      * @DplanPermissions("area_simple_language_overview_description_page")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_misccontent_static_simple_language', path: '/leichte-sprache')]
     public function showSimpleLanguagePageAction(CustomerService $customerService): Response
     {
         $templateVars['customer'] = $customerService->getCurrentCustomer();

--- a/demosplan/DemosPlanCoreBundle/Controller/News/DemosPlanNewsController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/News/DemosPlanNewsController.php
@@ -77,19 +77,15 @@ class DemosPlanNewsController extends BaseController
     /**
      * Stelle eine Newsdetailansicht für die Beteiligungsebene dar.
      *
-     * @Route(
-     *     name="DemosPlan_news_news_public_detail",
-     *     path="/verfahren/{procedure}/public/aktuelles/{newsID}"
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @param string $procedure Procedure Id
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_news_public_detail', path: '/verfahren/{procedure}/public/aktuelles/{newsID}')]
     public function newsPublicDetailAction(
         BrandingService $brandingService,
         CurrentProcedureService $currentProcedureService,
@@ -126,17 +122,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Exportiere vorhandene News zu einem Verfahren.
      *
-     * @Route(
-     *     name="DemosPlan_globalnews_news_export",
-     *     path="/news/export"
-     * )
      *
      * @DplanPermissions("area_globalnews")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_news_export', path: '/news/export')]
     public function globalnewsExportAction(ServiceOutput $serviceOutputNews, TranslatorInterface $translator)
     {
         $pdfName = $translator->trans('news.global.export', [], 'page-title');
@@ -152,17 +144,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Exportiere vorhandene News zu einem Verfahren.
      *
-     * @Route(
-     *     name="DemosPlan_news_news_export",
-     *     path="/verfahren/{procedure}/aktuelles/export"
-     * )
      *
      * @DplanPermissions("area_news")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_news_export', path: '/verfahren/{procedure}/aktuelles/export')]
     public function newsExportAction(ServiceOutput $serviceOutputNews, TranslatorInterface $translator, string $procedure)
     {
         $pdfName = $translator->trans('news.export', [], 'page-title');
@@ -178,17 +166,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Gib die globalen News je nach Eingeloggt/Ausgeloggt und Übersicht aus.
      *
-     * @Route(
-     *     name="DemosPlan_globalnews_news",
-     *     path="/news"
-     * )
      *
      * @DplanPermissions("area_globalnews")
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_news', path: '/news')]
     public function newsListGlobalIndexAction(
         Breadcrumb $breadcrumb,
         CurrentUserService $currentUserService,
@@ -238,17 +222,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Liste der Verfahrensmitteilungen auf öffentlicher Verfahrensdetail-Seite.
      *
-     * @Route(
-     *     name="DemosPlan_news_news_public",
-     *     path="/verfahren/{procedure}/public/aktuelles"
-     * )
      *
      * @DplanPermissions("area_news")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_news_public', path: '/verfahren/{procedure}/public/aktuelles')]
     public function newsPublicListAction(Request $request, CurrentProcedureService $currentProcedureService, CurrentUserService $currentUserService, string $procedure)
     {
         try {
@@ -289,18 +269,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Gib die Adminliste der News aus.
      *
-     * @Route(
-     *     name="DemosPlan_news_administration_news",
-     *     path="/verfahren/{procedure}/verwalten/aktuelles",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_news")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_administration_news', path: '/verfahren/{procedure}/verwalten/aktuelles', options: ['expose' => true])]
     public function newsAdminListAction(Request $request, TranslatorInterface $translator, string $procedure)
     {
         $procedureId = $procedure;
@@ -331,18 +306,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * Gib die Adminliste der News aus.
      *
-     * @Route(
-     *     name="DemosPlan_globalnews_administration_news",
-     *     path="/news/verwalten",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_globalnews")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_administration_news', path: '/news/verwalten', options: ['expose' => true])]
     public function globalNewsAdminListAction(ManualListSorter $manualListSorter, Request $request, TranslatorInterface $translator)
     {
         $this->handleNewsAdminListManualSortPostRequest($request, $translator);
@@ -431,22 +401,13 @@ class DemosPlanNewsController extends BaseController
      * path /verfahren/{procedure}/verwalten/aktuelles/neu would be interpreted as
      * /verfahren/{procedure}/verwalten/aktuelles/{newsID} with "neu" as {newsId}
      *
-     * @Route(
-     *     name="DemosPlan_news_administration_news_new_get",
-     *     path="/verfahren/{procedure}/verwalten/aktuelles/neu",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_news_administration_news_new_post",
-     *     path="/verfahren/{procedure}/verwalten/aktuelles/neu",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_news")
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_administration_news_new_get', path: '/verfahren/{procedure}/verwalten/aktuelles/neu', methods: ['GET'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_news_administration_news_new_post', path: '/verfahren/{procedure}/verwalten/aktuelles/neu', methods: ['POST'])]
     public function newsAdminNewAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -477,17 +438,6 @@ class DemosPlanNewsController extends BaseController
     /**
      * Gib das Editformular der News aus.
      *
-     * @Route(
-     *     name="DemosPlan_news_administration_news_edit_get",
-     *     path="/verfahren/{procedure}/verwalten/aktuelles/{newsID}",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_news_administration_news_edit_post",
-     *     path="/verfahren/{procedure}/verwalten/aktuelles/{newsID}",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_news")
      *
@@ -495,6 +445,8 @@ class DemosPlanNewsController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_news_administration_news_edit_get', path: '/verfahren/{procedure}/verwalten/aktuelles/{newsID}', methods: ['GET'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_news_administration_news_edit_post', path: '/verfahren/{procedure}/verwalten/aktuelles/{newsID}', methods: ['POST'])]
     public function newsAdminEditAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -524,17 +476,6 @@ class DemosPlanNewsController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_globalnews_administration_news_edit_get",
-     *     path="/news/{newsID}/edit",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_globalnews_administration_news_edit_post",
-     *     path="/news/{newsID}/edit",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_globalnews")
      *
@@ -542,6 +483,8 @@ class DemosPlanNewsController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_administration_news_edit_get', path: '/news/{newsID}/edit', methods: ['GET'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_globalnews_administration_news_edit_post', path: '/news/{newsID}/edit', methods: ['POST'])]
     public function globalnewsAdminEditAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -567,17 +510,6 @@ class DemosPlanNewsController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_globalnews_administration_news_new_get",
-     *     path="/news/neu",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_globalnews_administration_news_new_post",
-     *     path="/news/neu",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_globalnews")
      *
@@ -585,6 +517,8 @@ class DemosPlanNewsController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_administration_news_new_get', path: '/news/neu', methods: ['GET'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_globalnews_administration_news_new_post', path: '/news/neu', methods: ['POST'])]
     public function globalnewsAdminNewAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -614,17 +548,13 @@ class DemosPlanNewsController extends BaseController
     /**
      * News detail. Needs to be situated after all other /news/ routes as otherwise it catches the route.
      *
-     * @Route(
-     *     name="DemosPlan_globalnews_news_detail",
-     *     path="/news/{newsID}"
-     * )
      *
      * @DplanPermissions("area_globalnews")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_globalnews_news_detail', path: '/news/{newsID}')]
     public function globalnewsDetailAction(Breadcrumb $breadcrumb, TranslatorInterface $translator, string $newsID)
     {
         // Template Variable aus Storage Ergebnis erstellen(Output)

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
@@ -72,10 +72,10 @@ class EntrypointController extends BaseController
      * role combination. Guests that end up here will be redirected to
      * the platform's external start page.
      *
-     * @Route(path="/loggedin", name="core_home_loggedin")
      *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(path: '/loggedin', name: 'core_home_loggedin')]
     public function loggedInIndexEntrypointAction(Request $request): Response
     {
         // check whether user tried to call route before login
@@ -150,14 +150,13 @@ class EntrypointController extends BaseController
      * ends up at this page, they may need to be re-routed to
      * their designated logged-in index page.
      *
-     * @Route(path="/", name="core_home", options={"expose": true})
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(path: '/', name: 'core_home', options: ['expose' => true])]
     public function indexAction(
         ContentService $contentService,
         PublicIndexProcedureLister $procedureLister,

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -30,12 +30,10 @@ class FileController extends BaseController
      *
      * @DplanPermissions("area_main_file")
      *
-     * @Route(path="/file/{hash}",
-     *        name="core_file",
-     *        options={"expose": true})
      *
      * @return BinaryFileDownload|Response
      */
+    #[Route(path: '/file/{hash}', name: 'core_file', options: ['expose' => true])]
     public function fileAction(FileService $fileService, string $hash)
     {
         try {
@@ -50,11 +48,8 @@ class FileController extends BaseController
      * Check Procedure permissions when procedureId is given in route and serve file if allowed.
      *
      * @DplanPermissions("area_main_file")
-     *
-     * @Route(path="/file/{procedureId}/{hash}",
-     *        name="core_file_procedure",
-     *        options={"expose": true})
      */
+    #[Route(path: '/file/{procedureId}/{hash}', name: 'core_file_procedure', options: ['expose' => true])]
     public function fileProcedureAction(FileService $fileService, string $procedureId, string $hash): Response
     {
         try {
@@ -123,12 +118,10 @@ class FileController extends BaseController
      *
      * @DplanPermissions("area_demosplan")
      *
-     * @Route(path="/image/{hash}",
-     *        name="core_logo",
-     *        options={"expose": true})
      *
      * @param string $hash
      */
+    #[Route(path: '/image/{hash}', name: 'core_logo', options: ['expose' => true])]
     public function imageAction(Request $request, FileService $fileService, $hash): Response
     {
         // Für den Abruf der Bilder muss keine extra Session gestartet werden

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/HttpErrorController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/HttpErrorController.php
@@ -23,14 +23,10 @@ class HttpErrorController extends BaseController
     /**
      * Create custom 404 Response.
      *
-     * @Route(
-     *     path="notfound",
-     *     methods={"GET"},
-     *     name="core_404"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(path: 'notfound', methods: ['GET'], name: 'core_404')]
     public function custom404Action(Request $request): Response
     {
         $content = '';
@@ -61,14 +57,10 @@ class HttpErrorController extends BaseController
     /**
      * Create custom 500 page.
      *
-     * @Route(
-     *     path="error",
-     *     methods={"GET"},
-     *     name="core_500"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(path: 'error', methods: ['GET'], name: 'core_500')]
     public function custom500Action(TranslatorInterface $translator): Response
     {
         $content = 'Ein Fehler ist aufgetreten';

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
@@ -21,9 +21,8 @@ class KeycloakController extends AbstractController
 {
     /**
      * Link to this controller to start the "connect" process.
-     *
-     * @Route("/connect/keycloak_ozg", name="connect_keycloak_ozg_start")
      */
+    #[Route(path: '/connect/keycloak_ozg', name: 'connect_keycloak_ozg_start')]
     public function connectAction(ClientRegistry $clientRegistry)
     {
         // will redirect to keycloak!
@@ -36,9 +35,8 @@ class KeycloakController extends AbstractController
      * After going to keycloak, you're redirected back here
      * because this is the "redirect_route" you configured
      * in config/packages/knpu_oauth2_client.yaml.
-     *
-     * @Route("/connect/keycloak_ozg/check", name="connect_keycloak_ozg_check")
      */
+    #[Route(path: '/connect/keycloak_ozg/check', name: 'connect_keycloak_ozg_check')]
     public function connectCheckAction(Request $request, ClientRegistry $clientRegistry)
     {
         // ** if you want to *authenticate* the user, then

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
@@ -25,13 +25,8 @@ class LocationSearchController extends BaseController
      * Suggest locations.
      *
      * @DplanPermissions("area_demosplan")
-     *
-     * @Route(
-     *     path="/suggest/location/json",
-     *     name="core_suggest_location_json",
-     *     options={"expose": true}
-     * )
      */
+    #[Route(path: '/suggest/location/json', name: 'core_suggest_location_json', options: ['expose' => true])]
     public function searchLocationJsonAction(Request $request, LocationService $locationService): Response
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/MaintenanceController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/MaintenanceController.php
@@ -109,14 +109,13 @@ class MaintenanceController extends BaseController
     /**
      * User facing page for active service mode.
      *
-     * @Route(path="/servicemode", name="core_service_mode")
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(path: '/servicemode', name: 'core_service_mode')]
     public function serviceModeAction(GlobalConfigInterface $globalConfig)
     {
         /** @var GlobalConfig $globalConfig */
@@ -138,10 +137,10 @@ class MaintenanceController extends BaseController
     /**
      * Simple Action to evaluate response code for heartbeat monitoring.
      *
-     * @Route(path="/_heartbeat", name="core_server_heartbeat")
      *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(path: '/_heartbeat', name: 'core_server_heartbeat')]
     public function heartbeatAction(): Response
     {
         return new Response('OK');
@@ -153,14 +152,13 @@ class MaintenanceController extends BaseController
      * These tasks are run regularily *and* require a session which is
      * why they are currently managed in this action
      *
-     * @Route(path="/maintenance/{key}", name="core_maintenance")
      *
      * @DplanPermissions("area_demosplan")
      *
      * @param string $key
-     *
      * @throws Throwable
      */
+    #[Route(path: '/maintenance/{key}', name: 'core_maintenance')]
     public function maintenanceTasksAction(
         EventDispatcherInterface $eventDispatcher,
         GlobalConfigInterface $globalConfig,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
@@ -28,14 +28,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class AuthorizedUsersController extends BaseController
 {
     /**
-     * @Route(
-     *     "/verfahren/{procedureId}/berechtigte",
-     *      name="dplan_admin_procedure_authorized_users",
-     *      methods={"HEAD", "GET"}
-     * )
-     *
      * @DplanPermissions("area_admin_consultations")
      */
+    #[Route(path: '/verfahren/{procedureId}/berechtigte', name: 'dplan_admin_procedure_authorized_users', methods: ['HEAD', 'GET'])]
     public function listAction(string $procedureId)
     {
         return $this->renderTemplate(
@@ -48,14 +43,9 @@ class AuthorizedUsersController extends BaseController
     }
 
     /**
-     * @Route(
-     *     "/verfahren/{procedureId}/berechtigte/export",
-     *      name="dplan_admin_procedure_authorized_users_export",
-     *      methods={"HEAD", "GET"}, options={"expose": true}
-     * )
-     *
      * @DplanPermissions("area_admin_consultations")
      */
+    #[Route(path: '/verfahren/{procedureId}/berechtigte/export', name: 'dplan_admin_procedure_authorized_users_export', methods: ['HEAD', 'GET'], options: ['expose' => true])]
     public function exportAction(
         ConsultationTokenService $consultationTokenService,
         CurrentUserInterface $currentUser,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ConsultationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ConsultationController.php
@@ -28,13 +28,10 @@ class ConsultationController extends BaseController
     /**
      * Handle Autorisation via ConsultationTokens.
      *
-     * @Route(
-     *     name="core_auth_procedure_consultation",
-     *     path="/consultation/auth/{procedureId}"
-     * )
      *
      * @DplanPermissions("feature_public_consultation")
      */
+    #[Route(name: 'core_auth_procedure_consultation', path: '/consultation/auth/{procedureId}')]
     public function procedureConsultationAuthorizeAction(
         ConsultationTokenService $consultationTokenService,
         EventDispatcherPostInterface $eventDispatcherPost,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanBoilerplateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanBoilerplateAPIController.php
@@ -21,18 +21,14 @@ use Symfony\Component\Routing\Annotation\Route;
 class DemosPlanBoilerplateAPIController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/procedures/{procedureId}/relationships/boilerplates",
-     *        methods={"GET"},
-     *        name="dplan_api_procedure_boilerplate_list",
-     *        options={"expose": true})
      *
      * Returns all Boilerplates(means "Textbausteine"/"_predefined_texts", not "ProcedureBlueprints"!)
      * of a specific procedure, with the category as key in a JsonResponse.
      *
      * @DplanPermissions("area_admin_boilerplates")
-     *
      * @param string $procedureId specify the Procedure, whose Boilerplates will be loaded
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/relationships/boilerplates', methods: ['GET'], name: 'dplan_api_procedure_boilerplate_list', options: ['expose' => true])]
     public function getProcedureListAction(ProcedureService $procedureService, string $procedureId): APIResponse
     {
         $boilerplates = $procedureService->getBoilerplateList($procedureId);
@@ -42,15 +38,11 @@ class DemosPlanBoilerplateAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/procedures/{procedureId}/relationships/boilerplate_groups",
-     *        methods={"GET"},
-     *        name="dplan_api_procedure_boilerplate_group_list",
-     *        options={"expose": true})
      *
      * Returns all boilerplateGroups of a specific procedure, as JsonResponse.
-     *
      * @param string $procedureId specify the Procedure, whose BoilerplateGroups will be loaded
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/relationships/boilerplate_groups', methods: ['GET'], name: 'dplan_api_procedure_boilerplate_group_list', options: ['expose' => true])]
     public function getProcedureGroupListAction(ProcedureService $procedureService, string $procedureId): APIResponse
     {
         $groups = $procedureService->getBoilerplateGroups($procedureId);

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
@@ -27,16 +27,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanMailController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_procedure_mail_send_all_submitters_view",
-     *     path="/verfahren/{procedureId}/mail",
-     *     methods={"HEAD", "GET"},
-     * )
-     * @Route(
-     *     name="dplan_procedure_mail_send_all_submitters_send",
-     *     path="/verfahren/{procedureId}/mail",
-     *     methods={"POST"},
-     * )
      *
      * @DplanPermissions("area_procedure_send_submitter_email")
      *
@@ -46,6 +36,8 @@ class DemosPlanMailController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'dplan_procedure_mail_send_all_submitters_view', path: '/verfahren/{procedureId}/mail', methods: ['HEAD', 'GET'])]
+    #[Route(name: 'dplan_procedure_mail_send_all_submitters_send', path: '/verfahren/{procedureId}/mail', methods: ['POST'])]
     public function sendAllSubmittersAction(
         CurrentUserService $currentUser,
         FormFactoryInterface $formFactory,
@@ -151,20 +143,15 @@ class DemosPlanMailController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_procedure_mail_send_all_submitters_confirm_view",
-     *     path="/verfahren/{procedureId}/mailconfirm",
-     *     methods={"HEAD", "GET"},
-     * )
      *
      * @DplanPermissions("area_procedure_send_submitter_email")
      *
      * @param string $procedureId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_procedure_mail_send_all_submitters_confirm_view', path: '/verfahren/{procedureId}/mailconfirm', methods: ['HEAD', 'GET'])]
     public function sendAllSubmittersConfirmViewAction(Request $request, SubmitterService $submitterService, $procedureId)
     {
         // @improve T14122
@@ -199,20 +186,15 @@ class DemosPlanMailController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_procedure_mail_send_all_submitters_confirm_send",
-     *     path="/verfahren/{procedureId}/mailconfirm",
-     *     methods={"POST"},
-     * )
      *
      * @DplanPermissions("area_procedure_send_submitter_email")
      *
      * @param string $procedureId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_procedure_mail_send_all_submitters_confirm_send', path: '/verfahren/{procedureId}/mailconfirm', methods: ['POST'])]
     public function sendAllSubmittersConfirmSendAction(
         CurrentUserService $currentUser,
         Request $request,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanPlisController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanPlisController.php
@@ -26,18 +26,13 @@ class DemosPlanPlisController extends BaseController
     /**
      * Gib den Planungsanlass zu einem Verfahren aus der PLIS-Datenbank aus.
      *
-     * @Route(
-     *     name="DemosPlan_plis_get_procedure",
-     *     path="/plis/getProcedure/{uuid}",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("feature_use_plis")
      *
      * @param string $uuid
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_plis_get_procedure', path: '/plis/getProcedure/{uuid}', options: ['expose' => true])]
     public function getLgvPlisPlanningcauseAction(Plis $procedureHandlerBobhh, $uuid)
     {
         try {
@@ -67,18 +62,13 @@ class DemosPlanPlisController extends BaseController
     /**
      * Gib den Namen zu einem Verfahren aus der PLIS-Datenbank aus.
      *
-     * @Route(
-     *     name="DemosPlan_plis_get_procedure_name",
-     *     path="/plis/getProcedureName/{uuid}",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("feature_use_plis")
      *
      * @param string $uuid Procedure Identifier
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_plis_get_procedure_name', path: '/plis/getProcedureName/{uuid}', options: ['expose' => true])]
     public function getLgvPlisProcedureNameJsonAction(Plis $plis, $uuid)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -79,13 +79,9 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedure/",
-     *        methods={"GET"},
-     *        name="dplan_api_procedure_"
-     * )
-     *
      * @DplanPermissions("area_public_participation")
      */
+    #[Route(path: '/api/1.0/procedure/', methods: ['GET'], name: 'dplan_api_procedure_')]
     public function listAction(Request $request): APIResponse
     {
         $rawData = $this->forward(
@@ -98,20 +94,15 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/mark/participated",
-     *     methods={"POST"},
-     *     name="dp_api_procedure_mark_participated",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_procedures_mark_participated")
      *
      * @param string $procedureId
      *
      * @return JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/mark/participated', methods: ['POST'], name: 'dp_api_procedure_mark_participated', options: ['expose' => true])]
     public function markParticipatedAction($procedureId)
     {
         try {
@@ -126,20 +117,15 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/unmark/participated",
-     *     methods={"POST"},
-     *     name="dp_api_procedure_unmark_participated",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_procedures_mark_participated")
      *
      * @param string $procedureId
      *
      * @return JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/unmark/participated', methods: ['POST'], name: 'dp_api_procedure_unmark_participated', options: ['expose' => true])]
     public function unMarkParticipatedAction($procedureId)
     {
         try {
@@ -156,16 +142,11 @@ class DemosPlanProcedureAPIController extends APIController
     /**
      * Returns a JSON with the available filters for the assessment table.
      *
-     * @Route("/api/1.0/procedures/{procedureId}/statementemptyfilters",
-     *     methods={"GET"},
-     *     name="dp_api_procedure_get_statement_empty_filters",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @return \demosplan\DemosPlanCoreBundle\Response\APIResponse|JsonResponse
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/statementemptyfilters', methods: ['GET'], name: 'dp_api_procedure_get_statement_empty_filters', options: ['expose' => true])]
     public function getStatementEmptyFilterAction(StatementFilterHandler $statementFilterHandler)
     {
         return $this->getStatementEmptyFilter($statementFilterHandler);
@@ -174,35 +155,25 @@ class DemosPlanProcedureAPIController extends APIController
     /**
      * Returns a JSON with the available filters for the original statements list.
      *
-     * @Route("/api/1.0/procedures/{procedureId}/originalstatementemptyfilters",
-     *     methods={"GET"},
-     *     name="dp_api_procedure_get_original_statement_empty_filters",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @return \demosplan\DemosPlanCoreBundle\Response\APIResponse|JsonResponse
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/originalstatementemptyfilters', methods: ['GET'], name: 'dp_api_procedure_get_original_statement_empty_filters', options: ['expose' => true])]
     public function getOriginalStatementEmptyFilterAction(StatementFilterHandler $statementFilterHandler)
     {
         return $this->getStatementEmptyFilter($statementFilterHandler, true);
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/originalfilters/{filterHash}",
-     *     methods={"GET"},
-     *     name="dp_api_procedure_get_original_filters",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
      * @param string $filterHash
-     *
      * @return APIResponse
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/originalfilters/{filterHash}', methods: ['GET'], name: 'dp_api_procedure_get_original_filters', options: ['expose' => true])]
     public function getOriginalStatementFilterAction(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -227,19 +198,14 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/statementfilters/{filterHash}",
-     *     methods={"GET"},
-     *     name="dp_api_procedure_get_statement_filters",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
      * @param string $filterHash
-     *
      * @return APIResponse
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/statementfilters/{filterHash}', methods: ['GET'], name: 'dp_api_procedure_get_statement_filters', options: ['expose' => true])]
     public function getNonOriginalStatementFilterAction(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -264,16 +230,11 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/updatefilterhash",
-     *     methods={"POST"},
-     *     name="dplan_api_procedure_update_filter_hash",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @param string $procedureId
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/updatefilterhash', methods: ['POST'], name: 'dplan_api_procedure_update_filter_hash', options: ['expose' => true])]
     public function updateNonOriginalFilterSetAction(
         AssessmentHandler $assessmentHandler,
         Request $request,
@@ -283,16 +244,11 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/updatefilterhash/original",
-     *     methods={"POST"},
-     *     name="dplan_api_procedure_update_original_filter_hash",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @param string $procedureId
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/updatefilterhash/original', methods: ['POST'], name: 'dplan_api_procedure_update_original_filter_hash', options: ['expose' => true])]
     public function updateOriginalFilterSetAction(
         AssessmentHandler $assessmentHandler,
         Request $request,
@@ -441,20 +397,15 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedures/{procedureId}/statementfilters/delete/{filterSetId}",
-     *     methods={"DELETE"},
-     *     name="dplan_api_procedure_delete_statement_filter",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $filterSetId
      *
      * @return JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/procedures/{procedureId}/statementfilters/delete/{filterSetId}', methods: ['DELETE'], name: 'dplan_api_procedure_delete_statement_filter', options: ['expose' => true])]
     public function deleteStatementFilterAction(Request $request, UserFilterSetService $userFilterSetService, $filterSetId)
     {
         try {
@@ -517,14 +468,9 @@ class DemosPlanProcedureAPIController extends APIController
     }
 
     /**
-     * @Route("/api/1.0/procedure/{procedureId}/relationships/invitedPublicAffairsAgents",
-     *     methods={"POST"},
-     *     name="dplan_api_procedure_add_invited_public_affairs_bodies",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("area_admin_invitable_institution")
      */
+    #[Route(path: '/api/1.0/procedure/{procedureId}/relationships/invitedPublicAffairsAgents', methods: ['POST'], name: 'dplan_api_procedure_add_invited_public_affairs_bodies', options: ['expose' => true])]
     public function addInvitedPublicAffairsAgentsAction(Request $request, ResourceLinkageFactory $linkageFactory, string $procedureId): JsonResponse
     {
         // Check if normalizer succeeded, even if we don't need its object here
@@ -545,18 +491,13 @@ class DemosPlanProcedureAPIController extends APIController
      * Search for Procedures and returns a resultlist
      * in json format.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_search_ajax",
-     *     path="/verfahren/suche/ajax",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @return JsonResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_search_ajax', path: '/verfahren/suche/ajax', options: ['expose' => true])]
     public function searchProceduresAjaxAction(
         ProcedureResourceType $procedureResourceType,
         PublicIndexProcedureLister $procedureLister,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -199,19 +199,15 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Verteiler für den Einstiegspunkt in das Verfahren.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_entrypoint",
-     *     path="/verfahren/{procedure}/entrypoint",
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @param Request                            $request      Unused
      * @param GlobalConfigInterface|GlobalConfig $globalConfig
      * @param string                             $procedure
-     *
      * @return RedirectResponse
      */
+    #[Route(name: 'DemosPlan_procedure_entrypoint', path: '/verfahren/{procedure}/entrypoint')]
     public function procedureEntrypointAction(Request $request, GlobalConfigInterface $globalConfig, $procedure)
     {
         $route = $globalConfig->getProcedureEntrypointRoute();
@@ -224,15 +220,11 @@ class DemosPlanProcedureController extends BaseController
      *
      * @DplanPermissions("area_demosplan")
      *
-     * @Route(
-     *     path="/plan/{slug}",
-     *     name="core_procedure_slug"
-     * )
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/plan/{slug}', name: 'core_procedure_slug')]
     public function procedureSlugAction(CurrentUserInterface $currentUser, ServiceOutput $procedureOutput, string $slug = '')
     {
         try {
@@ -261,18 +253,13 @@ class DemosPlanProcedureController extends BaseController
      *
      * @see https://yaits.demos-deutschland.de/w/demosplan/functions/proceduredashboard/ Wiki: Verfahrensübersicht
      *
-     * @Route(
-     *     name="DemosPlan_procedure_dashboard",
-     *     path="/verfahren/{procedure}/uebersicht",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_dashboard")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_dashboard', path: '/verfahren/{procedure}/uebersicht', options: ['expose' => true])]
     public function procedureDashboardAction(
         CurrentUserService $currentUserService,
         PermissionsInterface $permissions,
@@ -725,18 +712,13 @@ class DemosPlanProcedureController extends BaseController
      * Creates a new procedure (not a procedure template, use
      * {@link DemosPlanProcedureController::newProcedureTemplateAction()} for that).
      *
-     * @Route(
-     *     name="DemosPlan_procedure_new",
-     *     path="/verfahren/neu",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_admin_new_procedure")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_new', path: '/verfahren/neu', options: ['expose' => true])]
     public function newProcedureAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
@@ -831,18 +813,13 @@ class DemosPlanProcedureController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_master_new",
-     *     path="/verfahren/blaupausen/neu",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_procedure_templates")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_master_new', path: '/verfahren/blaupausen/neu', options: ['expose' => true])]
     public function newProcedureTemplateAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
@@ -939,20 +916,15 @@ class DemosPlanProcedureController extends BaseController
     /**
      * TöB hinzufügen Liste.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_member_add_mastertoeblist",
-     *     path="/verfahren/{procedure}/einstellungen/benutzer/hinzufuegen/mastertoeblist",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions({"area_main_procedures","area_admin_invitable_institution"})
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_member_add_mastertoeblist', path: '/verfahren/{procedure}/einstellungen/benutzer/hinzufuegen/mastertoeblist', options: ['expose' => true])]
     public function administrationNewMemberListMastertoeblistAction(
         CurrentProcedureService $currentProcedureService,
         MasterToebService $masterToebService,
@@ -1008,17 +980,13 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Email to invite unregistered public agencies.
      *
-     * @Route(
-     *     name="DemosPlan_invite_unregistered_public_agency_email",
-     *     path="/verfahren/{procedureId}/einstellungen/unregistrierte_toeb_email"
-     * )
      *
      * @DplanPermissions("area_invite_unregistered_public_agencies")
      *
      * @param string $procedureId
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_invite_unregistered_public_agency_email', path: '/verfahren/{procedureId}/einstellungen/unregistrierte_toeb_email')]
     public function administrationUnregisteredPublicAgencyEMailAction(
         AddressBookEntryService $addressBookEntryService,
         Request $request,
@@ -1087,15 +1055,11 @@ class DemosPlanProcedureController extends BaseController
     /**
      * List of unregistered public agencies, which will be filled by address book of organisations.
      *
-     * @Route(
-     *     name="DemosPlan_invite_unregistered_public_agency_list",
-     *     path="/verfahren/{procedureId}/einstellungen/{organisationId}/unregistrierte_toeb_liste"
-     * )
      *
      * @DplanPermissions("area_invite_unregistered_public_agencies")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_invite_unregistered_public_agency_list', path: '/verfahren/{procedureId}/einstellungen/{organisationId}/unregistrierte_toeb_liste')]
     public function administrationUnregisteredPublicAgencyListAction(
         AddressBookEntryService $addressBookEntryService,
         Request $request,
@@ -1139,11 +1103,6 @@ class DemosPlanProcedureController extends BaseController
      *
      * This route is redirected to in demosplan/DemosPlanProcedureBundle/Controller/DemosPlanProcedureController.php:2373
      *
-     * @Route(
-     *     name="DemosPlan_admin_member_email",
-     *     path="/verfahren/{procedureId}/einstellungen/mitglieder_email",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_main_procedures","area_admin_invitable_institution")
      *
@@ -1152,6 +1111,7 @@ class DemosPlanProcedureController extends BaseController
      * @throws SyntaxError
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_admin_member_email', path: '/verfahren/{procedureId}/einstellungen/mitglieder_email', options: ['expose' => true])]
     public function administrationMemberEMailAction(
         OrgaService $orgaService,
         Request $request,
@@ -1242,16 +1202,6 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Allgemeine Einstellungen eines Verfahrens.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_edit",
-     *     path="/verfahren/{procedure}/einstellungen",
-     *     defaults={"isMaster": false}
-     * )
-     * @Route(
-     *     name="DemosPlan_procedure_edit_master",
-     *     path="/verfahren/blaupause/{procedure}/einstellungen",
-     *     defaults={"isMaster": true}
-     * )
      *
      * @DplanPermissions({"area_main_procedures", "area_admin_preferences"})
      *
@@ -1265,6 +1215,8 @@ class DemosPlanProcedureController extends BaseController
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */
+    #[Route(name: 'DemosPlan_procedure_edit', path: '/verfahren/{procedure}/einstellungen', defaults: ['isMaster' => false])]
+    #[Route(name: 'DemosPlan_procedure_edit_master', path: '/verfahren/blaupause/{procedure}/einstellungen', defaults: ['isMaster' => true])]
     public function administrationEditAction(
         ContentService $contentService,
         CurrentUserService $currentUser,
@@ -1514,18 +1466,13 @@ class DemosPlanProcedureController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedure_edit_ajax",
-     *     path="/verfahren/{procedure}/einstellungen/update",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions({"area_main_procedures","area_admin_preferences"})
      *
      * @param string $procedure
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_procedure_edit_ajax', path: '/verfahren/{procedure}/einstellungen/update', options: ['expose' => true])]
     public function administrationEditAjaxAction(
         CurrentProcedureService $currentProcedureService,
         CurrentUserService $currentUser,
@@ -1558,16 +1505,11 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Starting point for importing items into a procedure.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_import",
-     *     path="/verfahren/{procedureId}/import",
-     *     options={"expose":true}
-     * )
      *
      * @DplanPermissions({"area_main_procedures", "area_admin_import"})
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_import', path: '/verfahren/{procedureId}/import', options: ['expose' => true])]
     public function administrationImportAction(
         CurrentUserService $currentUser,
         PermissionsInterface $permissions,
@@ -1661,18 +1603,13 @@ class DemosPlanProcedureController extends BaseController
     /**
      * öffentliche Verfahrensdetailseite.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_public_detail",
-     *     path="/verfahren/{procedure}/public/detail",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_procedure_public_detail', path: '/verfahren/{procedure}/public/detail', options: ['expose' => true])]
     public function publicDetailAction(
         BrandingService $brandingService,
         ContentService $contentService,
@@ -2033,15 +1970,11 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Display Procedures to user where orga is allowed to input new statements.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_list_data_input_orga_procedures",
-     *     path="/verfahren/datainput/list"
-     * )
      *
      * @DplanPermissions("area_statement_data_input_orga")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_list_data_input_orga_procedures', path: '/verfahren/datainput/list')]
     public function dataInputOrgaChooseProcedureAction(CurrentUserService $currentUser): Response
     {
         $organisationId = $currentUser->getUser()->getOrganisationId();
@@ -2059,18 +1992,13 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Verwalte die Abonnements/Benachrichtigunsgservices für eine Region.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_list_subscriptions",
-     *     path="/verfahren/abonnieren",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_subscriptions")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_list_subscriptions', path: '/verfahren/abonnieren', options: ['expose' => true])]
     public function subscribeAction(CurrentUserService $currentUser, Request $request)
     {
         $templateVars = [];
@@ -2132,22 +2060,16 @@ class DemosPlanProcedureController extends BaseController
 
     // @improve: T15117
     // @improve: T15850
-
     /**
-     * @Route(
-     *     name="DemosPlan_procedure_member_index",
-     *     path="/verfahren/{procedure}/einstellungen/benutzer",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_invitable_institution")
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_procedure_member_index', path: '/verfahren/{procedure}/einstellungen/benutzer', options: ['expose' => true])]
     public function administrationMemberListAction(
         Breadcrumb $breadcrumb,
         MailService $mailService,
@@ -2346,17 +2268,13 @@ class DemosPlanProcedureController extends BaseController
     /**
      * TöB hinzufügen Liste.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_member_add",
-     *     path="/verfahren/{procedure}/einstellungen/benutzer/hinzufuegen"
-     * )
      *
      * @DplanPermissions({"area_main_procedures","area_admin_invitable_institution"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_member_add', path: '/verfahren/{procedure}/einstellungen/benutzer/hinzufuegen')]
     public function administrationNewMemberListAction(
         Breadcrumb $breadcrumb,
         MessageBagInterface $messageBag,
@@ -2421,20 +2339,15 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Hole die Liste der Textbausteine, gegebenfalls lösche markeirte Textbausteine.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_boilerplate_list",
-     *     path="/verfahren/{procedure}/textbausteine",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_boilerplates")
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_boilerplate_list', path: '/verfahren/{procedure}/textbausteine', options: ['expose' => true])]
     public function boilerplateListAction(
         ProcedureHandler $procedureHandler,
         Request $request,
@@ -2501,17 +2414,11 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Creation and editing of places, each is either process or procedure template related.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_places_list",
-     *     path="/verfahren/{procedureId}/schritte",
-     * )
-     * @Route(
-     *     name="DemosPlan_procedure_template_places_list",
-     *     path="/verfahren/blaupause/{procedureId}/schritte",
-     * )
      *
      * @DplanPermissions("area_manage_segment_places")
      */
+    #[Route(name: 'DemosPlan_procedure_places_list', path: '/verfahren/{procedureId}/schritte')]
+    #[Route(name: 'DemosPlan_procedure_template_places_list', path: '/verfahren/blaupause/{procedureId}/schritte')]
     public function showProcedurePlacesAction(string $procedureId)
     {
         return $this->renderTemplate('@DemosPlanProcedure/DemosPlanProcedure/administration_places.html.twig', [
@@ -2522,20 +2429,15 @@ class DemosPlanProcedureController extends BaseController
     /**
      * Bearbeite bestehende und neue Textbausteine.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_boilerplate_edit",
-     *     path="/verfahren/{procedure}/textbaustein/{boilerplateId}/{selectedGroupId}",
-     *     defaults={"boilerplateId": "new", "selectedGroupId": ""},
-     * )
      *
      * @DplanPermissions("area_admin_boilerplates")
      *
      * @param string $procedure
      * @param string $boilerplateId
      * @param string $selectedGroupId
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_procedure_boilerplate_edit', path: '/verfahren/{procedure}/textbaustein/{boilerplateId}/{selectedGroupId}', defaults: ['boilerplateId' => 'new', 'selectedGroupId' => ''])]
     public function boilerplateEditAction(FormFactoryInterface $formFactory, Request $request, $procedure, $boilerplateId, $selectedGroupId)
     {
         $boilerplateValueObject = new BoilerplateVO();
@@ -2636,10 +2538,6 @@ class DemosPlanProcedureController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedure_boilerplate_group_delete",
-     *     path="/verfahren/{procedure}/boilerplate/{boilerplateGroupId}/delete",
-     * )
      *
      * @DplanPermissions("area_admin_boilerplates")
      *
@@ -2647,9 +2545,9 @@ class DemosPlanProcedureController extends BaseController
      * @param string $boilerplateGroupId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_boilerplate_group_delete', path: '/verfahren/{procedure}/boilerplate/{boilerplateGroupId}/delete')]
     public function boilerplateGroupDeleteAction(Request $request, $procedure, $boilerplateGroupId)
     {
         $procedureService = $this->procedureService;
@@ -2672,12 +2570,6 @@ class DemosPlanProcedureController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedure_boilerplate_group_edit",
-     *     path="/verfahren/{procedure}/boilerplategroup/{boilerplateGroupId}",
-     *     defaults={"boilerplateGroupId": "new"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_boilerplates")
      *
@@ -2685,9 +2577,9 @@ class DemosPlanProcedureController extends BaseController
      * @param string $boilerplateGroupId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_boilerplate_group_edit', path: '/verfahren/{procedure}/boilerplategroup/{boilerplateGroupId}', defaults: ['boilerplateGroupId' => 'new'], options: ['expose' => true])]
     public function boilerplateGroupEditAction(FormFactoryInterface $formFactory, Request $request, $procedure, $boilerplateGroupId)
     {
         $boilerplateGroupValueObject = new BoilerplateGroupVO();

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
@@ -30,19 +30,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanProcedureExportController extends DemosPlanProcedureController
 {
     /**
-     * @Route(
-     *     name="DemosPlan_title_page_export.tex.twig",
-     *     path="/verfahren/{procedure}/titlepage/export"
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_title_page_export.tex.twig', path: '/verfahren/{procedure}/titlepage/export')]
     public function titlePageExportAction(
         CurrentUserInterface $currentUser,
         PermissionsInterface $permissions,
@@ -78,20 +74,15 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
     /**
      * PDF-Export der Institutionen-Liste.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_member_index_pdf",
-     *     path="/verfahren/{procedure}/einstellungen/benutzer/pdf",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions({"area_main_procedures","area_admin_invitable_institution"})
      *
      * @param string $procedure
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_member_index_pdf', path: '/verfahren/{procedure}/einstellungen/benutzer/pdf', options: ['expose' => true])]
     public function administrationMemberListPdfAction(
         CurrentProcedureService $currentProcedureService,
         ExportService $exportService,
@@ -132,19 +123,15 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
     /**
      * Export Procedure.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_export",
-     *     path="/verfahren/{procedure}/export",
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @param string $procedure
      *
      * @return StreamedResponse|RedirectResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_export', path: '/verfahren/{procedure}/export')]
     public function exportProcedureAction(
         CurrentUserService $currentUser,
         ExportService $exportService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayerCategoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayerCategoryAPIController.php
@@ -21,28 +21,20 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class DemosPlanProcedureLayerCategoryAPIController.
- *
- * @Route(
- *     "/api/1.0/GisLayerCategory",
- *     options={"expose": true}
- * )
  */
+#[Route(path: '/api/1.0/GisLayerCategory', options: ['expose' => true])]
 class DemosPlanProcedureLayerCategoryAPIController extends APIController
 {
     /**
      * Delete a specific GisLayerCategory.
      *
-     * @Route(
-     *     path="/{layerCategoryId}",
-     *     methods={"DELETE"},
-     *     name="dplan_api_procedure_layer_category_delete")
      *
      * @DplanPermissions({"area_admin_map","feature_map_category"})
      *
      * @return $this|JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/{layerCategoryId}', methods: ['DELETE'], name: 'dplan_api_procedure_layer_category_delete')]
     public function layerCategoryDeleteAction(string $layerCategoryId, MapService $mapService)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayersAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayersAPIController.php
@@ -23,22 +23,17 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class DemosPlanProcedureLayersAPIController.
- *
- * @Route(
- *     path="/api/1.0/procedure/{procedureId}/layers",
- *     name="dplan_api_procedure_layer_",
- *     options={"expose": true}
- * )
  */
+#[Route(path: '/api/1.0/procedure/{procedureId}/layers', name: 'dplan_api_procedure_layer_', options: ['expose' => true])]
 class DemosPlanProcedureLayersAPIController extends APIController
 {
     /**
      * get params: type.
      *
-     * @Route(methods={"GET"}, name="list")
      *
      * @DplanPermissions("area_map_participation_area")
      */
+    #[Route(methods: ['GET'], name: 'list')]
     public function layersListAction(MapHandler $mapHandler, string $procedureId): APIResponse
     {
         $rootLayerCategory = $mapHandler->getRootLayerCategoryForProcedure($procedureId);
@@ -48,12 +43,11 @@ class DemosPlanProcedureLayersAPIController extends APIController
     }
 
     /**
-     * @Route(methods={"POST", "PATCH"}, name="update")
      *
      * @DplanPermissions("area_admin_map")
-     *
      * @throws MessageBagException
      */
+    #[Route(methods: ['POST', 'PATCH'], name: 'update')]
     public function layersUpdateAction(MapHandler $mapHandler): APIResponse
     {
         $rootCategory = $this->getRequestJson('data');
@@ -81,14 +75,13 @@ class DemosPlanProcedureLayersAPIController extends APIController
     /**
      * Delete a specific GisLayer.
      *
-     * @Route(path="{layerId}", methods={"DELETE"}, name="delete")
      *
      * @DplanPermissions("area_admin_map")
      *
      * @return $this|JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '{layerId}', methods: ['DELETE'], name: 'delete')]
     public function layerDeleteAction(MapHandler $mapHandler, string $layerId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -63,10 +63,6 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * Public procedure search.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_list_search",
-     *     path="/verfahren/suche",
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
@@ -75,9 +71,9 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
      *                      else in the application
      *
      * @return RedirectResponse|Response|null
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_list_search', path: '/verfahren/suche')]
     public function publicProcedureSearchAction(
         BrandingService $brandingService,
         ContentService $contentService,
@@ -137,10 +133,6 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * Orga branded index page.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_public_orga_index",
-     *     path="/plaene/{orgaSlug}"
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
@@ -149,9 +141,9 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
      *                      else in the application
      *
      * @return RedirectResponse|Response|null
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_public_orga_index', path: '/plaene/{orgaSlug}')]
     public function publicOrgaIndexAction(
         BrandingService $brandingService,
         ContentService $contentService,
@@ -211,17 +203,13 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     }
 
     /**
-     * @Route(
-     *     path="/verfahren/suche/stellungnahmen",
-     *     methods={"GET"},
-     *     name="DemosPlan_procedure_search_statements")
      *
      * @DplanPermissions("area_admin_procedures", "area_search_submitter_in_procedures")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(path: '/verfahren/suche/stellungnahmen', methods: ['GET'], name: 'DemosPlan_procedure_search_statements')]
     public function findProceduresByStatementAuthorViewAction(ProcedureHandler $procedureHandler)
     {
         $procedures = $procedureHandler->getProceduresForAdmin();
@@ -237,17 +225,11 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedures_delete",
-     *     path="/verfahren/delete",
-     *     methods={"POST"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_procedures")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedures_delete', path: '/verfahren/delete', methods: ['POST'], options: ['expose' => true])]
     public function deleteProceduresAction(Request $request): RedirectResponse
     {
         $this->deleteProceduresOrProcedureTemplates($request);
@@ -256,17 +238,11 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedure_templates_delete",
-     *     path="/verfahren/blaupausen/delete",
-     *     methods={"POST"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_procedure_templates")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_templates_delete', path: '/verfahren/blaupausen/delete', methods: ['POST'], options: ['expose' => true])]
     public function deleteMasterProceduresAction(Request $request): RedirectResponse
     {
         $this->deleteProceduresOrProcedureTemplates($request);
@@ -275,19 +251,13 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedures_export",
-     *     path="/verfahren/export",
-     *     methods={"GET"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_procedures")
      *
      * @return StreamedResponse|RedirectResponse
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedures_export', path: '/verfahren/export', methods: ['GET'], options: ['expose' => true])]
     public function exportProceduresAction(ExportService $exportService, Request $request): Response
     {
         $selectedProcedures = $this->getSelectedItems($request);
@@ -303,22 +273,13 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * Liste der Verfahren, die der User administriert.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_administration_post",
-     *     path="/verfahren/verwalten",
-     *     methods={"POST"},
-     * )
-     * @Route(
-     *     name="DemosPlan_procedure_administration_get",
-     *     path="/verfahren/verwalten",
-     *     methods={"GET"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_procedures")
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_administration_post', path: '/verfahren/verwalten', methods: ['POST'])]
+    #[Route(name: 'DemosPlan_procedure_administration_get', path: '/verfahren/verwalten', methods: ['GET'], options: ['expose' => true])]
     public function proceduresListAction(ProcedureListService $procedureListService): Response
     {
         $title = 'procedure.admin.list';
@@ -336,17 +297,11 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * Liste der Verfahrens-Vorlagen, die der User administriert.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_templates_list",
-     *     path="/verfahren/blaupausen",
-     *     methods={"GET"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_admin_procedure_templates")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_templates_list', path: '/verfahren/blaupausen', methods: ['GET'], options: ['expose' => true])]
     public function proceduresMasterListAction(
         PermissionsInterface $permissions,
         ProcedureListService $procedureListService,
@@ -378,18 +333,13 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * JSON-String der Verfahren in der öffentlichen Beteiligung.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_public_list_json",
-     *     path="/list/json",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_public_list_json', path: '/list/json', options: ['expose' => true])]
     public function publicProcedureListJsonAction(
         CurrentUserInterface $currentUser,
         ContentService $contentService,
@@ -504,16 +454,11 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * (Umkreis-)Suche nach Verfahren in der öffentlichen Beteiligung.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_public_suggest_procedure_location_json",
-     *     path="/suggest/procedureLocation/json",
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions("area_public_participation")
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_procedure_public_suggest_procedure_location_json', path: '/suggest/procedureLocation/json', options: ['expose' => true])]
     public function searchProcedureJsonAction(
         Request $request,
         CurrentProcedureService $currentProcedureService,
@@ -602,17 +547,13 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
     /**
      * Redirects to procedure filtering by orga slug.
      *
-     * @Route(
-     *     name="DemosPlan_procedure_public_orga_id_index",
-     *     path="/oid/{orgaId}"
-     * )
      *
      * @DplanPermissions("area_public_participation")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_procedure_public_orga_id_index', path: '/oid/{orgaId}')]
     public function publicOrgaIdIndexAction(OrgaHandler $orgaHandler, string $orgaId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
@@ -44,17 +44,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanProcedureTypeController extends BaseController
 {
     /**
-     * @Route(
-     *     name="DemosPlan_procedureType_list",
-     *     path="verfahrenstypen",
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions({"area_procedure_type_edit"})
      *
      * @throws QueryException
      * @throws UserNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_list', path: 'verfahrenstypen', methods: ['GET'])]
     public function procedureTypeListAction(
         ProcedureTypeService $procedureTypeService): Response
     {
@@ -72,11 +68,6 @@ class DemosPlanProcedureTypeController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedureType_create_select",
-     *     path="verfahrenstypen/auswahl",
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions({"area_procedure_type_edit"})
      *
@@ -85,6 +76,7 @@ class DemosPlanProcedureTypeController extends BaseController
      * @throws ResourceNotFoundException
      * @throws UserNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_create_select', path: 'verfahrenstypen/auswahl', methods: ['GET'])]
     public function procedureTypeCreateBaseSelectAction(
         Breadcrumb $breadcrumb,
         FormFactoryInterface $formFactory,
@@ -128,17 +120,11 @@ class DemosPlanProcedureTypeController extends BaseController
      * For the moment, this method looks very much like the editAction, because it is basically the preparation step for a duplication.
      * This will be different when we have the case of actually creating new procedureTypes from scratch.
      *
-     * @Route(
-     *     name="DemosPlan_procedureType_duplicate",
-     *     path="verfahrenstypen/{procedureTypeId}/duplicate",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_procedure_type_edit"})
-     *
      * @throws ResourceNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_duplicate', path: 'verfahrenstypen/{procedureTypeId}/duplicate', methods: ['GET'], options: ['expose' => true])]
     public function procedureTypeCreateAction(
         Breadcrumb $breadcrumb,
         EntityFetcher $entityFetcher,
@@ -193,12 +179,6 @@ class DemosPlanProcedureTypeController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedureType_edit",
-     *     path="verfahrenstypen/{procedureTypeId}/edit",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_procedure_type_edit"})
      *
@@ -207,6 +187,7 @@ class DemosPlanProcedureTypeController extends BaseController
      * @throws ResourceNotFoundException
      * @throws UserNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_edit', path: 'verfahrenstypen/{procedureTypeId}/edit', methods: ['GET'], options: ['expose' => true])]
     public function procedureTypeEditAction(
         Breadcrumb $breadcrumb,
         EntityFetcher $entityFetcher,
@@ -254,12 +235,6 @@ class DemosPlanProcedureTypeController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedureType_create_save",
-     *     path="verfahrenstypen/create",
-     *     methods={"POST"},
-     *     options={"expose": false}
-     * )
      *
      * @DplanPermissions("area_procedure_type_edit")
      *
@@ -271,6 +246,7 @@ class DemosPlanProcedureTypeController extends BaseController
      * @throws ResourceNotFoundException
      * @throws UserNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_create_save', path: 'verfahrenstypen/create', methods: ['POST'], options: ['expose' => false])]
     public function procedureTypeCreateSaveAction(
         EntityFetcher $entityFetcher,
         EntityWrapperFactory $wrapperFactory,
@@ -385,12 +361,6 @@ class DemosPlanProcedureTypeController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_procedureType_edit_save",
-     *     path="verfahrenstypen/{procedureTypeId}/edit",
-     *     methods={"POST"},
-     *     options={"expose": false}
-     * )
      *
      * @DplanPermissions("area_procedure_type_edit")
      *
@@ -402,6 +372,7 @@ class DemosPlanProcedureTypeController extends BaseController
      * @throws ResourceNotFoundException
      * @throws UserNotFoundException
      */
+    #[Route(name: 'DemosPlan_procedureType_edit_save', path: 'verfahrenstypen/{procedureTypeId}/edit', methods: ['POST'], options: ['expose' => false])]
     public function procedureTypeEditSaveAction(
         EntityFetcher $entityFetcher,
         EntityWrapperFactory $wrapperFactory,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanSubmitterController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanSubmitterController.php
@@ -28,15 +28,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanSubmitterController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_submitters_list",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/submitters/list")
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_submitters")
      */
+    #[Route(name: 'dplan_submitters_list', methods: 'GET', path: '/verfahren/{procedureId}/submitters/list')]
     public function listAction(string $procedureId): Response
     {
         return $this->renderTemplate(
@@ -49,15 +45,9 @@ class DemosPlanSubmitterController extends BaseController
     }
 
     /**
-     * @Route(
-     *      name="dplan_admin_procedure_submitter_export",
-     *      path="/verfahren/{procedureId}/einreicher/export",
-     *      methods={"GET"},
-     *      options={"expose": true}
-     * )
-     *
      * @DplanPermissions("area_admin_submitters")
      */
+    #[Route(name: 'dplan_admin_procedure_submitter_export', path: '/verfahren/{procedureId}/einreicher/export', methods: ['GET'], options: ['expose' => true])]
     public function exportAction(
         Request $request,
         FileResponseGeneratorStrategy $responseGenerator,

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
@@ -42,16 +42,11 @@ class ProcedureProposalController extends BaseController
     /**
      * List ProcedureProposals.
      *
-     * @Route(
-     *    path="/procedure_proposal_list",
-     *    methods={"GET"},
-     *    name="dplan_procedure_proposals_list"
-     * )
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_procedure_proposal_edit")
      */
+    #[Route(path: '/procedure_proposal_list', methods: ['GET'], name: 'dplan_procedure_proposals_list')]
     public function listProcedureProposalAction(): Response
     {
         $procedureProposals = $this->procedureProposalService->getProcedureProposals();
@@ -68,16 +63,11 @@ class ProcedureProposalController extends BaseController
     /**
      * Get single procedure proposal by id.
      *
-     * @Route(
-     *    path="proposal/{procedureProposalId}",
-     *    methods={"GET"},
-     *    name="dplan_procedure_proposal_view"
-     * )
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_procedure_proposal_edit")
      */
+    #[Route(path: 'proposal/{procedureProposalId}', methods: ['GET'], name: 'dplan_procedure_proposal_view')]
     public function getProcedureProposalAction(ProcedureProposalHandler $proposalHandler, string $procedureProposalId): Response
     {
         try {
@@ -103,15 +93,11 @@ class ProcedureProposalController extends BaseController
     /**
      * Generate new ProcedureProposal.
      *
-     * @Route(
-     *     path="/procedure_proposal_create",
-     *     name="dplan_procedure_proposals_create"
-     * )
      *
      * @throws Exception
-     *
      * @DplanPermissions("feature_create_procedure_proposal")
      */
+    #[Route(path: '/procedure_proposal_create', name: 'dplan_procedure_proposals_create')]
     public function addProcedureProposalAction(Request $request, ProcedureProposalHandler $procedureProposalHandler): Response
     {
         $requestPost = $request->request->all();
@@ -146,19 +132,15 @@ class ProcedureProposalController extends BaseController
     /**
      * Generate new Procedure from ProcedureProposal.
      *
-     * @Route(
-     *     path="/verfahrensvorschlag/{procedureProposalId}/erstellen",
-     *     name="procedure_proposal_generate_procedure",
-     * )
      *
      * @return RedirectResponse|Response
      *
      * @throws MessageBagException
      *
      * @DplanPermissions("area_procedure_proposal_edit")
-     *
      * @deprecated a {@link DemosPlanProcedureAPIController::createAction} (does not exist yet) should be used instead with the data needed sent by the frontend in an JSON:API POST request
      */
+    #[Route(path: '/verfahrensvorschlag/{procedureProposalId}/erstellen', name: 'procedure_proposal_generate_procedure')]
     public function generateProcedure(string $procedureProposalId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureStatisticsRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureStatisticsRpcController.php
@@ -25,14 +25,8 @@ class ProcedureStatisticsRpcController extends APIController
      * @DplanPermissions("area_statement_segmentation")
      *
      * @return APIResponse|Response
-     *
-     * @Route(
-     *     path="/rpc/1.0/ProcedureStatistics/get/{procedureId}",
-     *     name="dplan_rpc_procedure_segmentation_statistics_segmentations_get",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      */
+    #[Route(path: '/rpc/1.0/ProcedureStatistics/get/{procedureId}', name: 'dplan_rpc_procedure_segmentation_statistics_segmentations_get', methods: ['GET'], options: ['expose' => true])]
     public function segmentationsGetAction(
         ProcedureStatisticsService $procedureStatisticsService,
         string $procedureId

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
@@ -25,13 +25,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class WerDenktWasAPIController extends BaseController
 {
     /**
-     * @Route(
-     *      path="/api/werdenktwas/procedures",
-     *     methods={"GET"}
-     * )
-     *
      * @DplanPermissions("area_public_participation")
      */
+    #[Route(path: '/api/werdenktwas/procedures', methods: ['GET'])]
     public function procedureListGeoJSONAction(TranslatorInterface $translator): ?JsonResponse
     {
         $searchProceduresResponse = $this->forward(

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
@@ -40,16 +40,11 @@ class DemosPlanReportAPIController extends APIController
      * - int page: Set the requested page (default: 1)
      * - array|string[] category: Set the categories from the requested group (default: [])
      *
-     * @Route(path="/api/1.0/reports/{procedureId}/{group}",
-     *        methods={"GET"},
-     *        name="dplan_api_report_procedure_list",
-     *        defaults={"group": null},
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_admin_protocol")
-     *
      * @param string $group
      */
+    #[Route(path: '/api/1.0/reports/{procedureId}/{group}', methods: ['GET'], name: 'dplan_api_report_procedure_list', defaults: ['group' => null], options: ['expose' => true])]
     public function listProcedureReportsAction(
         JsonApiPaginationParser $paginationParser,
         EntityFetcher $entityFetcher,

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -33,19 +33,15 @@ class DemosPlanReportController extends BaseController
     /**
      * Show a report.
      *
-     * @Route(
-     *     name="dm_plan_report_table_view",
-     *     path="/report/view/{procedureId}"
-     * )
      *
      * @DplanPermissions("area_admin_protocol")
      *
      * @param string $procedureId
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'dm_plan_report_table_view', path: '/report/view/{procedureId}')]
     public function viewReportAction(Request $request, $procedureId)
     {
         return $this->renderTemplate(
@@ -60,19 +56,13 @@ class DemosPlanReportController extends BaseController
     /**
      * Generates a PDF Report for the given procedure.
      *
-     * @Route(
-     *     name="dplan_export_report",
-     *     path="/report/export/{procedureId}",
-     *     methods={"GET"},
-     *     options={"expose": true},
-     * )
      *
      * @DplanPermissions({"area_admin_protocol", "feature_export_protocol"})
      *
      * @param string $procedureId
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_export_report', path: '/report/export/{procedureId}', methods: ['GET'], options: ['expose' => true])]
     public function exportProcedureReportAction(
         ExportReportService $reportService,
         ParameterBagInterface $parameterBag,

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
@@ -40,20 +40,14 @@ class DraftsInfoApiController extends APIController
     /**
      * Gets the Statement's text with the segmented info.
      *
-     * @Route(
-     *     name="dplan_drafts_list_edit_ajax",
-     *     methods="GET",
-     *     path="/_ajax/verfahren/{procedureId}/statements/{statementId}/drafts-list",
-     *     options={"expose": true}
-     * )
      *
      * @throws LockedByAssignmentException
      * @throws MessageBagException
      * @throws StatementAlreadySegmentedException
      * @throws StatementNotFoundException
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_drafts_list_edit_ajax', methods: 'GET', path: '/_ajax/verfahren/{procedureId}/statements/{statementId}/drafts-list', options: ['expose' => true])]
     public function editAction(
         StatementToDraftsInfoTransformer $transformer,
         string $procedureId,
@@ -80,20 +74,14 @@ class DraftsInfoApiController extends APIController
     /**
      * Saves a Statement's draft segment (text + tags).
      *
-     * @Route(
-     *      name="dplan_drafts_list_save",
-     *      methods="PATCH",
-     *      path="/_ajax/verfahren/{procedureId}/drafts-list/save/{statementId}",
-     *      options={"expose": true}
-     * )
      *
      * @throws LockedByAssignmentException
      * @throws MessageBagException
      * @throws StatementAlreadySegmentedException
      * @throws StatementNotFoundException
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_drafts_list_save', methods: 'PATCH', path: '/_ajax/verfahren/{procedureId}/drafts-list/save/{statementId}', options: ['expose' => true])]
     public function saveAction(
         DraftsInfoHandler $draftsInfoHandler,
         Request $request,
@@ -120,12 +108,6 @@ class DraftsInfoApiController extends APIController
     /**
      * Confirms the Statement's drafts info so they are converted to Segment entities.
      *
-     * @Route(
-     *     name="dplan_drafts_list_confirm",
-     *     methods="POST",
-     *     path="/verfahren/{procedureId}/drafts-list/confirm",
-     *     options={"expose": true}
-     * )
      *
      * @throws LockedByAssignmentException
      * @throws MessageBagException
@@ -133,9 +115,9 @@ class DraftsInfoApiController extends APIController
      * @throws StatementAlreadySegmentedException
      * @throws StatementNotFoundException
      * @throws Exception
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_drafts_list_confirm', methods: 'POST', path: '/verfahren/{procedureId}/drafts-list/confirm', options: ['expose' => true])]
     public function confirmDraftsAction(
         CurrentUserService $currentUserProvider,
         DraftsInfoHandler $draftsInfoHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
@@ -31,14 +31,8 @@ class DraftsInfoController extends BaseController
      * Assigns the Statement to the user in session (to avoid concurrency problems) and
      * redirects to dplan_drafts_list_edit.
      *
-     * @Route(
-     *     name="dplan_drafts_list_claim",
-     *     methods="POST",
-     *     path="/verfahren/{procedureId}/statements/{statementId}/drafts-list",
-     *     options={"expose": true})
      *
      * @throws StatementNotFoundException
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
     // TODO: receiving the statement ID here may result in concurrency problems
@@ -46,6 +40,7 @@ class DraftsInfoController extends BaseController
     // it is unknown what happens if they both use it but it will be nothing good.
     // Instead of receiving the statement ID the BE should chose a statement by
     // itself in this route.
+    #[Route(name: 'dplan_drafts_list_claim', methods: 'POST', path: '/verfahren/{procedureId}/statements/{statementId}/drafts-list', options: ['expose' => true])]
     public function startSegmentationAction(
         CurrentUserService $currentUser,
         StatementService $statementService,
@@ -72,17 +67,11 @@ class DraftsInfoController extends BaseController
      * Gets the Twig Template to call the endpoint loading the Statement's Text with
      * the segmentation.
      *
-     * @Route(
-     *     name="dplan_drafts_list_edit",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/statement/{statementId}/drafts-list",
-     *     options={"expose": true}
-     * )
      *
      * @throws Exception
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_drafts_list_edit', methods: 'GET', path: '/verfahren/{procedureId}/statement/{statementId}/drafts-list', options: ['expose' => true])]
     public function editAction(
         string $procedureId,
         string $statementId,

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentBulkEditController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentBulkEditController.php
@@ -19,17 +19,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class SegmentBulkEditController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_segment_bulk_edit_form",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte/bulk-edit",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_segments_bulk_edit")
-     *
      * @throws Exception
      */
+    #[Route(name: 'dplan_segment_bulk_edit_form', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/bulk-edit', options: ['expose' => true])]
     public function showFormAction(string $procedureId): Response
     {
         return $this->renderTemplate('@DemosPlanProcedure/DemosPlanProcedure/administration_segments_bulk_edit.html.twig', [

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
@@ -35,14 +35,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class SegmentController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_segments_list",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte",
-     *     options={"expose": true})
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_segments_list', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte', options: ['expose' => true])]
     public function listAction(string $procedureId, HashedQueryService $filterSetService): RedirectResponse
     {
         $segmentListQuery = new SegmentListQuery();
@@ -57,10 +52,6 @@ class SegmentController extends BaseController
     }
 
     /**
-     * @Route(name="dplan_statement_segments_list",
-     *        methods="GET",
-     *        path="/verfahren/{procedureId}/{statementId}/abschnitte",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_segments_of_statement_list")
      *
@@ -68,6 +59,7 @@ class SegmentController extends BaseController
      * @throws StatementNotFoundException
      * @throws Exception
      */
+    #[Route(name: 'dplan_statement_segments_list', methods: 'GET', path: '/verfahren/{procedureId}/{statementId}/abschnitte', options: ['expose' => true])]
     public function statementSpecificListAction(
         CurrentUserInterface $currentUser,
         CurrentProcedureService $currentProcedureService,
@@ -109,17 +101,13 @@ class SegmentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_segments_process_import",
-     *     methods="POST",
-     *     path="/verfahren/{procedureId}/abschnitte/speichern",
-     *     options={"expose": true})
      *
      * @DplanPermissions("feature_segments_import_excel")
      *
      * @throws ProcedureNotFoundException
      * @throws Exception
      */
+    #[Route(name: 'dplan_segments_process_import', methods: 'POST', path: '/verfahren/{procedureId}/abschnitte/speichern', options: ['expose' => true])]
     public function importSegmentsFromXlsx(
         CurrentProcedureService $currentProcedureService,
         FileService $fileService,
@@ -195,14 +183,9 @@ class SegmentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_segments_list_by_query_hash",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte/{queryHash}",
-     *     options={"expose": true})
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(name: 'dplan_segments_list_by_query_hash', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/{queryHash}', options: ['expose' => true])]
     public function listFilteredAction(
         string $procedureId,
         string $queryHash,

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentRpcController.php
@@ -22,15 +22,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class SegmentRpcController extends APIController
 {
     /**
-     * @Route(
-     *     path="/rpc/1.0/statementListQuery/update/{queryHash}",
-     *     name="dplan_rpc_segment_list_query_update",
-     *     options={"expose": true},
-     *     methods={"PATCH"}
-     * )
-     *
      * @DplanPermissions("area_statement_segmentation")
      */
+    #[Route(path: '/rpc/1.0/statementListQuery/update/{queryHash}', name: 'dplan_rpc_segment_list_query_update', options: ['expose' => true], methods: ['PATCH'])]
     public function updateSegmentListQueryAction(CurrentProcedureService $currentProcedureService, string $queryHash, DrupalFilterParser $filterParser, HashedQueryService $filterSetService): Response
     {
         $procedureId = $currentProcedureService->getProcedureIdWithCertainty();

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -32,17 +32,12 @@ use ZipStream\ZipStream;
 class SegmentsExportController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_segments_export",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/{statementId}/abschnitte/export",
-     *     options={"expose": true})
      *
      * @throws StatementNotFoundException
      * @throws Exception
-     *
      * @DplanPermissions("feature_segments_of_statement_list")
      */
+    #[Route(name: 'dplan_segments_export', methods: 'GET', path: '/verfahren/{procedureId}/{statementId}/abschnitte/export', options: ['expose' => true])]
     public function exportAction(
         ProcedureHandler $procedureHandler,
         SegmentsExporter $exporter,
@@ -70,15 +65,9 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_statement_segments_export",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte/export/gruppiert",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_segments_of_statement_list")
      */
+    #[Route(name: 'dplan_statement_segments_export', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/gruppiert', options: ['expose' => true])]
     public function exportByStatementsFilterAction(
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
@@ -104,15 +93,9 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_statement_xls_export",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte/export/xlsx",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_admin_assessmenttable_export_statement_generic_xlsx")
      */
+    #[Route(name: 'dplan_statement_xls_export', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/xlsx', options: ['expose' => true])]
     public function exportByStatementsFilterXlsAction(
         JsonApiActionService $jsonApiActionService,
         ProcedureHandler $procedureHandler,
@@ -147,15 +130,9 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_statement_segments_export_packaged",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/abschnitte/export/gepackt",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_segments_of_statement_list")
      */
+    #[Route(name: 'dplan_statement_segments_export_packaged', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/gepackt', options: ['expose' => true])]
     public function exportPackagedStatementsAction(
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,

--- a/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
@@ -25,13 +25,11 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class SlugDraftApiController.
- *
- * @Route(path="/api/1.0/slug-draft", name="dp_api_slug_draft_", options={"expose": true})
  */
+#[Route(path: '/api/1.0/slug-draft', name: 'dp_api_slug_draft_', options: ['expose' => true])]
 class SlugDraftApiController extends APIController
 {
     /**
-     * @Route(methods={"POST"}, name="create")
      *
      * Currently this route is only needed when editing procedure or orga settings
      * but can be used by anyone as it has no security implications.
@@ -40,9 +38,9 @@ class SlugDraftApiController extends APIController
      * accordingly.
      *
      * @DplanPermissions("feature_short_url")
-     *
      * @return APIResponse|JsonResponse
      */
+    #[Route(methods: ['POST'], name: 'create')]
     public function createAction(SlugDraftTransformer $slugDraftTransformer)
     {
         $slugDraftType = $slugDraftTransformer->getType();

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -66,15 +66,11 @@ class DemosPlanAssessmentController extends BaseController
      *
      * NOTE: Only used by Statement Detail View
      *
-     * @Route(
-     *     name="DemosPlan_assessment_set_statement_assignment",
-     *     path="/assignment/statement/{entityId}/{assignOrUnassign}",
-     * )
      *
      * @DplanPermissions("feature_statement_assignment")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_assessment_set_statement_assignment', path: '/assignment/statement/{entityId}/{assignOrUnassign}')]
     public function setStatementAssigneeAction(
         CurrentUserService $currentUser,
         Request $request,
@@ -120,15 +116,11 @@ class DemosPlanAssessmentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_orga_list",
-     *     path="/statement/manual/list/{procedureId}",
-     * )
      *
      * @DplanPermissions("feature_statement_data_input_orga")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_orga_list', path: '/statement/manual/list/{procedureId}')]
     public function getOrgaStatementListAction(CurrentUserService $currentUser, StatementHandler $statementHandler, string $procedureId): Response
     {
         $organisationId = $currentUser->getUser()->getOrganisationId();
@@ -157,16 +149,11 @@ class DemosPlanAssessmentController extends BaseController
     /**
      * Create new Statement.
      *
-     * @Route(
-     *     name="DemosPlan_statement_new_submitted",
-     *     path="/statement/new/manual/{procedureId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statement_data_input_orga")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_new_submitted', path: '/statement/new/manual/{procedureId}', options: ['expose' => true])]
     public function newManualStatementAction(
         CurrentUserService $currentUser,
         FileUploadService $fileUploadService,
@@ -235,15 +222,11 @@ class DemosPlanAssessmentController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_single_view",
-     *     path="procedure/{procedureId}/statement/{statementId}/dataInput"
-     * )
      *
      * @DplanPermissions("feature_statement_data_input_orga")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_single_view', path: 'procedure/{procedureId}/statement/{statementId}/dataInput')]
     public function viewSingleStatementAction(
         Breadcrumb $breadcrumb,
         ProcedureService $procedureService,
@@ -284,15 +267,11 @@ class DemosPlanAssessmentController extends BaseController
     /**
      * Display single Statement cluster.
      *
-     * @Route(
-     *     name="DemosPlan_cluster_single_statement_view",
-     *     path="/verfahren/{procedure}/cluster/statement/{statementId}"
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_cluster_single_statement_view', path: '/verfahren/{procedure}/cluster/statement/{statementId}')]
     public function viewStatementClusterSingleStatementAction(StatementHandler $statementHandler, string $statementId): Response
     {
         $statement = $statementHandler->getStatement($statementId);
@@ -312,15 +291,11 @@ class DemosPlanAssessmentController extends BaseController
     /**
      * Detaches a single Statement from his cluster.
      *
-     * @Route(
-     *     name="DemosPlan_cluster_detach_statement",
-     *     path="/verfahren/{procedure}/cluster/statement/{statementId}/detach",
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_cluster_detach_statement', path: '/verfahren/{procedure}/cluster/statement/{statementId}/detach')]
     public function detachStatementFromClusterAction(StatementHandler $statementHandler, string $statementId): Response
     {
         try {
@@ -342,15 +317,11 @@ class DemosPlanAssessmentController extends BaseController
      * Resolves a single statementCluster.
      * All statements in the cluster will be detached.
      *
-     * @Route(
-     *     name="DemosPlan_cluster_resolve",
-     *     path="/verfahren/{procedure}/cluster/resolve/{headStatementId}",
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_cluster_resolve', path: '/verfahren/{procedure}/cluster/resolve/{headStatementId}')]
     public function resolveClusterAction(StatementHandler $statementHandler, string $headStatementId): Response
     {
         try {
@@ -371,14 +342,10 @@ class DemosPlanAssessmentController extends BaseController
     /**
      * Returns the base data for Vue components on the assessment table.
      *
-     * @Route(
-     *     name="DemosPlan_assessment_base_ajax",
-     *     path="/_ajax/assessment/{procedureId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_procedure_get_base_data")
      */
+    #[Route(name: 'DemosPlan_assessment_base_ajax', path: '/_ajax/assessment/{procedureId}', options: ['expose' => true])]
     public function assessmentBaseAjaxAction(
         CurrentUserService $currentUser,
         CountyService $countyService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
@@ -47,17 +47,6 @@ class DemosPlanAssessmentExportController extends BaseController
      * An Assessment table export Action that can handle all types of exports
      * specified in the export options yml.
      *
-     * @Route(
-     *     name="DemosPlan_assessment_table_export",
-     *     methods={"POST", "GET"},
-     *     path="/verfahren/abwaegung/export/{procedureId}",
-     *        options={"expose": true})
-     * @Route(
-     *     name="DemosPlan_assessment_table_original_export",
-     *     path="/verfahren/abwaegung/original/export/{procedureId}",
-     *     defaults={"original": true},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_assessmenttable")
      *
@@ -65,6 +54,8 @@ class DemosPlanAssessmentExportController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_assessment_table_export', methods: ['POST', 'GET'], path: '/verfahren/abwaegung/export/{procedureId}', options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_assessment_table_original_export', path: '/verfahren/abwaegung/original/export/{procedureId}', defaults: ['original' => true], options: ['expose' => true])]
     public function exportAction(
         Request $request,
         AssessmentTableExporterStrategy $assessmentExporter,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
@@ -78,18 +78,13 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Fragment Statement into multiple slices.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment",
-     *     path="/verfahren/{procedure}/fragment/{statementId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_admin_assessmenttable", "feature_statements_fragment_add"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_fragment', path: '/verfahren/{procedure}/fragment/{statementId}', options: ['expose' => true])]
     public function fragmentStatementAction(
         CountyService $countyService,
         MunicipalityService $municipalityService,
@@ -176,17 +171,13 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Return all data necessary to display a list that contains all
      * statement fragment versions related to a department.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_list_fragment_archived_reviewer",
-     *     path="/datensatz/liste/archive"
-     * )
      *
      *  @DplanPermissions({"area_statement_fragments_department_archive","feature_statements_fragment_list"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_statement_fragment_list_fragment_archived_reviewer', path: '/datensatz/liste/archive')]
     public function getStatementFragmentListArchiveAction(CurrentUserService $currentUser, Request $request, RouterInterface $router, TranslatorInterface $translator)
     {
         $templateVars = [];
@@ -262,20 +253,15 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Return all data necessary to display a list that contains all
      * statement fragments related to a department.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_list_fragment_reviewer",
-     *     path="/datensatz/liste",
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_statement_fragments_department","feature_statements_fragment_list"})
      *
      * @return RedirectResponse|Response
      *
      * @throws Exception
-     *
      * @internal param string $type
      */
+    #[Route(name: 'DemosPlan_statement_fragment_list_fragment_reviewer', path: '/datensatz/liste', options: ['expose' => true])]
     public function getStatementFragmentListAction(
         CountyService $countyService,
         CurrentUserService $currentUser,
@@ -367,22 +353,13 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Edit a single fragment.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_edit_ajax",
-     *     path="/_ajax/procedure/{procedure}/fragment/{fragmentId}/edit",
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_fragment_edit_reviewer_ajax",
-     *     path="/_ajax/fragment/{fragmentId}/reviewer/edit",
-     *     defaults={"isReviewer": true},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statements_fragment_edit")
      *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_statement_fragment_edit_ajax', path: '/_ajax/procedure/{procedure}/fragment/{fragmentId}/edit', options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_statement_fragment_edit_reviewer_ajax', path: '/_ajax/fragment/{fragmentId}/reviewer/edit', defaults: ['isReviewer' => true], options: ['expose' => true])]
     public function editStatementFragmentAjaxAction(
         CurrentUserService $currentUser,
         Request $request,
@@ -440,19 +417,13 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Delete a single fragment.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_delete_ajax",
-     *     path="/_ajax/procedure/{procedureId}/statement/{statementId}/fragment/{fragmentId}/delete",
-     *     methods={"POST"},
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_admin_assessmenttable","feature_statements_fragment_edit"})
      *
      * @param string $fragmentId
-     *
      * @return RedirectResponse|Response
      */
+    #[Route(name: 'DemosPlan_statement_fragment_delete_ajax', path: '/_ajax/procedure/{procedureId}/statement/{statementId}/fragment/{fragmentId}/delete', methods: ['POST'], options: ['expose' => true])]
     public function deleteFragmentStatementAjaxAction(Request $request, $fragmentId)
     {
         try {
@@ -494,20 +465,15 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Return fragment data as json.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_get_ajax",
-     *     path="/_ajax/procedure/{procedure}/statement/{statementId}/fragment/{fragmentId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_statements_fragment")
      *
      * @param string $procedure
      * @param string $statementId
      * @param string $fragmentId
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_statement_fragment_get_ajax', path: '/_ajax/procedure/{procedure}/statement/{statementId}/fragment/{fragmentId}', options: ['expose' => true])]
     public function getFragmentAjaxAction(Request $request, $procedure, $statementId, $fragmentId)
     {
         try {
@@ -522,18 +488,13 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Return all considerations of all fragments of a statement.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_considerations_get_ajax",
-     *     path="/_ajax/procedure/{procedure}/statement/{statementId}/fragmentconsiderations",
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_admin_assessmenttable","area_statements_fragment"})
      *
      * @param string $statementId
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_statement_fragment_considerations_get_ajax', path: '/_ajax/procedure/{procedure}/statement/{statementId}/fragmentconsiderations', options: ['expose' => true])]
     public function getFragmentConsiderationsAjaxAction($statementId)
     {
         try {
@@ -567,15 +528,11 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *
      * @DplanPermissions({"area_statements_fragment", "feature_statements_fragment_add"})
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_add",
-     *     path="/verfahren/{procedure}/fragment/{statementId}/add"
-     * )
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_fragment_add', path: '/verfahren/{procedure}/fragment/{statementId}/add')]
     public function addFragmentStatementAction(
         CurrentUserInterface $currentUser,
         Request $request,
@@ -652,15 +609,6 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Set a vote or advice to a fragment statement.
      *
-     * @Route(
-     *     name="DemosPlan_statement_fragment_update_redirect_fragment_reviewer",
-     *     path="/datensatz/update/reviewer",
-     *     defaults={"isReviewer": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_fragment_update_redirect",
-     *     path="/datensatz/update",
-     * )
      *
      *  @DplanPermissions({"area_statements_fragment","feature_statements_fragment_edit"})
      *
@@ -670,6 +618,8 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_fragment_update_redirect_fragment_reviewer', path: '/datensatz/update/reviewer', defaults: ['isReviewer' => true])]
+    #[Route(name: 'DemosPlan_statement_fragment_update_redirect', path: '/datensatz/update')]
     public function updateStatementFragmentAction(
         CurrentUserService $currentUser,
         StatementFragmentService $statementFragmentService,
@@ -744,18 +694,12 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     }
 
     // @improve T14122
-
     /**
      * Returns fragment data for a statement on the assessment table.
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
-     * @Route(
-     *     name="DemosPlan_assessment_statement_fragments_ajax",
-     *     path="/_ajax/assessment/{procedureId}/{statementId}",
-     *     options={"expose": true}
-     * )
      */
+    #[Route(name: 'DemosPlan_assessment_statement_fragments_ajax', path: '/_ajax/assessment/{procedureId}/{statementId}', options: ['expose' => true])]
     public function assessmentStatementFragmentsAjaxAction(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
@@ -822,20 +766,15 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
     /**
      * Exports a subset of fragments from the fragmentList to PDF.
      *
-     * @Route(
-     *     name="DemosPlan_fragment_list_export",
-     *     path="/datensatz/liste/export",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_statements_fragment")
      *
      * @param Request $request ;
      *
      * @return Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_fragment_list_export', path: '/datensatz/liste/export', options: ['expose' => true])]
     public function exportFragmentListAction(CurrentUserService $currentUser, Request $request, TranslatorInterface $translator)
     {
         $vars = $request->request->all();

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanClaimAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanClaimAPIController.php
@@ -82,26 +82,18 @@ class DemosPlanClaimAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/statement/{statementId}/relationships/assignee",
-     *        methods={"PATCH"},
-     *        name="dplan_claim_statements_api",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("feature_statement_assignment")
      */
+    #[Route(path: '/api/1.0/statement/{statementId}/relationships/assignee', methods: ['PATCH'], name: 'dplan_claim_statements_api', options: ['expose' => true])]
     public function updateStatementAssignmentAction(string $statementId): APIResponse
     {
         return $this->updateStatementOrStatementFragmentAssignment($statementId, Statement::class);
     }
 
     /**
-     * @Route(path="/api/1.0/fragment/{entityId}/relationships/assignee",
-     *        methods={"PATCH"},
-     *        name="dplan_claim_fragments_api",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("feature_statement_assignment")
      */
+    #[Route(path: '/api/1.0/fragment/{entityId}/relationships/assignee', methods: ['PATCH'], name: 'dplan_claim_fragments_api', options: ['expose' => true])]
     public function updateFragmentAssignmentAction(string $entityId): APIResponse
     {
         return $this->updateStatementOrStatementFragmentAssignment($entityId, StatementFragment::class);

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
@@ -28,19 +28,14 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class DemosPlanEntityContentChangeAPIController extends APIController
 {
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{procedureId}/entitycontentchange/{entityContentChangeId}",
-     *        name="dplan_api_history_of_all_fields_of_specific_datetime",
-     *        methods={"GET"},
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_statement_content_changes_view")
-     *
      * This action provides all formatted diffs of all EntityContentChange objects of one specific change instance.
      * A change instance is a moment in time when an entity is changed. E.g. if person A changes Statement B at time C.
      * Then the combination of ABC is a change instance.
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/entitycontentchange/{entityContentChangeId}', name: 'dplan_api_history_of_all_fields_of_specific_datetime', methods: ['GET'], options: ['expose' => true])]
     public function getEntityContentChangeAction(
         EntityContentChangeService $contentChangeService,
         string $entityContentChangeId
@@ -53,18 +48,12 @@ class DemosPlanEntityContentChangeAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(
-     *     path="/api/1.0/statements/{procedureId}/statementfragment/{statementFragmentId}/history",
-     *     name="dplan_api_statement_fragment_history",
-     *     methods={"GET"},
-     *     options={"expose": true})
      *
      * @DplanPermissions("feature_statement_fragment_content_changes_view")
-     *
      * @return APIResponse|JsonResponse
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/statementfragment/{statementFragmentId}/history', name: 'dplan_api_statement_fragment_history', methods: ['GET'], options: ['expose' => true])]
     public function getStatementFragmentHistoryAction(
         CurrentProcedureService $currentProcedureService,
         EntityContentChangeDisplayHandler $displayHandler,
@@ -87,17 +76,13 @@ class DemosPlanEntityContentChangeAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/segments/{procedureId}/entitycontentchange/{entityContentChangeId}",
-     *        name="dplan_api_segments_history_of_all_fields_of_specific_datetime",
-     *        methods={"GET"},
-     *        options={"expose": true})
      *
      * This action provides all formatted diffs of all EntityContentChange objects of one specific change instance.
      * A change instance is a moment in time when an entity is changed. E.g. if person A changes Statement B at time C.
      * Then the combination of ABC is a change instance.
-     *
      * @DplanPermissions("feature_segment_content_changes_view")
      */
+    #[Route(path: '/api/1.0/segments/{procedureId}/entitycontentchange/{entityContentChangeId}', name: 'dplan_api_segments_history_of_all_fields_of_specific_datetime', methods: ['GET'], options: ['expose' => true])]
     public function getSegmentContentChangeAction(
         EntityContentChangeService $contentChangeService,
         string $entityContentChangeId

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanSimplifiedStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanSimplifiedStatementController.php
@@ -30,18 +30,12 @@ class DemosPlanSimplifiedStatementController extends BaseController
     /**
      * Creates a new Statement from the simplified form.
      *
-     * @Route(
-     *     name="dplan_simplified_new_statement_create",
-     *     methods={"POST"},
-     *     path="/verfahren/{procedureId}/stellungnahmen/neu",
-     *     options={"expose": true}
-     * )
      *
      * @throws MessageBagException
      * @throws UserNotFoundException
-     *
      * @DplanPermissions("feature_simplified_new_statement_create")
      */
+    #[Route(name: 'dplan_simplified_new_statement_create', methods: ['POST'], path: '/verfahren/{procedureId}/stellungnahmen/neu', options: ['expose' => true])]
     public function createAction(
         TraceableEventDispatcher $eventDispatcher,
         ManualSimplifiedStatementCreator $statementCreator,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -94,21 +94,16 @@ class DemosPlanStatementAPIController extends APIController
         $this->permissions = $permissions;
     }
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{statementId}/copy/{procedureId}",
-     *        methods={"POST"},
-     *        name="dplan_api_statement_copy_to_procedure",
-     *        options={"expose": true})
      *
      * Copy Statement into (another) procedure.
      *
      * @DplanPermissions("feature_statement_copy_to_procedure")
      *
      * @return APIResponse|JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/statements/{statementId}/copy/{procedureId}', methods: ['POST'], name: 'dplan_api_statement_copy_to_procedure', options: ['expose' => true])]
     public function copyStatementAction(ProcedureHandler $procedureHandler, Request $request, StatementHandler $statementHandler, string $statementId)
     {
         try {
@@ -192,19 +187,14 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{statementId}/move/{procedureId}",
-     *        methods={"POST"},
-     *        name="dplan_api_statement_move",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_statement_move_to_procedure")
      *
      * @return APIResponse|JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/statements/{statementId}/move/{procedureId}', methods: ['POST'], name: 'dplan_api_statement_move', options: ['expose' => true])]
     public function moveStatementAction(
         CurrentProcedureService $currentProcedureService,
         ProcedureHandler $procedureHandler,
@@ -293,19 +283,14 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{procedureId}/{statementId}/edit",
-     *        methods={"POST"},
-     *        name="dplan_api_statement_edit",
-     *        options={"expose": true})
      *
      * @param string $statementId
      *
      * @DplanPermissions("area_admin_assessmenttable")
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/{statementId}/edit', methods: ['POST'], name: 'dplan_api_statement_edit', options: ['expose' => true])]
     public function editStatementAction(StatementService $statementService, ValidatorInterface $validator, $statementId)
     {
         try {
@@ -405,15 +390,10 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/assessmentqueryhash/{filterSetHash}/statements/{procedureId}/",
-     *        methods={"GET"},
-     *        name="dplan_assessmentqueryhash_get_procedure_statement_list",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("area_admin_assessmenttable")
      */
+    #[Route(path: '/api/1.0/assessmentqueryhash/{filterSetHash}/statements/{procedureId}/', methods: ['GET'], name: 'dplan_assessmentqueryhash_get_procedure_statement_list', options: ['expose' => true])]
     public function listAction(
         AssessmentHandler $assessmentHandler,
         HashedQueryService $filterSetService,
@@ -492,20 +472,15 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{procedureId}/statements/group",
-     *        methods={"POST"},
-     *        name="dplan_api_create_group_statement",
-     *        options={"expose": true})
      *
      * Creates a new Statements cluster for current procedure.
      * HeadStatement and Statements to be used for the cluster are received in the requestBody.
      *
      * @DplanPermissions("area_admin_assessmenttable","feature_statement_cluster")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/statements/group', methods: ['POST'], name: 'dplan_api_create_group_statement', options: ['expose' => true])]
     public function createGroupStatementAction(StatementHandler $statementHandler, string $procedureId): APIResponse
     {
         try {
@@ -541,20 +516,15 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{procedureId}/statements/group",
-     *        methods={"PATCH"},
-     *        name="dplan_api_update_group_statement",
-     *        options={"expose": true})
      *
      * Updates an existing Statements cluster in current procedure.
      * Cluster and Statements to be used are received in the requestBody.
      *
      * @DplanPermissions("area_admin_assessmenttable","feature_statement_cluster")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/statements/group', methods: ['PATCH'], name: 'dplan_api_update_group_statement', options: ['expose' => true])]
     public function updateGroupStatementAction(StatementHandler $statementHandler, string $procedureId): APIResponse
     {
         try {
@@ -583,12 +553,7 @@ class DemosPlanStatementAPIController extends APIController
     }
 
     // @improve T12984
-
     /**
-     * @Route(path="/api/1.0/statements/{procedureId}/statements/bulk-edit",
-     *        methods={"POST"},
-     *        name="dplan_assessment_table_assessment_table_statement_bulk_edit_api_action",
-     *        options={"expose": true})
      *
      * Do nothing cases (error response), not all cases implemented yet:
      * <ul>
@@ -608,9 +573,9 @@ class DemosPlanStatementAPIController extends APIController
      * @DplanPermissions("area_admin_assessmenttable","feature_statement_bulk_edit")
      *
      * @return JsonResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/statements/{procedureId}/statements/bulk-edit', methods: ['POST'], name: 'dplan_assessment_table_assessment_table_statement_bulk_edit_api_action', options: ['expose' => true])]
     public function statementBulkEditApiAction(StatementService $statementService, ValidatorInterface $validator, string $procedureId)
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -147,27 +147,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * PDF-Export der Statements.
      *
-     * @Route(
-     *     name="DemosPlan_statement_list_released_group_export_pdf",
-     *     path="/verfahren/{procedure}/stellungnahmen/freigabenGruppe/pdf",
-     *     defaults={"title": "statements.final.group", "type": "releasedGroup"}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_list_final_group_export_pdf",
-     *     path="/verfahren/{procedure}/stellungnahmen/endfassungenGruppe/pdf",
-     *     defaults={"title": "statements.final.group", "type": "finalGroup"}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_single_export_pdf",
-     *     path="/verfahren/{procedure}/stellungnahmen/single/pdf",
-     *     defaults={"type": "single"},
-     *     options={"expose": true})
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_list_final_citizen_export_pdf",
-     *     path="/verfahren/{procedure}/stellungnahmen/endfassungenCitizen/pdf",
-     *     defaults={"title": "statements.final.own", "type": "finalCitizen"}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
@@ -178,6 +157,9 @@ class DemosPlanStatementController extends BaseController
      *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_statement_list_released_group_export_pdf', path: '/verfahren/{procedure}/stellungnahmen/freigabenGruppe/pdf', defaults: ['title' => 'statements.final.group', 'type' => 'releasedGroup'])]
+    #[Route(name: 'DemosPlan_statement_list_final_group_export_pdf', path: '/verfahren/{procedure}/stellungnahmen/endfassungenGruppe/pdf', defaults: ['title' => 'statements.final.group', 'type' => 'finalGroup'])]
+    #[Route(name: 'DemosPlan_statement_single_export_pdf', path: '/verfahren/{procedure}/stellungnahmen/single/pdf', defaults: ['type' => 'single'], options: ['expose' => true])]
     public function pdfAction(
         CurrentProcedureService $currentProcedureService,
         Request $request,
@@ -220,18 +202,13 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_list_public",
-     *     path="/verfahren/{procedure}/stellungnahmen/toeb",
-     *     defaults={"templateName": "list_public"}
-     * )
      *
      * @DplanPermissions("area_statements_public")
      *
      * @return RedirectResponse|Response|null
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_list_public', path: '/verfahren/{procedure}/stellungnahmen/toeb', defaults: ['templateName' => 'list_public'])]
     public function otherCompaniesListAction(
         Request $request,
         CurrentProcedureService $currentProcedureService,
@@ -302,10 +279,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * Einreichen einer Stellungnahme aus der öffentlichen Beteiligung.
      *
-     * @Route(
-     *     name="DemosPlan_statement_public_submit",
-     *     path="/verfahren/{procedure}/stellungnahmen/public/submit"
-     * )
      *
      * @DplanPermissions({"feature_new_statement", "area_statements_draft"})
      *
@@ -314,6 +287,7 @@ class DemosPlanStatementController extends BaseController
      * @throws MessageBagException
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_statement_public_submit', path: '/verfahren/{procedure}/stellungnahmen/public/submit')]
     public function submitPublicStatementAction(
         MapService $mapService,
         Request $request,
@@ -520,54 +494,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * The GET parameter reset resets the filters in session.
      *
-     * @Route(
-     *     name="DemosPlan_statement_list_final_group",
-     *     path="/verfahren/{procedure}/stellungnahmen/endfassungenGruppe",
-     *     defaults={
-     *          "templateName": "list_final_group",
-     *          "released": true,
-     *          "scope": "group",
-     *          "submitted": true,
-     *          "title": "statements.final.group",
-     *      },
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_list_released",
-     *     path="/verfahren/{procedure}/stellungnahmen/freigaben",
-     *     defaults={
-     *          "templateName": "list_released",
-     *          "released": true,
-     *          "scope": "own",
-     *          "submitted": "both",
-     *          "title": "statements.released",
-     *      },
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_list_draft",
-     *     path="/verfahren/{procedure}/stellungnahmen/entwuerfe",
-     *     defaults={
-     *          "templateName": "list_draft",
-     *          "released": false,
-     *          "scope": "own",
-     *          "submitted": false,
-     *          "title": "statements.drafts",
-     *      },
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_list_released_group",
-     *     path="/verfahren/{procedure}/stellungnahmen/freigabenGruppe",
-     *     defaults={
-     *          "templateName": "list_released_group",
-     *          "released": true,
-     *          "scope": "group",
-     *          "submitted": false,
-     *          "title": "statements.released.group",
-     *      },
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_statements")
      *
@@ -578,6 +504,10 @@ class DemosPlanStatementController extends BaseController
      *
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_statement_list_final_group', path: '/verfahren/{procedure}/stellungnahmen/endfassungenGruppe', defaults: ['templateName' => 'list_final_group', 'released' => true, 'scope' => 'group', 'submitted' => true, 'title' => 'statements.final.group'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_statement_list_released', path: '/verfahren/{procedure}/stellungnahmen/freigaben', defaults: ['templateName' => 'list_released', 'released' => true, 'scope' => 'own', 'submitted' => 'both', 'title' => 'statements.released'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_statement_list_draft', path: '/verfahren/{procedure}/stellungnahmen/entwuerfe', defaults: ['templateName' => 'list_draft', 'released' => false, 'scope' => 'own', 'submitted' => false, 'title' => 'statements.drafts'], options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_statement_list_released_group', path: '/verfahren/{procedure}/stellungnahmen/freigabenGruppe', defaults: ['templateName' => 'list_released_group', 'released' => true, 'scope' => 'group', 'submitted' => false, 'title' => 'statements.released.group'], options: ['expose' => true])]
     public function listAction(
         BrandingService $brandingService,
         Breadcrumb $breadcrumb,
@@ -827,19 +757,15 @@ class DemosPlanStatementController extends BaseController
     /**
      * Stellungahme mitzeichnen.
      *
-     * @Route(
-     *     name="DemosPlan_statement_public_vote",
-     *     path="/verfahren/{procedure}/stellungnahmen/public/{statementID}/vote"
-     * )
      *
      * @DplanPermissions("feature_statements_vote_may_vote")
      *
      * @param string $procedure Procedure Id
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_public_vote', path: '/verfahren/{procedure}/stellungnahmen/public/{statementID}/vote')]
     public function votePublicStatementAction(
         BrandingService $brandingService,
         MapService $mapService,
@@ -915,10 +841,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * Stellungahme mitzeichnen.
      *
-     * @Route(
-     *     name="DemosPlan_statement_public_like",
-     *     path="/verfahren/{procedure}/stellungnahmen/public/{statementId}/vote/anonymous",
-     * )
      *
      * @DplanPermissions("feature_statements_like_may_like")
      *
@@ -926,9 +848,9 @@ class DemosPlanStatementController extends BaseController
      * @param string $statementId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_public_like', path: '/verfahren/{procedure}/stellungnahmen/public/{statementId}/vote/anonymous')]
     public function likePublicStatementAction(
         EventDispatcherPostInterface $eventDispatcherPost,
         Request $request,
@@ -963,12 +885,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * Speichere eine Stellungnahme via Ajax-Aufruf.
      *
-     * @Route(
-     *     name="DemosPlan_statement_public_participation_new_ajax",
-     *     methods="POST",
-     *     path="/verfahren/{procedure}/stellungnahmen/public/neu/ajax",
-     *     options={"expose": true}
-     * )
      *
      * @param string $procedure Procedure Id
      *
@@ -977,9 +893,9 @@ class DemosPlanStatementController extends BaseController
      * initially use area_demosplan, specific permissions are checked below
      *
      * @throws Throwable
-     *
      * @DplanPermissions("area_demosplan")
      */
+    #[Route(name: 'DemosPlan_statement_public_participation_new_ajax', methods: 'POST', path: '/verfahren/{procedure}/stellungnahmen/public/neu/ajax', options: ['expose' => true])]
     public function newPublicStatementAjaxAction(
         CurrentProcedureService $currentProcedureService,
         EventDispatcherPostInterface $eventDispatcherPost,
@@ -1128,17 +1044,13 @@ class DemosPlanStatementController extends BaseController
     /**
      * Detailansicht einer Stellungnahme in der Bürgeransicht.
      *
-     * @Route(
-     *     name="DemosPlan_statement_public_participation_published",
-     *     path="/verfahren/{procedure}/stellungnahme/{statementID}"
-     * )
      *
      * @DplanPermissions("area_statements_public_published_public")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_public_participation_published', path: '/verfahren/{procedure}/stellungnahme/{statementID}')]
     public function publicStatementDetailAction(
         StatementService $statementService,
         string $statementID
@@ -1166,18 +1078,13 @@ class DemosPlanStatementController extends BaseController
     /**
      * Edit Statement.
      *
-     * @Route(
-     *     name="DemosPlan_statement_edit",
-     *     path="/verfahren/{procedure}/stellungnahmen/{statementID}/edit",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions({"area_statements_draft","feature_statements_draft_edit"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_edit', path: '/verfahren/{procedure}/stellungnahmen/{statementID}/edit', options: ['expose' => true])]
     public function editStatementAction(
         FileUploadService $fileUploadService,
         MessageBagInterface $messageBag,
@@ -1242,20 +1149,15 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_send",
-     *     path="/verfahren/{procedure}/stellungnahmen/{statementID}/send",
-     *     options={"expose": true}
-     * )
      *
      * @param string $procedure
      * @param string $statementID
      * @param string $target
      *
      * @return RedirectResponse|Response
-     *
      * @throws Throwable
      */
+    #[Route(name: 'DemosPlan_statement_send', path: '/verfahren/{procedure}/stellungnahmen/{statementID}/send', options: ['expose' => true])]
     public function sendStatementAction(Breadcrumb $breadcrumb, Request $request, TranslatorInterface $translator, $procedure, $statementID)
     {
         try {
@@ -1380,15 +1282,6 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_versions",
-     *     path="/verfahren/{procedure}/stellungnahmen/{statementID}/version",
-     *     options={"expose": true}
-     * )
-     * @Route(
-     *     name="DemosPlan_statement_versiondetail",
-     *     path="/verfahren/{procedure}/stellungnahmen/{statementID}/version/{versionID}"
-     * )
      *
      * @DplanPermissions("feature_statements_draft_versions")
      *
@@ -1396,10 +1289,11 @@ class DemosPlanStatementController extends BaseController
      * @param string $statementID ID of the DraftStatement
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException|UserNotFoundException
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_versions', path: '/verfahren/{procedure}/stellungnahmen/{statementID}/version', options: ['expose' => true])]
+    #[Route(name: 'DemosPlan_statement_versiondetail', path: '/verfahren/{procedure}/stellungnahmen/{statementID}/version/{versionID}')]
     public function versionsOfStatementAction(
         Request $request,
         RouterInterface $router,
@@ -1442,19 +1336,14 @@ class DemosPlanStatementController extends BaseController
     /**
      * Veröffentliche die Stellungnahme für andere TöB.
      *
-     * @Route(
-     *     name="DemosPlan_statement_publish",
-     *     path="/verfahren/{procedure}/stellungnahme/{statementID}/publish",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statements_released_group_submit")
      *
      * @param string $procedure
      * @param string $statementID
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_statement_publish', path: '/verfahren/{procedure}/stellungnahme/{statementID}/publish', options: ['expose' => true])]
     public function publishStatementAction(
         DraftStatementHandler $draftStatementHandler,
         TranslatorInterface $translator,
@@ -1489,11 +1378,6 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_unpublish",
-     *     path="/verfahren/{procedure}/stellungnahme/{statementID}/unpublish",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statements_released_group_submit")
      *
@@ -1503,9 +1387,9 @@ class DemosPlanStatementController extends BaseController
      * @param string $statementID
      *
      * @return RedirectResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_statement_unpublish', path: '/verfahren/{procedure}/stellungnahme/{statementID}/unpublish', options: ['expose' => true])]
     public function unpublishStatementAction(
         DraftStatementHandler $draftStatementHandler,
         TranslatorInterface $translator,
@@ -1542,11 +1426,6 @@ class DemosPlanStatementController extends BaseController
     /**
      * Get draftStatement.
      *
-     * @Route(
-     *     name="DemosPlan_statement_get_ajax",
-     *     path="/rest/draftStatement/get/{procedureId}/{draftStatementId}",
-     *     options={"expose": true})
-     * )
      *
      * @DplanPermissions("area_statements")
      *
@@ -1557,6 +1436,7 @@ class DemosPlanStatementController extends BaseController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_get_ajax', path: '/rest/draftStatement/get/{procedureId}/{draftStatementId}', options: ['expose' => true])]
     public function getDraftStatementAjaxAction(DocumentHandler $documentHandler, Request $request, StatementHandler $statementHandler, string $procedureId, $draftStatementId)
     {
         try {
@@ -1578,15 +1458,11 @@ class DemosPlanStatementController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_statement_get_count_internal",
-     *     path="/rest/statement/count/{procedure}",
-     * )
      *
      * @DplanPermissions("area_statements")
-     *
      * @return JsonResponse
      */
+    #[Route(name: 'DemosPlan_statement_get_count_internal', path: '/rest/statement/count/{procedure}')]
     public function getStatementCountInternalAction(Request $request, StatementHandler $statementHandler, string $procedure)
     {
         $userRole = $this->currentUser->getUser()->getDplanRolesString();
@@ -2473,17 +2349,12 @@ class DemosPlanStatementController extends BaseController
      * List all statements per procedure
      * without any possibilities to edit.
      *
-     * @Route(
-     *     name="dplan_procedure_statement_list",
-     *     methods={"GET"},
-     *     path="/verfahren/{procedureId}/einwendungen",
-     *     options={"expose": true})
      *
      * @throws ProcedureNotFoundException
      * @throws Exception
-     *
      * @DplanPermissions("area_admin_statement_list")
      */
+    #[Route(name: 'dplan_procedure_statement_list', methods: ['GET'], path: '/verfahren/{procedureId}/einwendungen', options: ['expose' => true])]
     public function readOnlyStatementListAction(
         string $procedureId,
         ProcedureCoupleTokenFetcher $tokenFetcher,
@@ -2512,18 +2383,12 @@ class DemosPlanStatementController extends BaseController
     /**
      * Imports Statements from a xlsx-file.
      *
-     * @Route(
-     *     name="DemosPlan_statement_import",
-     *     methods={"POST"},
-     *     path="/verfahren/{procedureId}/stellungnahmen/import",
-     *     options={"expose": true}
-     * )
      *
      * @throws ProcedureNotFoundException
      * @throws Exception
-     *
      * @DplanPermissions({"feature_statements_import_excel"})
      */
+    #[Route(name: 'DemosPlan_statement_import', methods: ['POST'], path: '/verfahren/{procedureId}/stellungnahmen/import', options: ['expose' => true])]
     public function importStatementsAction(
         FileService $fileService,
         PermissionsInterface $permissions,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -33,18 +33,13 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
     /**
      * Renders the admin view of a single tag.
      *
-     * @Route(
-     *     name="DemosPlan_statement_administration_tag",
-     *     path="/verfahren/{procedure}/tag/{tag}",
-     *     defaults={"master": false}
-     * )
      *
      * @DplanPermissions("area_admin_statements_tag")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_administration_tag', path: '/verfahren/{procedure}/tag/{tag}', defaults: ['master' => false])]
     public function tagViewAction(
         ProcedureService $procedureService,
         Request $request,
@@ -108,19 +103,13 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
     /**
      * List of Tags that are being used in this procedures.
      *
-     * @Route(
-     *     name="DemosPlan_statement_administration_tags",
-     *     path="/verfahren/{procedure}/schlagworte",
-     *     defaults={"master": false},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_admin_statements_tag")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_administration_tags', path: '/verfahren/{procedure}/schlagworte', defaults: ['master' => false], options: ['expose' => true])]
     public function tagListAction(
         StatementHandler $statementHandler,
         TranslatorInterface $translator,
@@ -146,18 +135,13 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
     /**
      * Edit Tags and topics that are being used in this procedures.
      *
-     * @Route(
-     *     name="DemosPlan_statement_administration_tags_edit",
-     *     path="/verfahren/{procedure}/schlagworte/edit",
-     *     defaults={"master": false},
-     * )
      *
      * @DplanPermissions("area_admin_statements_tag")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_statement_administration_tags_edit', path: '/verfahren/{procedure}/schlagworte/edit', defaults: ['master' => false])]
     public function tagListEditAction(
         FileUploadService $fileUploadService,
         Request $request,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/GdprConsentRevokeTokenController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/GdprConsentRevokeTokenController.php
@@ -30,14 +30,11 @@ class GdprConsentRevokeTokenController extends BaseController
     private const POST_PARAM_KEY_GDPR_CONSENT_REVOKE_TOKEN = 'gdprConsentRevokeToken';
 
     /**
-     * @Route(path="/einwilligung-widerrufen",
-     *        methods={"POST"},
-     *        name="DemosPlan_statement_revoke_gdpr_consent_post")
      *
      * @DplanPermissions("area_gdpr_consent_revoke_page")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/einwilligung-widerrufen', methods: ['POST'], name: 'DemosPlan_statement_revoke_gdpr_consent_post')]
     public function revokeGdprConsentPostAction(GdprConsentRevokeTokenService $gdprConsentRevokeTokenService, Request $request): Response
     {
         try {
@@ -65,13 +62,10 @@ class GdprConsentRevokeTokenController extends BaseController
     /**
      * @DplanPermissions("area_demosplan")
      *
-     * @Route(path="/einwilligung-widerrufen",
-     *        methods={"GET"},
-     *        name="DemosPlan_statement_revoke_gdpr_consent_get"
-     * )
      *
      * @throws Exception
      */
+    #[Route(path: '/einwilligung-widerrufen', methods: ['GET'], name: 'DemosPlan_statement_revoke_gdpr_consent_get')]
     public function revokeGdprConsentGetAction(PermissionsInterface $permissions): Response
     {
         if ($permissions->hasPermission('area_gdpr_consent_revoke_page')) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/SegmentHistoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/SegmentHistoryAPIController.php
@@ -25,14 +25,9 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class SegmentHistoryAPIController extends APIController
 {
     /**
-     * @Route("/api/1.0/SegmentHistory/{segmentId}",
-     *     methods={"GET"},
-     *     name="dplan_api_segment_history_get",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_segment_content_changes_view")
      */
+    #[Route(path: '/api/1.0/SegmentHistory/{segmentId}', methods: ['GET'], name: 'dplan_api_segment_history_get', options: ['expose' => true])]
     public function getAction(
         CurrentProcedureService $currentProcedureService,
         EntityContentChangeDisplayHandler $displayHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeController.php
@@ -29,14 +29,10 @@ class StatementAnonymizeController extends BaseController
      * @throws MessageBagException
      * @throws Exception
      *
-     * @Route(
-     *     path="/procedure/{procedureId}/statement/{statementId}/anonymize",
-     *     name="DemosPlan_statement_anonymize_view",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_statement_anonymize")
      */
+    #[Route(path: '/procedure/{procedureId}/statement/{statementId}/anonymize', name: 'DemosPlan_statement_anonymize_view', options: ['expose' => true])]
     public function statementAnonymizeAction(
         AssessmentHandler $assessmentHandler,
         StatementHandler $statementHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeRpcController.php
@@ -30,13 +30,8 @@ class StatementAnonymizeRpcController extends RpcController
      * @DplanPermissions("area_statement_anonymize")
      *
      * @return RedirectResponse|Response
-     *
-     * @Route(
-     *     path="/rpc/1.0/statement/anonymize",
-     *     name="dplan_rpc_statement_anonymize",
-     *     options={"expose": true}
-     * )
      */
+    #[Route(path: '/rpc/1.0/statement/anonymize', name: 'dplan_rpc_statement_anonymize', options: ['expose' => true])]
     public function statementAnonymizeRpcAction(
         Request $request,
         StatementAnonymizeHandler $statementAnonymizeHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
@@ -30,16 +30,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class StatementFragmentAPIController extends APIController
 {
     /**
-     * @Route("/api/1.0/statement-fragment/{statementFragmentId}/edit",
-     *     methods={"PATCH"},
-     *     name="dplan_api_statement_fragment_edit",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_statements_fragment_edit")
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/api/1.0/statement-fragment/{statementFragmentId}/edit', methods: ['PATCH'], name: 'dplan_api_statement_fragment_edit', options: ['expose' => true])]
     public function updateAction(PermissionsInterface $permissions, Request $request, StatementHandler $statementHandler, string $statementFragmentId)
     {
         if (!($this->requestData instanceof TopLevel)) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementHistoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementHistoryAPIController.php
@@ -25,14 +25,9 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class StatementHistoryAPIController extends APIController
 {
     /**
-     * @Route("/api/1.0/StatementHistory/{statementId}",
-     *     methods={"GET"},
-     *     name="dplan_api_statement_history_get",
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("feature_statement_content_changes_view")
      */
+    #[Route(path: '/api/1.0/StatementHistory/{statementId}', methods: ['GET'], name: 'dplan_api_statement_history_get', options: ['expose' => true])]
     public function getAction(
         CurrentProcedureService $currentProcedureService,
         EntityContentChangeDisplayHandler $displayHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
@@ -28,13 +28,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class TagTopicAPIController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/TagTopic/",
-     *        methods={"POST"},
-     *        name="dplan_api_tag_topic_create",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("feature_json_api_tag_topic_create")
      */
+    #[Route(path: '/api/1.0/TagTopic/', methods: ['POST'], name: 'dplan_api_tag_topic_create', options: ['expose' => true])]
     public function createAction(
         CurrentProcedureService $currentProcedureService,
         PermissionsInterface $permissions,

--- a/demosplan/DemosPlanCoreBundle/Controller/Survey/SurveyController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Survey/SurveyController.php
@@ -30,16 +30,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class SurveyController extends BaseController
 {
     /**
-     * @Route(
-     *     name="dplan_survey_new",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/umfrage/neu")
      *
      * @DplanPermissions("area_survey_management")
      *
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'dplan_survey_new', methods: 'GET', path: '/verfahren/{procedureId}/umfrage/neu')]
     public function newAction(
         string $procedureId,
         SurveyHandler $surveyHandler,
@@ -82,16 +79,13 @@ class SurveyController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_survey_create",
-     *     methods="POST",
-     *     path="/verfahren/{procedureId}/umfrage/create")
      *
      * @DplanPermissions("area_survey_management")
      *
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'dplan_survey_create', methods: 'POST', path: '/verfahren/{procedureId}/umfrage/create')]
     public function createAction(
         string $procedureId,
         SurveyHandler $surveyHandler,
@@ -127,16 +121,13 @@ class SurveyController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_survey_edit",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/umfrage/{surveyId}/edit")
      *
      * @DplanPermissions("area_survey_management")
      *
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'dplan_survey_edit', methods: 'GET', path: '/verfahren/{procedureId}/umfrage/{surveyId}/edit')]
     public function editAction(
         string $procedureId,
         string $surveyId,
@@ -169,16 +160,13 @@ class SurveyController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_survey_update",
-     *     methods="POST",
-     *     path="/verfahren/{procedureId}/umfrage/{surveyId}/update")
      *
      * @DplanPermissions("area_survey_management")
      *
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'dplan_survey_update', methods: 'POST', path: '/verfahren/{procedureId}/umfrage/{surveyId}/update')]
     public function updateAction(
         string $procedureId,
         string $surveyId,
@@ -211,16 +199,13 @@ class SurveyController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="dplan_survey_show",
-     *     methods="GET",
-     *     path="/verfahren/{procedureId}/umfrage/{surveyId}")
      *
      * @DplanPermissions("area_survey")
      *
      * @throws MessageBagException
      * @throws Exception
      */
+    #[Route(name: 'dplan_survey_show', methods: 'GET', path: '/verfahren/{procedureId}/umfrage/{surveyId}')]
     public function showAction(
         string $procedureId,
         string $surveyId,

--- a/demosplan/DemosPlanCoreBundle/Controller/Survey/SurveyVoteAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Survey/SurveyVoteAPIController.php
@@ -37,12 +37,8 @@ class SurveyVoteAPIController extends APIController
 {
     /**
      * @DplanPermissions("area_survey")
-     *
-     * @Route(path="/api/1.0/survey/{surveyId}/relationships/votes",
-     *        methods={"GET"},
-     *        name="dplan_surveyvote_list",
-     *        options={"expose": true})
      */
+    #[Route(path: '/api/1.0/survey/{surveyId}/relationships/votes', methods: ['GET'], name: 'dplan_surveyvote_list', options: ['expose' => true])]
     public function listAction(
         SurveyService $surveyService,
         SurveyVoteService $surveyVoteService,
@@ -63,15 +59,11 @@ class SurveyVoteAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/surveyVote/{surveyVoteId}",
-     *        methods={"PATCH"},
-     *        name="dplan_surveyvote_update",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_survey_management")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/surveyVote/{surveyVoteId}', methods: ['PATCH'], name: 'dplan_surveyvote_update', options: ['expose' => true])]
     public function updateSurveyVoteAction(
         CurrentProcedureService $currentProcedureService,
         SurveyVoteService $surveyVoteService,
@@ -98,16 +90,11 @@ class SurveyVoteAPIController extends APIController
     }
 
     /**
-     * @Route(
-     *     name="dplan_surveyvote_create",
-     *     methods="POST",
-     *     path="/api/1.0/surveyVote",
-     *     options={"expose": true})
      *
      * @DplanPermissions("feature_surveyvote_may_vote")
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'dplan_surveyvote_create', methods: 'POST', path: '/api/1.0/surveyVote', options: ['expose' => true])]
     public function createAction(
         SurveyVoteCreateHandler $surveyVoteCreateHandler,
         SurveyVoteHandler $surveyVoteHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -35,16 +35,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanCustomerController extends BaseController
 {
     /**
-     * @Route(path="/einstellungen/plattform",
-     *        methods={"GET"},
-     *        name="dplan_user_customer_showSettingsPage",
-     *        options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_customer_settings")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/einstellungen/plattform', methods: ['GET'], name: 'dplan_user_customer_showSettingsPage', options: ['expose' => true])]
     public function showSettingsPageAction(
         CustomerHandler $customerHandler,
         EntityWrapperFactory $wrapperFactory,
@@ -87,15 +82,11 @@ class DemosPlanCustomerController extends BaseController
     }
 
     /**
-     * @Route(path="/einstellungen/plattform",
-     *        methods={"POST"},
-     *        name="DemosPlan_user_setting_page_post",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_customer_settings")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/einstellungen/plattform', methods: ['POST'], name: 'DemosPlan_user_setting_page_post', options: ['expose' => true])]
     public function editSettingsAction(
         CustomerHandler $customerHandler,
         Request $request,
@@ -131,15 +122,11 @@ class DemosPlanCustomerController extends BaseController
     }
 
     /**
-     * @Route(path="/einstellungen/plattform/send/mail",
-     *        methods={"GET", "POST"},
-     *        name="dplan_customer_mail_send_all_users"
-     * )
      *
      * @DplanPermissions("area_customer_send_mail_to_users")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/einstellungen/plattform/send/mail', methods: ['GET', 'POST'], name: 'dplan_customer_mail_send_all_users')]
     public function sendMailToAllCustomersAction(
         Request $request,
         TranslatorInterface $translator,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
@@ -21,15 +21,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class DemosPlanDepartmentAPIController extends APIController
 {
     /**
-     * @Route(path="/api/1.0/{organisationId}/department/",
-     *        methods={"GET"},
-     *        name="dplan_api_department_list",
-     *        options={"expose": true})
      *
      * @DplanPermissions("area_manage_users")
-     *
      * @param string $organisationId
      */
+    #[Route(path: '/api/1.0/{organisationId}/department/', methods: ['GET'], name: 'dplan_api_department_list', options: ['expose' => true])]
     public function listAction(ApiResourceService $apiResourceService, OrgaHandler $orgaHandler, $organisationId): APIResponse
     {
         $orga = $orgaHandler->getOrga($organisationId);

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
@@ -34,18 +34,13 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 class DemosPlanDepartmentController extends BaseController
 {
     /**
-     * @Route(
-     *     name="DemosPlan_user_verify_department_switch_or_update",
-     *     path="/department/verifychanges",
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_verify_department_switch_or_update', path: '/department/verifychanges', methods: ['GET'])]
     public function verifyDepartmentSwitchOrUpdateAction(AuthenticationUtils $authenticationUtils, Request $request)
     {
         try {
@@ -70,19 +65,15 @@ class DemosPlanDepartmentController extends BaseController
     /**
      * List departments of specific organisation.
      *
-     * @Route(
-     *     name="DemosPlan_department_list",
-     *     path="/department/list/{orgaId}"
-     * )
      *
      * @DplanPermissions("area_manage_departments")
      *
      * @param null $orgaId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_department_list', path: '/department/list/{orgaId}')]
     public function listDepartmentsAction(
         CurrentUserService $currentUser,
         CustomerHandler $customerHandler,
@@ -135,17 +126,13 @@ class DemosPlanDepartmentController extends BaseController
     /**
      * Creates a new department and relate to a existing organisation.
      *
-     * @Route(
-     *     name="DemosPlan_department_add",
-     *     path="/department/add"
-     * )
      *
      * @DplanPermissions("feature_department_add")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_department_add', path: '/department/add')]
     public function addDepartmentAction(Request $request, UserHandler $userHandler)
     {
         $requestPost = $request->request;
@@ -178,17 +165,13 @@ class DemosPlanDepartmentController extends BaseController
     /**
      * Edit Departments.
      *
-     * @Route(
-     *     name="DemosPlan_department_edit",
-     *     path="/department/edit/{departmentId}"
-     * )
      *
      * @DplanPermissions("area_manage_orgas")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_department_edit', path: '/department/edit/{departmentId}')]
     public function editDepartmentAction(Request $request)
     {
         return $this->renderTemplate(
@@ -204,19 +187,15 @@ class DemosPlanDepartmentController extends BaseController
      * Administrate departments of a specific organisation.
      * In this case administrate means, save or delete departments.
      *
-     * @Route(
-     *     name="DemosPlan_departments_admin",
-     *     path="/departments/admin/{orgaId}"
-     * )
      *
      * @DplanPermissions("area_manage_departments")
      *
      * @param string $orgaId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_departments_admin', path: '/departments/admin/{orgaId}')]
     public function adminDepartmentsAction(Request $request, UserHandler $userHandler, $orgaId)
     {
         // wenn der request gefüllt ist, bearbeite ihn

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanInvitableToebAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanInvitableToebAPIController.php
@@ -22,10 +22,10 @@ class DemosPlanInvitableToebAPIController extends APIController
     /**
      * @return JsonResponse
      *
-     * @Route(path="/api/1.0/procedure/{procedureId}/InvitableToeb", methods={"GET"}, name="dplan_api_invitable_toeb_list")
      *
      * @DplanPermissions({"area_main_procedures","area_admin_invitable_institution"})
      */
+    #[Route(path: '/api/1.0/procedure/{procedureId}/InvitableToeb', methods: ['GET'], name: 'dplan_api_invitable_toeb_list')]
     public function listAction(OrgaService $orgaService)
     {
         $orgaList = $orgaService->getInvitablePublicAgencies();

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
@@ -53,17 +53,13 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Anzeige der MasterTöBliste.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist",
-     *     path="/mastertoeblist"
-     * )
      *
      * @DplanPermissions("area_manage_mastertoeblist")
      *
      * @return RedirectResponse|Response
-     *
      * @throws \Exception
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist', path: '/mastertoeblist')]
     public function masterToebListAction()
     {
         $templateVars = [];
@@ -82,16 +78,11 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Update einer Orga via ajax.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_update_ajax",
-     *     path="/mastertoeblist/organisation/update",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_manage_mastertoeblist")
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_update_ajax', path: '/mastertoeblist/organisation/update', options: ['expose' => true])]
     public function updateMasterToebListAjaxAction(Request $request)
     {
         $requestPost = $request->request;
@@ -109,20 +100,15 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Gibt es neue Protokolleinträge seit dem letzen Aufruf des Protokolls.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_has_new_reportentry_ajax",
-     *     path="/mastertoeblist/report/hasNewReportentry/{userId}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_report_mastertoeblist")
      *
      * @param string $userId
      *
      * @return Response
-     *
      * @throws \Exception
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_has_new_reportentry_ajax', path: '/mastertoeblist/report/hasNewReportentry/{userId}', options: ['expose' => true])]
     public function reportMasterToebListHasNewEntryAjaxAction(ContentService $contentService, $userId)
     {
         $hasNewReportEntry = false;
@@ -176,18 +162,13 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Anlegen einer Orga via ajax.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_add_ajax",
-     *     path="/mastertoeblist/organisation/add",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_manage_mastertoeblist")
      *
      * @return Response
-     *
      * @throws CustomerNotFoundException
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_add_ajax', path: '/mastertoeblist/organisation/add', options: ['expose' => true])]
     public function addMasterToebAjaxAction(
         CustomerHandler $customerHandler,
         OrgaService $orgaService,
@@ -245,16 +226,11 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Löschen einer Orga via ajax.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_delete_ajax",
-     *     path="/mastertoeblist/organisation/delete",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_manage_mastertoeblist")
-     *
      * @return Response
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_delete_ajax', path: '/mastertoeblist/organisation/delete', options: ['expose' => true])]
     public function deleteMasterToebAjaxAction(Request $request)
     {
         $requestPost = $request->request;
@@ -271,18 +247,13 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Gebe eine Liste von geänderten Einträgen der Master-Toeb-Liste aus.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_report",
-     *     path="/mastertoeblist/report",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_report_mastertoeblist")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException|\Exception
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_report', path: '/mastertoeblist/report', options: ['expose' => true])]
     public function masterToebListReportAction(
         CurrentProcedureService $currentProcedureService,
         CurrentUserService $currentUser,
@@ -434,11 +405,6 @@ class DemosPlanMasterToebController extends BaseController
      * https://github.com/PHPOffice/PhpSpreadsheet, MIT
      * https://github.com/yectep/phpspreadsheet-bundle, MIT
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_export",
-     *     path="/mastertoeblist/export",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_use_mastertoeblist")
      *
@@ -447,6 +413,7 @@ class DemosPlanMasterToebController extends BaseController
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_export', path: '/mastertoeblist/export', options: ['expose' => true])]
     public function masterToebListExportAction(
         FileResponseGeneratorStrategy $responseGenerator,
         PermissionsInterface $permissions,
@@ -470,17 +437,13 @@ class DemosPlanMasterToebController extends BaseController
     /**
      * Zusammenführen von angemeldeten Organisationen mit Organisationen aus der Master-TöB-Liste.
      *
-     * @Route(
-     *     name="DemosPlan_user_mastertoeblist_merge",
-     *     path="/mastertoeblist/merge"
-     * )
      *
      * @DplanPermissions("area_merge_mastertoeblist")
      *
      * @return RedirectResponse|Response
-     *
      * @throws \Exception
      */
+    #[Route(name: 'DemosPlan_user_mastertoeblist_merge', path: '/mastertoeblist/merge')]
     public function masterToebListMergeAction(Request $request)
     {
         $masterToebListService = $this->masterToebService;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
@@ -62,17 +62,13 @@ class DemosPlanOrgaController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_verify_orga_switch_or_update",
-     *     path="/organisation/verifychanges"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_verify_orga_switch_or_update', path: '/organisation/verifychanges')]
     public function verifyOrgaSwitchOrUpdateAction(AuthenticationUtils $authenticationUtils, Request $request)
     {
         $session = $request->getSession();
@@ -119,18 +115,13 @@ class DemosPlanOrgaController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_orga_edit_view",
-     *     path="/organisation/edit/{orgaId}",
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions("area_manage_orgadata")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_orga_edit_view', path: '/organisation/edit/{orgaId}', methods: ['GET'])]
     public function editOrgaViewAction(CurrentUserService $currentUser, OrgaTypeRepository $orgaTypeRepository, string $orgaId)
     {
         $accessPreventionRedirect = $this->preventInvalidOrgaAccess($orgaId, $currentUser->getUser());
@@ -152,18 +143,13 @@ class DemosPlanOrgaController extends BaseController
     /**
      * Edit Organisation.
      *
-     * @Route(
-     *     name="DemosPlan_orga_edit_save",
-     *     path="/organisation/edit/{orgaId}",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_manage_orgadata")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_orga_edit_save', path: '/organisation/edit/{orgaId}', methods: ['POST'])]
     public function editOrgaSaveAction(
         CurrentUserService $currentUser,
         EventDispatcherPostInterface $eventDispatcherPost,
@@ -212,20 +198,15 @@ class DemosPlanOrgaController extends BaseController
     /**
      * Edit Organisation design (logo).
      *
-     * @Route(
-     *     name="DemosPlan_orga_branding_edit",
-     *     path="/organisation/branding/edit/{orgaId}",
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_manage_orgadata","feature_orga_logo_edit"})
      *
      * @param string $orgaId
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_orga_branding_edit', path: '/organisation/branding/edit/{orgaId}', options: ['expose' => true])]
     public function editOrgaBrandingAction(Request $request, FileUploadService $fileUploadService, OrgaTypeRepository $orgaTypeRepository, $orgaId)
     {
         $requestPost = $request->request;
@@ -329,15 +310,11 @@ class DemosPlanOrgaController extends BaseController
     /**
      * List of organisations to administrate.
      *
-     * @Route(
-     *     name="DemosPlan_orga_list",
-     *     path="/organisation/list"
-     * )
      *
      * @DplanPermissions("area_organisations")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_orga_list', path: '/organisation/list')]
     public function listOrgasAction(): RedirectResponse|Response
     {
         $templateVars['proceduresDirectlinkPrefix'] = $this->generateUrl(
@@ -360,15 +337,11 @@ class DemosPlanOrgaController extends BaseController
     /**
      * Wechsle die Organisation eines Users.
      *
-     * @Route(
-     *     name="DemosPlan_user_switch_orga",
-     *     path="/organisation/switch"
-     * )
      *
      * @DplanPermissions("feature_switchorga")
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_switch_orga', path: '/organisation/switch')]
     public function switchOrgaAction(
         CurrentUserInterface $currentUser,
         OsiHHAuthenticator $osiHHAuthenticator,
@@ -430,17 +403,11 @@ class DemosPlanOrgaController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_orga_register_form",
-     *     path="/organisation/register",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions("feature_orga_registration")
-     *
      * @throws CustomerNotFoundException
      */
+    #[Route(name: 'DemosPlan_orga_register_form', path: '/organisation/register', methods: ['GET'], options: ['expose' => true])]
     public function editOrgaRegisterAction(CustomerHandler $customerHandler): Response
     {
         $customer = $customerHandler->getCurrentCustomer();
@@ -458,17 +425,11 @@ class DemosPlanOrgaController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_orga_register",
-     *     path="/organisation/register",
-     *     methods={"POST"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_orga_registration")
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_orga_register', path: '/organisation/register', methods: ['POST'], options: ['expose' => true])]
     public function createOrgaRegisterAction(
         CsrfTokenManagerInterface $csrfTokenManager,
         EventDispatcherPostInterface $eventDispatcherPost,
@@ -538,6 +499,6 @@ class DemosPlanOrgaController extends BaseController
             $this->logger->error($e->getMessage());
         }
 
-        return $this->redirect($this->generateUrl('DemosPlan_orga_register_form'));
+        return $this->redirectToRoute('DemosPlan_orga_register_form');
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -51,15 +51,10 @@ class DemosPlanOrganisationAPIController extends APIController
     /**
      * Get organisation by ID.
      *
-     * @Route(
-     *     "/api/1.0/Orga/{id}",
-     *     name="dplan_api_orga_get",
-     *     options={"expose": true},
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions("feature_orga_get")
      */
+    #[Route(path: '/api/1.0/Orga/{id}', name: 'dplan_api_orga_get', options: ['expose' => true], methods: ['GET'])]
     public function getAction(CurrentUserService $currentUser, OrgaHandler $orgaHandler, PermissionsInterface $permissions, string $id): APIResponse
     {
         try {
@@ -90,17 +85,11 @@ class DemosPlanOrganisationAPIController extends APIController
     /**
      * List organizations, depending on permissions.
      *
-     * @Route(
-     *     "/api/1.0/organisation/",
-     *     name="dplan_api_organisation_list",
-     *     options={"expose": true},
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions("area_organisations")
-     *
      * @return APIResponse
      */
+    #[Route(path: '/api/1.0/organisation/', name: 'dplan_api_organisation_list', options: ['expose' => true], methods: ['GET'])]
     public function listAction(
         CustomerHandler $customerHandler,
         DqlConditionFactory $conditionFactory,
@@ -269,16 +258,10 @@ class DemosPlanOrganisationAPIController extends APIController
      *
      * @see https://yaits.demos-deutschland.de/w/demosplan/functions/deletion_of_entity_objects/ delete entity objects
      *
-     * @Route(
-     *     "/api/1.0/organisation/{id}",
-     *     name="dplan_api_orga",
-     *     options={"expose": true},
-     *     methods={"DELETE"},
-     *     name="organisation_delete"
-     * )
      *
      * @DplanPermissions("feature_orga_delete")
      */
+    #[Route(path: '/api/1.0/organisation/{id}', name: 'organisation_delete', options: ['expose' => true], methods: ['DELETE'])]
     public function wipeOrgaAction(UserHandler $userHandler, string $id): APIResponse
     {
         $orgaId = $id;
@@ -305,19 +288,13 @@ class DemosPlanOrganisationAPIController extends APIController
     /**
      * Creates a new Organisation.
      *
-     * @Route(
-     *     "/api/1.0/organisation/",
-     *     options={"expose": true},
-     *     methods={"POST"},
-     *     name="organisation_create"
-     * )
      *
      * @DplanPermissions("area_manage_orgas")
      *
      * @return APIResponse
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/organisation/', options: ['expose' => true], methods: ['POST'], name: 'organisation_create')]
     public function createOrgaAction(Request $request, UserHandler $userHandler, CustomerHandler $customerHandler)
     {
         try {
@@ -353,18 +330,11 @@ class DemosPlanOrganisationAPIController extends APIController
     }
 
     /**
-     * @Route(
-     *     "/api/1.0/organisation/{id}",
-     *     name="dplan_api_orga",
-     *     options={"expose": true},
-     *     methods={"PATCH"},
-     *     name="organisation_update"
-     * )
      *
      * @DplanPermissions("feature_orga_edit")
-     *
      * @return APIResponse
      */
+    #[Route(path: '/api/1.0/organisation/{id}', name: 'organisation_update', options: ['expose' => true], methods: ['PATCH'])]
     public function updateOrgaAction(
         CustomerHandler $customerHandler,
         OrgaHandler $orgaHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
@@ -24,12 +24,8 @@ class DemosPlanRoleAPIController extends APIController
 {
     /**
      * @DplanPermissions("area_manage_users")
-     *
-     * @Route(path="/api/1.0/role/",
-     *        methods={"GET"},
-     *        name="dplan_api_role_list",
-     *        options={"expose": true})
      */
+    #[Route(path: '/api/1.0/role/', methods: ['GET'], name: 'dplan_api_role_list', options: ['expose' => true])]
     public function listAction(RoleService $roleService, OrgaService $orgaService, CurrentUserInterface $currentUser): APIResponse
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
@@ -86,15 +86,11 @@ class DemosPlanUserAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/user/{userId}/get",
-     *        methods={"GET"},
-     *        name="dplan_api_user_get",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_user_get")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/user/{userId}/get', methods: ['GET'], name: 'dplan_api_user_get', options: ['expose' => true])]
     public function getAction(string $userId): APIResponse
     {
         try {
@@ -121,15 +117,11 @@ class DemosPlanUserAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/user/",
-     *        methods={"GET"},
-     *        name="dplan_api_users_get",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_user_list")
-     *
      * @throws MessageBagException
      */
+    #[Route(path: '/api/1.0/user/', methods: ['GET'], name: 'dplan_api_users_get', options: ['expose' => true])]
     public function listAction(
         AdministratableUserResourceType $userType,
         DrupalFilterParser $filterParser,
@@ -184,17 +176,13 @@ class DemosPlanUserAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/user/",
-     *        methods={"POST"},
-     *        name="dplan_api_user_create",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_user_add")
      *
      * @throws MessageBagException
-     *
      * @deprecated Use `/api/2.0/User` instead ({@link GenericApiController::createAction()})
      */
+    #[Route(path: '/api/1.0/user/', methods: ['POST'], name: 'dplan_api_user_create', options: ['expose' => true])]
     public function createAction(UserHandler $userHandler): APIResponse
     {
         try {
@@ -244,15 +232,11 @@ class DemosPlanUserAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/user/{id}",
-     *        methods={"DELETE"},
-     *        name="dplan_api_user_delete",
-     *        options={"expose": true})
      *
      * @DplanPermissions("feature_user_delete")
-     *
      * @return APIResponse|EmptyResponse
      */
+    #[Route(path: '/api/1.0/user/{id}', methods: ['DELETE'], name: 'dplan_api_user_delete', options: ['expose' => true])]
     public function deleteAction(string $id): Response
     {
         $this->userService->wipeUser($id);
@@ -261,13 +245,9 @@ class DemosPlanUserAPIController extends APIController
     }
 
     /**
-     * @Route(path="/api/1.0/user/{id}",
-     *        methods={"PATCH"},
-     *        name="dplan_api_user_update",
-     *        options={"expose": true})
-     *
      * @DplanPermissions("feature_user_edit")
      */
+    #[Route(path: '/api/1.0/user/{id}', methods: ['PATCH'], name: 'dplan_api_user_update', options: ['expose' => true])]
     public function updateAction(string $id, UserHandler $userHandler): APIResponse
     {
         if (!($this->requestData instanceof TopLevel)) {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -71,18 +71,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Passwort ändern.
      *
-     * @Route(
-     *     name="DemosPlan_user_change_password",
-     *     path="/password/change",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_mydata_password")
      *
      * @return Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_change_password', path: '/password/change', options: ['expose' => true])]
     public function changePasswordAction(Request $request)
     {
         $requestPostFields = collect($request->request->all())->only(
@@ -103,17 +98,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      * Request change of email.
      * Send Mail to verify change of E-Mail-Address.
      *
-     * @Route(
-     *     name="DemosPlan_user_change_email_request",
-     *     path="/email/change"
-     * )
      *
      * @DplanPermissions("feature_change_own_email")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_change_email_request', path: '/email/change')]
     public function changeEmailRequestAction(Request $request, PasswordHasherFactoryInterface $hasherFactory)
     {
         $requestPostFields = collect($request->request->all())->only(
@@ -132,13 +123,10 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Set email address of user. Called via link which was sent to user via email.
      *
-     * @Route(
-     *     name="DemosPlan_user_doubleoptin_change_email",
-     *     path="email/change/doubleoptin/{uId}/{key}"
-     * )
      *
      * @DplanPermissions("feature_change_own_email")
      */
+    #[Route(name: 'DemosPlan_user_doubleoptin_change_email', path: 'email/change/doubleoptin/{uId}/{key}')]
     public function changeEmailConfirmationAction(string $uId, string $key): RedirectResponse
     {
         try {
@@ -164,18 +152,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_password_recover",
-     *     path="/password/recover",
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_demosplan","feature_password_recovery"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_password_recover', path: '/password/recover', options: ['expose' => true])]
     public function recoverPasswordAction(Request $request)
     {
         $requestPost = $request->request;
@@ -199,21 +182,8 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * This Action is only needed to define the routes.
      * Authentication is handled via guards located in Security/Authentication.
-     *
-     * @Route(
-     *     name="DemosPlan_user_login",
-     *     path="/user/login",
-     *     options={"expose": true})
-     * )
-     * @Route(
-     *     name="DemosPlan_user_login_osi_legacy",
-     *     path="/user/login/osi/legacy"
-     * )
-     * @Route(
-     *     name="DemosPlan_user_login_gateway",
-     *     path="/redirect/"
-     * )
      */
+    #[Route(name: 'DemosPlan_user_login', path: '/user/login', options: ['expose' => true])]
     public function loginAction(CurrentUserInterface $currentUser, LoggerInterface $logger): RedirectResponse
     {
         // this possibly never is never reached, but better safe than sorry
@@ -232,18 +202,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Alternatives Loginform auf einer ganzen Seite.
      *
-     * @Route(
-     *     name="DemosPlan_user_login_alternative",
-     *     path="/dplan/login",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return Response
-     *
      * @throws AccessDeniedException|Exception
      */
+    #[Route(name: 'DemosPlan_user_login_alternative', path: '/dplan/login', options: ['expose' => true])]
     public function alternativeLoginAction(
         CacheInterface $cache,
         CurrentUserInterface $currentUser,
@@ -318,15 +283,6 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      * Ausloggen bedeutet, dass ein Redirect auf die Homepage durchgeführt wird und bei diesem Response gleich
      * noch der Cookie mit dem ident-Code entwertet wird.
      *
-     * @Route(
-     *     name="DemosPlan_user_logout",
-     *     path="/user/logout"
-     * )
-     * @Route(
-     *     name="DemosPlan_user_logout_gateway",
-     *     path="/user/logout/gateway",
-     *     defaults={"toGateway": true}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
@@ -334,6 +290,8 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
      *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_logout', path: '/user/logout')]
+    #[Route(name: 'DemosPlan_user_logout_gateway', path: '/user/logout/gateway', defaults: ['toGateway' => true])]
     public function logoutAction(
         ParameterBagInterface $parameterBag,
         PermissionsInterface $permissions,
@@ -368,17 +326,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Dislay logout landing page.
      *
-     * @Route(
-     *     name="DemosPlan_user_logout_success",
-     *     path="/user/logout/success"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_logout_success', path: '/user/logout/success')]
     public function logoutSuccessAction(PermissionsInterface $permissions)
     {
         try {
@@ -393,17 +347,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_doubleoptin_invite_confirmation",
-     *     path="/doubleoptin/{uId}/{token}"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_doubleoptin_invite_confirmation', path: '/doubleoptin/{uId}/{token}')]
     public function confirmInvitationAction(UserHasher $userHasher, string $token, string $uId)
     {
         try {
@@ -423,18 +373,13 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_password_set",
-     *     path="/user/{uId}/setpass/{token}",
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_password_set', path: '/user/{uId}/setpass/{token}', options: ['expose' => true])]
     public function setPasswordAction(
         FlashMessageHandler $flashMessageHandler,
         LoginFormAuthenticator $loginFormAuthenticator,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -78,17 +78,13 @@ class DemosPlanUserController extends BaseController
     /**
      * Daten vervollständigen.
      *
-     * @Route(
-     *     name="DemosPlan_user_complete_data",
-     *     path="/willkommen"
-     * )
      *
      * @DplanPermissions("area_demosplan")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_complete_data', path: '/willkommen')]
     public function newUserCompleteDataAction(
         MailService $mailService,
         OrgaService $orgaService,
@@ -280,17 +276,13 @@ class DemosPlanUserController extends BaseController
     /**
      * Liste der Änderungen InvitableInstitution-Liste.
      *
-     * @Route(
-     *     name="DemosPlan_orga_toeblist_changes",
-     *     path="/organisations/visibilitylog"
-     * )
      *
      * @DplanPermissions("area_report_invitable_institutionlistchanges")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_orga_toeblist_changes', path: '/organisations/visibilitylog')]
     public function showInvitableInstitutionVisibilityChangesAction(UserService $userService)
     {
         $templateVars['reportEntries'] = $userService->getInvitableInstitutionShowlistChanges();
@@ -305,15 +297,11 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_switch_language",
-     *     path="/language"
-     * )
      *
      * @DplanPermissions("feature_plain_language")
-     *
      * @return RedirectResponse
      */
+    #[Route(name: 'DemosPlan_switch_language', path: '/language')]
     public function switchLanguageAction(EventDispatcherPostInterface $eventDispatcherPost, Request $request)
     {
         // change url:
@@ -336,17 +324,13 @@ class DemosPlanUserController extends BaseController
     /**
      * Portalseite des Nutzers.
      *
-     * @Route(
-     *     name="DemosPlan_user_portal",
-     *     path="/portal/user"
-     * )
      *
      * @DplanPermissions("area_portal_user")
      *
      * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
+    #[Route(name: 'DemosPlan_user_portal', path: '/portal/user')]
     public function portalUserAction(
         CurrentUserService $currentUser,
         ContentService $contentService,
@@ -381,15 +365,11 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_add",
-     *     path="/user/add"
-     * )
      *
      * @DplanPermissions("area_manage_users")
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_add', path: '/user/add')]
     public function addUserAction(Request $request, UserHandler $userHandler): RedirectResponse
     {
         try {
@@ -414,19 +394,13 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_citizen_register",
-     *     path="/user/register",
-     *     methods={"POST"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_citizen_registration")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_citizen_register', path: '/user/register', methods: ['POST'], options: ['expose' => true])]
     public function registerCitizenAction(
         CsrfTokenManagerInterface $csrfTokenManager,
         EventDispatcherPostInterface $eventDispatcherPost,
@@ -503,19 +477,13 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_citizen_registration_form",
-     *     path="/user/register",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
      *
      * @DplanPermissions("feature_citizen_registration")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_citizen_registration_form', path: '/user/register', methods: ['GET'], options: ['expose' => true])]
     public function showRegisterCitizenFormAction(CustomerService $customerService, ParameterBagInterface $parameterBag, Request $request)
     {
         $title = 'user.register';
@@ -536,17 +504,13 @@ class DemosPlanUserController extends BaseController
     /**
      * Speichere Nutzerdaten.
      *
-     * @Route(
-     *     name="DemosPlan_user_edit",
-     *     path="/user/edit"
-     * )
      *
      * @DplanPermissions("area_portal_user")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_edit', path: '/user/edit')]
     public function editUserAction(CurrentUserService $currentUser, ContentService $contentService, MailService $mailService, Request $request, UserHandler $userHandler)
     {
         try {
@@ -591,20 +555,15 @@ class DemosPlanUserController extends BaseController
      * Create a new AddressBookEntry for the given Organisation.
      * Included email-address will be validated.
      *
-     * @Route(
-     *     name="DemosPlan_create_addresses_entry",
-     *     path="/organisation/adressen/erstellen/{organisationId}",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_orga_address_book")
      *
      * @param string $organisationId
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_create_addresses_entry', path: '/organisation/adressen/erstellen/{organisationId}', methods: ['POST'])]
     public function createAddressBookEntryAction(
         AddressBookEntryService $addressBookEntryService,
         OrgaService $orgaService,
@@ -664,20 +623,15 @@ class DemosPlanUserController extends BaseController
      * Deletes a s by IDs.
      * Incoming organisationId is required, to verify action.
      *
-     * @Route(
-     *     name="DemosPlan_delete_email_addresses_entry",
-     *     path="/organisation/adressen/loeschen/{organisationId}",
-     *     methods={"POST"}
-     * )
      *
      * @DplanPermissions("area_admin_orga_address_book")
      *
      * @param string $organisationId
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_delete_email_addresses_entry', path: '/organisation/adressen/loeschen/{organisationId}', methods: ['POST'])]
     public function deleteAddressBookEntriesAction(AddressBookEntryService $addressBookEntryService, Request $request, $organisationId)
     {
         $checkResult = $this->checkUserOrganisation($organisationId, 'DemosPlan_get_address_book_entries');
@@ -712,18 +666,13 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_user_statements",
-     *     path="/portal/user/statements",
-     *     options={"expose": true}
-     * )
      *
      *  @DplanPermissions({"area_portal_user","feature_statement_gdpr_consent"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_statements', path: '/portal/user/statements', options: ['expose' => true])]
     public function statementListAction(CurrentUserService $currentUser, StatementService $statementService)
     {
         $user = $currentUser->getUser();
@@ -743,17 +692,13 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @Route(
-     *     name="DemosPlan_revoke_statement",
-     *     path="/portal/user/statement/{statementId}/revoke"
-     * )
      *
      *  @DplanPermissions({"area_portal_user","feature_statement_gdpr_consent_may_revoke"})
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_revoke_statement', path: '/portal/user/statement/{statementId}/revoke')]
     public function revokeGDPRConsentForStatementAction(
         CurrentUserService $currentUser,
         StatementAnonymizeService $statementAnonymizeService,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
@@ -30,14 +30,6 @@ class DemosPlanUserListController extends DemosPlanUserController
     /**
      * Teilnehmerliste anzeigen.
      *
-     * @Route(
-     *     name="DemosPlan_informationen_teilnehmende_public",
-     *     path="/informationen/teilnehmende/public"
-     * )
-     * @Route(
-     *     name="DemosPlan_informationen_teilnehmende",
-     *     path="/teilnehmende"
-     * )
      *
      * @DplanPermissions("area_main_view_participants")
      *
@@ -45,6 +37,8 @@ class DemosPlanUserListController extends DemosPlanUserController
      *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_informationen_teilnehmende_public', path: '/informationen/teilnehmende/public')]
+    #[Route(name: 'DemosPlan_informationen_teilnehmende', path: '/teilnehmende')]
     public function showParticipantsAction(OrgaService $orgaService)
     {
         // Teilnehmende Organisationen (öffentliche Liste)
@@ -62,17 +56,13 @@ class DemosPlanUserListController extends DemosPlanUserController
     /**
      * List users of a specific organisation.
      *
-     * @Route(
-     *     name="DemosPlan_user_list",
-     *     path="/user/list"
-     * )
      *
      * @DplanPermissions("area_manage_users")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_list', path: '/user/list')]
     public function listUsersAction(Request $request)
     {
         $title = 'user.admin.user';
@@ -86,18 +76,13 @@ class DemosPlanUserListController extends DemosPlanUserController
     /**
      * List all AddressBookEntries of specific Organisation.
      *
-     * @Route(
-     *     name="DemosPlan_get_address_book_entries",
-     *     path="/organisation/adressen/liste/{organisationId}",
-     *     methods={"GET"}
-     * )
      *
      * @DplanPermissions("area_admin_orga_address_book")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_get_address_book_entries', path: '/organisation/adressen/liste/{organisationId}', methods: ['GET'])]
     public function getAddressBookEntriesAction(AddressBookEntryService $addressBookEntryService, Request $request, string $organisationId)
     {
         $checkResult = $this->checkUserOrganisation($organisationId, 'DemosPlan_get_address_book_entries');
@@ -119,17 +104,13 @@ class DemosPlanUserListController extends DemosPlanUserController
      * Administrate users.
      * In this case administrate means, save or delete users.
      *
-     * @Route(
-     *     name="DemosPlan_user_admin",
-     *     path="/user/admin"
-     * )
      *
      * @DplanPermissions("area_manage_users")
      *
      * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
+    #[Route(name: 'DemosPlan_user_admin', path: '/user/admin')]
     public function adminUsersAction(Request $request, UserHandler $userHandler)
     {
         $userIdent = '';

--- a/demosplan/DemosPlanCoreBundle/Controller/User/InstitutionTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/InstitutionTagController.php
@@ -20,15 +20,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class InstitutionTagController extends BaseController
 {
     /**
-     * @Route(
-     *     name="DemosPlan_get_institution_tag_management",
-     *     path="/institutions/tags",
-     *     methods={"GET"},
-     *     options={"expose": true}
-     * )
-     *
      * @DplanPermissions("area_institution_tag_manage")
      */
+    #[Route(name: 'DemosPlan_get_institution_tag_management', path: '/institutions/tags', methods: ['GET'], options: ['expose' => true])]
     public function getInstitutionTagManagement(): Response
     {
         return $this->renderTemplate(

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/SingleDocument.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/SingleDocument.php
@@ -95,9 +95,8 @@ class SingleDocument extends CoreEntity implements SingleDocumentInterface
      * @var string
      *
      * @ORM\Column(name="_sd_title", type="string", length=256, nullable=false)
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, message="error.mandatoryfield.heading", groups={SingleDocument::IMPORT_CREATION})
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, message: 'error.mandatoryfield.heading', groups: [SingleDocument::IMPORT_CREATION])]
     protected $title = '';
 
     /**
@@ -120,9 +119,8 @@ class SingleDocument extends CoreEntity implements SingleDocumentInterface
      * @var string
      *
      * @ORM\Column(name="_sd_document", type="string", nullable=false, length=256)
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, message="error.mandatoryfield.file", groups={SingleDocument::IMPORT_CREATION})
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, message: 'error.mandatoryfield.file', groups: [SingleDocument::IMPORT_CREATION])]
     protected $document = '';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/EmailAddress.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/EmailAddress.php
@@ -55,10 +55,10 @@ class EmailAddress extends CoreEntity implements UuidEntityInterface, EmailAddre
      *
      * @ORM\Column(type="string", length=254, nullable=false, unique=true)
      *
-     * @Assert\NotBlank(allowNull=false)
      *
-     * @Assert\Email(mode="strict")
      */
+    #[Assert\NotBlank(allowNull: false)]
+    #[Assert\Email(mode: 'strict')]
     protected $fullAddress;
 
     public function getId(): ?string

--- a/demosplan/DemosPlanCoreBundle/Entity/EntitySyncLink.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/EntitySyncLink.php
@@ -49,28 +49,28 @@ class EntitySyncLink implements UuidEntityInterface
     /**
      * @var class-string<T>
      *
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
      *
      * @ORM\Column(type="string")
      */
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
     private $class;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
      *
      * @ORM\Column(type="string", length=36, options={"fixed":true})
      */
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
     private $sourceId;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
      *
      * @ORM\Column(type="string", length=36, options={"fixed":true})
      */
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
     private $targetId;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/GlobalContent.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/GlobalContent.php
@@ -64,9 +64,8 @@ class GlobalContent extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_pc_title", type="string", length=255, nullable=false, options={"default":""})
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.heading")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.heading')]
     protected $title = '';
 
     /**
@@ -74,12 +73,12 @@ class GlobalContent extends CoreEntity implements UuidEntityInterface
      *
      * @ORM\Column(name="_pc_description", type="text", length=65535, nullable=true)
      *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.teaser")
      *
-     * @Assert\Type("string", groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP})
      *
-     * @Assert\Length(max=NewsHandler::NEWS_DESCRIPTION_MAX_LENGTH, maxMessage="error.news.description.toolong", groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP})
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.teaser')]
+    #[Assert\Type('string', groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP])]
+    #[Assert\Length(max: NewsHandler::NEWS_DESCRIPTION_MAX_LENGTH, maxMessage: 'error.news.description.toolong', groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP])]
     protected $description = '';
 
     /**
@@ -87,10 +86,10 @@ class GlobalContent extends CoreEntity implements UuidEntityInterface
      *
      * @ORM\Column(name="_pc_text", type="text", length=65535, nullable=true)
      *
-     * @Assert\Type("string", groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP})
      *
-     * @Assert\Length(max=NewsHandler::NEWS_TEXT_MAX_LENGTH, maxMessage="error.news.text.toolong", groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP})
      */
+    #[Assert\Type('string', groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP])]
+    #[Assert\Length(max: NewsHandler::NEWS_TEXT_MAX_LENGTH, maxMessage: 'error.news.text.toolong', groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP])]
     protected $text = '';
 
     /**
@@ -125,9 +124,8 @@ class GlobalContent extends CoreEntity implements UuidEntityInterface
      * @var bool
      *
      * @ORM\Column(name="_pc_enabled", type="boolean", nullable=false, options={"default":false })
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.status")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.status')]
     protected $enabled = false;
 
     /**
@@ -174,9 +172,8 @@ class GlobalContent extends CoreEntity implements UuidEntityInterface
      *     joinColumns={@ORM\JoinColumn(name="_pc_id", referencedColumnName="_pc_id", onDelete="CASCADE")},
      *     inverseJoinColumns={@ORM\JoinColumn(name="_r_id", referencedColumnName="_r_id", onDelete="CASCADE")}
      * )
-     *
-     * @Assert\Count(min=1, groups={GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP}, minMessage="error.mandatoryfield.visibility")
      */
+    #[Assert\Count(min: 1, groups: [GlobalContent::NEW_GLOBAL_NEWS_VALIDATION_GROUP], minMessage: 'error.mandatoryfield.visibility')]
     protected $roles;
 
     // todo: why is this a n:m relation?

--- a/demosplan/DemosPlanCoreBundle/Entity/News/News.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/News/News.php
@@ -47,35 +47,35 @@ class News extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_p_id", type="string", length=36, options={"fixed":true}, nullable=false)
-     * @Assert\NotBlank(allowNull=false)
      */
+    #[Assert\NotBlank(allowNull: false)]
     protected $pId;
 
     /**
      * @var string
      *
      * @ORM\Column(name="_n_title", type="string", length=255, nullable=false)
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.heading")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.heading')]
     protected $title = '';
 
     /**
      * @var string
      *
      * @ORM\Column(name="_n_description", type="text", length=65535, nullable=false)
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.teaser")
-     * @Assert\Type("string", groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP})
-     * @Assert\Length(max=NewsHandler::NEWS_DESCRIPTION_MAX_LENGTH, maxMessage="error.news.description.toolong", groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP})
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.teaser')]
+    #[Assert\Type('string', groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP])]
+    #[Assert\Length(max: NewsHandler::NEWS_DESCRIPTION_MAX_LENGTH, maxMessage: 'error.news.description.toolong', groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP])]
     protected $description = '';
 
     /**
      * @var string
      *
      * @ORM\Column(name="_n_text", type="text", length=65535, nullable=false)
-     * @Assert\Type("string", groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP})
-     * @Assert\Length(max=NewsHandler::NEWS_TEXT_MAX_LENGTH, maxMessage="error.news.text.toolong", groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP})
      */
+    #[Assert\Type('string', groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP])]
+    #[Assert\Length(max: NewsHandler::NEWS_TEXT_MAX_LENGTH, maxMessage: 'error.news.text.toolong', groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP])]
     protected $text = '';
 
     /**
@@ -110,8 +110,8 @@ class News extends CoreEntity implements UuidEntityInterface
      * @var bool
      *
      * @ORM\Column(name="_n_enabled", type="boolean", nullable=false)
-     * @Assert\NotBlank(normalizer="trim", allowNull=false, groups={News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP}, message="error.mandatoryfield.status")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false, groups: [News::NEW_PROCEDURE_NEWS_VALIDATION_GROUP], message: 'error.mandatoryfield.status')]
     protected $enabled = false;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureCoupleToken.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureCoupleToken.php
@@ -48,9 +48,8 @@ class ProcedureCoupleToken implements UuidEntityInterface
      * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure")
      *
      * @ORM\JoinColumn(referencedColumnName="_p_id", nullable=false, unique=true)
-     *
-     * @Assert\NotNull(message="procedureCoupleToken.sourceProceudre.not.null")
      */
+    #[Assert\NotNull(message: 'procedureCoupleToken.sourceProceudre.not.null')]
     protected $sourceProcedure;
 
     /**
@@ -70,10 +69,10 @@ class ProcedureCoupleToken implements UuidEntityInterface
      *
      * @ORM\Column(type="string", length=12, nullable=false, unique=true, options={"fixed":true})
      *
-     * @Assert\Length(max=ProcedureCoupleToken::TOKEN_LENGTH, min=ProcedureCoupleToken::TOKEN_LENGTH, normalizer="trim")
      *
-     * @Assert\NotBlank(message="procedureCoupleToken.token.invalid", allowNull=false, normalizer="trim")
      */
+    #[Assert\Length(max: ProcedureCoupleToken::TOKEN_LENGTH, min: ProcedureCoupleToken::TOKEN_LENGTH, normalizer: 'trim')]
+    #[Assert\NotBlank(message: 'procedureCoupleToken.token.invalid', allowNull: false, normalizer: 'trim')]
     protected $token;
 
     public function __construct(Procedure $sourceProcedure, string $token)

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -50,45 +50,40 @@ class ProcedurePerson implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(type="text", nullable=false)
-     *
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
     private $fullName;
 
     /**
      * @var string|null
      *
      * @ORM\Column(type="text", nullable=true)
-     *
-     * @Assert\NotBlank(allowNull=true, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim')]
     private $streetName;
 
     /**
      * @var string|null
      *
      * @ORM\Column(type="text", nullable=true)
-     *
-     * @Assert\NotBlank(allowNull=true, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim')]
     private $streetNumber;
 
     /**
      * @var string|null
      *
      * @ORM\Column(type="text", nullable=true)
-     *
-     * @Assert\NotBlank(allowNull=true, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim')]
     private $city;
 
     /**
      * @var string|null
      *
      * @ORM\Column(type="text", nullable=true)
-     *
-     * @Assert\NotBlank(allowNull=true, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim')]
     private $postalCode;
 
     /**
@@ -96,10 +91,10 @@ class ProcedurePerson implements UuidEntityInterface
      *
      * @ORM\Column(type="text", nullable=true)
      *
-     * @Assert\NotBlank(allowNull=true, normalizer="trim")
      *
-     * @Assert\Email()
      */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim')]
+    #[Assert\Email]
     private $emailAddress;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureType.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureType.php
@@ -68,9 +68,8 @@ class ProcedureType extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(type="string", length=255, options={"fixed":true}, nullable=false, unique=true)
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $name;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
@@ -132,12 +132,12 @@ class ProcedureUiDefinition extends CoreEntity implements UuidEntityInterface
      *
      * @var string
      *
-     * @Assert\Length(min=0,max=500,maxMessage="procedureUiDefinition.statementPublicSubmitConfirmationText.maxLength",allowEmptyString=true)
      *
-     * @Assert\NotNull
      *
      * @ORM\Column(type="string", length=500, nullable=false, options={"default":""})
      */
+    #[Assert\Length(min: 0, max: 500, maxMessage: 'procedureUiDefinition.statementPublicSubmitConfirmationText.maxLength', options: ['allowEmptyString' => true])]
+    #[Assert\NotNull]
     private $statementPublicSubmitConfirmationText = '';
 
     public function getId(): ?string

--- a/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
@@ -86,18 +86,16 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_re_category", type="string", length=100, nullable=false, options={"fixed":true})
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $category;
 
     /**
      * @var string
      *
      * @ORM\Column(name="_re_group", type="string", length=100, nullable=false, options={"fixed":true})
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $group;
 
     /**
@@ -118,9 +116,8 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_u_name", type="string", length=255, nullable=false, options={"fixed":true})
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $userName;
 
     /**
@@ -136,18 +133,16 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_re_identifier_type", type="string", length=50, nullable=false)
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $identifierType;
 
     /**
      * @var string
      *
      * @ORM\Column(name="_re_identifier", type="string", length=36, options={"fixed":true}, nullable=false)
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $identifier;
 
     /**
@@ -163,9 +158,8 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      * @var string always in JSON format (a simple string is considered valid JSON)
      *
      * @ORM\Column(name="_re_message", type="text", nullable=false, length=15000000)
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $message;
 
     /**
@@ -190,9 +184,8 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface
      * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer")
      *
      * @ORM\JoinColumn(name="_c_id", referencedColumnName="_c_id", nullable=false)
-     *
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     protected $customer;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Slug.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Slug.php
@@ -41,10 +41,10 @@ class Slug extends CoreEntity implements UuidEntityInterface, SlugInterface
     /**
      * @var string
      *
-     * @Assert\Length(min=0, max=255)
      *
      * @ORM\Column(type="string")
      */
+    #[Assert\Length(min: 0, max: 255)]
     protected $name;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/ConsultationToken.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/ConsultationToken.php
@@ -81,9 +81,9 @@ class ConsultationToken
      *
      * @var string
      *
-     * @Assert\NotNull
      * @ORM\Column(type="string", length=1024, nullable=false)
      */
+    #[Assert\NotNull]
     private $note = '';
 
     /**
@@ -94,10 +94,10 @@ class ConsultationToken
      *
      * @var string
      *
-     * @Assert\NotBlank()
-     * @Assert\Regex("/^\w{8}$/")
      * @ORM\Column(type="string", length=8, nullable=false)
      */
+    #[Assert\NotBlank]
+    #[Assert\Regex('/^\w{8}$/')]
     private $token = '';
 
     /**
@@ -130,13 +130,13 @@ class ConsultationToken
      * @var Statement the original statement of the {@link ConsultationToken::$statement}, as
      *                original statements can not be deleted this property will never become `null`
      *
-     * @Assert\NotBlank
      *
      * @IsOriginalStatementConstraint
      *
      * @ORM\OneToOne(targetEntity=Statement::class)
      * @ORM\JoinColumn(referencedColumnName="_st_id", nullable=false)
      */
+    #[Assert\NotBlank]
     private $originalStatement;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Segment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Segment.php
@@ -33,9 +33,9 @@ class Segment extends Statement implements SegmentInterface
      *
      * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement", inversedBy="segmentsOfStatement", cascade={"persist"})
      * @ORM\JoinColumn(name="segment_statement_fk", referencedColumnName="_st_id", nullable=true)
-     * @Assert\NotNull(groups={Segment::VALIDATION_GROUP_IMPORT})
-     * @Assert\Type(groups={Segment::VALIDATION_GROUP_IMPORT}, type="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement")
      */
+    #[Assert\NotNull(groups: [Segment::VALIDATION_GROUP_IMPORT])]
+    #[Assert\Type(groups: [Segment::VALIDATION_GROUP_IMPORT], type: 'demosplan\DemosPlanCoreBundle\Entity\Statement\Statement')]
     protected $parentStatementOfSegment;
 
     /**
@@ -53,9 +53,9 @@ class Segment extends Statement implements SegmentInterface
     /**
      * @var int
      *
-     * @Assert\NotNull(groups={Segment::VALIDATION_GROUP_SEGMENT_MANDATORY})
      * @ORM\Column(type="integer", nullable=true)
      */
+    #[Assert\NotNull(groups: [Segment::VALIDATION_GROUP_SEGMENT_MANDATORY])]
     private $orderInProcedure;
 
     /**
@@ -71,10 +71,10 @@ class Segment extends Statement implements SegmentInterface
      *
      * @var Place
      *
-     * @Assert\NotBlank(groups={"Default", Segment::VALIDATION_GROUP_IMPORT})
      * @ORM\ManyToOne(targetEntity=Place::class)
      * @ORM\JoinColumn(referencedColumnName="id", nullable=true)
      */
+    #[Assert\NotBlank(groups: ['Default', Segment::VALIDATION_GROUP_IMPORT])]
     private $place;
 
     public function __construct()

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/SegmentComment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/SegmentComment.php
@@ -43,8 +43,8 @@ class SegmentComment implements UuidEntityInterface
      *     inversedBy="comments"
      * )
      * @ORM\JoinColumn(referencedColumnName="_st_id", nullable=false)
-     * @Assert\NotNull
      */
+    #[Assert\NotNull]
     protected $segment;
 
     /**
@@ -82,9 +82,9 @@ class SegmentComment implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(type="text", nullable=false)
-     * @Assert\NotBlank
-     * @Assert\Length(min=1, max=65536)
      */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 1, max: 65536)]
     protected $text;
 
     public function __construct(Segment $segment, User $submitter, Place $place, string $text)

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -226,9 +226,8 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      * @var string|null
      *
      * @ORM\Column(name="_st_intern_id", type="string", length=35, nullable=true, options={"fixed":true, "comment":"manuelle Eingangsnummer"})
-     *
-     * @Assert\Length(max=35)
      */
+    #[Assert\Length(max: 35)]
     protected $internId;
 
     /**
@@ -260,9 +259,8 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Orga")
      *
      * @ORM\JoinColumn(name="_o_id", referencedColumnName="_o_id", nullable=true, onDelete="RESTRICT")
-     *
-     * @Assert\Valid(groups={Statement::IMPORT_VALIDATION})
      */
+    #[Assert\Valid(groups: [Statement::IMPORT_VALIDATION])]
     protected $organisation;
 
     /**
@@ -371,10 +369,10 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      *
      * @ORM\Column(name="_st_submit_date", type="datetime", nullable=false)
      *
-     * @Assert\NotBlank(groups={Statement::IMPORT_VALIDATION}, message="statement.import.invalidSubmitDateBlank")
      *
-     * @Assert\Type("DateTime", groups={Statement::IMPORT_VALIDATION}, message="statement.import.invalidSubmitDateType")
      */
+    #[Assert\NotBlank(groups: [Statement::IMPORT_VALIDATION], message: 'statement.import.invalidSubmitDateBlank')]
+    #[Assert\Type('DateTime', groups: [Statement::IMPORT_VALIDATION], message: 'statement.import.invalidSubmitDateType')]
     protected $submit;
 
     /**
@@ -691,9 +689,8 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      * @var StatementMeta
      *
      * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\StatementMeta", mappedBy="statement", cascade={"persist", "remove"})
-     *
-     * @Assert\Valid(groups={Statement::IMPORT_VALIDATION})
      */
+    #[Assert\Valid(groups: [Statement::IMPORT_VALIDATION])]
     protected $meta;
 
     /**
@@ -843,9 +840,8 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      * @var string
      *
      * @ORM\Column(name="_st_submit_type", type="string", nullable=false)
-     *
-     * @Assert\NotBlank(groups={Statement::IMPORT_VALIDATION}, message="statement.import.invalidSubmitTypeBlank")
      */
+    #[Assert\NotBlank(groups: [Statement::IMPORT_VALIDATION], message: 'statement.import.invalidSubmitTypeBlank')]
     protected $submitType = 'system';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
@@ -264,9 +264,8 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface
      * @var int
      *
      * @ORM\Column(type="integer", nullable=false, options={"default":-1})
-     *
-     * @Assert\PositiveOrZero(groups={"mandatory"})
      */
+    #[Assert\PositiveOrZero(groups: ['mandatory'])]
     protected $sortIndex = -1;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementMeta.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementMeta.php
@@ -58,8 +58,8 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_stm_author_name", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidAuthorNull")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidAuthorNull')]
     protected $authorName = '';
 
     /**
@@ -82,24 +82,24 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(name="_stm_submit_name", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidSubmitNull")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidSubmitNull')]
     protected $submitName = '';
 
     /**
      * @var string
      *
      * @ORM\Column(name="_stm_orga_name", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidOrgaNameNull")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidOrgaNameNull')]
     protected $orgaName = '';
 
     /**
      * @var string
      *
      * @ORM\Column(name="_stm_orga_department_name", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidOrgaDepartmentNull")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidOrgaDepartmentNull')]
     protected $orgaDepartmentName = '';
 
     /**
@@ -129,9 +129,9 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
      *             !This is also the postal code of the unregistered user, if he give this data on new statement
      *
      * @ORM\Column(name="_stm_orga_postalcode", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidOrgaPostalNull")
      * @PostcodeConstraint(groups={Statement::IMPORT_VALIDATION})
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidOrgaPostalNull')]
     protected $orgaPostalCode = '';
 
     /**
@@ -139,8 +139,8 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
      *             !This is also the city of the unregistered user, if he give this data on new statement
      *
      * @ORM\Column(name="_stm_orga_city", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidOrgaCityNull")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidOrgaCityNull')]
     protected $orgaCity = '';
 
     /**
@@ -148,9 +148,9 @@ class StatementMeta extends CoreEntity implements UuidEntityInterface
      *             !This is also the email address of the unregistered user, if he give this data on new statement
      *
      * @ORM\Column(name="_stm_orga_email", type="string", length=255, nullable=false)
-     * @Assert\NotNull(groups={Statement::IMPORT_VALIDATION}, message="statementMeta.import.invalidOrgaMailNull")
-     * @Assert\Email(groups={Statement::IMPORT_VALIDATION}, message = "email.address.invalid")
      */
+    #[Assert\NotNull(groups: [Statement::IMPORT_VALIDATION], message: 'statementMeta.import.invalidOrgaMailNull')]
+    #[Assert\Email(groups: [Statement::IMPORT_VALIDATION], message: 'email.address.invalid')]
     protected $orgaEmail = '';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
@@ -58,19 +58,18 @@ class Tag extends CoreEntity implements UuidEntityInterface, TagInterface
      *
      * @ORM\JoinColumn(name="_tt_id", referencedColumnName="_tt_id", nullable = false)
      *
-     * @Assert\NotNull(groups={"Default", "segments_import"})
      *
-     * @Assert\Type(groups={"segments_import"}, type="demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic")
      */
+    #[Assert\NotNull(groups: ['Default', 'segments_import'])]
+    #[Assert\Type(groups: ['segments_import'], type: 'demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic')]
     protected $topic;
 
     /**
      * @var string
      *
      * @ORM\Column(name="_t_title", type="string", length=255, nullable=false)
-     *
-     * @Assert\NotBlank(groups={"Default", "segments_import"}, message="Tag title may not be empty.");
      */
+    #[Assert\NotBlank(groups: ['Default', 'segments_import'], message: 'Tag title may not be empty.')]
     protected $title = '';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Address.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Address.php
@@ -43,45 +43,40 @@ class Address extends CoreEntity implements UuidEntityInterface, AddressInterfac
      * @var string|null
      *
      * @ORM\Column(name="_a_code", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(min=0, max=10)
      */
+    #[Assert\Length(min: 0, max: 10)]
     protected $code;
 
     /**
      * @var string|null
      *
      * @ORM\Column(name="_a_street", type="string", length=100, nullable=true)
-     *
-     * @Assert\Length(min=1, max=100)
      */
+    #[Assert\Length(min: 1, max: 100)]
     protected $street;
 
     /**
      * @var string|null
      *
      * @ORM\Column(name="_a_street_1", type="string", length=100, nullable=true)
-     *
-     * @Assert\Length(min=1, max=100)
      */
+    #[Assert\Length(min: 1, max: 100)]
     protected $street1;
 
     /**
      * @var string|null
      *
      * @ORM\Column(name="_a_postalcode", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(min=5, max=5)
      */
+    #[Assert\Length(min: 5, max: 5)]
     protected $postalcode;
 
     /**
      * @var string|null
      *
      * @ORM\Column(name="_a_city", type="string", length=100, nullable=true)
-     *
-     * @Assert\Length(min=1, max=100)
      */
+    #[Assert\Length(min: 1, max: 100)]
     protected $city = '';
 
     /**
@@ -123,18 +118,16 @@ class Address extends CoreEntity implements UuidEntityInterface, AddressInterfac
      * @var string|null
      *
      * @ORM\Column(name="_a_email", type="string", length=364, nullable=true)
-     *
-     * @Assert\Email(message="email.address.invalid")
      */
+    #[Assert\Email(message: 'email.address.invalid')]
     protected $email;
 
     /**
      * @var string|null
      *
      * @ORM\Column(name="_a_url", type="string", length=364, nullable=true)
-     *
-     * @Assert\Url
      */
+    #[Assert\Url]
     protected $url;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
@@ -171,18 +171,16 @@ class Customer extends CoreEntity implements UuidEntityInterface, CustomerInterf
      * @var Branding|null
      *
      * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Branding", cascade={"persist", "remove"})
-     *
-     * @Assert\Valid
      */
+    #[Assert\Valid]
     protected $branding;
 
     /**
      * @var string
      *
      * @ORM\Column(name="accessibility_explanation", type="text",  nullable=false, options={"fixed":true})
-     *
-     * @Assert\Length(max=65000)
      */
+    #[Assert\Length(max: 65000)]
     protected $accessibilityExplanation = '';
 
     /**
@@ -215,9 +213,8 @@ class Customer extends CoreEntity implements UuidEntityInterface, CustomerInterf
      * @var string
      *
      * @ORM\Column(name="simple_language_overview_description", type="text", nullable=false, options={"default":""})
-     *
-     * @Assert\Length(max=65536)
      */
+    #[Assert\Length(max: 65536)]
     protected $overviewDescriptionInSimpleLanguage = '';
 
     public function __construct(string $name, string $subdomain, string $mapAttribution = '')

--- a/demosplan/DemosPlanCoreBundle/Entity/User/CustomerCounty.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/CustomerCounty.php
@@ -67,10 +67,10 @@ class CustomerCounty extends CoreEntity implements UuidEntityInterface
     /**
      * @var string
      *
-     * @Assert\NotNull()
-     * @Assert\Email()
      * @ORM\Column(type="text", length=255, options={"default":""}, nullable=false)
      */
+    #[Assert\NotNull]
+    #[Assert\Email]
     protected $eMailAddress;
 
     public function getId(): ?string

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
@@ -48,10 +48,10 @@ class InstitutionTag extends CoreEntity implements UuidEntityInterface, Institut
      *
      * @ORM\Column(type="string", length=255, nullable=false)
      *
-     * @Assert\NotNull(message="institutionTag.label.not.null")
      *
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
      */
+    #[Assert\NotNull(message: 'institutionTag.label.not.null')]
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
     protected $label;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -130,9 +130,8 @@ class Orga extends SluggedEntity implements OrgaInterface
      * @var string|null
      *
      * @ORM\Column(name="_o_email_reviewer_admin", type="string", length=4096, nullable=true)
-     *
-     * @Assert\Email(message="email.address.invalid")
      */
+    #[Assert\Email(message: 'email.address.invalid')]
     protected $emailReviewerAdmin;
 
     /**
@@ -179,9 +178,8 @@ class Orga extends SluggedEntity implements OrgaInterface
      * @var string|null
      *
      * @ORM\Column(name="_o_email2", type="string", length=364, nullable=true)
-     *
-     * @Assert\Email(message="email.address.invalid")
      */
+    #[Assert\Email(message: 'email.address.invalid')]
     protected $email2;
 
     /**
@@ -218,12 +216,9 @@ class Orga extends SluggedEntity implements OrgaInterface
      *     joinColumns={@ORM\JoinColumn(name="_o_id", referencedColumnName="_o_id", onDelete="RESTRICT")},
      *     inverseJoinColumns={@ORM\JoinColumn(name="_a_id", referencedColumnName="_a_id", onDelete="RESTRICT")}
      * )
-     *
-     * @Assert\All({
-     *
-     *     @Assert\Type(type="demosplan\DemosPlanCoreBundle\Entity\User\Address")
-     * })
      */
+    #[Assert\All([new Assert\Type(type: 'demosplan\DemosPlanCoreBundle\Entity\User\Address')])]
+    #[Assert\Type(type: 'demosplan\DemosPlanCoreBundle\Entity\User\Address')]
     protected $addresses;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -282,15 +282,17 @@ class User implements UserInterface, SamlUserInterface, UuidEntityInterface, Pas
     /**
      * @var Collection<int, UserRoleInCustomer>
      *
-     * @Assert\All({
      *
-     *     @Assert\NotNull(),
+     * 
      *
      *     @RoleAllowedConstraint()
      * })
      *
      * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
      */
+    #[Assert\All([new Assert\NotNull(), new RoleAllowedConstraint()])]
+    #[Assert\NotNull]
     protected $roleInCustomers;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Video.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Video.php
@@ -150,8 +150,8 @@ class Video implements UuidEntityInterface
      *
      * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer")
      * @ORM\JoinColumn(referencedColumnName="_c_id", nullable=false)
-     * @Assert\NotNull();
      */
+    #[Assert\NotNull]
     private $customerContext;
 
     /**
@@ -161,9 +161,9 @@ class Video implements UuidEntityInterface
      *
      * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\File", cascade={"persist"})
      * @ORM\JoinColumn(referencedColumnName="_f_ident", nullable=false)
-     * @Assert\NotNull();
      * @VideoFileConstraint()
      */
+    #[Assert\NotNull]
     private $file;
 
     /**
@@ -172,9 +172,9 @@ class Video implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=false)
-     * @Assert\NotBlank(allowNull=false, normalizer="trim")
-     * @Assert\Length(min=1, max=255, normalizer="trim")
      */
+    #[Assert\NotBlank(allowNull: false, normalizer: 'trim')]
+    #[Assert\Length(min: 1, max: 255, normalizer: 'trim')]
     private $title = '';
 
     /**
@@ -183,9 +183,9 @@ class Video implements UuidEntityInterface
      * @var string
      *
      * @ORM\Column(type="text", nullable=false)
-     * @Assert\NotNull()
-     * @Assert\Length(max=65535, normalizer="trim")
      */
+    #[Assert\NotNull]
+    #[Assert\Length(max: 65535, normalizer: 'trim')]
     private $description = '';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Workflow/Place.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Workflow/Place.php
@@ -42,10 +42,10 @@ class Place extends CoreEntity implements SortableInterface
      *
      * @var string
      *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false)
-     * @Assert\Length(min=1, max=255, normalizer="trim")
      * @ORM\Column(type="string", length=255, nullable=false)
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false)]
+    #[Assert\Length(min: 1, max: 255, normalizer: 'trim')]
     private $name;
 
     /**
@@ -53,27 +53,27 @@ class Place extends CoreEntity implements SortableInterface
      *
      * @var string
      *
-     * @Assert\NotNull()
-     * @Assert\Length(min=0, max=255, normalizer="trim")
      * @ORM\Column(type="string", length=255, nullable=false, options={"default":""})
      */
+    #[Assert\NotNull]
+    #[Assert\Length(min: 0, max: 255, normalizer: 'trim')]
     private $description = '';
 
     /**
      * @var int
      *
-     * @Assert\NotNull
      * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true, "default":0})
      */
+    #[Assert\NotNull]
     private $sortIndex;
 
     /**
      * @var Procedure
      *
-     * @Assert\NotNull
      * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure", inversedBy="segmentPlaces")
      * @ORM\JoinColumn(referencedColumnName="_p_id", nullable=false)
      */
+    #[Assert\NotNull]
     private $procedure;
 
     public function __construct(Procedure $procedure, string $name = '', int $sortIndex = 0, string $id = null)

--- a/demosplan/DemosPlanCoreBundle/EventDispatcher/EventDispatcherPostInterface.php
+++ b/demosplan/DemosPlanCoreBundle/EventDispatcher/EventDispatcherPostInterface.php
@@ -10,9 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventDispatcher;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
 use Exception;
-use Symfony\Component\EventDispatcher\Event;
 
 interface EventDispatcherPostInterface
 {

--- a/demosplan/DemosPlanCoreBundle/EventDispatcher/TraceableEventDispatcher.php
+++ b/demosplan/DemosPlanCoreBundle/EventDispatcher/TraceableEventDispatcher.php
@@ -10,9 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventDispatcher;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
 use Exception;
-use Symfony\Component\EventDispatcher\Event;
 
 class TraceableEventDispatcher extends \Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher implements EventDispatcherPostInterface
 {

--- a/demosplan/DemosPlanCoreBundle/Form/AbstractBaseResourceFormType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/AbstractBaseResourceFormType.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Form;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use Doctrine\ORM\Query\QueryException;
 use EDT\Wrapping\WrapperFactories\WrapperObject;
@@ -45,7 +46,7 @@ abstract class AbstractBaseResourceFormType extends AbstractType implements Data
      * @throws ReflectionException
      * @throws UserNotFoundException
      */
-    public function mapDataToForms($viewData, $forms): void
+    public function mapDataToForms($viewData, Traversable $forms): void
     {
         if (null === $viewData) {
             return;
@@ -72,7 +73,7 @@ abstract class AbstractBaseResourceFormType extends AbstractType implements Data
      * @throws ReflectionException
      * @throws UserNotFoundException
      */
-    public function mapFormsToData($forms, &$viewData): void
+    public function mapFormsToData(Traversable $forms, &$viewData): void
     {
         /** @var FormInterface[] $forms */
         $forms = iterator_to_array($forms);
@@ -93,9 +94,7 @@ abstract class AbstractBaseResourceFormType extends AbstractType implements Data
         $resolver->setDefault('empty_data', null);
     }
 
-    /**
-     * @required Because the constructor parameters are passed by the FormReqistry (which are none) we need to use setter injection
-     */
+    #[Required]
     public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceInterface.php
@@ -25,10 +25,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 interface ResourceInterface
 {
     /**
-     * @Assert\Length(min=36, max=36)
-     *
      * @return string|null
      */
+    #[Assert\Length(min: 36, max: 36)]
     public function getId();
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
@@ -135,9 +136,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setCurrentProcedureService(CurrentProcedureService $currentProcedureService): void
     {
         $this->currentProcedureService = $currentProcedureService;
@@ -145,9 +145,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setCustomerService(CustomerService $customerService): void
     {
         $this->currentCustomerService = $customerService;
@@ -155,9 +154,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setCurrentUserService(CurrentUserInterface $currentUserService): void
     {
         $this->currentUser = $currentUserService;
@@ -165,9 +163,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setGlobalConfig(GlobalConfigInterface $globalConfig): void
     {
         $this->globalConfig = $globalConfig;
@@ -175,9 +172,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
@@ -185,9 +181,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setMessageBag(MessageBagInterface $messageBag): void
     {
         $this->messageBag = $messageBag;
@@ -195,9 +190,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setResourceTypeService(ResourceTypeService $resourceTypeService): void
     {
         $this->resourceTypeService = $resourceTypeService;
@@ -205,9 +199,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setTransformerLoader(TransformerLoader $transformerLoader): void
     {
         $this->transformerLoader = $transformerLoader;
@@ -215,9 +208,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;
@@ -225,9 +217,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setConditionFactory(DqlConditionFactory $conditionFactory): void
     {
         $this->conditionFactory = $conditionFactory;
@@ -235,9 +226,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setTypeProvider(PrefilledResourceTypeProvider $typeProvider): void
     {
         $this->typeProvider = $typeProvider;
@@ -245,9 +235,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setWrapperFactory(EntityWrapperFactory $wrapperFactory): void
     {
         $this->wrapperFactory = $wrapperFactory;
@@ -255,9 +244,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setSortMethodFactory(SortMethodFactory $sortMethodFactory): void
     {
         $this->sortMethodFactory = $sortMethodFactory;
@@ -265,9 +253,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setApiLogger(ApiLogger $apiLogger): void
     {
         $this->apiLogger = $apiLogger;
@@ -275,9 +262,8 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setEventDispatcher(TraceableEventDispatcher $eventDispatcher): void
     {
         $this->eventDispatcher = $eventDispatcher;

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/Transformer/BaseTransformer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/Transformer/BaseTransformer.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Transformer;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\ApiRequest\ApiResourceServiceInterface;
@@ -70,9 +71,8 @@ abstract class BaseTransformer extends TransformerAbstract implements BaseTransf
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setPermissions(PermissionsInterface $permissions): void
     {
         $this->permissions = $permissions;
@@ -92,9 +92,8 @@ abstract class BaseTransformer extends TransformerAbstract implements BaseTransf
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setResourceService(ApiResourceServiceInterface $resourceService): void
     {
         $this->resourceService = $resourceService;
@@ -107,9 +106,8 @@ abstract class BaseTransformer extends TransformerAbstract implements BaseTransf
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setGlobalConfig(GlobalConfigInterface $globalConfig): void
     {
         $this->globalConfig = $globalConfig;

--- a/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/CoreHandler.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
@@ -176,9 +177,8 @@ class CoreHandler
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setRequestStack(RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;
@@ -196,9 +196,8 @@ class CoreHandler
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setStopwatch(Stopwatch $stopwatch)
     {
         $this->stopwatch = $stopwatch;
@@ -206,9 +205,8 @@ class CoreHandler
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setDemosplanConfig(GlobalConfigInterface $demosplanConfig)
     {
         $this->demosplanConfig = $demosplanConfig;
@@ -248,9 +246,8 @@ class CoreHandler
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;

--- a/demosplan/DemosPlanCoreBundle/Logic/CoreService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/CoreService.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -39,9 +40,8 @@ class CoreService
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
@@ -57,9 +57,8 @@ class CoreService
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setStopwatch(Stopwatch $stopwatch)
     {
         $this->stopwatch = $stopwatch;
@@ -103,9 +102,8 @@ class CoreService
 
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
-     *
-     * @required
      */
+    #[Required]
     public function setDoctrine(ManagerRegistry $doctrine)
     {
         $this->doctrine = $doctrine;

--- a/demosplan/DemosPlanCoreBundle/Logic/ExceptionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ExceptionService.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use Symfony\Component\HttpFoundation\Cookie;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedGuestException;
@@ -148,7 +149,7 @@ class ExceptionService
 
         if ($setRedirectLoggedInRouteCookie) {
             // save current route in cookie for later redirecting
-            $redirect->headers->setCookie(new PreviousRouteCookie($request));
+            $redirect->headers->setCookie(PreviousRouteCookie::create($request));
         }
 
         return $redirect;

--- a/demosplan/DemosPlanCoreBundle/Logic/FloodControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FloodControlService.php
@@ -138,17 +138,7 @@ class FloodControlService extends CoreService
         $cookie = $event->getRequest()->cookies->get(self::COOKIE_KEY);
         if (is_null($cookie)) {
             $event->getResponse()->headers->setCookie(
-                new Cookie(
-                    self::COOKIE_KEY,
-                    Json::encode([$identifier]),
-                    0,
-                    '/',
-                    null,
-                    false,
-                    true,
-                    false,
-                    'strict'
-                ));
+                Cookie::create(self::COOKIE_KEY, Json::encode([$identifier]), 0, '/', null, false, true, false, 'strict'));
             $this->getLogger()->debug('FloodControl: Set Floodcontrol Cookie '.self::COOKIE_KEY);
 
             return;
@@ -165,17 +155,7 @@ class FloodControlService extends CoreService
 
         // add new identifier to Cookie
         $event->getResponse()->headers->setCookie(
-            new Cookie(
-                self::COOKIE_KEY,
-                Json::encode($cookieValue->push($identifier)->toArray()),
-                0,
-                '/',
-                null,
-                false,
-                false,
-                false,
-                'strict'
-            )
+            Cookie::create(self::COOKIE_KEY, Json::encode($cookieValue->push($identifier)->toArray()), 0, '/', null, false, false, false, 'strict')
         );
 
         $this->getLogger()->debug('FloodControl: Cookie successfully checked');

--- a/demosplan/DemosPlanCoreBundle/Logic/ViewRenderer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ViewRenderer.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use Symfony\Component\HttpFoundation\Cookie;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Event\PreRenderEvent;
@@ -236,7 +237,7 @@ class ViewRenderer
 
         if ($setRedirectLoggedInRouteCookie) {
             // save current route in cookie for later redirecting
-            $redirect->headers->setCookie(new PreviousRouteCookie($request));
+            $redirect->headers->setCookie(PreviousRouteCookie::create($request));
         }
 
         return $redirect;

--- a/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermission.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermission.php
@@ -51,25 +51,21 @@ class ResolvablePermission
 
     /**
      * @var non-empty-string
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false)
-     * @Assert\Type(type="string")
-     * @Assert\Regex(pattern="/^[a-z]+(_[a-z]+)*$/")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false)]
+    #[Assert\Type(type: 'string')]
+    #[Assert\Regex(pattern: '/^[a-z]+(_[a-z]+)*$/')]
     private string $name;
 
     /**
      * @var non-empty-string
-     *
-     * @Assert\NotBlank(normalizer="trim", allowNull=false)
-     * @Assert\Type(type="string")
      */
+    #[Assert\NotBlank(normalizer: 'trim', allowNull: false)]
+    #[Assert\Type(type: 'string')]
     private string $label;
 
-    /**
-     * @Assert\NotNull()
-     * @Assert\Type(type="string")
-     */
+    #[Assert\NotNull]
+    #[Assert\Type(type: 'string')]
     private string $description;
 
     private bool $exposed;

--- a/demosplan/DemosPlanCoreBundle/Repository/CoreRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/CoreRepository.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Closure;
 use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
@@ -51,10 +52,10 @@ abstract class CoreRepository extends ServiceEntityRepository
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
      *
-     * @required
      *
      * @return $this
      */
+    #[Required]
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
@@ -65,10 +66,10 @@ abstract class CoreRepository extends ServiceEntityRepository
     /**
      * Please don't use `@required` for DI. It should only be used in base classes like this one.
      *
-     * @required
      *
      * @return $this
      */
+    #[Required]
     public function setValidator(ValidatorInterface $validator)
     {
         $this->validator = $validator;

--- a/demosplan/DemosPlanCoreBundle/Traits/DI/RequiresLoggerTrait.php
+++ b/demosplan/DemosPlanCoreBundle/Traits/DI/RequiresLoggerTrait.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Traits\DI;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Psr\Log\LoggerInterface;
 
 trait RequiresLoggerTrait
@@ -27,9 +28,7 @@ trait RequiresLoggerTrait
         return $this->logger;
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;

--- a/demosplan/DemosPlanCoreBundle/ValueObject/AssessmentTable/StatementBulkEditVO.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/AssessmentTable/StatementBulkEditVO.php
@@ -21,24 +21,21 @@ class StatementBulkEditVO extends ValueObject
 
     // @improve T12873
     /**
-     * @Assert\Valid()
-     *
      * @var StatementIdsInProcedureVO
      */
+    #[Assert\Valid]
     protected $statementIdsInProcedure;
 
     /**
      * @var string
-     *
-     * @Assert\Length(min=1)
      */
+    #[Assert\Length(min: 1)]
     protected $recommendationAddition;
 
     /**
-     * @Assert\Length(min=36, max=36)
-     *
      * @var string
      */
+    #[Assert\Length(min: 36, max: 36)]
     protected $assigneeId;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementFragmentUpdate.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementFragmentUpdate.php
@@ -44,23 +44,21 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final class StatementFragmentUpdate extends ValidatableValueObject
 {
     /**
-     * @Assert\All({
-     *     @Assert\Uuid()
-     * })
-     * @Assert\Count(min=1)
-     * @Assert\Valid()
-     * @Assert\NotNull()
      *
      * @var string[]
      */
+    #[Assert\All([new Assert\Uuid()])]
+    #[Assert\Count(min: 1)]
+    #[Assert\Valid]
+    #[Assert\NotNull]
     protected $statementFragmentIds;
 
     /**
-     * @Assert\Uuid()
-     * @Assert\NotNull()
      *
      * @var string
      */
+    #[Assert\Uuid]
+    #[Assert\NotNull]
     protected $procedureId;
 
     /**
@@ -71,11 +69,11 @@ final class StatementFragmentUpdate extends ValidatableValueObject
      * are added the validation needs to differentiate between "is null meaning not set" (valid) and "is null because
      * of the request" (invalid).
      *
-     * @Assert\Length(min=1)
-     * @Assert\Type(type="string")
      *
      * @var string
      */
+    #[Assert\Length(min: 1)]
+    #[Assert\Type(type: 'string')]
     protected $considerationAddition;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ValueObject/User/AddressBookEntryVO.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/User/AddressBookEntryVO.php
@@ -38,11 +38,11 @@ class AddressBookEntryVO extends ValueObject
     protected $organisation;
 
     /**
-     * @Assert\NotBlank(message = "email.address.invalid")
-     * @Assert\Email(message = "email.address.invalid")
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'email.address.invalid')]
+    #[Assert\Email(message: 'email.address.invalid')]
     protected $emailAddress;
 
     public function __construct(string $name, string $emailAddress, Orga $organisation)

--- a/demosplan/DemosPlanCoreBundle/ValueObject/User/CustomerResourceInterface.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/User/CustomerResourceInterface.php
@@ -32,41 +32,27 @@ interface CustomerResourceInterface extends ResourceInterface
     public const SIMPLE_LANGUAGE = 'simpleLanguage';
     public const SIMPLE_LANGUAGE_OVERVIEW_DESCRIPTION = 'overviewDescriptionInSimpleLanguage';
 
-    /**
-     * @Assert\Length(max=65000, groups={CustomerResourceInterface::DATA_PROTECTION})
-     */
+    #[Assert\Length(max: 65000, groups: [CustomerResourceInterface::DATA_PROTECTION])]
     public function getDataProtection(): ?string;
 
-    /**
-     * @Assert\Length(max=65000, groups={CustomerResourceInterface::IMPRINT})
-     */
+    #[Assert\Length(max: 65000, groups: [CustomerResourceInterface::IMPRINT])]
     public function getImprint(): ?string;
 
-    /**
-     * @Assert\Length(max=65000, groups={CustomerResourceInterface::TERMS_OF_USE})
-     */
+    #[Assert\Length(max: 65000, groups: [CustomerResourceInterface::TERMS_OF_USE])]
     public function getTermsOfUse(): ?string;
 
-    /**
-     * @Assert\Length(max=65000, groups={CustomerResourceInterface::XPLANNING})
-     */
+    #[Assert\Length(max: 65000, groups: [CustomerResourceInterface::XPLANNING])]
     public function getXplanning(): string;
 
     public function getLogo(): ?File;
 
-    /**
-     * @Assert\Length(min=0, max=4096, groups={CustomerResourceInterface::MAP_ATTRIBUTION})
-     */
+    #[Assert\Length(min: 0, max: 4096, groups: [CustomerResourceInterface::MAP_ATTRIBUTION])]
     public function getMapAttribution(): ?string;
 
-    /**
-     * @Assert\Length(min=5, max=4096, groups={CustomerResourceInterface::BASE_LAYER_URL})
-     */
+    #[Assert\Length(min: 5, max: 4096, groups: [CustomerResourceInterface::BASE_LAYER_URL])]
     public function getBaseLayerUrl(): ?string;
 
-    /**
-     * @Assert\Length(min=5, max=4096, groups={CustomerResourceInterface::BASE_LAYER_LAYERS})
-     */
+    #[Assert\Length(min: 5, max: 4096, groups: [CustomerResourceInterface::BASE_LAYER_LAYERS])]
     public function getBaseLayerLayers(): ?string;
 
     /**
@@ -74,9 +60,7 @@ interface CustomerResourceInterface extends ResourceInterface
      */
     public function getCssVars(): ?string;
 
-    /**
-     * @Assert\Length(max=65000, groups={CustomerResourceInterface::ACCESSIBILITY_EXPLANATION})
-     */
+    #[Assert\Length(max: 65000, groups: [CustomerResourceInterface::ACCESSIBILITY_EXPLANATION])]
     public function getAccessibilityExplanation(): string;
 
     public function getSignLanguageOverviewDescription(): string;

--- a/demosplan/DemosPlanCoreBundle/ValueObject/ValidatableValueObject.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/ValidatableValueObject.php
@@ -25,10 +25,10 @@ class ValidatableValueObject extends ValueObject
      * These assertions are not really needed but an example how to annotate
      * properties with validation assertions.
      *
-     * @Assert\NotNull()
      *
      * @var ValidatorInterface
      */
+    #[Assert\NotNull]
     private $validator;
 
     /** @var bool */

--- a/demosplan/DemosPlanProcedureBundle/Form/BoilerplateType.php
+++ b/demosplan/DemosPlanProcedureBundle/Form/BoilerplateType.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanProcedureBundle\Form;
 
+use Traversable;
 use demosplan\DemosPlanProcedureBundle\ValueObject\BoilerplateVO;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
@@ -87,7 +88,7 @@ class BoilerplateType extends AbstractType implements DataMapperInterface
      *
      * @param BoilerplateVO $data
      */
-    public function mapDataToForms($data, $forms)
+    public function mapDataToForms($data, Traversable $forms)
     {
         $forms = \iterator_to_array($forms);
         /* @var FormInterface[] $forms */
@@ -103,7 +104,7 @@ class BoilerplateType extends AbstractType implements DataMapperInterface
      *
      * @param BoilerplateVO $boilerplateVO
      */
-    public function mapFormsToData($forms, &$boilerplateVO)
+    public function mapFormsToData(Traversable $forms, &$boilerplateVO)
     {
         $forms = \iterator_to_array($forms);
         /** @var FormInterface[] $forms */

--- a/demosplan/DemosPlanProcedureBundle/Form/PreparationMailType.php
+++ b/demosplan/DemosPlanProcedureBundle/Form/PreparationMailType.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanProcedureBundle\Form;
 
+use Traversable;
 use demosplan\DemosPlanProcedureBundle\ValueObject\PreparationMailVO;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
@@ -53,7 +54,7 @@ class PreparationMailType extends AbstractType implements DataMapperInterface
             ->setDataMapper($this);
     }
 
-    public function mapDataToForms($data, $forms)
+    public function mapDataToForms($data, Traversable $forms)
     {
         $forms = iterator_to_array($forms);
         /* @var FormInterface[] $forms */
@@ -62,7 +63,7 @@ class PreparationMailType extends AbstractType implements DataMapperInterface
         $forms['r_email_address']->setData($data ? $data->getSendMail() : true);
     }
 
-    public function mapFormsToData($forms, &$data)
+    public function mapFormsToData(Traversable $forms, &$data)
     {
         $forms = iterator_to_array($forms);
         /** @var FormInterface[] $forms */

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateCategoryVO.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateCategoryVO.php
@@ -17,9 +17,8 @@ class BoilerplateCategoryVO extends ValueObject
 {
     /**
      * @var string
-     *
-     * @Assert\NotBlank(message = "Der Name der Kategorie darf nicht leer sein")
      */
+    #[Assert\NotBlank(message: 'Der Name der Kategorie darf nicht leer sein')]
     protected $id;
 
     /**

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateGroupVO.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateGroupVO.php
@@ -23,9 +23,8 @@ class BoilerplateGroupVO extends ValueObject
 
     /**
      * @var string
-     *
-     * @Assert\NotBlank(message = "Der Titel der Gruppe darf nicht leer sein")
      */
+    #[Assert\NotBlank(message: 'Der Titel der Gruppe darf nicht leer sein')]
     protected $title;
 
     /** @var Boilerplate[] */

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateVO.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/BoilerplateVO.php
@@ -26,15 +26,9 @@ class BoilerplateVO extends ValueObject
 
     /**
      * @var string
-     *
-     * @Assert\NotBlank(message = "boilerplate.title.not.blank")
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 250,
-     *      minMessage = "boilerplate.title.min.length",
-     *      maxMessage = "boilerplate.title.max.length"
-     * )
      */
+    #[Assert\NotBlank(message: 'boilerplate.title.not.blank')]
+    #[Assert\Length(min: 1, max: 250, minMessage: 'boilerplate.title.min.length', maxMessage: 'boilerplate.title.max.length')]
     protected $title;
 
     /**
@@ -47,9 +41,8 @@ class BoilerplateVO extends ValueObject
 
     /**
      * @var string
-     *
-     * @Assert\NotBlank(message = "Der Text darf nicht leer sein")
      */
+    #[Assert\NotBlank(message: 'Der Text darf nicht leer sein')]
     protected $text;
 
     /** @var Procedure */

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/EmailAddressVO.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/EmailAddressVO.php
@@ -18,11 +18,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class EmailAddressVO extends ValueObject
 {
     /**
-     * @Assert\NotBlank(message = "email.address.invalid")
-     * @Assert\Email(message = "email.address.invalid")
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'email.address.invalid')]
+    #[Assert\Email(message: 'email.address.invalid')]
     protected $fullAddress;
 
     /**

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/PreparationMailVO.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/PreparationMailVO.php
@@ -26,25 +26,25 @@ use Symfony\Component\Validator\Constraints as Assert;
 class PreparationMailVO extends ValueObject
 {
     /**
-     * @Assert\NotBlank(message="mail.subject.notblank")
-     * @Assert\Length(max=78, maxMessage="mail.subject.max.length", min=2, minMessage="mail.subject.min.length")
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'mail.subject.notblank')]
+    #[Assert\Length(max: 78, maxMessage: 'mail.subject.max.length', min: 2, minMessage: 'mail.subject.min.length')]
     protected $mailSubject;
     /**
-     * @Assert\NotBlank(message="mail.body.notblank")
-     * @Assert\Length(min = 2, max = 25000, maxMessage="mail.body.max.length")
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'mail.body.notblank')]
+    #[Assert\Length(min: 2, max: 25000, maxMessage: 'mail.body.max.length')]
     protected $mailBody;
     /**
-     * @Assert\NotNull()
-     * @Assert\IsTrue(message="mail.send.true")
      *
      * @var bool
      */
+    #[Assert\NotNull]
+    #[Assert\IsTrue(message: 'mail.send.true')]
     protected $sendMail;
 
     /**

--- a/demosplan/DemosPlanProcedureBundle/ValueObject/ProcedureFormData.php
+++ b/demosplan/DemosPlanProcedureBundle/ValueObject/ProcedureFormData.php
@@ -28,22 +28,19 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ProcedureFormData extends ValueObject
 {
     /**
-     * @Assert\Type(type=EmailAddressVO::class)
-     *
      * @var EmailAddressVO
      */
+    #[Assert\Type(type: EmailAddressVO::class)]
     protected $agencyMainEmailAddress;
 
     /**
-     * @Assert\Type(type=Collection::class)
-     * @Assert\Count(max=100)
-     * @Assert\NotNull()
-     * @Assert\All({
-     *     @Assert\Type(type=EmailAddressVO::class)
-     * })
      *
      * @var Collection<int, EmailAddressVO>
      */
+    #[Assert\Type(type: Collection::class)]
+    #[Assert\Count(max: 100)]
+    #[Assert\NotNull]
+    #[Assert\All([new Assert\Type(type: EmailAddressVO::class)])]
     protected $agencyExtraEmailAddresses;
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27388

Rector SymfonyLevelSetList::UP_TO_SYMFONY_54 was run on the app. It mostly modified routes and assertions to use php annotations

### How to review/test
code review if any, as it was done by rector

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
