### PR TITLE
feat (refs T33162): fix year replacement of copyright

### DIFF
--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -64,9 +64,9 @@ export default {
   computed: {
     defaultAttributions () {
       const currentYear = formatDate(new Date(), 'YYYY')
-      // If a value is currently given, replace the {year} placeholder within that value
+      // If a value is currently given, replace the {currentYear} placeholder within that value
       if (this?.attributions) {
-        return this.attributions.replaceAll('{year}', currentYear)
+        return this.attributions.replaceAll('{currentYear}', currentYear)
       }
       // If not, default to the default message
       return Translator.trans('map.attribution.default', {

--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -1753,7 +1753,7 @@ export default {
       let label = ''
 
       if (hasOwnProp(this.procedureSettings, 'copyright') && this.procedureSettings.copyright !== '') {
-        label = this.procedureSettings.copyright.replace('{year}', currentYear)
+        label = this.procedureSettings.copyright.replace('{currentYear}', currentYear)
       } else {
         label = Translator.trans('map.attribution.default', {
           linkImprint: Routing.generate('DemosPlan_misccontent_static_imprint'),

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
@@ -827,7 +827,7 @@ class MapService extends CoreService
             return null;
         }
 
-        return str_replace('{year}', date('Y'), $mapAttribution);
+        return str_replace('{currentYear}', date('Y'), $mapAttribution);
     }
 
     protected function convertArrayValuesToFloats(array $someArray): array

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation.html.twig
@@ -66,7 +66,7 @@
             });
 
             L.control.attribution({
-                prefix: '{{ map.mapAttribution|default|replace({'{year}': 'now'|date('Y')})|wysiwyg }}' || Translator.trans('map.attribution.default', {
+                prefix: '{{ map.mapAttribution|default|replace({'{currentYear}': 'now'|date('Y')})|wysiwyg }}' || Translator.trans('map.attribution.default', {
                     linkImprint: Routing.generate('DemosPlan_misccontent_static_imprint'),
                     currentYear: {{ 'now' | date('Y') }}
                 })

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1948,7 +1948,7 @@ map.attribution.default: "Lizenzrechtliche Angaben im <a href=\"{linkImprint}\">
 map.attribution.exports: "© basemap.de BKG (www.basemap.de) / LVermGeo SH (www.LVermGeoSH.schleswig-holstein.de)"
 map.attribution: "Copyright-Vermerk"
 map.attribution.hint: "Der Copyright-Vermerk bzw. die Quellengabe wird in einer Leiste unterhalb der Karte angezeigt."
-map.attribution.placeholder: "Um das aktuelle Jahr darzustellen, nutzen Sie diesen Platzhalter: <strong>'{year'}</strong>"
+map.attribution.placeholder: "Um das aktuelle Jahr darzustellen, nutzen Sie diesen Platzhalter: <strong>'{currentYear'}</strong>"
 map.base: "Grundkarte"
 map.base.url: "URL der Grundkarte"
 map.base.url.hint: "Geben Sie hier die Web-Adresse für einen Web-Map-Service (WMS) ein. Die in der Adresse angegebene Kartenebene wird auf der Startseite als Grundkarte angezeigt. Die Kartenebene muss die Projektion EPSG:3857 (Web Mercator) unterstützen."


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33162

Change the placeholfer for the current year from {year} to {currentYear}. It's more meaningful and {currentYear} is already used in the database, which also causes the error that {currentYear} was not replaced because the modified code assumed {year}.

### How to review/test
code review
check the web interface of diplanbau, it should now show 2023 instead of {currentYear} in the copyright of maps.

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
