### PR TITLE
Fix(refs T31372): Add ID to confirm message

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
@@ -17,9 +17,9 @@
         v-if="attachments.originalAttachment.hash"
         :attachment="attachments.originalAttachment" />
       <p
+        v-else
         class="color--grey"
-        v-text="Translator.trans('none')"
-        v-else />
+        v-text="Translator.trans('none')" />
     </div>
     <div class="space-stack-s">
       <dp-label
@@ -33,26 +33,27 @@
         </li>
       </ul>
       <p
+        v-else
         class="color--grey"
-        v-text="Translator.trans('none')"
-        v-else />
-      <dp-upload-files
-        :class="editable ? '' : 'pointer-events-none opacity-7'"
-        :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
-        ref="uploadStatementAttachment"
-        id="uploadStatementAttachment"
-        name="uploadStatementAttachment"
-        allowed-file-types="all"
-        :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
-        :max-number-of-files="1000"
-        :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '2GB' }) }"
-        @file-remove="removeFileId"
-        @upload-success="setFileId" />
-      <dp-button
-        :busy="isProcessing"
-        :disabled="fileIds.length === 0"
-        :text="Translator.trans('save')"
-        @click="save('generic')" />
+        v-text="Translator.trans('none')" />
+      <template v-if="editable">
+        <dp-upload-files
+          :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+          ref="uploadStatementAttachment"
+          id="uploadStatementAttachment"
+          name="uploadStatementAttachment"
+          allowed-file-types="all"
+          :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
+          :max-number-of-files="1000"
+          :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '2GB' }) }"
+          @file-remove="removeFileId"
+          @upload-success="setFileId" />
+        <dp-button
+          :busy="isProcessing"
+          :disabled="fileIds.length === 0"
+          :text="Translator.trans('save')"
+          @click="save('generic')" />
+      </template>
     </div>
   </div>
 </template>
@@ -78,8 +79,8 @@ export default {
     },
 
     /**
-     * Editable can be used to disable DpUploadFiles on css level
-     * but keep the uploaded files list accessible at the same time.
+     * When true upload files and save button will not be rendered,
+     * but the attachments are still shown
      */
     editable: {
       type: Boolean,

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -213,7 +213,7 @@
 
         <button
           v-if="isAssignedToMe"
-          class="segment-list-toolbar__button btn btn--primary"
+          class="segment-list-toolbar__button btn btn--primary icon-only"
           data-cy="segmentEdit"
           :aria-label="Translator.trans('edit')"
           v-tooltip="{

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -210,6 +210,10 @@ class DemosPlanAssessmentController extends BaseController
                 }
 
                 if ($newStatement instanceof Statement) {
+                    $this->getMessageBag()->add(
+                        'confirm', 'confirm.statement.saved',
+                    );
+
                     return $this->redirectToRoute(
                         'DemosPlan_statement_new_submitted',
                         ['procedureId' => $procedureId]

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -211,7 +211,7 @@ class DemosPlanAssessmentController extends BaseController
 
                 if ($newStatement instanceof Statement) {
                     $this->getMessageBag()->add(
-                        'confirm', 'confirm.statement.saved',
+                        'confirm', 'confirm.statement.new', ['externId' => $newStatement->getExternId()]
                     );
 
                     return $this->redirectToRoute(

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -677,8 +677,10 @@ class DraftStatementService extends CoreService
     /**
      * Stellungsnahmen werden eingereicht.
      *
-     * Nach dem Aufruf haben sich folgende Werte der Stellungsnahmen geändert:
+     * After calling this method - the following attributes of the draft-statement(s) will be altered:
      * submitted = true
+     * rejected = false
+     * rejectedReason = ''
      *
      * @param string|array $draftStatementIds
      * @param User         $user
@@ -748,10 +750,12 @@ class DraftStatementService extends CoreService
             }
 
             $data = [
-                'ident'         => $draftStatementId,
-                'submitted'     => true,
-                'released'      => true,
-                'submittedDate' => new DateTime(),
+                'ident'             => $draftStatementId,
+                'submitted'         => true,
+                'released'          => true,
+                'submittedDate'     => new DateTime(),
+                'rejected'          => false,
+                'rejectedReason'    => '',
             ];
 
             $draftStatement = $this->updateDraftStatement($data, false);

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_segmentlist.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_segmentlist.scss
@@ -31,7 +31,7 @@ $utility-border-thickness: $dp-border-thickness;
             background-color: $dp-color-selection-bg;
         }
 
-        &--assigned + .segment-list-row--assigned {
+        &--assigned + .segment-list-row--assigned:not(.fullscreen) {
             margin-top: $inuit-base-spacing-unit--tiny;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
@@ -141,14 +141,16 @@
                 line-height: 27px;
                 text-align: center;
 
+                cursor: pointer;
+
                 &:not(:last-child) {
                     margin-right: 1px;
                 }
 
                 &.active,
                 &:hover {
-                    @extend %tabs-btn-color;
-                    background: $dp-color-main;
+                    background-color: $dp-color-main;
+                    color: $dp-color-main-contrast;
                 }
             }
         }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
@@ -82,7 +82,7 @@
     %fileName:{{ statement.mapFile|getFile('name')|raw }}:{{ statement.mapFile|getFile('hash') }}%
     \caption{Kartenauschnitt}
 	\label{fig1}
-        {{ procedure.settings.copyright }}
+        {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')}) }}
     \end{figure}
     {% endif %}
     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/statement_macros.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/statement_macros.tex.twig
@@ -20,7 +20,7 @@
             %fileName:{{ statement.mapFile|getFile('name')|raw }}:{{ statement.mapFile|getFile('hash') }}%
             \caption{Kartenauschnitt}
             \label{fig1}
-                {{ procedure.settings.copyright|latex|raw }}
+                {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
             \end{figure}
         {% endif %}
     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry.tex.twig
@@ -22,7 +22,7 @@
 \caption {Kartenauschnitt}
 \label{{ '{' }}fig1{{ '}' }}
 %fileName:{{ statement.mapFile|getFile('name')|wysiwyg }}:{{ statement.mapFile|getFile('hash') }}%
-    {{ procedure.settings.copyright|latex|raw }}
+    {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
 {% endif %}
 {% endif %}
 \ParallelRText{{ '{}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
@@ -39,7 +39,7 @@
         \caption {Kartenauschnitt}
         \label{{ '{' }}fig1{{ '}' }}
         %fileName:{{ statement.mapFile|getFile('name')|wysiwyg }}:{{ statement.mapFile|getFile('hash') }}%
-        {{ procedure.settings.copyright|latex|raw }}
+        {{ procedure.settings.copyright|replace({'{currentYear}': 'now'|date('Y')})|latex|raw }}
         \end{figure}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31372

After creating a new manuall statement the confirmmessage should include the external Id, so the User knows about it. 


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
