### PR TITLE
fix(refs T33234): Remove incorrect late permission evaluation

### DIFF
--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -109,7 +109,6 @@ export default {
   computed: {
     availableImportOptions () {
       return [
-        ...this.asyncComponents,
         {
           name: ExcelImport.name,
           permissions: ['feature_statements_import_excel', 'feature_segments_import_excel'],
@@ -122,7 +121,7 @@ export default {
         }
       ].filter((component) => {
         return hasAnyPermissions(component.permissions)
-      })
+      }).concat(this.asyncComponents)
     }
   },
 
@@ -162,7 +161,6 @@ export default {
 
             this.asyncComponents.push({
               name: addon.entry,
-              permissions: ['feature_statements_import_excel'],
               title: addon.options.title
             })
           }

--- a/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
@@ -65,6 +65,10 @@ final class FrontendAssetProvider
                 return [];
             }
 
+            // TODO: filter assets based on their permission to only send
+            //       usable addons to the client and relieve ourselves from outer
+            //       permission checks in addon components
+
             return $this->createAddonFrontendAssetsEntry($hookData, $assetContents);
         }, $this->registry->getAddonInfos());
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/33234

The addon hook configurations do not yet provide permission information. If we were to evaluate those, we should filter the scripts in the RPC method instead of loading all scripts on the users' machine and evaluating on the client side.

In addition, previously no import tabs would have been loadable from addons at all if the excel import were disabled.

Yes, I know this PR adds a TODO. Please be gentle with me. I created a [matching Ticket](https://yaits.demos-deutschland.de/T33332).

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
