### PR TITLE
chore: fix deprecation in migration template

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/migration.tpl
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/migration.tpl
@@ -3,6 +3,7 @@
 namespace <namespace>;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -40,7 +41,7 @@ class <className> extends AbstractMigration
     private function abortIfNotMysql(): void
     {
         $this->abortIf(
-            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
             "Migration can only be executed safely on 'mysql'."
         );
     }


### PR DESCRIPTION
Check of the database platform via getName() is deprecated. 

### How to review/test
code review or create a new migration and check the deprecations

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
