### PR TITLE
fix (refs T33109): Fix adding of similar statement submitters

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -3043,8 +3043,9 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
             if ($newOriginalStatement instanceof Statement) {
                 $assessableStatement = $this->createNonOriginalStatement($originalStatement, $newOriginalStatement);
 
-                if ($assessableStatement instanceof Statement && $this->permissions->hasPermission('feature_similar_statement_submitter')) {
+                if ($this->permissions->hasPermission('feature_similar_statement_submitter')) {
                     $this->attachSimilarStatementSubmitters($assessableStatement, $data);
+                    $this->statementService->updateStatementObject($assessableStatement);
                 }
 
                 /** @var ManualStatementCreatedEvent $assessableStatementEvent */


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33109

Flush similar statement submitter on create a new statement, to ensure added submitters, will be stored in DB.


### PR Checklist
- [x] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
