### PR TITLE
chore: Bump required node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
   },
   "engines": {
     "npm": ">= 6.0.0",
-    "node": ">= 14.15.1"
+    "node": ">= 16.0.0"
   },
   "browserslist": [
     "last 5 versions",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
   },
   "engines": {
     "npm": ">= 6.0.0",
-    "node": ">= 16.0.0"
+    "node": ">= 16.18.1"
   },
   "browserslist": [
     "last 5 versions",


### PR DESCRIPTION
Set required node engine to 16 since this is the lowest Version for some dependencies