### PR TITLE
chore: Backmerge of release_ewm_3.0

### DIFF
--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -16,7 +16,7 @@
       <dp-multiselect
         v-if="availableGroupOptions.length > 1"
         :allow-empty="false"
-        :custom-label="props =>`${props.option.title}`"
+        :custom-label="option =>`${option.title}`"
         data-cy="selectedGroups"
         multiple
         :options="availableGroupOptions"

--- a/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
+++ b/client/js/components/procedure/AdministrationImport/AdministrationImport.vue
@@ -109,7 +109,6 @@ export default {
   computed: {
     availableImportOptions () {
       return [
-        ...this.asyncComponents,
         {
           name: ExcelImport.name,
           permissions: ['feature_statements_import_excel', 'feature_segments_import_excel'],
@@ -122,7 +121,7 @@ export default {
         }
       ].filter((component) => {
         return hasAnyPermissions(component.permissions)
-      })
+      }).concat(this.asyncComponents)
     }
   },
 
@@ -162,7 +161,6 @@ export default {
 
             this.asyncComponents.push({
               name: addon.entry,
-              permissions: ['feature_statements_import_excel'],
               title: addon.options.title
             })
           }

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -152,7 +152,9 @@
           {{ placesObject[rowData.relationships.place.data.id].attributes.name }}
         </template>
         <template v-slot:text="rowData">
-          <div v-cleanhtml="rowData.attributes.text" />
+          <div
+            v-cleanhtml="rowData.attributes.text"
+            class="overflow-word-break" />
         </template>
         <template v-slot:recommendation="rowData">
           <div v-cleanhtml="rowData.attributes.recommendation !== '' ? rowData.attributes.recommendation : '-'" />

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -68,7 +68,7 @@
         @click="toggleClaimSegment" />
     </div>
     <div
-      class="segment-list-col--l"
+      class="segment-list-col--l overflow-word-break"
       v-cleanhtml="visibleSegmentText" />
     <div class="segment-list-col--s">
       <button
@@ -85,7 +85,7 @@
           aria-hidden="true" />
       </button>
     </div>
-    <div class="segment-list-col--l">
+    <div class="segment-list-col--l overflow-word-break">
       <div
         v-if="isAssignedToMe === false"
         :class="{ 'color--grey': visibleRecommendation === '' }"

--- a/client/js/components/statement/assessmentTable/AssignEntityModal.vue
+++ b/client/js/components/statement/assessmentTable/AssignEntityModal.vue
@@ -30,7 +30,7 @@
             v-model="selected"
             :allow-empty="false"
             class="u-n-ml-0_25"
-            :custom-label="props => `${props.option.name} ${props.option.id === currentUserId ? '(Sie)' : ''}`"
+            :custom-label="option => `${option.name} ${option.id === currentUserId ? '(Sie)' : ''}`"
             :name="`r_${entityId}`"
             :options="[{ id: '', name: '-'}, ...users]"
             :max-height="150"

--- a/client/js/components/statement/assessmentTable/ConsolidateModal.vue
+++ b/client/js/components/statement/assessmentTable/ConsolidateModal.vue
@@ -86,7 +86,7 @@
         v-model="selectedStatements"
         :allow-empty="false"
         :class="validations.selection ? 'u-mb' : 'u-mb-0_25'"
-        :custom-label="props =>`${props.option.extid}`"
+        :custom-label="option =>`${option.extid}`"
         :max-height="150"
         multiple
         :options="initialStatementSelection"
@@ -142,7 +142,7 @@
           id="clusters-single-select"
           v-model="headStatement"
           :class="{ 'u-mb': validations.headStatement, 'u-mb-0_25': false === validations.headStatement }"
-          :custom-label="props => props.option.extid"
+          :custom-label="option => option.extid"
           :options="selectedStatementsWithoutGroups"
           ref="multiselect"
           track-by="id"

--- a/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditFragment.vue
@@ -62,7 +62,7 @@
             v-model="options.newAssignee.value"
             :allow-empty="false"
             class="u-mb width-450"
-            :custom-label="props => `${props.option.name} ${props.option.id === currentUserId ? '(Sie)' : ''}`"
+            :custom-label="option => `${option.name} ${option.id === currentUserId ? '(Sie)' : ''}`"
             :options="users"
             track-by="id"
             @input="() => {options.newAssignee.isValid() ? $refs.newAssignee.$el.querySelector(options.newAssignee.elementToReceiveErrorBorder).classList.remove('border--error') : null}">

--- a/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
@@ -63,7 +63,7 @@
             v-model="options.newAssignee.value"
             :allow-empty="false"
             class="u-mb width-450"
-            :custom-label="props => `${props.option.name} ${props.option.id === currentUserId ? '(Sie)' : ''}`"
+            :custom-label="option => `${option.name} ${option.id === currentUserId ? '(Sie)' : ''}`"
             :options="users"
             track-by="id"
             @input="() => {options.newAssignee.isValid() ? $refs.newAssignee.$el.querySelector(options.newAssignee.elementToReceiveErrorBorder).classList.remove('border--error') : null}">

--- a/client/js/components/statement/statement/SelectStatementCluster.vue
+++ b/client/js/components/statement/statement/SelectStatementCluster.vue
@@ -34,7 +34,7 @@
       v-model="selected"
       :allow-empty="false"
       class="u-1-of-1 u-mr-0_75 show-error-from-sibling"
-      :custom-label="props =>`${props.option.externId ? props.option.externId : ''} ${props.option.name ? props.option.name : ''}`"
+      :custom-label="option =>`${option.externId ? option.externId : ''} ${option.name ? option.name : ''}`"
       :options="clusterList"
       ref="multiselect"
       track-by="id"

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -136,7 +136,7 @@
       <dp-multiselect
         :id="userId + ':userRoles'"
         class="u-mb-0_5"
-        :custom-label="props =>`${ roles[props.option.id].attributes.name }`"
+        :custom-label="option =>`${ roles[option.id].attributes.name }`"
         data-cy="role"
         label="name"
         multiple

--- a/composer.lock
+++ b/composer.lock
@@ -2055,16 +2055,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.6.3",
+            "version": "3.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a"
+                "reference": "19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
-                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f",
+                "reference": "19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f",
                 "shasum": ""
             },
             "require": {
@@ -2147,7 +2147,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.6.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.4"
             },
             "funding": [
                 {
@@ -2163,7 +2163,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-01T05:46:46+00:00"
+            "time": "2023-06-15T07:40:12+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -2931,16 +2931,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.15.2",
+            "version": "2.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "bf449bef7ddc47e62c22f9a06dacc1736abe1c0b"
+                "reference": "4c3bd208018c26498e5f682aaad45fa00ea307d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/bf449bef7ddc47e62c22f9a06dacc1736abe1c0b",
-                "reference": "bf449bef7ddc47e62c22f9a06dacc1736abe1c0b",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/4c3bd208018c26498e5f682aaad45fa00ea307d5",
+                "reference": "4c3bd208018c26498e5f682aaad45fa00ea307d5",
                 "shasum": ""
             },
             "require": {
@@ -2969,14 +2969,14 @@
                 "doctrine/annotations": "^1.13 || ^2",
                 "doctrine/coding-standard": "^9.0.2 || ^12.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.10.14",
+                "phpstan/phpstan": "~1.4.10 || 1.10.18",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.30.0 || 5.11.0"
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -3026,9 +3026,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.15.2"
+                "source": "https://github.com/doctrine/orm/tree/2.15.3"
             },
-            "time": "2023-06-01T09:35:50+00:00"
+            "time": "2023-06-22T12:36:06+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -4258,16 +4258,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.7.0",
+            "version": "v6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "71278f20b0a623389beefe87a641d03948a38870"
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/71278f20b0a623389beefe87a641d03948a38870",
-                "reference": "71278f20b0a623389beefe87a641d03948a38870",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/48b0210c51718d682e53210c24d25c5a10a2299b",
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b",
                 "shasum": ""
             },
             "require": {
@@ -4315,9 +4315,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.7.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.8.0"
             },
-            "time": "2023-06-14T15:29:26+00:00"
+            "time": "2023-06-20T16:45:35+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
@@ -5987,16 +5987,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "3.25.0",
+            "version": "3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "d1384d37926a32b38731c1d9fed6dc71ad630d8b"
+                "reference": "926a7d57438fa1ff4ab794551c5ae26e68536853"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/d1384d37926a32b38731c1d9fed6dc71ad630d8b",
-                "reference": "d1384d37926a32b38731c1d9fed6dc71ad630d8b",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/926a7d57438fa1ff4ab794551c5ae26e68536853",
+                "reference": "926a7d57438fa1ff4ab794551c5ae26e68536853",
                 "shasum": ""
             },
             "require": {
@@ -6071,7 +6071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/serializer/issues",
-                "source": "https://github.com/schmittjoh/serializer/tree/3.25.0"
+                "source": "https://github.com/schmittjoh/serializer/tree/3.26.0"
             },
             "funding": [
                 {
@@ -6079,7 +6079,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-09T15:44:27+00:00"
+            "time": "2023-06-24T19:25:58+00:00"
         },
         {
             "name": "jms/serializer-bundle",
@@ -6562,20 +6562,20 @@
         },
         {
             "name": "lcobucci/clock",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/clock.git",
-                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc"
+                "reference": "30a854ceb22bd87d83a7a4563b3f6312453945fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/clock/zipball/039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
-                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/30a854ceb22bd87d83a7a4563b3f6312453945fc",
+                "reference": "30a854ceb22bd87d83a7a4563b3f6312453945fc",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0",
+                "php": "~8.2.0",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -6583,13 +6583,13 @@
             },
             "require-dev": {
                 "infection/infection": "^0.26",
-                "lcobucci/coding-standard": "^9.0",
+                "lcobucci/coding-standard": "^10.0.0",
                 "phpstan/extension-installer": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-deprecation-rules": "^1.1.1",
-                "phpstan/phpstan-phpunit": "^1.3.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
-                "phpunit/phpunit": "^9.5.27"
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^10.0.17"
             },
             "type": "library",
             "autoload": {
@@ -6610,7 +6610,7 @@
             "description": "Yet another clock abstraction",
             "support": {
                 "issues": "https://github.com/lcobucci/clock/issues",
-                "source": "https://github.com/lcobucci/clock/tree/3.0.0"
+                "source": "https://github.com/lcobucci/clock/tree/3.1.0"
             },
             "funding": [
                 {
@@ -6622,7 +6622,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-12-19T15:00:24+00:00"
+            "time": "2023-03-20T19:12:25+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -7047,7 +7047,7 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "v2.4.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
@@ -7109,7 +7109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/v2.4.0"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/2.4.0"
             },
             "funding": [
                 {
@@ -7901,16 +7901,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.5",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -7951,9 +7951,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-05-19T20:20:00+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "nyholm/dsn",
@@ -9633,16 +9633,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.19",
+            "version": "1.10.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "af5a296ff02610c1bfb4ddfac9fd4a08657b9046"
+                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/af5a296ff02610c1bfb4ddfac9fd4a08657b9046",
-                "reference": "af5a296ff02610c1bfb4ddfac9fd4a08657b9046",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
+                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
                 "shasum": ""
             },
             "require": {
@@ -9691,7 +9691,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-14T15:26:58+00:00"
+            "time": "2023-06-21T20:07:58+00:00"
         },
         {
             "name": "predis/predis",
@@ -11278,16 +11278,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "3.19.1",
+            "version": "3.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "dd1057fb37d4484ebb2d1bc9b05fa5969c078436"
+                "reference": "644ad9768c18139a80ac510090fad000d9ffd8a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/dd1057fb37d4484ebb2d1bc9b05fa5969c078436",
-                "reference": "dd1057fb37d4484ebb2d1bc9b05fa5969c078436",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/644ad9768c18139a80ac510090fad000d9ffd8a4",
+                "reference": "644ad9768c18139a80ac510090fad000d9ffd8a4",
                 "shasum": ""
             },
             "require": {
@@ -11367,7 +11367,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/3.19.1"
+                "source": "https://github.com/getsentry/sentry-php/tree/3.20.1"
             },
             "funding": [
                 {
@@ -11379,7 +11379,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2023-05-25T06:19:09+00:00"
+            "time": "2023-06-26T11:01:40+00:00"
         },
         {
             "name": "sentry/sentry-symfony",
@@ -11781,16 +11781,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.4.23",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "983c79ff28612cdfd66d8e44e1a06e5afc87e107"
+                "reference": "e2013521c0f07473ae69a01fce0af78fc3ec0f23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/983c79ff28612cdfd66d8e44e1a06e5afc87e107",
-                "reference": "983c79ff28612cdfd66d8e44e1a06e5afc87e107",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/e2013521c0f07473ae69a01fce0af78fc3ec0f23",
+                "reference": "e2013521c0f07473ae69a01fce0af78fc3ec0f23",
                 "shasum": ""
             },
             "require": {
@@ -11858,7 +11858,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.23"
+                "source": "https://github.com/symfony/cache/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -11874,7 +11874,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T15:38:51+00:00"
+            "time": "2023-06-22T08:06:06+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -12201,16 +12201,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "4645e032d0963fb614969398ca28e47605b1a7da"
+                "reference": "f0410c30a6c86bbce6c719c2b5cfc343362b982e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4645e032d0963fb614969398ca28e47605b1a7da",
-                "reference": "4645e032d0963fb614969398ca28e47605b1a7da",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f0410c30a6c86bbce6c719c2b5cfc343362b982e",
+                "reference": "f0410c30a6c86bbce6c719c2b5cfc343362b982e",
                 "shasum": ""
             },
             "require": {
@@ -12270,7 +12270,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.24"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -12286,7 +12286,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-05T14:42:55+00:00"
+            "time": "2023-06-24T09:45:28+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -12474,16 +12474,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.23",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "4a286c916b74ecfb6e2caf1aa31d3fe2a34b7e08"
+                "reference": "d2aefa5a7acc5511422792931d14d1be96fe9fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/4a286c916b74ecfb6e2caf1aa31d3fe2a34b7e08",
-                "reference": "4a286c916b74ecfb6e2caf1aa31d3fe2a34b7e08",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/d2aefa5a7acc5511422792931d14d1be96fe9fea",
+                "reference": "d2aefa5a7acc5511422792931d14d1be96fe9fea",
                 "shasum": ""
             },
             "require": {
@@ -12529,7 +12529,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.23"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -12545,7 +12545,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-08T21:20:19+00:00"
+            "time": "2023-06-05T08:05:41+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -12918,16 +12918,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.23",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5"
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
                 "shasum": ""
             },
             "require": {
@@ -12962,7 +12962,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.23"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -12978,7 +12978,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-02T11:38:35+00:00"
+            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/finder",
@@ -13213,16 +13213,16 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "c06a56a47817d29318aaace1c655cbde16c998e8"
+                "reference": "c9d65bdab4a26e110ec4c87b3aa5de108c0f860d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/c06a56a47817d29318aaace1c655cbde16c998e8",
-                "reference": "c06a56a47817d29318aaace1c655cbde16c998e8",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/c9d65bdab4a26e110ec4c87b3aa5de108c0f860d",
+                "reference": "c9d65bdab4a26e110ec4c87b3aa5de108c0f860d",
                 "shasum": ""
             },
             "require": {
@@ -13268,7 +13268,7 @@
                 "symfony/translation": "<5.3",
                 "symfony/twig-bridge": "<4.4",
                 "symfony/twig-bundle": "<4.4",
-                "symfony/validator": "<5.2",
+                "symfony/validator": "<5.3.11",
                 "symfony/web-profiler-bundle": "<4.4",
                 "symfony/workflow": "<5.2"
             },
@@ -13301,7 +13301,7 @@
                 "symfony/string": "^5.0|^6.0",
                 "symfony/translation": "^5.3|^6.0",
                 "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-                "symfony/validator": "^5.2|^6.0",
+                "symfony/validator": "^5.3.11|^6.0",
                 "symfony/web-link": "^4.4|^5.0|^6.0",
                 "symfony/workflow": "^5.2|^6.0",
                 "symfony/yaml": "^4.4|^5.0|^6.0",
@@ -13343,7 +13343,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v5.4.24"
+                "source": "https://github.com/symfony/framework-bundle/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -13359,20 +13359,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T13:05:00+00:00"
+            "time": "2023-06-15T07:35:04+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "9e89ac4c9dfe29f4ed2b10a36e62720286632ad6"
+                "reference": "ccbb572627466f03a3d7aa1b23483787f5969afc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/9e89ac4c9dfe29f4ed2b10a36e62720286632ad6",
-                "reference": "9e89ac4c9dfe29f4ed2b10a36e62720286632ad6",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/ccbb572627466f03a3d7aa1b23483787f5969afc",
+                "reference": "ccbb572627466f03a3d7aa1b23483787f5969afc",
                 "shasum": ""
             },
             "require": {
@@ -13434,7 +13434,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v5.4.24"
+                "source": "https://github.com/symfony/http-client/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -13450,7 +13450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-07T13:11:28+00:00"
+            "time": "2023-06-21T14:44:30+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -13532,16 +13532,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "3c59f97f6249ce552a44f01b93bfcbd786a954f5"
+                "reference": "f66be2706075c5f6325d2fe2b743a57fb5d23f6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3c59f97f6249ce552a44f01b93bfcbd786a954f5",
-                "reference": "3c59f97f6249ce552a44f01b93bfcbd786a954f5",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f66be2706075c5f6325d2fe2b743a57fb5d23f6b",
+                "reference": "f66be2706075c5f6325d2fe2b743a57fb5d23f6b",
                 "shasum": ""
             },
             "require": {
@@ -13588,7 +13588,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.24"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -13604,20 +13604,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-19T07:21:23+00:00"
+            "time": "2023-06-22T08:06:06+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f38b722e1557eb3f487d351b48f5a1279b50e9d1"
+                "reference": "f6c92fe64bbdad7616cb90663c24f6350f3ca464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f38b722e1557eb3f487d351b48f5a1279b50e9d1",
-                "reference": "f38b722e1557eb3f487d351b48f5a1279b50e9d1",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6c92fe64bbdad7616cb90663c24f6350f3ca464",
+                "reference": "f6c92fe64bbdad7616cb90663c24f6350f3ca464",
                 "shasum": ""
             },
             "require": {
@@ -13700,7 +13700,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.24"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -13716,7 +13716,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-27T08:06:30+00:00"
+            "time": "2023-06-26T05:58:08+00:00"
         },
         {
             "name": "symfony/inflector",
@@ -13793,16 +13793,16 @@
         },
         {
             "name": "symfony/intl",
-            "version": "v5.4.23",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "962789bbc76c82c266623321ffc24416f574b636"
+                "reference": "4c4cbf57c9623b55e7d19479488bd93fee68450a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/962789bbc76c82c266623321ffc24416f574b636",
-                "reference": "962789bbc76c82c266623321ffc24416f574b636",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/4c4cbf57c9623b55e7d19479488bd93fee68450a",
+                "reference": "4c4cbf57c9623b55e7d19479488bd93fee68450a",
                 "shasum": ""
             },
             "require": {
@@ -13861,7 +13861,7 @@
                 "localization"
             ],
             "support": {
-                "source": "https://github.com/symfony/intl/tree/v5.4.23"
+                "source": "https://github.com/symfony/intl/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -13877,7 +13877,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-13T10:36:25+00:00"
+            "time": "2023-06-19T09:28:43+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -15787,16 +15787,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.22",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "c2ac11eb34947999b7c38fb4c835a57306907e6d"
+                "reference": "56bfc1394f7011303eb2e22724f9b422d3f14649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/c2ac11eb34947999b7c38fb4c835a57306907e6d",
-                "reference": "c2ac11eb34947999b7c38fb4c835a57306907e6d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/56bfc1394f7011303eb2e22724f9b422d3f14649",
+                "reference": "56bfc1394f7011303eb2e22724f9b422d3f14649",
                 "shasum": ""
             },
             "require": {
@@ -15857,7 +15857,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.22"
+                "source": "https://github.com/symfony/routing/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -15873,7 +15873,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T14:59:20+00:00"
+            "time": "2023-06-05T14:18:47+00:00"
         },
         {
             "name": "symfony/security-bundle",
@@ -16296,16 +16296,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "12535bb7b1d3b53802bf18d61a98bb1145fabcdb"
+                "reference": "e528ace5951925459cb6620cc4d67c20ed616fdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/12535bb7b1d3b53802bf18d61a98bb1145fabcdb",
-                "reference": "12535bb7b1d3b53802bf18d61a98bb1145fabcdb",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/e528ace5951925459cb6620cc4d67c20ed616fdd",
+                "reference": "e528ace5951925459cb6620cc4d67c20ed616fdd",
                 "shasum": ""
             },
             "require": {
@@ -16379,7 +16379,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v5.4.24"
+                "source": "https://github.com/symfony/serializer/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -16395,7 +16395,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-12T08:37:35+00:00"
+            "time": "2023-05-31T11:43:23+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -17083,16 +17083,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "47794a3cb530e01593ecad9856ba80f5c011e36b"
+                "reference": "62b6cd0a2da0553db0400c3f13899afbdeefaa77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/47794a3cb530e01593ecad9856ba80f5c011e36b",
-                "reference": "47794a3cb530e01593ecad9856ba80f5c011e36b",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/62b6cd0a2da0553db0400c3f13899afbdeefaa77",
+                "reference": "62b6cd0a2da0553db0400c3f13899afbdeefaa77",
                 "shasum": ""
             },
             "require": {
@@ -17175,7 +17175,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v5.4.24"
+                "source": "https://github.com/symfony/validator/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -17191,20 +17191,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T13:05:00+00:00"
+            "time": "2023-06-21T09:57:24+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "8e12706bf9c68a2da633f23bfdc15b4dce5970b3"
+                "reference": "82269f73c0f0f9859ab9b6900eebacbe54954ede"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/8e12706bf9c68a2da633f23bfdc15b4dce5970b3",
-                "reference": "8e12706bf9c68a2da633f23bfdc15b4dce5970b3",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82269f73c0f0f9859ab9b6900eebacbe54954ede",
+                "reference": "82269f73c0f0f9859ab9b6900eebacbe54954ede",
                 "shasum": ""
             },
             "require": {
@@ -17263,7 +17263,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.24"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -17279,7 +17279,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T13:05:00+00:00"
+            "time": "2023-06-20T20:56:26+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -21650,16 +21650,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v6.3.0",
+            "version": "v6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "f8d75b4d9bf7243979b2c2e5e6cd73f03e10579f"
+                "reference": "0b0bf59b0d9bd1422145a123a67fb12af546ef0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/f8d75b4d9bf7243979b2c2e5e6cd73f03e10579f",
-                "reference": "f8d75b4d9bf7243979b2c2e5e6cd73f03e10579f",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/0b0bf59b0d9bd1422145a123a67fb12af546ef0d",
+                "reference": "0b0bf59b0d9bd1422145a123a67fb12af546ef0d",
                 "shasum": ""
             },
             "require": {
@@ -21711,7 +21711,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.3.0"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.3.1"
             },
             "funding": [
                 {
@@ -21727,7 +21727,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-30T09:01:24+00:00"
+            "time": "2023-06-23T13:25:16+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",

--- a/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
@@ -62,6 +62,10 @@ final class FrontendAssetProvider
                 return [];
             }
 
+            // TODO: filter assets based on their permission to only send
+            //       usable addons to the client and relieve ourselves from outer
+            //       permission checks in addon components
+
             return $this->createAddonFrontendAssetsEntry($hookData, $assetContents);
         }, $this->registry->getAddonInfos());
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -1743,7 +1743,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      */
     public function getSubmitDateString()
     {
-        return null === $this->submit ? '' : $this->getSubmitObject()->format('d-m-Y');
+        return null === $this->getSubmitObject() ? '' : $this->getSubmitObject()->format('d.m.Y');
     }
 
     /**
@@ -3347,7 +3347,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
             return '';
         }
 
-        return null === $this->getMeta()->getAuthoredDateObject() ? '' : $this->getMeta()->getAuthoredDateObject()->format('d-m-Y');
+        return null === $this->getMeta()->getAuthoredDateObject() ? '' : $this->getMeta()->getAuthoredDateObject()->format('d.m.Y');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -271,6 +271,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         $exportData['meta'] = $this->entityHelper->toArray($exportData['meta']);
         $exportData['submitDateString'] = $segmentOrStatement->getSubmitDateString();
         $exportData['countyNames'] = $segmentOrStatement->getCountyNames();
+        $exportData['meta']['authoredDate'] = $segmentOrStatement->getAuthoredDateString();
 
         // Some data is stored on parentStatement instead on Segment and have to get from there
         if ($segmentOrStatement instanceof Segment) {
@@ -284,10 +285,11 @@ class SegmentsByStatementsExporter extends SegmentsExporter
             $exportData['memo'] = $segmentOrStatement->getParentStatementOfSegment()->getMemo();
             $exportData['internId'] = $segmentOrStatement->getParentStatementOfSegment()->getInternId();
             $exportData['oName'] = $segmentOrStatement->getParentStatementOfSegment()->getOName();
-            $exportData['meta']['authoredDate'] = $segmentOrStatement->getParentStatementOfSegment()->getAuthoredDate();
+            $exportData['meta']['authoredDate'] = $segmentOrStatement->getParentStatementOfSegment()->getAuthoredDateString();
             $exportData['dName'] = $segmentOrStatement->getParentStatementOfSegment()->getDName();
             $exportData['status'] = $segmentOrStatement->getPlace()->getName(); // Segments using place instead of status
             $exportData['fileNames'] = $segmentOrStatement->getParentStatementOfSegment()->getFileNames();
+            $exportData['submitDateString'] = $segmentOrStatement->getParentStatementOfSegment()->getSubmitDateString();
         }
         $exportData['tagNames'] = $segmentOrStatement->getTagNames();
         $exportData['tags'] = array_map($this->entityHelper->toArray(...), $exportData['tags']->toArray());

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -97,36 +97,47 @@ class SegmentsExporter
     protected function addStatementInfo(Section $section, Statement $statement): void
     {
         $table = $section->addTable($this->styles['statementInfoTable']);
-
         $orgaInfoHeader = new ExportOrgaInfoHeader($statement, $this->currentUser, $this->translator);
 
-        $row1 = $table->addRow();
-        $this->addSegmentCell($row1, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row1, '', $this->styles['statementInfoEmptyCell']);
-        $creationDate = $statement->getCreated()->format('d.m.Y');
-        $creationText = $this->translator->trans('segments.export.statement.creation.date', ['date' => $creationDate]);
-        $this->addSegmentCell($row1, $creationText, $this->styles['statementInfoTextCell']);
+        if ('' !== $statement->getAuthoredDateString()) {
+            $authoredDateRow = $table->addRow();
+            $this->addSegmentCell($authoredDateRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($authoredDateRow, '', $this->styles['statementInfoEmptyCell']);
+            $authoredAt = $this->translator->trans('statement.date.authored').': '.$statement->getAuthoredDateString();
+            $this->addSegmentCell($authoredDateRow, $authoredAt, $this->styles['statementInfoTextCell']);
+        }
 
-        $row2 = $table->addRow();
-        $this->addSegmentCell($row2, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row2, '', $this->styles['statementInfoEmptyCell']);
+        if ('' !== $statement->getSubmitDateString()) {
+            $submitDateRow = $table->addRow();
+            $this->addSegmentCell($submitDateRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($submitDateRow, '', $this->styles['statementInfoEmptyCell']);
+            $submittedAt = $this->translator->trans('statement.date.submitted').': '.$statement->getSubmitDateString();
+            $this->addSegmentCell($submitDateRow, $submittedAt, $this->styles['statementInfoTextCell']);
+        }
+
+        $textRow = $table->addRow();
+        $this->addSegmentCell($textRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($textRow, '', $this->styles['statementInfoEmptyCell']);
         $externIdText = $this->translator->trans('segments.export.statement.extern.id', ['externId' => $statement->getExternId()]);
-        $this->addSegmentCell($row2, $externIdText, $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($textRow, $externIdText, $this->styles['statementInfoTextCell']);
 
-        $row3 = $table->addRow();
-        $this->addSegmentCell($row3, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row3, '', $this->styles['statementInfoEmptyCell']);
-        $internIdText = $this->translator->trans('segments.export.statement.intern.id', ['internId' => $statement->getInternId()]);
-        $this->addSegmentCell($row3, $internIdText, $this->styles['statementInfoTextCell']);
+        if (null !== $statement->getInternId() && '' !== $statement->getInternId()) {
+            $internIdRow = $table->addRow();
+            $this->addSegmentCell($internIdRow, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+            $this->addSegmentCell($internIdRow, '', $this->styles['statementInfoEmptyCell']);
+            $internIdText = $this->translator->trans('segments.export.statement.intern.id', ['internId' => $statement->getInternId()]);
+            $this->addSegmentCell($internIdRow, $internIdText, $this->styles['statementInfoTextCell']);
+        }
 
-        $row4 = $table->addRow();
-        $this->addSegmentCell($row4, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
-        $this->addSegmentCell($row4, '', $this->styles['statementInfoEmptyCell']);
-        $this->addSegmentCell($row4, '', $this->styles['statementInfoTextCell']);
-
+        // formation only
         $row5 = $table->addRow();
         $this->addSegmentCell($row5, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
         $this->addSegmentCell($row5, '', $this->styles['statementInfoEmptyCell']);
+        $this->addSegmentCell($row5, '', $this->styles['statementInfoTextCell']);
+
+        $row6 = $table->addRow();
+        $this->addSegmentCell($row6, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
+        $this->addSegmentCell($row6, '', $this->styles['statementInfoEmptyCell']);
 
         $section->addTextBreak(2);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -446,10 +446,6 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
             $explodedParts = explode('.', (string) $attributeKey);
             switch (count($explodedParts)) {
                 case 2:
-                    if ('authoredDate' === $explodedParts[1]) {
-                        $timestamp = $statementArray[$explodedParts[0]][$explodedParts[1]];
-                        $statementArray[$explodedParts[0]][$explodedParts[1]] = date('d-m-Y', $timestamp);
-                    }
                     $formattedStatement[$attributeKey] = $statementArray[$explodedParts[0]][$explodedParts[1]];
                     break;
                 case 3:

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -2907,8 +2907,9 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
             if ($newOriginalStatement instanceof Statement) {
                 $assessableStatement = $this->createNonOriginalStatement($originalStatement, $newOriginalStatement);
 
-                if ($assessableStatement instanceof Statement && $this->permissions->hasPermission('feature_similar_statement_submitter')) {
+                if ($this->permissions->hasPermission('feature_similar_statement_submitter')) {
                     $this->attachSimilarStatementSubmitters($assessableStatement, $data);
+                    $this->statementService->updateStatementObject($assessableStatement);
                 }
 
                 /** @var ManualStatementCreatedEvent $assessableStatementEvent */

--- a/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
@@ -17,6 +17,7 @@ use DemosEurope\DemosplanAddon\Permission\Validation\PermissionFilterException;
 use DemosEurope\DemosplanAddon\Permission\Validation\PermissionFilterValidatorInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\EntityFetcher;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
@@ -144,6 +145,16 @@ class PermissionResolver implements PermissionFilterValidatorInterface
         // fulfill.
         if (null === $evaluationTarget) {
             return [] === $conditions;
+        }
+
+        if ($evaluationTarget instanceof FunctionalUser) {
+            foreach ($conditions as $condition) {
+                if (!$this->conditionEvaluator->evaluateCondition($evaluationTarget, $condition)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         $conditions[] = $this->conditionFactory->propertyHasValue($evaluationTarget->getId(), ['id']);

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -1019,12 +1019,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             })
             ->all();
 
-        // Add addon permissions to list of core permissions. Not mixing them would be preferred,
-        // but this is currently needed to expose addon permissions to the frontend.
-        $this->permissions = collect($this->addonPermissionCollections)
-            ->flatMap(fn (ResolvablePermissionCollection $collection): array => $collection->getPermissions())
-            ->merge($this->corePermissions->toArray())
-            ->all();
+        $this->permissions = $this->corePermissions->toArray();
     }
 
     /**
@@ -1309,6 +1304,14 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 }
             }
         );
+    }
+
+    /**
+     * @return ResolvablePermissionCollection[]
+     */
+    public function getAddonPermissionCollections(): array
+    {
+        return $this->addonPermissionCollections;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermissionCollection.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ResolvablePermissionCollection.php
@@ -90,4 +90,12 @@ class ResolvablePermissionCollection implements ResolvablePermissionCollectionIn
             $this->permissions
         );
     }
+
+    /**
+     * @return ResolvablePermission[]
+     */
+    public function getResolvePermissions(): array
+    {
+        return $this->permissions;
+    }
 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2880,7 +2880,6 @@ segments.bulk.edit.recommendations.warning.empty.text.replace: |
     }
 segments.export.pagination: "Seite {PAGE} von {NUMPAGES}"
 segments.export.segment.id: "Abschnitts-ID"
-segments.export.statement.creation.date: "Einwendung/Stellungnahme vom {date}"
 segments.export.statement.export.date: "Synopse vom {date}"
 segments.export.statement.extern.id: "ID: {externId}"
 segments.export.statement.intern.id: "Eingangsnummer: {internId}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,9 +1118,9 @@
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
 "@babel/runtime@^7.13.10":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
-  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  version "7.22.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
+  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1438,9 +1438,9 @@
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
 "@demos-europe/demosplan-ui@^0":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.6.tgz#90708b4c754fdc9366f563e2cc07d0fd5fc41148"
-  integrity sha512-kq8Jkk+r1yfGoQ3aIUCjolhHtne5p+NGkaNjcrg1Xtm58AuDb6on/CcYomMeXJGeOcRQZ0P4N7SluBP888pFlA==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.4.tgz#ba1df51f16967922cda237f46e9da9308dde169c"
+  integrity sha512-sxZ/VD3Z9zCSWNCgvhHrss3jMCvWJlrB7qlZ8dlFIuxIVSKXChF4OiH6EU4vjkepxRhpZunZBY//li2Yt4iumA==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"


### PR DESCRIPTION
Squashed commit of the following:

commit f5d366ebc8b3a1f1e5311d758da5c3c49fea1fae
Author: graupnerdemos <graupner@demos-deutschland.de>
Date:   Mon Jun 19 17:51:16 2023 +0200

    fix: Allow complete permission evaluation without valid user (#1565)

    We cannot evaluate the permissions via the db without an existing user
    and need to revert to evaluating directly with edt

commit 8b948b3a2a3d0453c130a0cba5955d7f90e3d4e7
Author: graupnerdemos <graupner@demos-deutschland.de>
Date:   Mon Jun 19 16:33:21 2023 +0200

    feat(refs T33234): Add rudimentary support for exposing addon permissions (#1564)

    Addon permissions are not configured in the classic array way the core permissions
    are evaluated in. Thus, all addon permissions, while having been marked as exposed,
    were dropped when building the frontend permission list.

    This change is only a rudimentary solution to exposing the addon permissions as
    the correct way would be to redo the permission checking in the frontend to
    include addon names and eventually use something more akin to hasPermission(name, context)
    with the context being core or an addon name

commit 24e0728b0a10724161f8e7734da93227ec856205
Author: graupnerdemos <graupner@demos-deutschland.de>
Date:   Mon Jun 19 11:57:47 2023 +0200

    fix(refs T33234): Remove incorrect late permission evaluation (#1562)

    The addon hook configurations do not yet provide permission information.
    If we were to evaluate those, we should filter the scripts in the RPC
    method instead of loading all scripts on the users' machine and evaluating
    on the client side.

    In addition, previously no import tabs would have been loadable from addons
    at all if the excel import were disabled.

commit 20a4775ba44d993d47030fd227762dbc81acb486
Author: bakridemos <102021913+bakridemos@users.noreply.github.com>
Date:   Fri Jun 16 15:48:57 2023 +0200

    fix adjust demosplan addon version

    - some changes made in the 0.0.4 are required.
    - adjust composer.lock

    Signed-off-by: Hamza Bakri <bakri@demos-deutschland.de>

commit ba2a3fc0624088822180994f69715bd20b669682
Author: salisdemos <40487461+salisdemos@users.noreply.github.com>
Date:   Wed Jun 14 18:15:33 2023 +0200

    chore: pick sublte button (#1535)

    * feat(refs T21517): Adapt DpButton usage to new dpui version

    demosplan-ui 0.1.3 introduces a new button variant, "subtle".
    As the styles for demosplan-ui are currently implememted
    in demosplan-core, also the new variant is implemented here.
    Since demosplan-ui 0.1.3 drops slots, these places have to be adapted
    to use icons instead of slots. All needed icons are already implemented
    in demosplan-ui.

    When icons come with a proportion signifier class, we
    can further tweak spacing of icons inside buttons. this will
    eventually be released later on.

    (cherry picked from commit d427b942fa62e60f8b549e1462160a6651b58835)

    * chore: Bump demosplan-ui to 0.1.4

    * Update package.json

    ---------

    Co-authored-by: spiess-demos <40452344+spiess-demos@users.noreply.github.com>

commit 03225dcc776ef7966149108504cb717ab4ee6450
Author: graupnerdemos <graupner@demos-deutschland.de>
Date:   Wed Jun 14 14:36:18 2023 +0200

    fix (refs T33142): uses parent statement submit date (#1530)

    If the entity is a segment, it now uses the submit date from the parent statement and not its own date.

    Co-authored-by: AlexMenschoid <meyer-schlichtmann@demos-deutschland.de>

commit 3f2a89f47b683a1d7e71880df025b56ca50c0c87
Author: salisdemos <40487461+salisdemos@users.noreply.github.com>
Date:   Wed Jun 14 13:05:33 2023 +0200

    fix/refs T33256): Break segments overflow (#1528)

    Add overflow-word-break to segments text boxes

commit fd7a721f5161e85df13480f0530a25bbcb156491
Author: Steffi <101879352+gruenbergerdemos@users.noreply.github.com>
Date:   Wed Jun 14 11:17:50 2023 +0200

    feat(refs T33153): Revert custom label for multiselect (#1505)

    * feat(refs T33153): Revert custom label for multiselect

    Vue multiselect uses here option and not props.

commit ad98d0328cdbdb5924f38615ef436c0153124975
Author: spiess-demos <40452344+spiess-demos@users.noreply.github.com>
Date:   Wed Jun 14 10:57:52 2023 +0200

    feat(refs T33153): Bump demosplan-ui plus some cherrypicks (#1524)

    bump demosplan-ui
    and minor fix: remove fullscreen margin + button padding (#1507)

commit 4f550faca6f9c8f586a9f04e6bfc54c5615e8830
Author: Alexander Marten <marten@demos-deutschland.de>
Date:   Tue Jun 13 16:37:57 2023 +0200

    fix (refs T33109): Flush added similar statement submitter on create new statement.

commit ebf7903824f504f3c4c862537a2d81e5bcb4da31
Author: AlexMenschoid <meyer-schlichtmann@demos-deutschland.de>
Date:   Thu Jun 8 15:43:47 2023 +0200

    fix (refs T33142): uses parent statement submit date

    If the entity is a segment, it now uses the submit date from the parent statement and not its own date.

commit 281841ae9e0c9fbce0c2844da62999451b29fdb3
Author: Demos-CI <devops-system+github@demos-deutschland.de>
Date:   Tue Jun 13 11:18:42 2023 +0000

    style: Apply php-cs-fixer

commit b6d761eeb5448e8d52baa0c3b7015973c304184f
Author: Alexander Marten <marten@demos-deutschland.de>
Date:   Tue Jun 13 13:13:24 2023 +0200

    fix (refs T33142): Add submitDate and authoredDate to export of statements/segments if given.

    - only add rows in case of content is given.
    - remove unused translation
    - rename variables to enhance readability

commit f7e5a282954163e672e8e305b9a8cefe9e2b1015
Author: Alexander Marten <marten@demos-deutschland.de>
Date:   Mon Jun 12 15:06:35 2023 +0200

    fix (refs T33144): Avoid interpreting a 0 as timestamp.

    Actually authored date can be null/empty.
    Export this that way by ensure getting string date in both cases by already existing method
    and make another error prone converting obsolete.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
