### PR TITLE
feature (refs T32342): delete rejected flag&Reason when submitting draftStatement(s)

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -677,8 +677,10 @@ class DraftStatementService extends CoreService
     /**
      * Stellungsnahmen werden eingereicht.
      *
-     * Nach dem Aufruf haben sich folgende Werte der Stellungsnahmen geändert:
+     * After calling this method - the following attributes of the draft-statement(s) will be altered:
      * submitted = true
+     * rejected = false
+     * rejectedReason = ''
      *
      * @param string|array $draftStatementIds
      * @param User         $user
@@ -748,10 +750,12 @@ class DraftStatementService extends CoreService
             }
 
             $data = [
-                'ident'         => $draftStatementId,
-                'submitted'     => true,
-                'released'      => true,
-                'submittedDate' => new DateTime(),
+                'ident'             => $draftStatementId,
+                'submitted'         => true,
+                'released'          => true,
+                'submittedDate'     => new DateTime(),
+                'rejected'          => false,
+                'rejectedReason'    => ''
             ];
 
             $draftStatement = $this->updateDraftStatement($data, false);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -755,7 +755,7 @@ class DraftStatementService extends CoreService
                 'released'          => true,
                 'submittedDate'     => new DateTime(),
                 'rejected'          => false,
-                'rejectedReason'    => ''
+                'rejectedReason'    => '',
             ];
 
             $draftStatement = $this->updateDraftStatement($data, false);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32342

Description:
Resets the rejected flag on draft-statements when submitting them.
Also deletes a potential rejectedReason.

### How to review/test
login as a 'Institutions-Sachbearbeitung' choose any procedure and create a new statement. Hand in this statement.
login as the 'Institutions-Koordination' corresponding to the prior chosen 'Institutions-Sachbearbeitung' (same organisation)
choose the procedure where you handed in the statement and go to 
'Stellungnahmen zum Verfahren' -> 'freigaben der Organisation' 
and reject the statement you just handed in.
login as a 'Institutions-Sachbearbeitung' choose same procedure and go to
'Stellungnahmen zum Verfahren' -> 'Meine Entwürfe' and hand in the rejected statement again.
login as the 'Institutions-Koordination' corresponding to the prior chosen 'Institutions-Sachbearbeitung' (same organisation)
choose the procedure where you handed in the statement and go to 
'Stellungnahmen zum Verfahren' -> 'freigaben der Organisation' 
and this time hand in the previously rejected statement.

Now check under 'Stellungnahmen zum Verfahren' -> 'Einreichungen der Organisation'
there should not be a rejected reason attached to the statement.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
