### PR TITLE
feat(refs T33234): Add rudimentary support for exposing addon permissions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -1037,12 +1037,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             })
             ->all();
 
-        // Add addon permissions to list of core permissions. Not mixing them would be preferred,
-        // but this is currently needed to expose addon permissions to the frontend.
-        $this->permissions = collect($this->addonPermissionCollections)
-            ->flatMap(fn (ResolvablePermissionCollection $collection): array => $collection->getPermissions())
-            ->merge($this->corePermissions->toArray())
-            ->all();
+        $this->permissions = $this->corePermissions->toArray();
     }
 
     /**
@@ -1336,6 +1331,14 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 }
             }
         );
+    }
+
+    /**
+     * @return ResolvablePermissionCollection[]
+     */
+    public function getAddonPermissionCollections(): array
+    {
+        return $this->addonPermissionCollections;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermissionCollection.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermissionCollection.php
@@ -93,4 +93,12 @@ class ResolvablePermissionCollection implements ResolvablePermissionCollectionIn
             $this->permissions
         );
     }
+
+    /**
+     * @return ResolvablePermission[]
+     */
+    public function getResolvePermissions(): array
+    {
+        return $this->permissions;
+    }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33234

Addon permissions are not configured in the classic array way the core permissions are evaluated in. Thus, all addon permissions, while having been marked as exposed, were dropped when building the frontend permission list.

This change is only a rudimentary solution to exposing the addon permissions as the correct way would be to redo the permission checking in the frontend to include addon names and eventually use something more akin to hasPermission(name, context) with the context being core or an addon name

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
