### PR TITLE
feature (refs T33554): fix procedure export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -60,7 +60,7 @@ class ZipExportService
             // set maximum filesize to load into memory to 120 MB
             $options->setLargeFileSize(120 * 1024 * 1024);
             // do not compress large files. Store should be default but somehow isn't if not set
-            $options->setLargeFileMethod(Method::STORE);
+            $options->setLargeFileMethod(Method::STORE());
 
             $zip = new ZipStream($name, $options);
             $fillZipFunction($zip);
@@ -72,7 +72,7 @@ class ZipExportService
     public function addFileToZipStream(string $filePath, string $zipPath, ZipStream $zip): void
     {
         $fileOptions = new File();
-        $fileOptions->setMethod(Method::STORE);
+        $fileOptions->setMethod(Method::STORE());
         $zip->addFileFromPath($zipPath, $filePath, $fileOptions);
 
         $this->logger->info('Added File to Zip');

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -16,9 +16,6 @@ use demosplan\DemosPlanCoreBundle\Exception\InvalidParameterTypeException;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
 use Exception;
-
-use function get_class;
-
 use Patchwork\Utf8;
 use PhpOffice\PhpWord\Writer\PDF;
 use PhpOffice\PhpWord\Writer\WriterInterface;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33554

Description: ZipExportService should return void, but return int.

### How to review/test
just check it in browser

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly