### PR TITLE
fix: tweak export tab colors

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
@@ -141,14 +141,16 @@
                 line-height: 27px;
                 text-align: center;
 
+                cursor: pointer;
+
                 &:not(:last-child) {
                     margin-right: 1px;
                 }
 
                 &.active,
                 &:hover {
-                    @extend %tabs-btn-color;
-                    background: $dp-color-main;
+                    background-color: $dp-color-main;
+                    color: $dp-color-main-contrast;
                 }
             }
         }


### PR DESCRIPTION
the active/hover styles were overridden in diplanbau in such a way that there was no chance spotting the currently active tab. also, pointer.

### How to review/test
in the export modal of the "classic" assessment table, the tabs for docx / pdf should clearly indicate active state.

![image](https://github.com/demos-europe/demosplan-core/assets/40452344/4fd5af11-71f1-4a40-9613-c4abab188b88)
