### PR TITLE
feat: Remove unused properties in StatementService.php

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -135,7 +135,6 @@ use Elastica\Query;
 use Elastica\Query\AbstractQuery;
 use Elastica\Query\BoolQuery;
 use Exception;
-use FOS\ElasticaBundle\Index\IndexManager;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Pagerfanta\Exception\NotValidCurrentPageException;
 use ReflectionException;
@@ -196,12 +195,6 @@ class StatementService extends CoreService implements StatementServiceInterface
 
     /** @var UserService */
     protected $userService;
-
-    /** @var IndexManager */
-    protected $esIndexManager;
-
-    /** @var DemosPlanStatementAPIController */
-    protected $statementApiController;
 
     /** @var HashedQueryService */
     protected $filterSetService;


### PR DESCRIPTION
I removed two unused properties from the StatementService.

### How to review/test
Check if the properties are still used

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
