### PR TITLE
Change config to use tailwind

### DIFF
--- a/client/fe/config/config.js
+++ b/client/fe/config/config.js
@@ -82,7 +82,8 @@ class Config {
           /split-statement/
         ],
         greedy: [
-          /tooltip/
+          /tooltip/,
+          /swagger-ui/
         ]
       }
     }

--- a/client/fe/config/config.js
+++ b/client/fe/config/config.js
@@ -75,7 +75,7 @@ class Config {
           /ol-.+/,
           /plyr-.+/,
           /uppy-.+/,
-          /color-.+/,
+          /^color-.+/,
           /tabs-component.*/
         ],
         deep: [
@@ -90,7 +90,7 @@ class Config {
     this.cssPrefixExcludes = {
       externalClassPrefixes: [
         'ad-', // Classes for the a11y-datepicker
-        'cc-', // Classes for the cookieconsent banner (cc-banner etc)
+        'cc-', // Classes for the cookie consent banner (cc-banner etc)
         'ol-', // Classes for open layers (to prevent our overrides)
         'plupload_', // Classes for plUpload (to prevent our overrides)
         'v-tooltip', // V-tooltip

--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -125,23 +125,29 @@ const moduleRules =
           loader: 'css-loader',
           options: {
             /*
-             * The importLoaders option gets postcss-loader to also process css imports.
+             * "importLoaders: 1" gets postcss-loader to also process css imports.
              * @see https://webpack.js.org/loaders/css-loader/#importloaders
              * However when omitting the .css extension from the @imported css files,
              * sass-loader will treat the import like a scss file, inlining it
              * instead of leaving the css @import unprocessed as a native import.
              * @see https://github.com/webpack-contrib/sass-loader/issues/101#issuecomment-128684387
              */
-            importLoaders: 1,
+            importLoaders: config.isProduction === true ? 1 : 0,
+            sourceMap: false,
             url: false
           }
         },
         {
           loader: 'postcss-loader',
           options: {
-            postcssOptions: {
-              plugins: postCssPlugins
-            }
+            postcssOptions: (loaderContext) => {
+              // Do not pass 3rd party css through postCss in dev mode to gain some speed
+              const skipPostCss = /node_modules/.test(loaderContext.resourcePath) && config.isProduction === false
+              return {
+                plugins: skipPostCss ? [] : postCssPlugins
+              }
+            },
+            sourceMap: false
           }
         },
         {

--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -6,7 +6,6 @@
  *
  * All rights reserved
  */
-
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const config = require('../config/config').config
 const resolveDir = require('./util').resolveDir
@@ -153,7 +152,7 @@ const moduleRules =
         {
           loader: 'sass-loader',
           options: {
-            implementation: require('sass'),
+            implementation: require('sass-embedded'),
             additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
             sassOptions: {
               includePaths: [

--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -96,13 +96,6 @@ if (config.cssPurge.enabled) {
 const moduleRules =
   [
     {
-      test: /\.css$/,
-      use: [
-        MiniCssExtractPlugin.loader,
-        'vue-loader'
-      ]
-    },
-    {
       test: /\.vue$/,
       loader: 'vue-loader'
     },
@@ -127,24 +120,19 @@ const moduleRules =
     {
       test: /\.s?css$/,
       use: [
-        {
-          loader: 'vue-style-loader'
-        },
-        {
-          loader: MiniCssExtractPlugin.loader,
-          // Output path is declared in the plugin due to weird webpack path declarations
-          options: {
-            /*
-             * You can specify a publicPath here
-             * by default it uses publicPath in webpackOptions.output
-             */
-            esModule: false,
-            publicPath: '../../css/'
-          }
-        },
+        MiniCssExtractPlugin.loader,
         {
           loader: 'css-loader',
           options: {
+            /*
+             * The importLoaders option gets postcss-loader to also process css imports.
+             * @see https://webpack.js.org/loaders/css-loader/#importloaders
+             * However when omitting the .css extension from the @imported css files,
+             * sass-loader will treat the import like a scss file, inlining it
+             * instead of leaving the css @import unprocessed as a native import.
+             * @see https://github.com/webpack-contrib/sass-loader/issues/101#issuecomment-128684387
+             */
+            importLoaders: 1,
             url: false
           }
         },

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -88,6 +88,7 @@ const bundlesConfig = merge(baseConfig, {
     return {
       style: config.stylesEntryPoint,
       'style-public': config.publicStylesEntryPoint,
+      'demosplan-ui': './node_modules/@demos-europe/demosplan-ui/style/style.css',
       ...bundleEntryPoints(config.clientBundleGlob)
     }
   },

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -6,7 +6,6 @@
  *
  * All rights reserved
  */
-
 const merge = require('webpack-merge').default
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const DefinePlugin = require('webpack').DefinePlugin
@@ -63,7 +62,7 @@ const baseConfig = {
       timers: require.resolve('timers-browserify'),
       /*
        * Prevent webpack from injecting useless setImmediate polyfill because Vue
-       * source contains it (although only uses it if it's native).
+       * source contains it (although it only uses it if it's native).
        */
       setImmediate: false,
       /*

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/_settings-color.dplan.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/_settings-color.dplan.scss
@@ -18,10 +18,10 @@
 
 // Color tokens from demosplan-ui.
 
-@import '@demos-europe/demosplan-ui/tokens/scss/color.palette';
-@import '@demos-europe/demosplan-ui/tokens/scss/color.data';
-@import '@demos-europe/demosplan-ui/tokens/scss/color.brand';
-@import '@demos-europe/demosplan-ui/tokens/scss/color.ui';
+@import '~@demos-europe/demosplan-ui/tokens/scss/color.palette';
+@import '~@demos-europe/demosplan-ui/tokens/scss/color.data';
+@import '~@demos-europe/demosplan-ui/tokens/scss/color.brand';
+@import '~@demos-europe/demosplan-ui/tokens/scss/color.ui';
 
 
 // Variables that are not defined in demosplan-ui but used globally within demosplan.

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
@@ -7,6 +7,7 @@
 //  All rights reserved
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+
 // INUIT 5
 
 // Because inuitcss is broken apart into lots of small, composable modules, it is important that you as
@@ -23,6 +24,16 @@
 // Read more about inuit: https://github.com/inuitcss/inuitcss
 
 
+// Tailwind
+
+// This project is in the process of migrating from INUIT 5 to Tailwind.
+// A custom Tailwind build is separately included in the 'demosplan-ui' entrypoint. It contains...
+// - Tailwind Preflight, an opinionated set of base styles (see https://tailwindcss.com/docs/preflight)
+// - Tailwind Utility Classes (to be configured by demosplan-ui design tokens).
+// As Tailwind is configured to use !important everywhere, its utility classes should always win,
+// at least if not outpaced by even higher specificity.
+
+
 // This file is imported from projects/<project>/app/Resources/DemosPlanCoreBundle/client/scss/style.scss
 // after importing the following files, which declare all variables needed for project specific style compilation:
 // - settings-color.project.dplan
@@ -31,9 +42,6 @@
 // - <core>/settings-fonts.dplan
 // - settings.project.dplan
 
-// Styles from demosplan-ui (Tailwindcss)
-// @TODO make purgeCss work for tailwind styles. After that, we can start adopting tailwind in demosPlan.
-// @import url('~demosplan-ui/style/style.css');
 
 // Design tokens - the visual atoms of the demosplan-ui design system.
 // The files are included here to make tokens available to objects and components.
@@ -62,14 +70,9 @@
 @import 'inuit-5/tools.widths';
 
 // Generic
-@import 'inuit-5/generic.box-sizing';
-@import '~normalize.css/normalize.css';
-@import 'inuit-5/generic.reset';
 @import 'inuit-5/generic.shared';
 
 // Base (Elements)
-@import 'inuit-5/base.images';
-@import 'inuit-5/base.lists';
 @import 'inuit-5/base.page';
 @import 'base.dplan';
 
@@ -89,6 +92,7 @@
 @import 'trumps-3rd-party-resets.dplan';
 @import 'inuit-5/trumps.widths';
 @import 'inuit-5/trumps.widths-responsive';
+
 
 // After including core_style.scss (this file), the project style.scss file that serves as an entry point for style
 // compilation also includes two more project specific files, which contain project overrides on a very specific level:

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
@@ -47,9 +47,9 @@
 // The files are included here to make tokens available to objects and components.
 // Color tokens are imported within _settings-color.dplan.sss.
 // Color tokens may be overridden from within <project-scss-path>/settings-color.project.dplan
-@import '@demos-europe/demosplan-ui/tokens/scss/boxShadow';
-@import '@demos-europe/demosplan-ui/tokens/scss/fontSize';
-@import '@demos-europe/demosplan-ui/tokens/scss/rounded';
+@import '~@demos-europe/demosplan-ui/tokens/scss/boxShadow';
+@import '~@demos-europe/demosplan-ui/tokens/scss/fontSize';
+@import '~@demos-europe/demosplan-ui/tokens/scss/rounded';
 
 // Base settings, sync inuit with demosplan settings
 @import 'settings.dplan';

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0",
+    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#94b7714",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "postcss-prefix-selector": "^1.16.0",
     "postcss-preset-env": "^8.3.2",
     "purgecss-webpack-plugin": "^5.0.0",
-    "sass": "^1.62.0",
+    "sass-embedded": "^1.62.0",
     "sass-loader": "^13.3.1",
     "source-map-loader": "^4.0.1",
     "stylelint": "^14.16.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "github:demos-europe/demosplan-ui#94b7714",
+    "@demos-europe/demosplan-ui": "^0",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "lscache": "^1.3.2",
-    "normalize.css": "^8.0.1",
     "ol": "~7.3.0",
     "plyr": "^3.7.8",
     "portal-vue": "^2.1.7",

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -31,7 +31,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundle('style.css') }}
+            {{ webpackBundles(['demosplan-ui.css', 'style.css']) }}
         {% endblock stylesheets %}
 
         {% block component_header %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
@@ -28,7 +28,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundle('style-public.css') }}
+            {{ webpackBundles(['demosplan-ui.css', 'style-public.css']) }}
         {% endblock stylesheets %}
 
         {% block component_header %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,10 +1432,9 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz#c9c61d9fe5ca5ac664e1153bb0aa0eba1c6d6308"
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
-"@demos-europe/demosplan-ui@^0":
+"@demos-europe/demosplan-ui@github:demos-europe/demosplan-ui#94b7714":
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.3.tgz#7a7a99c6b74a8d7aba8f1215ce09795bf4a39ac7"
-  integrity sha512-6jPXqb9Stg/CjiqTDIaCM0h2hb5Y/C7wJ0jpE86P8k7Uq5b3oIXGe18GBVO+dx6GL/9zy4ZMfQyD6fwnhpIpYg==
+  resolved "https://codeload.github.com/demos-europe/demosplan-ui/tar.gz/94b771441572b88499031a4b6aaa69f5631695e9"
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6678,11 +6678,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
-normalize.css@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
-  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
-
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,9 +1118,9 @@
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
 "@babel/runtime@^7.13.10":
-  version "7.22.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
-  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1438,9 +1438,9 @@
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
 "@demos-europe/demosplan-ui@^0":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.3.tgz#7a7a99c6b74a8d7aba8f1215ce09795bf4a39ac7"
-  integrity sha512-6jPXqb9Stg/CjiqTDIaCM0h2hb5Y/C7wJ0jpE86P8k7Uq5b3oIXGe18GBVO+dx6GL/9zy4ZMfQyD6fwnhpIpYg==
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.5.tgz#66949478955c3324e774ac43f97bb5f23ee65b94"
+  integrity sha512-89QxpvgmEpFiURXaigkDA+0m+Qx49J0zDgbuAvEHUZa7ef09OKnDL4urHRI2FlmJNvkL1jVWwNTnYwN74nUF2g==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"
@@ -3244,10 +3244,15 @@ core-js-compat@^3.25.1, core-js-compat@^3.30.1, core-js-compat@^3.30.2:
   dependencies:
     browserslist "^4.21.5"
 
-core-js@3, core-js@^3.26.1, core-js@^3.30.2, core-js@^3.6.5:
+core-js@3, core-js@^3.30.2:
   version "3.30.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"
   integrity sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==
+
+core-js@^3.26.1, core-js@^3.6.5:
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.31.0.tgz#4471dd33e366c79d8c0977ed2d940821719db344"
+  integrity sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==
 
 cosmiconfig@^7.1.0:
   version "7.1.0"
@@ -3819,7 +3824,12 @@ data-urls@^4.0.0:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^12.0.0"
 
-dayjs@^1.11.5, dayjs@^1.11.7:
+dayjs@^1.11.5:
+  version "1.11.8"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
+  integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
+
+dayjs@^1.11.7:
   version "1.11.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
@@ -7677,7 +7687,16 @@ prosemirror-schema-basic@^1.2.2:
   dependencies:
     prosemirror-model "^1.19.0"
 
-prosemirror-schema-list@^1.1.4, prosemirror-schema-list@^1.2.3:
+prosemirror-schema-list@^1.1.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.3.0.tgz#05374702cf35a3ba5e7ec31079e355a488d52519"
+  integrity sha512-Hz/7gM4skaaYfRPNgr421CU4GSwotmEwBVvJh5ltGiffUJwm7C8GfN/Bc6DR1EKEp5pDKhODmdXXyi9uIsZl5A==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.7.3"
+
+prosemirror-schema-list@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.2.3.tgz#12e3d70cb17780980a3c28588ed7c888121d5e8d"
   integrity sha512-HD8yjDOusz7JB3oBFCaMOpEN9Z9DZttLr6tcASjnvKMc0qTyX5xgAN8YiMFFEcwyhF7WZrZ2YQkAwzsn8ICVbQ==
@@ -7695,7 +7714,18 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.1, pr
     prosemirror-transform "^1.0.0"
     prosemirror-view "^1.27.0"
 
-prosemirror-tables@^1.1.1, prosemirror-tables@^1.3.2:
+prosemirror-tables@^1.1.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.3.3.tgz#6074d9e0553961920f7ed8c8290277ba00b58641"
+  integrity sha512-t10hbu4sNDInic3AQYd8ouPN457zVJIhVDqSdqgsVXNoa1watYXBxqNSVrNQoGOFG4Ivreyp3hQE3KG1f9bSpw==
+  dependencies:
+    prosemirror-keymap "^1.1.2"
+    prosemirror-model "^1.8.1"
+    prosemirror-state "^1.3.1"
+    prosemirror-transform "^1.2.1"
+    prosemirror-view "^1.13.3"
+
+prosemirror-tables@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.3.2.tgz#ca208c6a55d510af14b652d23e800e00ba6bebd4"
   integrity sha512-/9JTeN6s58Zq66HXaxP6uf8PAmc7XXKZFPlOGVtLvxEd6xBP6WtzaJB9wBjiGUzwbdhdMEy7V62yuHqk/3VrnQ==
@@ -7706,10 +7736,10 @@ prosemirror-tables@^1.1.1, prosemirror-tables@^1.3.2:
     prosemirror-transform "^1.2.1"
     prosemirror-view "^1.13.3"
 
-prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.2.1, prosemirror-transform@^1.2.8:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.7.2.tgz#f3e57d8424afa6ab7c2b2319cc0ac58e75f7160b"
-  integrity sha512-b94lVUdA9NyaYRb2WuGSgb5YANiITa05dtew9eSK+KkYu64BCnU27WhJPE95gAWAnhV57CM3FabWXM23gri8Kg==
+prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.2.1, prosemirror-transform@^1.2.8, prosemirror-transform@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.7.3.tgz#cc2225cd1bf88a3c62404b9eb051ff73e9c716a6"
+  integrity sha512-qDapyx5lqYfxVeUWEw0xTGgeP2S8346QtE7DxkalsXlX89lpzkY6GZfulgfHyk1n4tf74sZ7CcXgcaCcGjsUtA==
   dependencies:
     prosemirror-model "^1.0.0"
 
@@ -9228,9 +9258,9 @@ w3c-hr-time@^1.0.2:
     browser-process-hrtime "^1.0.0"
 
 w3c-keyname@^2.2.0:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.7.tgz#e29549e9ac97ac5cb2993c8222994e97922ef377"
-  integrity sha512-XB8aa62d4rrVfoZYQaYNy3fy+z4nrfy2ooea3/0BnBzXW0tSdZ+lRgjzBZhk0La0H6h8fVyYCxx/qkQcAIuvfg==
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 w3c-xmlserializer@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,11 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
   integrity sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==
 
+"@bufbuild/protobuf@^1.0.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-1.2.1.tgz#f8b1fbbe79726a4eafa9772ddde147b57f85d177"
+  integrity sha512-cwwGvLGqvoaOZmoP5+i4v/rbW+rHkguvTehuZyM2p/xpmaNSdT2h3B7kHw33aiffv35t1XrYHIkdJSEkSEMJuA==
+
 "@csstools/cascade-layer-name-parser@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.2.tgz#35253f57c6c83d684fe396672486c644e6a84127"
@@ -1432,9 +1437,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz#c9c61d9fe5ca5ac664e1153bb0aa0eba1c6d6308"
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
-"@demos-europe/demosplan-ui@github:demos-europe/demosplan-ui#94b7714":
+"@demos-europe/demosplan-ui@^0":
   version "0.1.3"
-  resolved "https://codeload.github.com/demos-europe/demosplan-ui/tar.gz/94b771441572b88499031a4b6aaa69f5631695e9"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.3.tgz#7a7a99c6b74a8d7aba8f1215ce09795bf4a39ac7"
+  integrity sha512-6jPXqb9Stg/CjiqTDIaCM0h2hb5Y/C7wJ0jpE86P8k7Uq5b3oIXGe18GBVO+dx6GL/9zy4ZMfQyD6fwnhpIpYg==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"
@@ -2624,7 +2630,7 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -2912,11 +2918,6 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
 bluebird@^3.1.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -2942,7 +2943,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2970,6 +2971,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-builder@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-builder/-/buffer-builder-0.2.0.tgz#3322cd307d8296dab1f604618593b261a3fade8f"
+  integrity sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==
 
 buffer-from@^1.0.0, buffer-from@^1.1.2:
   version "1.1.2"
@@ -3044,21 +3050,6 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
-
-"chokidar@>=3.0.0 <4.0.0":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -4738,7 +4729,7 @@ fscreen@^1.2.0:
   resolved "https://registry.yarnpkg.com/fscreen/-/fscreen-1.2.0.tgz#1a8c88e06bc16a07b473ad96196fb06d6657f59e"
   integrity sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -4836,7 +4827,7 @@ glob-all@^3.3.1:
     glob "^7.2.3"
     yargs "^15.3.1"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -5267,13 +5258,6 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -5338,7 +5322,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -6674,7 +6658,7 @@ normalize-package-data@^3.0.0:
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -6951,7 +6935,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -7880,13 +7864,6 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
-
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -8078,6 +8055,13 @@ rw@1, rw@^1.3.3:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
+rxjs@^7.4.0:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -8097,6 +8081,66 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass-embedded-darwin-arm64@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.62.0.tgz#4179d60b8342257360380c3a7febd6c5c1f50266"
+  integrity sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==
+
+sass-embedded-darwin-x64@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.62.0.tgz#e3b2a588e110434022f791380d66cb4579d6936a"
+  integrity sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==
+
+sass-embedded-linux-arm64@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.62.0.tgz#8856545daf4616baf0e4b38a625e289b202e5f9b"
+  integrity sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==
+
+sass-embedded-linux-arm@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.62.0.tgz#545bdbb30cdb410345d4e50d6570be5b454a33c1"
+  integrity sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==
+
+sass-embedded-linux-ia32@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.62.0.tgz#943bafe6843fe0b91a681885d12a2e5d415f5149"
+  integrity sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==
+
+sass-embedded-linux-x64@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.62.0.tgz#906b38af47ade06dd8c08cbf018904619db44b67"
+  integrity sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==
+
+sass-embedded-win32-ia32@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.62.0.tgz#eaf59a67dc245787ce775087ed128a9c044c548a"
+  integrity sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==
+
+sass-embedded-win32-x64@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.62.0.tgz#032b67294dc968879e98976f36d75aef44f49a97"
+  integrity sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==
+
+sass-embedded@^1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.62.0.tgz#43cc1ee78d317b7bc090bb3edf89e965bdc64015"
+  integrity sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==
+  dependencies:
+    "@bufbuild/protobuf" "^1.0.0"
+    buffer-builder "^0.2.0"
+    immutable "^4.0.0"
+    rxjs "^7.4.0"
+    supports-color "^8.1.1"
+  optionalDependencies:
+    sass-embedded-darwin-arm64 "1.62.0"
+    sass-embedded-darwin-x64 "1.62.0"
+    sass-embedded-linux-arm "1.62.0"
+    sass-embedded-linux-arm64 "1.62.0"
+    sass-embedded-linux-ia32 "1.62.0"
+    sass-embedded-linux-x64 "1.62.0"
+    sass-embedded-win32-ia32 "1.62.0"
+    sass-embedded-win32-x64 "1.62.0"
+
 sass-loader@^13.3.1:
   version "13.3.1"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.1.tgz#32ee5791434b9b4dbd1adcce76fcb4cea49cc12c"
@@ -8104,15 +8148,6 @@ sass-loader@^13.3.1:
   dependencies:
     klona "^2.0.6"
     neo-async "^2.6.2"
-
-sass@^1.62.0:
-  version "1.62.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.62.1.tgz#caa8d6bf098935bc92fc73fa169fb3790cacd029"
-  integrity sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==
-  dependencies:
-    chokidar ">=3.0.0 <4.0.0"
-    immutable "^4.0.0"
-    source-map-js ">=0.6.2 <2.0.0"
 
 sax@>=0.6.0:
   version "1.2.4"
@@ -8295,7 +8330,7 @@ source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -8597,7 +8632,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -8854,6 +8889,11 @@ tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 tslib@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27594

This PR includes tailwind within demosplan. 

To test it, just run `yarn install`, followed by a `yarn dev:<project>`.

| build | time |
| --- | --- |
| no postcss-loader | 16s |
| with postcss-loader <- this was the status quo | 19s |
| no postcss-loader, with demosplan-ui | 26s |
| with postcss-loader, with demosplan-ui | 43s |
| with postcss-loader, with demosplan-ui, skip 3rd party css | 30s |
| **with postcss-loader, with demosplan-ui, skip 3rd party css, add sass-embedded** | **21s** |

So, at the moment this adds 2 seconds to the build.

### Todos

- [x] Update demosplan-ui to include the below PR

### Linked PRs

- https://github.com/demos-europe/demosplan-ui/pull/294
