### PR TITLE
chore: fix platform requirements syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -198,10 +198,10 @@
             "demos-europe/demosplan-addon-installer": true,
             "bamarni/composer-bin-plugin": true,
             "php-http/discovery": false
+        },
+        "platform": {
+          "php": "8.1"
         }
-    },
-    "platform": {
-      "php": "8.1"
     },
     "conflict": {
       "twig/twig": "<2.10"


### PR DESCRIPTION
We need to set platform requirements to ensure that vendor dependencies remain compatible with php 8.1 even when composer update is performed on a php 8.2 machine. Otherwise problems like #1617 will occur.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
