### PR TITLE
feat (refs T32934): Improve performance on Assessment Table by adding database index

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -43,8 +43,10 @@ class Version20230601095828 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
+        $this->addSql('SET foreign_key_checks = 0');
         $this->addSql('ALTER TABLE _statement DROP FOREIGN KEY FK_8D47F06B84040EA6');
         $this->addSql('DROP INDEX IDX_8D47F06B84040EA6 ON _statement');
+        $this->addSql('SET foreign_key_checks = 1');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230601095828 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T32934: Improve performance on Assessment Table by adding database index';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _statement ADD CONSTRAINT FK_8D47F06B84040EA6 FOREIGN KEY (segment_statement_fk) REFERENCES _statement (_st_id)');
+        $this->addSql('CREATE INDEX IDX_8D47F06B84040EA6 ON _statement (segment_statement_fk)');
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _statement DROP FOREIGN KEY FK_8D47F06B84040EA6');
+        $this->addSql('DROP INDEX IDX_8D47F06B84040EA6 ON _statement');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -22,7 +32,6 @@ class Version20230601095828 extends AbstractMigration
 
         $this->addSql('ALTER TABLE _statement ADD CONSTRAINT FK_8D47F06B84040EA6 FOREIGN KEY (segment_statement_fk) REFERENCES _statement (_st_id)');
         $this->addSql('CREATE INDEX IDX_8D47F06B84040EA6 ON _statement (segment_statement_fk)');
-
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -30,8 +30,10 @@ class Version20230601095828 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
+        $this->addSql('SET foreign_key_checks = 0');
         $this->addSql('ALTER TABLE _statement ADD CONSTRAINT FK_8D47F06B84040EA6 FOREIGN KEY (segment_statement_fk) REFERENCES _statement (_st_id)');
         $this->addSql('CREATE INDEX IDX_8D47F06B84040EA6 ON _statement (segment_statement_fk)');
+        $this->addSql('SET foreign_key_checks = 1');
     }
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32934

The sql query to fetch statements was not able to use an database index, which lead to degraded performance

### How to review/test
call a page with 100 Statements

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
