### PR TITLE
Fix(T33451): issue with the projection being set to EPSG:25832

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -275,6 +275,8 @@ export default {
     },
 
     extractDataFromWMSCapabilities () {
+      const isProjectionInOptions = this.findProjectionInOptions
+
       // Show available layers in layers dropdown
       if (Array.isArray(this.currentCapabilities.Capability.Layer.Layer)) {
         this.addLayerToOptions(this.currentCapabilities.Capability.Layer.Layer, 'Name')
@@ -292,7 +294,7 @@ export default {
             projectionsFromSource: availableCRS.join(', '),
             availableProjectionsFromSystem: this.availableProjections.join(', ')
           }))
-        } else if (this.projectionOptions.includes(this.projection) === false) {
+        } else if (isProjectionInOptions === false) {
           this.projection = this.projectionOptions[0].value
         }
       }
@@ -383,6 +385,12 @@ export default {
             dplan.notify.warning(Translator.trans('matrixset.no.supported.projections'))
           }
         }
+      })
+    },
+
+    findProjectionInOptions () {
+      return this.projectionOptions.some(obj => {
+        return obj.value === this.projection
       })
     },
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33451

**Description:** This PR adds a method called `findProjectionInOptions` which checks if options contain the current projection. The previous check was always false because it attempted to check a value in the array of objects and the projection has consistently been set to EPSG:25832.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
