### PR TITLE
chore: provide loggedin to security user to be able to use app.user.loggedin in twig

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -78,5 +79,10 @@ final class SecurityUser implements UserInterface, EquatableInterface, PasswordA
         }
 
         return true;
+    }
+
+    public function isLoggedIn(): bool
+    {
+        return !in_array(RoleInterface::GUEST, $this->roles, true);
     }
 }


### PR DESCRIPTION
Some twig templates use app.user.loggedin to receive the login status of a user. With the refactoring to a distinct SecurityUser this was broken.

### How to review/test
Call any page in dev mode where app.user.loggedin is used in twig like paragraph detail page in public detail

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
