### PR TITLE
chore (refs T33621): use SecurityUser in Authentication

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use demosplan\DemosPlanCoreBundle\Entity\User\SecurityUser;
 use demosplan\DemosPlanCoreBundle\Logic\OzgKeycloakUserDataMapper;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserDataInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -81,7 +82,7 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
                     $this->logger->info('doctrine transaction commit.');
                     $request->getSession()->set('userId', $user->getId());
 
-                    return $user;
+                    return new SecurityUser($user);
                 } catch (Exception $e) {
                     $this->entityManager->getConnection()->rollBack();
                     $this->logger->info('doctrine transaction rollback.');


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33621

SecurityUser needs to be used in Authentication, otherwise, the `User` will be persisted in the session which may be too big to be stored in the default Blob column size

### How to review/test
code review might be best as you need to login via keycloak

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
