### PR TITLE
Fix Language for PhpWord generated Docx exports

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -43,9 +43,7 @@ use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Html;
-use PhpOffice\PhpWord\Style\Language;
 use PhpOffice\PhpWord\Writer\WriterInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
@@ -197,7 +195,7 @@ class DocxExporter
          * Therefore this workaround with similar but project specific creation of
          * documents.
          */
-        $phpWord = $this->initializePhpWord();
+        $phpWord = PhpWordConfigurator::getPreConfiguredPhpWord();
 
         $incomingStatements = $outputResult->getStatements();
         $procedure = $this->getProcedureHandler()->getProcedureWithCertainty($outputResult->getProcedure()['id']);
@@ -522,21 +520,6 @@ class DocxExporter
             ->pluck('id')
             ->unique()
             ->all();
-    }
-
-    protected function initializePhpWord(): PhpWord
-    {
-        $phpWord = new PhpWord();
-        // avoid problems with < in statementTexts T3921
-        Settings::setOutputEscapingEnabled(true);
-        // https://stackoverflow.com/questions/33267654/
-        $phpWord->getSettings()->setUpdateFields(true);
-        $phpWord->getSettings()->setThemeFontLang(new Language(Language::DE_DE));
-
-        // http://phpword.readthedocs.org/en/latest/index.html
-        // https://github.com/PHPOffice/PHPWord
-
-        return $phpWord;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/PhpWordConfigurator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/PhpWordConfigurator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Export;
+
+use PhpOffice\PhpWord\ComplexType\ProofState;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\Style\Language;
+
+/**
+ * Common configurations for PHPWord instances since unfortunately we
+ * have several places where we need to obtain new instances.
+ */
+class PhpWordConfigurator
+{
+    public static function getPreConfiguredPhpWord(): PhpWord
+    {
+        $phpWord = new PhpWord();
+
+        // avoid problems with < in statementTexts T3921
+        Settings::setOutputEscapingEnabled(true);
+        // https://stackoverflow.com/questions/33267654/
+        $phpWord->getSettings()->setUpdateFields(true);
+
+        // http://phpword.readthedocs.org/en/latest/index.html
+        // https://github.com/PHPOffice/PHPWord
+
+        $configurator = new self();
+        $configurator->configureDocumentLanguage($phpWord);
+
+        return $phpWord;
+    }
+
+    /**
+     * Configures the document language settings and sets the
+     * proof states for grammar and spelling to clean. The latter
+     * is done to significantly reduce loading times for large documents.
+     */
+    protected function configureDocumentLanguage(PhpWord $phpWord): void
+    {
+        $language = new Language();
+
+        $language->setLatin(Language::DE_DE);
+        $language->setLangId(Language::DE_DE_ID);
+
+        $phpWord->getSettings()->setThemeFontLang($language);
+
+        $proofState = new ProofState();
+
+        $proofState->setSpelling(ProofState::CLEAN);
+        $proofState->setGrammar(ProofState::CLEAN);
+
+        $phpWord->getSettings()->setProofState($proofState);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -21,6 +21,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\HandlerException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
+use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserInterface;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
@@ -64,11 +65,14 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     public function exportAll(Procedure $procedure, Statement ...$statements): WriterInterface
     {
         Settings::setOutputEscapingEnabled(true);
+
+        $phpWord = PhpWordConfigurator::getPreConfiguredPhpWord();
+
         if (0 === count($statements)) {
-            return $this->exportEmptyStatements(new PhpWord(), $procedure);
+            return $this->exportEmptyStatements($phpWord, $procedure);
         }
 
-        return $this->exportStatements(new PhpWord(), $procedure, $statements);
+        return $this->exportStatements($phpWord, $procedure, $statements);
     }
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31218

This consolidates the language settings to be used on more PhpWord
    instances throughout the codebase. In addition, documents are
    generated with a clean proof read and grammar state to improve
    loading performance in MS Word.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
