### PR TITLE
Bump demosplan-ui to v0.1.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,9 +1438,9 @@
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
 "@demos-europe/demosplan-ui@^0":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.5.tgz#66949478955c3324e774ac43f97bb5f23ee65b94"
-  integrity sha512-89QxpvgmEpFiURXaigkDA+0m+Qx49J0zDgbuAvEHUZa7ef09OKnDL4urHRI2FlmJNvkL1jVWwNTnYwN74nUF2g==
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.6.tgz#90708b4c754fdc9366f563e2cc07d0fd5fc41148"
+  integrity sha512-kq8Jkk+r1yfGoQ3aIUCjolhHtne5p+NGkaNjcrg1Xtm58AuDb6on/CcYomMeXJGeOcRQZ0P4N7SluBP888pFlA==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"
@@ -2280,7 +2280,21 @@
     "@uppy/utils" "^5.3.0"
     namespace-emitter "^2.0.1"
 
-"@uppy/core@^3.0.1", "@uppy/core@^3.2.0":
+"@uppy/core@^3.0.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@uppy/core/-/core-3.2.1.tgz#5cf38508f674529ea8302c99cd42b5bb3d93cd21"
+  integrity sha512-vqNwhVcJb9N4Mx1AhDvq4YrjGzqQiy5i2YA2LP/NODVBowMnHK4+g/gFOkZF8dHnKwnvVizZK/vR1K6CXocrGg==
+  dependencies:
+    "@transloadit/prettier-bytes" "0.0.9"
+    "@uppy/store-default" "^3.0.3"
+    "@uppy/utils" "^5.4.0"
+    lodash "^4.17.21"
+    mime-match "^1.0.2"
+    namespace-emitter "^2.0.1"
+    nanoid "^4.0.0"
+    preact "^10.5.13"
+
+"@uppy/core@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@uppy/core/-/core-3.2.0.tgz#4ccd2110f7fd797fb5b13a3048880c77c5f40bd5"
   integrity sha512-w/jdNCIdmxt4uPt4UBPfzmQ7HanIE73GiKKeHtZo6Gp+HWOsUhY7DBimGUk3IsX/vMJTSB2+RhZAUOBGRaP5fA==
@@ -2316,20 +2330,20 @@
   integrity sha512-/zlvQNj4HjkthI+7dNdj/8mOlTg1Zb1gJ/ZsOxof0g3xXD+OAwm7asRnOwpfj2dos+lExdW/zMn8XsRGsuvb6Q==
 
 "@uppy/tus@^3.0.1":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@uppy/tus/-/tus-3.1.0.tgz#1080593a05ddf90ac3a00291ecfb74843dda33a3"
-  integrity sha512-oFSa6WtDv2yXO/U02wZ8pQEIxEdtBs5N80fi1anipiJASvNJ+pCrl812QDQLdd/roXJkg0jIEP4/8Eod2d6yGg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@uppy/tus/-/tus-3.1.1.tgz#5e0c8f771486e390b05fdaae5f4581d26c75e2c5"
+  integrity sha512-cwUgu23fHN3xXWQ/1bpMCD0Ib02iR2+ZtmMvhOKY/804j/g90Lo8cCpFu3ag+iTEpPpvGopqr0d/jAkxVWAFEw==
   dependencies:
     "@uppy/companion-client" "^3.1.3"
-    "@uppy/utils" "^5.3.0"
+    "@uppy/utils" "^5.4.0"
     tus-js-client "^3.0.0"
 
-"@uppy/utils@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@uppy/utils/-/utils-5.3.0.tgz#60803328536da73a11c8e747ed365c903b6a5f7e"
-  integrity sha512-tPW+HtRkjanFQAa/XD2e6kjJ7ZeMHtVxEVeBeRtKTnltsCA9kNF2gDwxtUVPEWyLrKzW+CvRm60NDiOKaWUuww==
+"@uppy/utils@^5.3.0", "@uppy/utils@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@uppy/utils/-/utils-5.4.0.tgz#1f0816334ef8cfe3eaaf7c6a1d3dc28ac9bbced8"
+  integrity sha512-X9f43OvTcymhoiDEzA2CqH7W5pADTVv2bhQ/9NUaVwYRLUadDjZc27ZgnNraKSYgnOhKFJlC63nyCwcd0yaQIQ==
   dependencies:
-    lodash.throttle "^4.1.1"
+    lodash "^4.17.21"
 
 "@vue/compiler-sfc@2.7.14":
   version "2.7.14"
@@ -7741,7 +7755,18 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.1, pr
     prosemirror-transform "^1.0.0"
     prosemirror-view "^1.27.0"
 
-prosemirror-tables@^1.1.1, prosemirror-tables@^1.3.3:
+prosemirror-tables@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.3.4.tgz#0b7cc16d49f90c5b834c9f29291c545478ce9ab0"
+  integrity sha512-z6uLSQ1BLC3rgbGwZmpfb+xkdvD7W/UOsURDfognZFYaTtc0gsk7u/t71Yijp2eLflVpffMk6X0u0+u+MMDvIw==
+  dependencies:
+    prosemirror-keymap "^1.1.2"
+    prosemirror-model "^1.8.1"
+    prosemirror-state "^1.3.1"
+    prosemirror-transform "^1.2.1"
+    prosemirror-view "^1.13.3"
+
+prosemirror-tables@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.3.3.tgz#6074d9e0553961920f7ed8c8290277ba00b58641"
   integrity sha512-t10hbu4sNDInic3AQYd8ouPN457zVJIhVDqSdqgsVXNoa1watYXBxqNSVrNQoGOFG4Ivreyp3hQE3KG1f9bSpw==


### PR DESCRIPTION
v0.1.6 contains some utility class changes that are needed to un-break things.

### How to review/test
Things should just work as before, but the search ui above the login list should not look broken anymore.