### PR TITLE
chore(refs T32012): Remove unnecessary Use of vuex

### DIFF
--- a/client/js/InitVue.js
+++ b/client/js/InitVue.js
@@ -29,12 +29,10 @@ import HamburgerMenuButton from './components/button/HamburgerMenuButton'
 import NotifyContainer from '@DpJs/components/shared/NotifyContainer'
 import PortalVue from 'portal-vue'
 import Vue from 'vue'
-import Vuex from 'vuex'
 
 loadSentry()
 // Add plugins to Vue instance
 Vue.use(PortalVue)
-Vue.use(Vuex)
 Vue.use(DPVueCorePlugin)
 
 // Register components that are used globally

--- a/client/js/VueConfigLocal.js
+++ b/client/js/VueConfigLocal.js
@@ -21,7 +21,6 @@ import { DpMultiselect, DpObscure } from '@demos-europe/demosplan-ui'
 import lscache from 'lscache'
 import PortalVue from 'portal-vue'
 import { VTooltip } from 'v-tooltip'
-import Vuex from 'vuex'
 
 /*
  * This is copied from DpVueCore.js
@@ -78,7 +77,6 @@ global.dplan = dplan
 // Add plugins to Vue instance
 Vue.use(PortalVue)
 
-Vue.use(Vuex)
 Vue.use(DPVueCorePlugin)
 
 Vue.directive('tooltip', VTooltip)


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32012 

For some reason we initiallized vuex a couple of times.
In the End we don't have to init it at all because the vuex-json-api-lib does it for us.

In vue3 initializing it more than once throws an error. That didn't happen in vue2