### PR TITLE
fix: Allow complete permission evaluation without valid user

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
@@ -17,6 +17,7 @@ use DemosEurope\DemosplanAddon\Permission\Validation\PermissionFilterException;
 use DemosEurope\DemosplanAddon\Permission\Validation\PermissionFilterValidatorInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\EntityFetcher;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
@@ -147,6 +148,16 @@ class PermissionResolver implements PermissionFilterValidatorInterface
         // fulfill.
         if (null === $evaluationTarget) {
             return [] === $conditions;
+        }
+
+        if ($evaluationTarget instanceof FunctionalUser) {
+            foreach ($conditions as $condition) {
+                if (!$this->conditionEvaluator->evaluateCondition($evaluationTarget, $condition)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         $conditions[] = $this->conditionFactory->propertyHasValue($evaluationTarget->getId(), ['id']);


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33234

We cannot evaluate the permissions via the db without an existing user and need to revert to evaluating directly with edt


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
