### PR TITLE
fix(T33012): issue with an empty tags dropdown

### DIFF
--- a/client/js/components/statement/assessmentTable/DpEditFieldMultiSelect.vue
+++ b/client/js/components/statement/assessmentTable/DpEditFieldMultiSelect.vue
@@ -40,7 +40,7 @@
         label="name"
         multiple
         :name="`${entityId}:${fieldKey}`"
-        :options="options"
+        :options="selectOptions"
         track-by="id"
         @input="val => handleInput(val)">
         <template v-slot:option="{ props }">
@@ -161,7 +161,8 @@ export default {
       selected: [],
 
       //  Previously selected value to be able to restore it on reset
-      selectedBefore: []
+      selectedBefore: [],
+      selectOptions: []
     }
   },
 
@@ -207,6 +208,7 @@ export default {
 
       this.selected = this.value.map(el => optionsToSearch.find(opt => opt.id === el.id))
       this.selectedBefore = this.selected
+      this.selectOptions = optionsToSearch
     },
 
     save () {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33012

**Description:**  This PR fixes the issue with an empty tags dropdown. The options for the DpMultiselect need to be passed correctly, with the data structure: {id: '', name: ''}.

- convert the data before passing it to the multiselect

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
