### PR TITLE
feature (refs T32782): check for weak passwords only after succesful login

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
+++ b/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace demosplan\DemosPlanCoreBundle\Security\HTTP\EventListener;
 

--- a/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
+++ b/demosplan/DemosPlanCoreBundle/Security/HTTP/EventListener/WeakPasswordCheckerEventListener.php
@@ -22,7 +22,9 @@ class WeakPasswordCheckerEventListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [CheckPassportEvent::class => ['checkPassport']];
+        // this should be handled after the CheckCredentialsListener::checkPassport() has veryfied
+        // that the users credentials are correct - therefore the negativ priority is set here. refs T32782:
+        return [CheckPassportEvent::class => ['checkPassport', -1]];
     }
 
     public function checkPassport(CheckPassportEvent $event): void


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32782

Description:
The CheckPassportEvent has many different listeners which do not belong to our Code.
They use priorities from 2000 down to 0. On login failure an Exception is thrown preventing further events being triggered.
 Our own listener needs to be called last - only after successful login - to check for weak passwords - so a negative priority was added.

### How to review/test
try to log in with an existing user and a wrong pw... check the flashbag messages.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
