### PR TITLE
chore: use distinct addon contract version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "demos-europe/edt-dql": "^0.16.0",
         "demos-europe/edt-extra": "^0.16.0",
         "demos-europe/edt-paths": "^0.16.0",
-        "demos-europe/demosplan-addon": "dev-main",
+        "demos-europe/demosplan-addon": "^0.1.0",
         "doctrine/annotations": "^1.13",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d1d63fafb03dc565231a9a5ac8daaf4",
+    "content-hash": "dd190e111aaa9099f30389e263b08f2d",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1289,16 +1289,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "dev-main",
+            "version": "v0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "2a756de9774c3996117bcfb16d6e9f4bec65e504"
+                "reference": "f289d3031104e248319fb2f49a7f2f2b0b967dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/2a756de9774c3996117bcfb16d6e9f4bec65e504",
-                "reference": "2a756de9774c3996117bcfb16d6e9f4bec65e504",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/f289d3031104e248319fb2f49a7f2f2b0b967dd3",
+                "reference": "f289d3031104e248319fb2f49a7f2f2b0b967dd3",
                 "shasum": ""
             },
             "require": {
@@ -1322,7 +1322,6 @@
                 "composer/composer": "^2.1",
                 "phpstan/phpstan": "^1.9"
             },
-            "default-branch": true,
             "type": "package",
             "autoload": {
                 "psr-4": {
@@ -1335,9 +1334,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/main"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.1"
             },
-            "time": "2023-06-15T12:00:18+00:00"
+            "time": "2023-06-16T13:59:12+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",
@@ -22148,9 +22147,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "demos-europe/demosplan-addon": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
We want to use a distinct version of the addon contracts to be safe about the code used.

### How to review/test
run `composer update demos-europe/demosplan-addon` and be sure that v0.1 is installed

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-documentation/pull/34

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
