### PR TITLE
feature (refs T32776): update composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1289,16 +1289,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.4",
+            "version": "v0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "6c8ba877eba21082cf98509de8da8eba12e688e9"
+                "reference": "be7573c459ba8abc4663b87aa5a6567bc67a880b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/6c8ba877eba21082cf98509de8da8eba12e688e9",
-                "reference": "6c8ba877eba21082cf98509de8da8eba12e688e9",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/be7573c459ba8abc4663b87aa5a6567bc67a880b",
+                "reference": "be7573c459ba8abc4663b87aa5a6567bc67a880b",
                 "shasum": ""
             },
             "require": {
@@ -1334,9 +1334,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.4"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.5"
             },
-            "time": "2023-07-06T10:57:32+00:00"
+            "time": "2023-07-13T09:47:55+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T32776

Description:
updates the composer.lock to get the newest version 0.5 of demosplan-addon

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
