### PR TITLE
fix(refs T33500): bump demosplan-ui to latest version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,9 +1118,9 @@
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
 "@babel/runtime@^7.13.10":
-  version "7.22.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
-  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1438,9 +1438,9 @@
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
 "@demos-europe/demosplan-ui@^0":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.4.tgz#ba1df51f16967922cda237f46e9da9308dde169c"
-  integrity sha512-sxZ/VD3Z9zCSWNCgvhHrss3jMCvWJlrB7qlZ8dlFIuxIVSKXChF4OiH6EU4vjkepxRhpZunZBY//li2Yt4iumA==
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.7.tgz#239145c37a1afd43a19e411cee32686a391506c1"
+  integrity sha512-gFojtRMfuvvY64S2cPgvDeMfFd6/dqBrgdC/PCko6Fvf0dLrIHUtAIHL5cxjGkXjPdgKTVnloh+1UMUa2ypNRg==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33500

After merging back an old release, the version of demosplan-ui went to 0.1.4 which does not yet have tailwind.

### How to review/test
yarn install, yarn dev:<project>, everything should be fine.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
