### PR TITLE
chore: upgrade passwords during test login

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,6 +14,9 @@ security:
                 - saltlessMd5
         demosplan\DemosPlanCoreBundle\Entity\User\User:
             algorithm: auto
+            migrate_from:
+                - customSha512
+                - saltlessMd5
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 
     providers:


### PR DESCRIPTION
In the context of pre login check for testusers `User` objects are used instead of `SecurityUser` objects. We need to automatically update their passwords in order to be able to change testuser passwords to something known.

### How to review/test
Code review or set `alternative_login_testuser_defaultpass` to something new, update a user's password with the md5 hash of it, clear the cache and visit the login page. The user should appear in the login list

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
