### PR TITLE
chore (refs T33424): avoid unnecessary user set

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -55,6 +55,7 @@ use Doctrine\ORM\TransactionRequiredException;
 use EDT\Querying\FluentQueries\FluentQuery;
 use Exception;
 use Symfony\Component\Validator\Validation;
+
 use function array_key_exists;
 use function array_merge;
 use function array_unique;

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -1362,9 +1362,9 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             $procedureSettings->setDesignatedPublicEndDate($convertedDate);
         }
 
-        if (array_key_exists('designatedPublicSwitchDate', $data['settings'])
-            || array_key_exists('designatedPublicPhase', $data['settings'])
-            || array_key_exists('designatedPublicEndDate', $data['settings'])) {
+        if (($data['settings']['designatedPublicSwitchDate'] ?? null) !== null
+        || ($data['settings']['designatedPublicPhase'] ?? null) !== null
+        || ($data['settings']['designatedPublicEndDate'] ?? null) !== null) {
             $procedureSettings->setDesignatedPublicPhaseChangeUser($data['currentUser']);
         }
     }
@@ -1388,9 +1388,9 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             $procedureSettings->setDesignatedEndDate($convertedDate);
         }
 
-        if (array_key_exists('designatedSwitchDate', $data['settings'])
-            || array_key_exists('designatedPhase', $data['settings'])
-            || array_key_exists('designatedEndDate', $data['settings'])) {
+        if (($data['settings']['designatedSwitchDate'] ?? null) !== null
+            || ($data['settings']['designatedPhase'] ?? null) !== null
+            || ($data['settings']['designatedEndDate'] ?? null) !== null) {
             $procedureSettings->setDesignatedPhaseChangeUser($data['currentUser']);
         }
     }


### PR DESCRIPTION
Ticket: https://yaits.demos-deutschland.de/T33424

Request keys are always set with value null which leads to an user set that is unnecessary. Moreover it lead to weird exceptions on one (and only one) environment. This way it is cleaner anyhow.

### How to review/test
Save procedure phases in procedure detail settings

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
