### PR TITLE
fix: Change check for response status

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1265,7 +1265,7 @@ export default {
            * Handling for successful responses
            * if its not an HTML-Response like after creating a new one
            */
-          if (response.statusText === 'OK') {
+          if (response.status === 200) {
             dplan.notify.notify('confirm', Translator.trans('confirm.statement.saved'))
 
             this.updateInitialFilesAfterSave()


### PR DESCRIPTION
For some reasons, the good old wy to check against OK doesn't work on one instance. checking against 200 is better anyway