### PR TITLE
bug(refs T33015): check if authored date is valid when converting pdfs

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -591,7 +591,7 @@ export default {
     this.setInitialValues()
     // Synchronize values.authoredDate with the date value provided by data only if date is existing and format is valid.
     if (hasOwnProp(this.values.submitter, 'date') && dayjs(this.values.submitter.date, 'YYYY-MM-DD', true).isValid()) {
-      this.$set(this.values, 'authoredDate', this.values.submitter.date)
+      this.$set(this.values, 'authoredDate', dayjs(this.values.submitter.date).format('DD.MM.YYYY'))
     }
 
   }


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T33015

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- Since I forgot that the datepicker only accepts the format 'DD.MM.YYYY', the implementation of passing the correct value format was missing and added now.

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
