### PR TITLE
fix (ref:T30158) Define Statements files accessibility 

### DIFF
--- a/client/js/components/map/publicdetail/controls/legendList/DpLayerLegend.vue
+++ b/client/js/components/map/publicdetail/controls/legendList/DpLayerLegend.vue
@@ -29,7 +29,7 @@
           <a
             :class="prefixClass('c-map__group-item display--block')"
             target="_blank"
-            :href="Routing.generate('core_file', { hash: planPdf.hash })"
+            :href="Routing.generate('core_file_procedure', { hash: planPdf.hash, procedureId: procedureId})"
             :title="planPdfTitle">
             <i
               :class="prefixClass('fa fa-download')"
@@ -52,7 +52,7 @@
             <a
               :class="prefixClass('c-map__group-item display--block')"
               target="_blank"
-              :href="Routing.generate('core_file', { hash: layer.legend.hash })"
+              :href="Routing.generate('core_file_procedure', { hash: layer.legend.hash, procedureId: procedureId })"
               :title="`${layer.name} (${layer.legend.mimeType}, ${layer.legend.fileSize})`">
               {{ layer.name }}
             </a>
@@ -85,7 +85,12 @@ export default {
     planPdf: {
       type: Object,
       default: () => ({})
-    }
+    },
+
+  procedureId: {
+    type: String,
+    required: true
+  }
   },
 
   data () {

--- a/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
+++ b/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
@@ -35,7 +35,7 @@
       enctype="multipart/form-data">
       <dp-upload-files
         allowed-file-types="xls"
-        :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+        :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
         :max-file-size="100 * 1024 * 1024/* 100 MiB */"
         needs-hidden-input
         :translations="{ dropHereOr: Translator.trans('form.button.upload.file.allowed.formats', { browse: '{browse}', allowedFormats: '.xls, .xlsx, .ods', maxUploadSize: '100 MB' }) }"

--- a/client/js/components/procedure/AdministrationImport/StatementPdfImport/StatementPdfImport.vue
+++ b/client/js/components/procedure/AdministrationImport/StatementPdfImport/StatementPdfImport.vue
@@ -16,7 +16,7 @@
     <dp-upload-files
       ref="uploader"
       id="statementUpload"
-      :get-file-by-hash="(hash) => Routing.generate('core_file', { hash: hash })"
+      :get-file-by-hash="(hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
       allowed-file-types="pdf"
       :max-file-size="100000000"
       :max-number-of-files="maxNumberOfFiles"

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -311,7 +311,7 @@
         <dp-upload-files
           class="u-mb"
           id="r_attachment_original"
-          :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+          :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
           name="r_attachment_original"
           allowed-file-types="all"
           :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
@@ -328,7 +328,7 @@
         id="r_upload"
         name="r_upload"
         allowed-file-types="all"
-        :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+        :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
         :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
         :max-number-of-files="1000"
         needs-hidden-input

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -199,7 +199,7 @@
               v-if="hasPermission('feature_read_source_statement_via_api')"
               :class="{'is-disabled': getOriginalPdfAttachmentHashBySegment(rowData) === null}"
               target="_blank"
-              :href="Routing.generate('core_file', { hash: getOriginalPdfAttachmentHashBySegment(rowData) })"
+              :href="Routing.generate('core_file_procedure', { hash: getOriginalPdfAttachmentHashBySegment(rowData), procedureId: procedureId })"
               rel="noopener noreferrer">
               {{ Translator.trans('original.pdf') }}
             </a>

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -209,6 +209,7 @@
       :editable="editable"
       :attachments="attachments"
       class="u-pt-0_5 border--bottom u-pb-0_5"
+      :procedure-id="procedureId"
       :statement-id="statement.id"
       @change="(value) => emitInput('attachments', value)" />
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
@@ -38,7 +38,7 @@
         v-else />
       <dp-upload-files
         :class="editable ? '' : 'pointer-events-none opacity-7'"
-        :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+        :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
         ref="uploadStatementAttachment"
         id="uploadStatementAttachment"
         name="uploadStatementAttachment"
@@ -86,6 +86,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+
+    procedureId: {
+      type: String,
+      required: true
     },
 
     statementId: {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachmentsLink.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachmentsLink.vue
@@ -9,7 +9,7 @@
 
 <template>
   <a
-    :href="Routing.generate('core_file', { hash: attachment.hash })"
+    :href="Routing.generate('core_file_procedure', { hash: attachment.hash, procedureId: procedureId})"
     rel="noopener"
     target="_blank">
     {{ attachment.filename }}
@@ -21,6 +21,11 @@ export default {
   name: 'StatementMetaAttachmentsLink',
 
   props: {
+    procedureId: {
+      type: String,
+      required: true
+    },
+
     attachment: {
       type: Object,
       required: true

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -93,17 +93,19 @@
                 <div class="overflow-x-scroll overflow-word-break max-height-500 max-width-600 width-max-content">
                   <span class="display--block weight--bold">{{ Translator.trans('original.pdf') }}</span>
                   <statement-meta-attachments-link
-                    class="display--block whitespace--normal u-mr-0_75"
                     v-if="originalAttachment.hash"
-                    :attachment="originalAttachment" />
+                    :attachment="originalAttachment"
+                    class="display--block whitespace--normal u-mr-0_75"
+                    :procedure-id="procedureId" />
                   <span
                     v-if="additionalAttachments.length > 0"
                     class="display--block weight--bold">{{ Translator.trans('more.attachments') }}</span>
                   <statement-meta-attachments-link
-                    class="display--block whitespace--normal u-mr-0_75"
                     v-for="attachment in additionalAttachments"
                     :key="attachment.hash"
-                    :attachment="attachment" />
+                    :attachment="attachment"
+                    class="display--block whitespace--normal u-mr-0_75"
+                    :procedure-id="procedureId" />
                 </div>
               </template>
             </dp-flyout>

--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -615,7 +615,7 @@
                 <a
                   v-if="hasOwnProp(statement.sourceAttachment, 'filename') && hasPermission('feature_read_source_statement_via_api')"
                   class="u-pr-0_5 o-hellip border--right u-mr-0_5"
-                  :href="Routing.generate('core_file', { hash: statement.sourceAttachment.hash })"
+                  :href="Routing.generate('core_file_procedure', { hash: statement.sourceAttachment.hash, procedureId: procedureId })"
                   rel="noopener"
                   target="_blank"
                   :title="Translator.trans('attachment.original')">
@@ -626,7 +626,7 @@
                   v-for="file in statement.files"
                   :key="file.hash"
                   class="u-pr-0_5 o-hellip"
-                  :href="Routing.generate('core_file', { hash: file.hash })"
+                  :href="Routing.generate('core_file_procedure', { hash: file.hash, procedureId: procedureId })"
                   rel="noopener"
                   target="_blank"
                   :title="Translator.trans('attachments')">

--- a/client/js/components/statement/fragmentList/Fragment.vue
+++ b/client/js/components/statement/fragmentList/Fragment.vue
@@ -468,7 +468,7 @@
           v-for="file in statementFiles"
           :key="file.hash"
           class="o-hellip u-pr-0_5"
-          :href="Routing.generate('core_file', { hash: file.hash })"
+          :href="Routing.generate('core_file_procedure', { hash: file.hash, procedureId: fragment.procedureId })"
           rel="noopener"
           target="_blank">
           {{ file.name }}

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -162,7 +162,7 @@
             <a
               v-if="hasPermission('feature_read_source_statement_via_api')"
               :class="{'is-disabled': originalPdf === null}"
-              :href="Routing.generate('core_file', { hash: originalPdf })"
+              :href="Routing.generate('core_file_procedure', { hash: originalPdf, procedureId: procedureId })"
               rel="noreferrer noopener"
               target="_blank">
               {{ Translator.trans('original.pdf') }}

--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -118,7 +118,7 @@
               rel="noopener"
               class="o-hellip"
               :class="statement.files.length > 0 ? 'border--right border-color--grey-light u-mr-0_5 u-pr-0_5' : ''"
-              :href="Routing.generate('core_file', { hash: statement.sourceAttachment.hash })">
+              :href="Routing.generate('core_file_procedure', { hash: statement.sourceAttachment.hash, procedureId: procedureId })">
               {{ statement.sourceAttachment.filename }}
             </a>
 
@@ -129,7 +129,7 @@
               target="_blank"
               rel="noopener"
               class="o-hellip"
-              :href="Routing.generate('core_file', { hash: file.hash })">
+              :href="Routing.generate('core_file_procedure', { hash: file.hash, procedureId: procedureId })">
               {{ file.filename }}
             </a>
           </div>

--- a/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
@@ -334,6 +334,12 @@ export default {
       validator: (val) => typeof val === 'string' || Array.isArray(val) || val === null,
       default: null
     },
+
+    procedureId: {
+      type: String,
+      required: true
+    },
+
     rejectedReason: {
       type: [String, null],
       required: false,
@@ -407,7 +413,7 @@ export default {
 
   methods: {
     renderAttachments (attachments) {
-      const transformedAttachments = attachments.map(a => `<a href="${Routing.generate('core_file', { hash: a.hash })}">${a.name}</a>`)
+      const transformedAttachments = attachments.map(a => `<a href="${Routing.generate('core_file_procedure', { hash: a.hash, procedureId: this.procedureId })}">${a.name}</a>`)
       return transformedAttachments.length > 0 ? transformedAttachments.join(', ') : Translator.trans('notspecified')
     },
 

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -255,7 +255,7 @@
                   :class="prefixClass('o-hellip')">
                   <a
                     :class="prefixClass('u-valign--top')"
-                    :href="Routing.generate('core_file', { hash: file.hash })"
+                    :href="Routing.generate('core_file_procedure', { hash: file.hash, procedureId: procedureId })"
                     rel="noopener"
                     target="_blank">
                     {{ file.name }}
@@ -278,7 +278,7 @@
                 <dp-upload-files
                   id="upload_files"
                   allowed-file-types="pdf-img-zip"
-                  :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
+                  :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
                   :max-file-size="2 * 1024 * 1024 * 1024/* 2 GiB */"
                   :max-number-of-files="20"
                   ref="uploadFiles"

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -56,7 +56,7 @@ class FileController extends BaseController
     public function fileProcedureAction(FileService $fileService, string $procedureId, string $hash): Response
     {
         try {
-            return $this->prepareResponseWithHash($fileService, $hash, $procedureId);
+            return $this->prepareResponseWithHash($fileService, $hash, true, $procedureId);
         } catch (Exception $e) {
             $this->getLogger()->info('Could not serve Procedure file: ', [$e]);
             throw new NotFoundHttpException();
@@ -66,14 +66,14 @@ class FileController extends BaseController
     /**
      * @throws Exception
      */
-    protected function prepareResponseWithHash(FileService $fileService, string $hash, ?string $procedureId = null): Response
+    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, ?string $procedureId = null): Response
     {
         $fs = new Filesystem();
         // @improve T14122
         $file = $fileService->getFileInfo($hash);
 
         // ensure that procedure access check matches file procedure
-        if (!$this->isValidProcedure($procedureId, $file)) {
+        if (!$this->isValidProcedure($procedureId, $file, $strictCheck)) {
             $this->getLogger()->info(
                 'Tried to access file from different Procedure: ',
                 [$file->getProcedure()->getId(), $procedureId]
@@ -99,10 +99,10 @@ class FileController extends BaseController
         return $response;
     }
 
-    private function isValidProcedure(?string $procedureId, FileInfo $file): bool
+    private function isValidProcedure(?string $procedureId, FileInfo $file, bool $strictCheck): bool
     {
         // do not check if no procedure is given
-        if (null === $procedureId) {
+        if (!$strictCheck && null === $procedureId) {
             return true;
         }
 

--- a/demosplan/DemosPlanDocumentBundle/Tools/ServiceImporter.php
+++ b/demosplan/DemosPlanDocumentBundle/Tools/ServiceImporter.php
@@ -332,8 +332,9 @@ class ServiceImporter implements ServiceImporterInterface
                             $stringToReplace = '/file/'.substr($f, 2);
                             $paragraph['text'] = str_replace(
                                 $stringToReplace,
-                                $this->router->generate('core_file', [
-                                    'hash' => $hash,
+                                $this->router->generate('core_file_procedure', [
+                                    'hash'        => $hash,
+                                    'procedureId' => $procedureId,
                                 ]),
                                 $paragraph['text']
                             );

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/includes/single_document_file_upload.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/includes/single_document_file_upload.html.twig
@@ -3,7 +3,7 @@
         id="r_document"
         allowed-file-types="pdf-zip-video"
         :get-file-by-hash="(hash) => {
-           return Routing.generate('core_file', { hash: hash })
+           return Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
         }"
         :label="{
           hint: Translator.trans('file.upload.pdf.zip.mp4'),
@@ -21,7 +21,7 @@
         id="r_document"
         allowed-file-types="pdf-video"
         :get-file-by-hash="(hash) => {
-           return Routing.generate('core_file', { hash: hash })
+           return Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
         }"
         :label="{
           hint: Translator.trans('file.upload.pdf.mp4'),

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
@@ -79,7 +79,7 @@
                 table: true
             }"
             :routes="{
-              getFileByHash: (hash) => Routing.generate('core_file', { hash: hash })
+             getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
             }"
             procedure-id="{{ procedure }}"
             :required="true">

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/paragraph_admin_new.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/paragraph_admin_new.html.twig
@@ -70,7 +70,7 @@
                 table: true
             }"
             :routes="{
-              getFileByHash: (hash) => Routing.generate('core_file', { hash: hash })
+               getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
             }"
             procedure-id="{{ procedure }}"
             :required="true">

--- a/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_new.html.twig
+++ b/templates/bundles/DemosPlanDocumentBundle/DemosPlanDocument/single_document_admin_new.html.twig
@@ -67,7 +67,8 @@
             {% endif %}
 
             {% include "@DemosPlanDocument/DemosPlanDocument/includes/single_document_file_upload.html.twig" with {
-                required: true
+                required: true,
+                procedure: procedure
             } %}
 
             <div class="text--right space-inline-s">

--- a/templates/bundles/DemosPlanMapBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanMapBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -302,7 +302,7 @@
                         class="{{ 'c-map__tool o-link--default'|prefixClass }}"
                         target="_blank"
                         rel="noopener"
-                        href="{{ path('core_file', { 'hash': procedureSettings.planDrawPDF|getFile('hash') }) }}"
+                        href="{{ path('core_file_procedure', { 'hash': procedureSettings.planDrawPDF|getFile('hash'), 'procedureId': procedure|default() }) }}"
                         title="{{ 'drawing.download'|trans }} ({{ procedureSettings.planDrawPDF|getFile('mimeType') }} {{ procedureSettings.planDrawPDF|getFile('size','MB') }})">
                         <i class="{{ 'fa fa-download'|prefixClass }}" aria-hidden="true"></i>
                         {{ "drawing.download"|trans }}
@@ -327,7 +327,8 @@
                 <dp-layer-legend
                     v-show="Boolean({{ display_legend_box }})"
                     :layers-with-legend-files="JSON.parse('{{ layers_with_legend_files|json_encode|e('js', 'utf-8') }}')"
-                    :plan-pdf="JSON.parse('{{ planPdf|json_encode|e('js', 'utf-8') }}')">
+                    :plan-pdf="JSON.parse('{{ planPdf|json_encode|e('js', 'utf-8') }}')"
+                    procedure-id="{{ procedure|default('') }}">
                 </dp-layer-legend>
 
                 {# Zoom to extend, measure length + area #}

--- a/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail_form_statement.html.twig
+++ b/templates/bundles/DemosPlanProcedureBundle/DemosPlanProcedure/public_detail_form_statement.html.twig
@@ -163,7 +163,7 @@
                             {{ "attachments" |trans }}
                         </p>
 
-                        <div class="{{ 'display--none o-hellip'|prefixClass }}" data-statement-files="{{ path('core_file', {'hash': '---hash---'}) }}">
+                        <div class="{{ 'display--none o-hellip'|prefixClass }}" data-statement-files="{{ path('core_file_procedure', {'hash': '---hash---', 'procedureId': procedure}) }}">
                             <a href="#" target="_blank"></a>
                             <label class="{{ 'lbl--text display--inline-block u-mb-0_25 u-ml'|prefixClass }}">
                                 <input value="---hash---" name="delete_file[]" type="checkbox">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30158

Description:  

- use fileProcedureAction instead fileAction to access files.

- add bool parameters 'strictCheck' which define if a procedureId is available and has to be checked if true ( here is fileProcedureAction used ) or not if false ( here is fileAction used ).

- adjust route name in twigs and add procedure Id for routing



Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
