### PR TITLE
F remove fs margin

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -213,7 +213,7 @@
 
         <button
           v-if="isAssignedToMe"
-          class="segment-list-toolbar__button btn btn--primary"
+          class="segment-list-toolbar__button btn btn--primary icon-only"
           data-cy="segmentEdit"
           :aria-label="Translator.trans('edit')"
           v-tooltip="{

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_segmentlist.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_segmentlist.scss
@@ -31,7 +31,7 @@ $utility-border-thickness: $dp-border-thickness;
             background-color: $dp-color-selection-bg;
         }
 
-        &--assigned + .segment-list-row--assigned {
+        &--assigned + .segment-list-row--assigned:not(.fullscreen) {
             margin-top: $inuit-base-spacing-unit--tiny;
         }
 


### PR DESCRIPTION
This corrects some margin-top in fullscreen mode, as well as a strangely misplaced icon.

### How to review/test
in ewm, go to the "Erwiderungen verfassen"-view of a statemet  that already has segments.

- the button which opens the edit mode should be not padded strangely. it should look this way:
![image](https://github.com/demos-europe/demosplan-core/assets/40452344/7fc33732-fb9e-44ce-b0a8-ca3549102e72)

- proceed to fullscreen mode. there should not be any margin-top above the light blue area

