### PR TITLE
chore: remove unused twig block

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -618,9 +618,3 @@
         }
     </script>
 {% endblock javascripts %}
-
-{% block base_side -%}
-    {% if app.user.loggedIn == true %}
-        {{- parent() -}}
-    {% endif %}
-{%- endblock %}


### PR DESCRIPTION
Twig block base_side is not used any more, therefore it can be deleted


### How to review/test
search for block base_side

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
