### PR TITLE
bug(refs T33391): Fix z-index for tooltip

### DIFF
--- a/client/js/components/map/map/DpOlMapEditFeature.vue
+++ b/client/js/components/map/map/DpOlMapEditFeature.vue
@@ -210,11 +210,7 @@ export default {
     getZIndex (element) {
       const z = window.getComputedStyle(element).getPropertyValue('z-index')
       if (isNaN(z)) {
-        if (element.nodeName !== 'HTML') {
-          return this.getZIndex(element.parentNode)
-        } else {
-          return 1
-        }
+        return (element.nodeName === 'HTML') ? 1 : this.getZIndex(element.parentNode)
       }
 
       return z

--- a/client/js/components/map/map/DpOlMapEditFeature.vue
+++ b/client/js/components/map/map/DpOlMapEditFeature.vue
@@ -155,7 +155,7 @@ export default {
 
   computed: {
     tooltipClass () {
-      return this.zIndexSuper ? 'u-z-super' : null
+      return this.zIndexSuper ? 'u-z-super' : ''
     },
 
     map () {
@@ -210,7 +210,11 @@ export default {
     getZIndex (element) {
       const z = window.getComputedStyle(element).getPropertyValue('z-index')
       if (isNaN(z)) {
-        return this.getZIndex(element.parentNode)
+        if (element.nodeName !== 'HTML') {
+          return this.getZIndex(element.parentNode)
+        } else {
+          return 1
+        }
       }
 
       return z


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33391

- Return empty string instead of null if we don't need any tooltip classes, because otherwise v-tooltip gets internal errors
- Return 1 for z-index if all elements have z-index auto and stop recursion if outer element is reached (html)

### How to review/test
Go to Verfahren -> Planungsdokument und Planzeichnung -> Verfahren verorten. The tooltip for the edit map features (eg Auswählen und bearbeiten) should work (switch between the different tooltips) and there should be no warnings or errors in the console.