### PR TITLE
feat(refs T32104): show attribution in map overview

### DIFF
--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -36,7 +36,8 @@
         :options="{
           scaleSelect: false,
           autoSuggest: false,
-          controls: [],
+          controls: [attributionControl],
+          defaultAttribution: mapAttribution,
           initView: false,
           initCenter: false,
           procedureExtent: true
@@ -233,6 +234,7 @@
 
 <script>
 import { checkResponse, dpApi, DpDatepicker, DpToggle, hasOwnProp } from '@demos-europe/demosplan-ui'
+import { Attribution } from 'ol/control'
 import DpOlMap from '@DpJs/components/map/map/DpOlMap'
 import DpOlMapLayerVector from '@DpJs/components/map/map/DpOlMapLayerVector'
 import { fromExtent } from 'ol/geom/Polygon'
@@ -248,6 +250,12 @@ export default {
   },
 
   props: {
+    mapAttribution: {
+      required: false,
+      type: String,
+      default: ''
+    },
+
     procedureId: {
       required: false,
       type: String,
@@ -320,6 +328,10 @@ export default {
   },
 
   computed: {
+    attributionControl () {
+      return new Attribution({ collapsible: false })
+    },
+
     features () {
       /*
        *  Transform the value that is saved as a string into valid GeoJSON

--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -66,7 +66,7 @@ export default {
       const currentYear = formatDate(new Date(), 'YYYY')
       // If a value is currently given, replace the {year} placeholder within that value
       if (this?.attributions) {
-        return this.attributions.replace('{year}', currentYear)
+        return this.attributions.replaceAll('{year}', currentYear)
       }
       // If not, default to the default message
       return Translator.trans('map.attribution.default', {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -11,15 +11,15 @@
 
     {% if hasPermission('area_admin_map') and (templateVars.procedure.master == true or templateVars.procedure.procedureBehaviorDefinition.isAllowedToEnableMap) %}
         <dp-map-settings-preview
-            procedure-id="{{ procedure }}"
-            procedure-coordinate="{{ procedureSettings.coordinate }}"
-            init-extent="{{ procedureSettings.mapExtent }}"
-            :procedure-default-initial-extent="JSON.parse('{{ templateVars.procedureDefaultInitialExtent|json_encode|e('js', 'utf-8') }}')"
-            territory="{{ procedureSettings.territory }}"
-            map-attribution="{{ procedureSettings.copyright }}"
             drawing="{{ procedureSettings.planDrawPDF}}"
             drawing-explanation="{{ procedureSettings.planPDF}}"
+            init-extent="{{ procedureSettings.mapExtent }}"
             :is-blueprint="Boolean({{ templateVars.procedure.master }})"
+            map-attribution="{{ procedureSettings.copyright }}"
+            procedure-coordinate="{{ procedureSettings.coordinate }}"
+            :procedure-default-initial-extent="JSON.parse('{{ templateVars.procedureDefaultInitialExtent|json_encode|e('js', 'utf-8') }}')"
+            procedure-id="{{ procedure }}"
+            territory="{{ procedureSettings.territory }}"
         >
         </dp-map-settings-preview>
     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -16,6 +16,7 @@
             init-extent="{{ procedureSettings.mapExtent }}"
             :procedure-default-initial-extent="JSON.parse('{{ templateVars.procedureDefaultInitialExtent|json_encode|e('js', 'utf-8') }}')"
             territory="{{ procedureSettings.territory }}"
+            map-attribution="{{ procedureSettings.copyright }}"
             drawing="{{ procedureSettings.planDrawPDF}}"
             drawing-explanation="{{ procedureSettings.planPDF}}"
             :is-blueprint="Boolean({{ templateVars.procedure.master }})"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32104

Map attribution should also be shown in the map settings overview map.

### PR Checklist

- [ ] Tests updated/created
- [ ] Update documentation
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
