### PR TITLE
fix (refs T33375): Login as citizen via keycloak

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -75,7 +75,7 @@ class OzgKeycloakUserDataMapper
         'Support'                           => Role::PLATFORM_SUPPORT,
         'Plattform Administration'          => Role::CUSTOMER_MASTER_USER,
         'Redaktion'                         => Role::CONTENT_EDITOR,
-        'Privatperson/Angemeldet'           => Role::CITIZEN,
+        'Privatperson-Angemeldet'           => Role::CITIZEN,
         'Fachliche Leitstelle'              => Role::PROCEDURE_CONTROL_UNIT,
     ];
 
@@ -433,8 +433,10 @@ class OzgKeycloakUserDataMapper
             foreach ($rolesOfCustomer[$customer->getSubdomain()] as $roleName) {
                 $this->logger->info('Role found for subdomain '.$customer->getSubdomain().': '.$roleName);
                 if (array_key_exists($roleName, self::ROLETITLE_TO_ROLECODE)) {
+                    $this->logger->info('Role recognized: '.$roleName);
                     $recognizedRoleCodes[] = self::ROLETITLE_TO_ROLECODE[$roleName];
                 } else {
+                    $this->logger->info('Role not recognized: '.$roleName);
                     $unIdentifiedRoles[] = $roleName;
                 }
             }
@@ -446,6 +448,7 @@ class OzgKeycloakUserDataMapper
         if (0 === count($requestedRoles)) {
             throw new AuthenticationCredentialsNotFoundException('no roles could be identified');
         }
+        $this->logger->info('Finally recognized Roles: ', [$requestedRoles]);
 
         return $requestedRoles;
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33375

Citizen role needs to be renamed in keycloak as the / otherwise infers with the role extraction logic

### How to review/test
code review might be easiest

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
