### PR TITLE
feature (refs T32796): remove procedure from procedure_message table

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230706091408.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230706091408.php
@@ -30,8 +30,7 @@ class Version20230706091408 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-        $this->addSql('CREATE TABLE procedure_message (id CHAR(36) NOT NULL, procedure_id CHAR(36) NOT NULL, message LONGTEXT NOT NULL, created_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, modification_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, error TINYINT(1) DEFAULT false NOT NULL, deleted TINYINT(1) DEFAULT false NOT NULL, request_count INT DEFAULT 0 NOT NULL, UNIQUE INDEX UNIQ_E7F5DA961624BCD2 (procedure_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 FOREIGN KEY (procedure_id) REFERENCES _procedure (_p_id)');
+        $this->addSql('CREATE TABLE procedure_message (id CHAR(36) NOT NULL, message LONGTEXT NOT NULL, created_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, modification_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, error TINYINT(1) DEFAULT false NOT NULL, deleted TINYINT(1) DEFAULT false NOT NULL, request_count INT DEFAULT 0 NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
     }
 
     /**
@@ -41,7 +40,6 @@ class Version20230706091408 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-        $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
         $this->addSql('DROP TABLE procedure_message');
     }
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230706091408.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230706091408.php
@@ -30,7 +30,8 @@ class Version20230706091408 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-        $this->addSql('CREATE TABLE procedure_message (id CHAR(36) NOT NULL, message LONGTEXT NOT NULL, created_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, modification_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, error TINYINT(1) DEFAULT false NOT NULL, deleted TINYINT(1) DEFAULT false NOT NULL, request_count INT DEFAULT 0 NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE procedure_message (id CHAR(36) NOT NULL, procedure_id CHAR(36) NOT NULL, message LONGTEXT NOT NULL, created_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, modification_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, error TINYINT(1) DEFAULT false NOT NULL, deleted TINYINT(1) DEFAULT false NOT NULL, request_count INT DEFAULT 0 NOT NULL, UNIQUE INDEX UNIQ_E7F5DA961624BCD2 (procedure_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 FOREIGN KEY (procedure_id) REFERENCES _procedure (_p_id)');
     }
 
     /**
@@ -40,6 +41,7 @@ class Version20230706091408 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
+        $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
         $this->addSql('DROP TABLE procedure_message');
     }
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
@@ -31,8 +31,6 @@ class Version20230711125038 extends AbstractMigration
     {
         $this->abortIfNotMysql();
         $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
-        $table = $schema->getTable('procedure_message');
-        $table->dropColumn('procedure_id');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
@@ -31,7 +31,7 @@ class Version20230711125038 extends AbstractMigration
     {
         $this->abortIfNotMysql();
         $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
-        $this->addSql('DROP INDEX UNIQ_E7F5DA961624BCD2 ON _procedure');
+        $this->addSql('DROP INDEX UNIQ_E7F5DA961624BCD2 ON procedure_message');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
@@ -31,6 +31,7 @@ class Version20230711125038 extends AbstractMigration
     {
         $this->abortIfNotMysql();
         $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
+        $this->addSql('DROP INDEX UNIQ_E7F5DA961624BCD2 ON _procedure');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/07/Version20230711125038.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230711125038 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs 32796 create ProcedureMessage in relation with XBeteiligung ';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
+        $table = $schema->getTable('procedure_message');
+        $table->dropColumn('procedure_id');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+    }
+
+    /**S
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32796

Set Migration for ProcedureMessage Table in relation with XBeteiligung's Entity

### How to review/test
check Migration File or run it

### Linked PRs (optional)

- {PR-number1} (https://github.com/demos-europe/demosplan-addon-xbeteiligung-async/pull/2)

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
