### PR TITLE
feature (refs T32960): Also create a version of the original draftSTN on first update

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -1078,6 +1078,16 @@ class DraftStatementService extends CoreService
             // Create and use versions of paragraph and Element
             $data = $this->getEntityVersions($data);
 
+            // before updating the draftstatement - check if a version allready exists
+            // if versioning is requested and no version exists yet - create a version of the original state as well
+            // before updating the entity. refs T32960:
+            if($createVersion && 0 === count($this->getVersionList($data['ident']))) {
+                $draftStatementBeforeUpdate = $this->draftStatementRepository->get($data['ident']);
+                if (null !== $draftStatementBeforeUpdate) {
+                    $this->draftStatementVersionRepository->createVersion($draftStatementBeforeUpdate);
+                }
+            }
+
             $draftStatement = $this->draftStatementRepository
                 ->update($data['ident'], $data);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -1081,7 +1081,7 @@ class DraftStatementService extends CoreService
             // before updating the draftstatement - check if a version allready exists
             // if versioning is requested and no version exists yet - create a version of the original state as well
             // before updating the entity. refs T32960:
-            if($createVersion && 0 === count($this->getVersionList($data['ident']))) {
+            if ($createVersion && 0 === count($this->getVersionList($data['ident']))) {
                 $draftStatementBeforeUpdate = $this->draftStatementRepository->get($data['ident']);
                 if (null !== $draftStatementBeforeUpdate) {
                     $this->draftStatementVersionRepository->createVersion($draftStatementBeforeUpdate);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32960

Description:
Also create a draftStatementVersion of the original draftStatement 
when updating the draftStatement the first time 
in order to show the original data to the author as well - when looking at the versions.
slack question: https://demosdeutschland.slack.com/archives/C04122AUGE7/p1688720607061929

### How to review/test
write a draft statement somewhere and navigate to 'your drafts' -> edit the statement and check the versions of it.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
