### PR TITLE
fix(refs T33576): use correct id

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
@@ -79,7 +79,7 @@
             <p class="{{ 'inline color--grey align-middle'|prefixClass }}">{{ templateVars.proceduresDirectlinkPrefix }}/</p>
 
             {{ uiComponent('form.input.text', {
-                id: 'orga_slug',
+                id: organisation.ident|default ~ ':slug',
                 name: organisation.ident|default ~ ':slug',
                 class: submittedAuthorClass|default,
                 value: organisation.currentSlug.name|default,


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33576

:warning: This was accidentally merged into main, so here it comes again.

If users click on the input label, at least the input should be focused - this way they won't experience it as a bug if the cursor turns to a pointer when hovering labels.

### How to review/test
As a planner org, go to "Daten der Organisation". When clicking the Label for the orga slug, the respective input field should be focused.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
