### PR TITLE
Prevent 2px jump of button

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -451,7 +451,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
 
             &.is-active {
                 background-color: $dp-color-highlight;
-                border: $dp-color-highlight;
+                border-color: $dp-color-highlight;
             }
         }
 


### PR DESCRIPTION
This PR fixes the 2px jump of the "Geltungsbereich" and "Planzeichnung" buttons.

![1px-jump](https://github.com/demos-europe/demosplan-core/assets/40452344/caae50df-4cb2-4114-86d5-796476f7f2b6)

.btn assigns `border: 1px solid transparent;`, so if the `border` shorthand specifies the color only, this actually means `border: none $dp-color-highlight initial;`, at least to my understanding.

### How to review/test
Buttons should have consistent sizing when activated and deactivated.
