### PR TITLE
fix (refs T33172): Replace '{currentYear}' with an actual value. (PDF export)

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
@@ -82,7 +82,7 @@
     %fileName:{{ statement.mapFile|getFile('name')|raw }}:{{ statement.mapFile|getFile('hash') }}%
     \caption{Kartenauschnitt}
 	\label{fig1}
-        {{ procedure.settings.copyright }}
+        {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')}) }}
     \end{figure}
     {% endif %}
     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/statement_macros.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/statement_macros.tex.twig
@@ -20,7 +20,7 @@
             %fileName:{{ statement.mapFile|getFile('name')|raw }}:{{ statement.mapFile|getFile('hash') }}%
             \caption{Kartenauschnitt}
             \label{fig1}
-                {{ procedure.settings.copyright|latex|raw }}
+                {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
             \end{figure}
         {% endif %}
     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry.tex.twig
@@ -22,7 +22,7 @@
 \caption {Kartenauschnitt}
 \label{{ '{' }}fig1{{ '}' }}
 %fileName:{{ statement.mapFile|getFile('name')|wysiwyg }}:{{ statement.mapFile|getFile('hash') }}%
-    {{ procedure.settings.copyright|latex|raw }}
+    {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
 {% endif %}
 {% endif %}
 \ParallelRText{{ '{}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
@@ -39,7 +39,7 @@
         \caption {Kartenauschnitt}
         \label{{ '{' }}fig1{{ '}' }}
         %fileName:{{ statement.mapFile|getFile('name')|wysiwyg }}:{{ statement.mapFile|getFile('hash') }}%
-        {{ procedure.settings.copyright|latex|raw }}
+        {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
         \end{figure}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33172

In verwalten > Abwägungstabelle > STN wählen mit Einzeichnungen > PDF-Export (Hoch- oder Querformat) and Public Detail > Stellungnahmen zum Verfahren > Entwurfsordner etc > STN wählen mit Einzeichnungen > Download als PDF the {currentYear} placeholder will not be replaced by a year value like 2023. 
The changes in the twig files should fix this. I'm not sure about the list_export_entry.text.twig. I don't know where it is used. But nothing is replaced there either.

### How to review/test
You could export statements with drawings (Einzeichnungen). On dev the procedure (Test_Export) holds already some statements with drawings. For verwalten > Abwägungstabelle > STN wählen mit Einzeichnungen > PDF-Export (Hoch- oder Querformat) I used the role "Fachplanung-Admin" and for Public Detail > Stellungnahmen zum Verfahren > Entwurfsordner etc > STN wählen mit Einzeichnungen > Download als PDF I used the role "Institutions-Sachbearbeitung".

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
