### PR TITLE
fix(refs T33640): update getcapabilities-url @blur, not @input

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -30,7 +30,7 @@
       }"
       name="r_url"
       required
-      @input="getLayerCapabilities"
+      @blur="getLayerCapabilities"
       @enter="getLayerCapabilities" />
 
     <dp-select

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,9 +1438,9 @@
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
 "@demos-europe/demosplan-ui@^0":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.7.tgz#239145c37a1afd43a19e411cee32686a391506c1"
-  integrity sha512-gFojtRMfuvvY64S2cPgvDeMfFd6/dqBrgdC/PCko6Fvf0dLrIHUtAIHL5cxjGkXjPdgKTVnloh+1UMUa2ypNRg==
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.8.tgz#7cfb87dcd6ebb70159292e90d9297783706433f6"
+  integrity sha512-a0LhGInNYaKgTCa8YGefupf7Ynfx9/lD3EhiBEstVQuUR/jaIVGAQaARMHlEuo6KQztTW8xT/QJmzDpMxEV8QA==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@uppy/core" "^3.0.1"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33640

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

To avoid fetching the getCapabilities while typing in url field. We have to wait until the input is done, so the chance that there is a valid url is more likely.
This change only works with  demosplan-ui@0.1.8  or higher, that including the "@bubble"-event in dpInput
(see changes in yarn.lock)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

as FPA go to `/verfahren/<procedure-id>/verwalten/gislayer/neu`.
start typing a URL in the url-Field. You should not get Errors while typing


### Linked PRs

- Other PR1 https://github.com/demos-europe/demosplan-ui/pull/356

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
