### PR TITLE
chore: only try to add constraint when it does not exist

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -29,10 +29,20 @@ class Version20230601095828 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->abortIfNotMysql();
+        $fkConstraints = $this->connection->createSchemaManager()->listTableForeignKeys('_statement');
+        $constraintExists = false;
+        foreach ($fkConstraints as $constraint) {
+            if ($constraint->getName() === 'FK_8D47F06B84040EA6') {
+                $constraintExists = true;
+                break;
+            }
+        }
 
         $this->addSql('SET foreign_key_checks = 0');
-        $this->addSql('ALTER TABLE _statement ADD CONSTRAINT FK_8D47F06B84040EA6 FOREIGN KEY (segment_statement_fk) REFERENCES _statement (_st_id)');
-        $this->addSql('CREATE INDEX IDX_8D47F06B84040EA6 ON _statement (segment_statement_fk)');
+        if (!$constraintExists) {
+            $this->addSql('ALTER TABLE _statement ADD CONSTRAINT FK_8D47F06B84040EA6 FOREIGN KEY (segment_statement_fk) REFERENCES _statement (_st_id)');
+            $this->addSql('CREATE INDEX IDX_8D47F06B84040EA6 ON _statement (segment_statement_fk)');
+        }
         $this->addSql('SET foreign_key_checks = 1');
     }
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/06/Version20230601095828.php
@@ -32,7 +32,7 @@ class Version20230601095828 extends AbstractMigration
         $fkConstraints = $this->connection->createSchemaManager()->listTableForeignKeys('_statement');
         $constraintExists = false;
         foreach ($fkConstraints as $constraint) {
-            if ($constraint->getName() === 'FK_8D47F06B84040EA6') {
+            if ('FK_8D47F06B84040EA6' === $constraint->getName()) {
                 $constraintExists = true;
                 break;
             }


### PR DESCRIPTION
When performing the migration on a just created database the index already exists. Obviously there are other cases as well, where the migration fails due to already existing constraint. We need to check the existence before creating it.
This PR alters an existing migration as it already leads to problems on multiple environments.

### How to review/test
You may manually delete the Migration Version20230601095828.php from the migrations database and perform migrations

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
