### PR TITLE
fix(refs T33353): Change way of replacing \n\r with blanks

### DIFF
--- a/client/js/components/core/DpEditor/libs/handleWordPaste.js
+++ b/client/js/components/core/DpEditor/libs/handleWordPaste.js
@@ -272,7 +272,7 @@ function buildListAsHtmlString (list) {
  * @return {string}
  */
 function prepareDataBeforeParsingMso (slice) {
-  const x = slice
+  return slice
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
     // Strip line breaks
@@ -291,9 +291,6 @@ function prepareDataBeforeParsingMso (slice) {
         .replace(/(&nbsp;|\s|\\r|\\n|\r|\n)/gmi, '')
       return `<span data-val-${p1}="${listStyleType}" />`
     })
-
-  console.log(x, slice)
-  return x
 }
 
 /**

--- a/client/js/components/core/DpEditor/libs/handleWordPaste.js
+++ b/client/js/components/core/DpEditor/libs/handleWordPaste.js
@@ -276,7 +276,7 @@ function prepareDataBeforeParsingMso (slice) {
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
     // Strip line breaks
-    .replace(/(\r\n)+?/gmi, ' ')
+    .replace(/(\r\n)+/gmi, ' ')
     // Strip html wrapper and remove conentless and non html like elements "<o:p>"
     .replace(/<(\/)?(html|o:p)[^>]*>/gmi, '')
     /*

--- a/client/js/components/core/DpEditor/libs/handleWordPaste.js
+++ b/client/js/components/core/DpEditor/libs/handleWordPaste.js
@@ -273,10 +273,10 @@ function buildListAsHtmlString (list) {
  */
 function prepareDataBeforeParsingMso (slice) {
   return slice
-    // Strip line breaks
-    .replace(/(&nbsp;|\r|\n)/gmi, ' ')
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
+    // Strip line breaks
+    .replace(/(\r\n)+?/gmi, ' ')
     // Strip html wrapper and remove conentless and non html like elements "<o:p>"
     .replace(/<(\/)?(html|o:p)[^>]*>/gmi, '')
     /*

--- a/client/js/components/core/DpEditor/libs/handleWordPaste.js
+++ b/client/js/components/core/DpEditor/libs/handleWordPaste.js
@@ -272,7 +272,7 @@ function buildListAsHtmlString (list) {
  * @return {string}
  */
 function prepareDataBeforeParsingMso (slice) {
-  return slice
+  const x = slice
     // Strip head
     .replace(/<head>(.|\n|\r)*?<\/head>/mi, '')
     // Strip line breaks
@@ -291,6 +291,9 @@ function prepareDataBeforeParsingMso (slice) {
         .replace(/(&nbsp;|\s|\\r|\\n|\r|\n)/gmi, '')
       return `<span data-val-${p1}="${listStyleType}" />`
     })
+
+  console.log(x, slice)
+  return x
 }
 
 /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33353

For some reason, the way it works atm on main doesn't worked here (#1628). So we had to adjust the fix a bit.



<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Paste Text from Word (not office365) into some editor (e.g. "Textbausteine Anlegen"). All blank spaces should be preserved.

As a Dev, this can't be tested, only reviewed since there is no real word on linux.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
