### PR TITLE
fix remove unused permission

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -821,9 +821,6 @@ feature_export_protocol:
     label: 'Exportieren des Verfahrensprotokolls'
     loginRequired: true
     parent: area_admin_protocol
-feature_export_statement_with_datasheet:
-    label: 'Export einer Stellungnahme mit einem Datenblatt'
-    loginRequired: true
 feature_forum_dev_release_edit:
     description: 'Enables an user to edit the release entries in the development forum, which is sort of an parent entry for user-story discussions'
     label: 'edit release entry in development forum section'

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -371,7 +371,6 @@ class PermissionsTest extends FunctionalTestCase
                     'feature_documents_new_statement',
                     'feature_draft_statement_add_address_to_institutions',
                     'feature_element_export',
-                    'feature_export_statement_with_datasheet',
                     'feature_gdpr_consent_revoke_by_token',
                     'feature_has_logout_landing_page',
                     'feature_institution_tag_create',

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -33,7 +33,6 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
-use SplFixedArray;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Tests\Base\FunctionalTestCase;
 use Tests\Base\MockMethodDefinition;


### PR DESCRIPTION
Description: 
remove the permission 'feature_export_statement_with_datasheet': this permission ist not used and the datasheets related logic is already moved from core, it will be used as an addon in the relevant projects.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Update documentation
