### PR TITLE
fix (refs T33506): Fix statement status data by adding missing necessary 'freq' key.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -451,7 +451,6 @@ class DemosPlanProcedureController extends BaseController
                 $statusValue = $aggregationBucket['value'];
                 $statusCount = $aggregationBucket['count'];
                 $statementStatusData[$statusValue]['count'] = $statusCount;
-                $statementStatusData[$statusValue]['freq'] = $priorityInitialValues;
 
                 // add link with filterhash to assessment table
                 if (0 < $statusCount) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -445,20 +445,22 @@ class DemosPlanProcedureController extends BaseController
         }
 
         // save status counts
-        $esResultMeta = $statementQueryResult->getFilterSet();
-        $aggregations = $esResultMeta['filters'];
+        $aggregations = $statementQueryResult->getFilterSet()['filters'];
         foreach ($aggregations[StatementService::AGGREGATION_STATEMENT_STATUS] as $aggregationBucket) {
-            $statusValue = $aggregationBucket['value'];
-            $statusCount = $aggregationBucket['count'];
-            $statementStatusData[$statusValue]['count'] = $statusCount;
+            if (array_key_exists($aggregationBucket['value'], $statementStatuses)) {
+                $statusValue = $aggregationBucket['value'];
+                $statusCount = $aggregationBucket['count'];
+                $statementStatusData[$statusValue]['count'] = $statusCount;
+                $statementStatusData[$statusValue]['freq'] = $priorityInitialValues;
 
-            // add link with filterhash to assessment table
-            if (0 < $statusCount) {
-                $statementStatusData[$statusValue]['url'] = $this->generateAssessmentTableFilterLinkFromStatus(
-                    $statusValue,
-                    $procedureId,
-                    'statement'
-                );
+                // add link with filterhash to assessment table
+                if (0 < $statusCount) {
+                    $statementStatusData[$statusValue]['url'] = $this->generateAssessmentTableFilterLinkFromStatus(
+                        $statusValue,
+                        $procedureId,
+                        'statement'
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33506
(Related Ticket: https://yaits.demos-deutschland.de/T32108)

Fix statement status data by adding missing necessary 'freq' key.
Also only add only $aggregations['status'] which is useful for the User, defined in form_options.yml

I do not understand, where some key-value-pairs are came from. like '1' : '1' or '0' : '0' for example.
I just filter these, but actually I would prefer to understand where and why they come from. Is there a deeper problem with ES or something?


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
