### PR TITLE
Use higher specificity for showing elements within wizard

### DIFF
--- a/client/js/lib/procedure/DPWizard.js
+++ b/client/js/lib/procedure/DPWizard.js
@@ -84,12 +84,13 @@ export default function DpWizard () {
         $items.find('.o-wizard__content').removeClass('is-active')
 
         $currentItem.find('legend').addClass('is-active-toggle')
-        $currentItem.find('.o-wizard__btn--next').show()
+        this.showElement($currentItem.find('.o-wizard__btn--next'))
+        this.showElement($wizardElements)
         $currentItem
           .addClass('o-wizard--active')
           .find('.o-wizard__content')
           .append(
-            $wizardElements.show().attr('aria-hidden', false)
+            $wizardElements.attr('aria-hidden', false)
           )
           .addClass('is-active')
 
@@ -103,13 +104,28 @@ export default function DpWizard () {
         return this
       },
 
+      showElement: function ($elements) {
+        const elements = $elements.toArray()
+        elements.forEach((element) => {
+          element.setAttribute('style', 'display: block !important')
+        })
+      },
+
       hide: function () {
         $form.removeClass('o-wizard-mode')
         this.$items.removeClass('o-wizard--active')
         this.$items.find('.o-wizard__content').removeClass('is-active')
-        $wizardElements.hide().attr('aria-hidden', true)
-        $form.find('.o-wizard__btn--next').hide()
+        $wizardElements.attr('aria-hidden', true)
+        this.hideElement($wizardElements)
+        this.hideElement($form.find('.o-wizard__btn--next'))
         return this
+      },
+
+      hideElement: function ($elements) {
+        const elements = $elements.toArray()
+        elements.forEach((element) => {
+          element.setAttribute('style', '')
+        })
       },
 
       buildMenu: function () {
@@ -165,11 +181,11 @@ export default function DpWizard () {
         const $doneBtn = this.$actions.done
 
         if (this.step === this.length) {
-          $nextBtn.hide()
-          $doneBtn.show()
+          this.showElement($doneBtn)
+          this.hideElement($nextBtn)
         } else {
-          $nextBtn.show()
-          $doneBtn.hide()
+          this.showElement($nextBtn)
+          this.hideElement($doneBtn)
         }
         return this
       },

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_wizard.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_wizard.scss
@@ -73,7 +73,7 @@
     // Hide plain tooltip texts that are revealed in wizard mode
     form:not(.o-wizard-mode) & {
         [data-wizard-tooltip-plain] {
-            display: none;
+            display: none !important;
         }
     }
 


### PR DESCRIPTION
As the tailwind display classes are configured to use !important, the jQuery show() method is now overruled by them. To keep the fix local, the show() and hide() functions were substituted with custom functions which apply the !important.

### How to review/test
The wizard (in "Grundeinstellungen" of a procedure) should show up and work "as intended".
