### PR TITLE
bug(refs T33031): Hide upload files when editable is false

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
@@ -17,9 +17,9 @@
         v-if="attachments.originalAttachment.hash"
         :attachment="attachments.originalAttachment" />
       <p
+        v-else
         class="color--grey"
-        v-text="Translator.trans('none')"
-        v-else />
+        v-text="Translator.trans('none')" />
     </div>
     <div class="space-stack-s">
       <dp-label
@@ -33,26 +33,27 @@
         </li>
       </ul>
       <p
+        v-else
         class="color--grey"
-        v-text="Translator.trans('none')"
-        v-else />
-      <dp-upload-files
-        :class="editable ? '' : 'pointer-events-none opacity-7'"
-        :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
-        ref="uploadStatementAttachment"
-        id="uploadStatementAttachment"
-        name="uploadStatementAttachment"
-        allowed-file-types="all"
-        :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
-        :max-number-of-files="1000"
-        :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '2GB' }) }"
-        @file-remove="removeFileId"
-        @upload-success="setFileId" />
-      <dp-button
-        :busy="isProcessing"
-        :disabled="fileIds.length === 0"
-        :text="Translator.trans('save')"
-        @click="save('generic')" />
+        v-text="Translator.trans('none')" />
+      <template v-if="editable">
+        <dp-upload-files
+          :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+          ref="uploadStatementAttachment"
+          id="uploadStatementAttachment"
+          name="uploadStatementAttachment"
+          allowed-file-types="all"
+          :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
+          :max-number-of-files="1000"
+          :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '2GB' }) }"
+          @file-remove="removeFileId"
+          @upload-success="setFileId" />
+        <dp-button
+          :busy="isProcessing"
+          :disabled="fileIds.length === 0"
+          :text="Translator.trans('save')"
+          @click="save('generic')" />
+      </template>
     </div>
   </div>
 </template>
@@ -78,8 +79,8 @@ export default {
     },
 
     /**
-     * Editable can be used to disable DpUploadFiles on css level
-     * but keep the uploaded files list accessible at the same time.
+     * When true upload files and save button will not be rendered,
+     * but the attachments are still shown
      */
     editable: {
       type: Boolean,


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33031

If the statement is not editable we don't need to show the component for upload, but only the attachments already uploaded.

### How to review/test
Couple a procedure and transfer a statement to VHT. On the detail site, you shouldn't see the upload files function, but only the attachments already uploaded.
