### PR TITLE
fix: also define color for hover state

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
@@ -52,6 +52,7 @@
         text-decoration: underline;
 
         &:hover {
+            color: $dp-color-white;
             color: $dp-color-alt--light-1;
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_link.scss
@@ -53,7 +53,7 @@
 
         &:hover {
             color: $dp-color-white;
-            color: $dp-color-alt--light-1;
+            opacity: .8;
         }
     }
 


### PR DESCRIPTION
Without this fix, in bobhh the :hover declaration of the base link took precedence, coloring the hovered link blue.