### PR TITLE
Fix(T33542): missing user menu

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/error.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/error.html.twig
@@ -1,7 +1,16 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
-{% block component_part %}
-    <h1>{{ templateTitle }}</h1>
-    <p>Ein technischer Fehler ist aufgetreten. Bitte überprüfen Sie die zuletzt durchgeführte Aktion und wiederholen Sie
-        sie gegebenenfalls.</p>
 
+{% block component_part %}
+    <h1>
+        {{ templateTitle }}
+    </h1>
+    <p>
+        Ein technischer Fehler ist aufgetreten. Bitte überprüfen Sie die zuletzt durchgeführte Aktion und wiederholen Sie
+        sie gegebenenfalls.
+    </p>
 {% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ webpackBundles(['core-genericBundle.js']) }}
+{% endblock javascripts %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/public_newsdetail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/public_newsdetail.html.twig
@@ -57,5 +57,6 @@
 {% endblock %}
 
 {% block javascripts %}
-
+    {{ parent() }}
+    {{ webpackBundles(['core-genericBundle.js']) }}
 {% endblock javascripts %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33542

**Description:**  This PR adds a webpack entry point to the public news detail and error pages.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
