### PR TITLE
fix(T33575): issue with the table when a row is expanded

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_toggle.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_toggle.scss
@@ -100,7 +100,7 @@
                 animation-fill-mode: forwards;
 
                 &.table-row {
-                    display: table-row;
+                    display: table-row !important;
                 }
             }
 
@@ -119,7 +119,7 @@
                 transform: translateY(0);
 
                 &.table-row {
-                    display: table-row;
+                    display: table-row !important;
                 }
             }
         }
@@ -132,7 +132,7 @@
                 display: block !important;
 
                 &.table-row {
-                    display: table-row;
+                    display: table-row !important;
                 }
             }
         }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33575

**Description:** This PR fixes an issue with the table when a row is expanded.

After some refactoring an `!important` declaration was added to the `display:block` property in the `is-active `and `is-visible` classes, which causes an issue when `is-active` is added to the `table-row`, because it has higher priority. 

it was necessary to add also the `!important` declaration to the '.table-row' class to fix the bug.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
