### PR TITLE
chore: check phpstan levels 0-2 for PRs

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -3,4 +3,14 @@ runner:
 #        cmd: "node_modules/.bin/eslint -c config/linters/eslintrc.js demosplan client"
 
     phpstan:
-        cmd: "DEVELOPMENT_CONTAINER=1 php bin/test dplan:phpstan --ci -l2"
+        cmd: "DEVELOPMENT_CONTAINER=1 php bin/console dplan:phpstan --ci -l0"
+        format: "phpstan"
+        level: error
+    phpstan-level1:
+        cmd: "DEVELOPMENT_CONTAINER=1 php bin/console dplan:phpstan --ci -l1"
+        format: "phpstan"
+        level: error
+    phpstan-level2:
+        cmd: "DEVELOPMENT_CONTAINER=1 php bin/console dplan:phpstan --ci -l2"
+        format: "phpstan"
+        level: info


### PR DESCRIPTION
At the moment phpstan is only checked for level 2, failures in level 0 or 1 are not detected, which is counterintuitive

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
