### PR TITLE
fix (refs T33144): Avoid interpreting a 0 as timestamp.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -279,6 +279,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         $exportData['meta'] = $this->entityHelper->toArray($exportData['meta']);
         $exportData['submitDateString'] = $segmentOrStatement->getSubmitDateString();
         $exportData['countyNames'] = $segmentOrStatement->getCountyNames();
+        $exportData['meta']['authoredDate'] = $segmentOrStatement->getAuthoredDateString();
 
         // Some data is stored on parentStatement instead on Segment and have to get from there
         if ($segmentOrStatement instanceof Segment) {
@@ -292,7 +293,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
             $exportData['memo'] = $segmentOrStatement->getParentStatementOfSegment()->getMemo();
             $exportData['internId'] = $segmentOrStatement->getParentStatementOfSegment()->getInternId();
             $exportData['oName'] = $segmentOrStatement->getParentStatementOfSegment()->getOName();
-            $exportData['meta']['authoredDate'] = $segmentOrStatement->getParentStatementOfSegment()->getAuthoredDate();
+            $exportData['meta']['authoredDate'] = $segmentOrStatement->getParentStatementOfSegment()->getAuthoredDateString();
             $exportData['dName'] = $segmentOrStatement->getParentStatementOfSegment()->getDName();
             $exportData['status'] = $segmentOrStatement->getPlace()->getName(); // Segments using place instead of status
             $exportData['fileNames'] = $segmentOrStatement->getParentStatementOfSegment()->getFileNames();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -470,10 +470,6 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
             $explodedParts = explode('.', $attributeKey);
             switch (count($explodedParts)) {
                 case 2:
-                    if ('authoredDate' === $explodedParts[1]) {
-                        $timestamp = $statementArray[$explodedParts[0]][$explodedParts[1]];
-                        $statementArray[$explodedParts[0]][$explodedParts[1]] = date('d-m-Y', $timestamp);
-                    }
                     $formattedStatement[$attributeKey] = $statementArray[$explodedParts[0]][$explodedParts[1]];
                     break;
                 case 3:


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33144

Actually authored date can be null/empty.
On trying to get the timestamp of auhtoredDate of a Statement/Segment, 0 will be returned in case of no date was set.
Because of this is actually a valid timestamp, it will be interpreted as '01.01.1970', which is not correct or intended.
To solve this, I simply use another method, which returns me the already to string converted authored date, without this "special" kind of interpretation and returning simple an empty string in case of no date is set.

+ Removing the now obsolete conversion from the export logic.

### How to review/test
Export statements with an empty authored date.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
