### PR TITLE
fix(refs T33148): Send Batch to add multiple Toeb to toeblist

### DIFF
--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -121,15 +121,13 @@ export default {
         url: Routing.generate('dplan_api_procedure_add_invited_public_affairs_bodies', {
           procedureId: this.procedureId
         }),
-        data: publicAgenciesIds.map(id => {
+        data: { data: publicAgenciesIds.map(id => {
           return {
-            data: {
-              type: 'publicAffairsAgent',
-              id: id
-            }
+            type: 'publicAffairsAgent',
+            id: id
           }
         })
-      })
+      }})
         // Refetch invitable institutions list to ensure that invited institutions are not displayed anymore
         .then(() => {
           this.getInstitutions({ procedureId: this.procedureId })

--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -116,13 +116,13 @@ export default {
         return dplan.notify.notify('warning', Translator.trans('organisation.select.first'))
       }
 
-      const invitePublicAgencies = publicAgenciesIds.map(id => {
-        return dpApi({
-          method: 'POST',
-          url: Routing.generate('dplan_api_procedure_add_invited_public_affairs_bodies', {
-            procedureId: this.procedureId
-          }),
-          data: {
+      dpApi({
+        method: 'POST',
+        url: Routing.generate('dplan_api_procedure_add_invited_public_affairs_bodies', {
+          procedureId: this.procedureId
+        }),
+        data: publicAgenciesIds.map(id => {
+          return {
             data: {
               type: 'publicAffairsAgent',
               id: id
@@ -130,8 +130,6 @@ export default {
           }
         })
       })
-
-      Promise.all(invitePublicAgencies)
         // Refetch invitable institutions list to ensure that invited institutions are not displayed anymore
         .then(() => {
           this.getInstitutions({ procedureId: this.procedureId })

--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -121,13 +121,15 @@ export default {
         url: Routing.generate('dplan_api_procedure_add_invited_public_affairs_bodies', {
           procedureId: this.procedureId
         }),
-        data: { data: publicAgenciesIds.map(id => {
-          return {
-            type: 'publicAffairsAgent',
-            id: id
-          }
-        })
-      }})
+        data: {
+          data: publicAgenciesIds.map(id => {
+            return {
+              type: 'publicAffairsAgent',
+              id: id
+            }
+          })
+        }
+      })
         // Refetch invitable institutions list to ensure that invited institutions are not displayed anymore
         .then(() => {
           this.getInstitutions({ procedureId: this.procedureId })

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the package demosplan.
  *
- * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */
@@ -83,6 +83,7 @@ class DemosPlanProcedureAPIController extends APIController
      *        methods={"GET"},
      *        name="dplan_api_procedure_"
      * )
+     *
      * @DplanPermissions("area_public_participation")
      */
     public function listAction(Request $request): APIResponse
@@ -102,6 +103,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_mark_participated",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("feature_procedures_mark_participated")
      *
      * @param string $procedureId
@@ -129,6 +131,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_unmark_participated",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("feature_procedures_mark_participated")
      *
      * @param string $procedureId
@@ -158,6 +161,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_get_statement_empty_filters",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @return \demosplan\DemosPlanCoreBundle\Response\APIResponse|JsonResponse
@@ -175,6 +179,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_get_original_statement_empty_filters",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @return \demosplan\DemosPlanCoreBundle\Response\APIResponse|JsonResponse
@@ -190,6 +195,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_get_original_filters",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
@@ -226,6 +232,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dp_api_procedure_get_statement_filters",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
@@ -262,6 +269,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dplan_api_procedure_update_filter_hash",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
@@ -280,6 +288,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dplan_api_procedure_update_original_filter_hash",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $procedureId
@@ -437,6 +446,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dplan_api_procedure_delete_statement_filter",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_assessmenttable")
      *
      * @param string $filterSetId
@@ -512,6 +522,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     name="dplan_api_procedure_add_invited_public_affairs_bodies",
      *     options={"expose": true}
      * )
+     *
      * @DplanPermissions("area_admin_invitable_institution")
      */
     public function addInvitedPublicAffairsAgentsAction(
@@ -542,6 +553,7 @@ class DemosPlanProcedureAPIController extends APIController
      *     path="/verfahren/suche/ajax",
      *     options={"expose": true},
      * )
+     *
      * @DplanPermissions("area_public_participation")
      *
      * @return JsonResponse

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -514,8 +514,11 @@ class DemosPlanProcedureAPIController extends APIController
      * )
      * @DplanPermissions("area_admin_invitable_institution")
      */
-    public function addInvitedPublicAffairsAgentsAction(Request $request, ResourceLinkageFactory $linkageFactory, string $procedureId): JsonResponse
-    {
+    public function addInvitedPublicAffairsAgentsAction(
+        Request $request,
+        ResourceLinkageFactory $linkageFactory,
+        string $procedureId
+    ): JsonResponse {
         // Check if normalizer succeeded, even if we don't need its object here
         if (null === $this->requestData) {
             throw BadRequestException::normalizerFailed();

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceLinkageFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceLinkageFactory.php
@@ -44,6 +44,6 @@ class ResourceLinkageFactory
             throw new InvalidArgumentException('expected JSON object with \'data\' as only field containing an array');
         }
 
-        return ToManyResourceLinkage::createFromArray($requestJson);
+        return ToManyResourceLinkage::createFromArray($requestJson[ContentField::DATA]);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceLinkageFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceLinkageFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * This file is part of the package demosplan.
  *
- * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33148

Adjust request structure to specification and fix use of ToManyResourceLinkage::createFromArray(), to allow 
add multiple agencies to one procedure in one request.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
