### PR TITLE
chore: add missing env var to allow cli debugging

### DIFF
--- a/docker/php8.1-cli-development/zshenv
+++ b/docker/php8.1-cli-development/zshenv
@@ -18,7 +18,7 @@ then
 fi
 
 function php-xdbg() {
-    php -dzend_extension=xdebug.so \
+    PHP_IDE_CONFIG="serverName=172.22.255.2" php -dzend_extension=xdebug.so \
         -dxdebug.mode=debug \
         -dxdebug.start_with_request=yes \
         -dxdebug.client_host=172.22.255.1 \


### PR DESCRIPTION
Debugging via cli `php-xdebug` does not work any more out of the box but needs a specific PHP_IDE_CONFIG env var

### How to review/test
try to debug via console

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
