### PR TITLE
feature (refs T33429): add datenerfassung role in dataMapper and difi…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -64,6 +64,7 @@ class OzgKeycloakUserDataMapper
         'Redaktion'                         => Role::CONTENT_EDITOR,
         'Privatperson-Angemeldet'           => Role::CITIZEN,
         'Fachliche Leitstelle'              => Role::PROCEDURE_CONTROL_UNIT,
+        'Datenerfassung'                    => Role::PROCEDURE_DATA_INPUT
     ];
 
     public function __construct(private readonly CustomerService $customerService, private readonly DepartmentRepository $departmentRepository, private readonly EntityManagerInterface $entityManager, private readonly GlobalConfig $globalConfig, private readonly LoggerInterface $logger, private readonly OrgaRepository $orgaRepository, private readonly OrgaService $orgaService, private readonly OrgaTypeRepository $orgaTypeRepository, private readonly RoleRepository $roleRepository, private readonly UserRepository $userRepository, private readonly UserRoleInCustomerRepository $userRoleInCustomerRepository, private readonly UserService $userService, private readonly ValidatorInterface $validator)


### PR DESCRIPTION
…ne keycloak authentication as parameters in diplanrog

**Ticket:** https://yaits.demos-deutschland.de/T33429

 Description: Set Keycloak configuration for diplanrog, and add a new role (datenerfassung) 

### How to review/test
 - Run keycloak in docker: `docker run -v /keycloak_data:/opt/keycloak/data/~ -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:21.1.2 start-dev
`
- Configuration Keycloak ([Doc](https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_wiki/wikis/EfA%20DiPlanung%20Wiki/244/Aufschl%C3%BCsselung-der-Rechte))
- run `http://diplanrog.dplan.local/app_dev.php/connect/keycloak_ozg/`
- base on [this](https://yaits.demos-deutschland.de/T29403#711355) Ticket


Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
