### PR TITLE
chore: remove vendor that is not needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,6 @@
         "liip/functional-test-bundle": "^4",
         "liip/test-fixtures-bundle": "^2.0.1",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "phpcompatibility/php-compatibility": "^9.3",
         "phpspec/prophecy": "^1.15",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-symfony": "^1.2",
@@ -202,9 +201,5 @@
     },
     "conflict": {
       "twig/twig": "<2.10"
-    },
-    "scripts": {
-      "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-      "post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility"
     }
 }


### PR DESCRIPTION
phpcompatibility/php-compatibility was introduced as a test and is not really needed. I would prefer to lower the amount of vendors and remove this dependency until we really need it

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
