### PR TITLE
fix (refs T33142): Add submitDate and authoredDate to export of state…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -1780,7 +1780,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
      */
     public function getSubmitDateString()
     {
-        return null === $this->submit ? '' : $this->getSubmitObject()->format('d-m-Y');
+        return null === $this->getSubmitObject() ? '' : $this->getSubmitObject()->format('d.m.Y');
     }
 
     /**
@@ -3384,7 +3384,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, SegmentInterf
             return '';
         }
 
-        return null === $this->getMeta()->getAuthoredDateObject() ? '' : $this->getMeta()->getAuthoredDateObject()->format('d-m-Y');
+        return null === $this->getMeta()->getAuthoredDateObject() ? '' : $this->getMeta()->getAuthoredDateObject()->format('d.m.Y');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -102,36 +102,47 @@ class SegmentsExporter
     protected function addStatementInfo(Section $section, Statement $statement): void
     {
         $table = $section->addTable($this->styles['statementInfoTable']);
-
         $orgaInfoHeader = new ExportOrgaInfoHeader($statement, $this->currentUser, $this->translator);
 
-        $row1 = $table->addRow();
-        $this->addSegmentCell($row1, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row1, '', $this->styles['statementInfoEmptyCell']);
-        $creationDate = $statement->getCreated()->format('d.m.Y');
-        $creationText = $this->translator->trans('segments.export.statement.creation.date', ['date' => $creationDate]);
-        $this->addSegmentCell($row1, $creationText, $this->styles['statementInfoTextCell']);
+        if ('' !==  $statement->getAuthoredDateString()) {
+            $authoredDateRow = $table->addRow();
+            $this->addSegmentCell($authoredDateRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($authoredDateRow, '', $this->styles['statementInfoEmptyCell']);
+            $authoredAt = $this->translator->trans('statement.date.authored').': '.$statement->getAuthoredDateString();
+            $this->addSegmentCell($authoredDateRow, $authoredAt, $this->styles['statementInfoTextCell']);
+        }
 
-        $row2 = $table->addRow();
-        $this->addSegmentCell($row2, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row2, '', $this->styles['statementInfoEmptyCell']);
+        if ('' !==  $statement->getSubmitDateString()) {
+            $submitDateRow = $table->addRow();
+            $this->addSegmentCell($submitDateRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($submitDateRow, '', $this->styles['statementInfoEmptyCell']);
+            $submittedAt = $this->translator->trans('statement.date.submitted').': '.$statement->getSubmitDateString();
+            $this->addSegmentCell($submitDateRow, $submittedAt, $this->styles['statementInfoTextCell']);
+        }
+
+        $textRow = $table->addRow();
+        $this->addSegmentCell($textRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($textRow, '', $this->styles['statementInfoEmptyCell']);
         $externIdText = $this->translator->trans('segments.export.statement.extern.id', ['externId' => $statement->getExternId()]);
-        $this->addSegmentCell($row2, $externIdText, $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($textRow, $externIdText, $this->styles['statementInfoTextCell']);
 
-        $row3 = $table->addRow();
-        $this->addSegmentCell($row3, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row3, '', $this->styles['statementInfoEmptyCell']);
-        $internIdText = $this->translator->trans('segments.export.statement.intern.id', ['internId' => $statement->getInternId()]);
-        $this->addSegmentCell($row3, $internIdText, $this->styles['statementInfoTextCell']);
+        if (null !== $statement->getInternId() && '' !== $statement->getInternId()) {
+            $internIdRow = $table->addRow();
+            $this->addSegmentCell($internIdRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($internIdRow, '', $this->styles['statementInfoEmptyCell']);
+            $internIdText = $this->translator->trans('segments.export.statement.intern.id', ['internId' => $statement->getInternId()]);
+            $this->addSegmentCell($internIdRow, $internIdText, $this->styles['statementInfoTextCell']);
+        }
 
-        $row4 = $table->addRow();
-        $this->addSegmentCell($row4, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row4, '', $this->styles['statementInfoEmptyCell']);
-        $this->addSegmentCell($row4, '', $this->styles['statementInfoTextCell']);
-
+        //formation only
         $row5 = $table->addRow();
         $this->addSegmentCell($row5, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
         $this->addSegmentCell($row5, '', $this->styles['statementInfoEmptyCell']);
+        $this->addSegmentCell($row5, '', $this->styles['statementInfoTextCell']);
+
+        $row6 = $table->addRow();
+        $this->addSegmentCell($row6, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($row6, '', $this->styles['statementInfoEmptyCell']);
 
         $section->addTextBreak(2);
     }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2879,7 +2879,6 @@ segments.bulk.edit.recommendations.warning.empty.text.replace: |
     }
 segments.export.pagination: "Seite {PAGE} von {NUMPAGES}"
 segments.export.segment.id: "Abschnitts-ID"
-segments.export.statement.creation.date: "Einwendung/Stellungnahme vom {date}"
 segments.export.statement.export.date: "Synopse vom {date}"
 segments.export.statement.extern.id: "ID: {externId}"
 segments.export.statement.intern.id: "Eingangsnummer: {internId}"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33142

Add submitDate and authoredDate to export of statements/segments if given.

- only add rows in case of content is given.
- remove unused translation
- rename variables to enhance readability

### How to review/test
Export Statements/Segments as described in the related Ticket.

### PR Checklist
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
