### PR TITLE
fix(refs T31372): Add Missing Confirmmassge when creating a manual STN

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -210,6 +210,10 @@ class DemosPlanAssessmentController extends BaseController
                 }
 
                 if ($newStatement instanceof Statement) {
+                    $this->getMessageBag()->add(
+                        'confirm', 'confirm.statement.saved',
+                    );
+
                     return $this->redirectToRoute(
                         'DemosPlan_statement_new_submitted',
                         ['procedureId' => $procedureId]


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31372

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Goto `statement/new/manual/<procedure-id>` and create a new manual statement. You should now see a confirm-message


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

