### PR TITLE
fix: add missing JSON:API deletion permission check

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DeletableDqlResourceTypeInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DeletableDqlResourceTypeInterface.php
@@ -26,4 +26,9 @@ interface DeletableDqlResourceTypeInterface extends ResourceTypeInterface
      * @return ResourceChange<T>
      */
     public function delete(object $entity): ResourceChange;
+
+    /**
+     * @return list<non-empty-string> list of permission identifiers, each and all permissions must be enabled for the resource to be deletable
+     */
+    public function getRequiredDeletionPermissions(): array;
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
@@ -51,13 +51,15 @@ final class GlobalNewsResourceType extends AbstractNewsResourceType implements D
      */
     public function delete(object $entity): ResourceChange
     {
-        if (!$this->currentUser->hasPermission('area_admin_globalnews')) {
-            throw new BadRequestException("deletion of GlobalNews not allowed: {$entity->getId()}");
-        }
         $resourceChange = new ResourceChange($entity, $this, []);
         $resourceChange->addEntityToDelete($entity);
 
         return $resourceChange;
+    }
+
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['area_admin_globalnews'];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
@@ -17,7 +17,6 @@ use DemosEurope\DemosplanAddon\Logic\ResourceChange;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\GlobalContent;
 use demosplan\DemosPlanCoreBundle\Entity\ManualListSort;
-use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PropertiesUpdater;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DeletableDqlResourceTypeInterface;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
@@ -239,7 +239,7 @@ class InstitutionTagResourceType extends DplanResourceType implements UpdatableD
         Collection $currentTaggedInstitutions,
         Collection $newTaggedInstitutions
     ): Collection {
-        return $newTaggedInstitutions->filter(static fn(Orga $newOrga): bool => !$currentTaggedInstitutions->contains($newOrga));
+        return $newTaggedInstitutions->filter(static fn (Orga $newOrga): bool => !$currentTaggedInstitutions->contains($newOrga));
     }
 
     /**
@@ -253,7 +253,7 @@ class InstitutionTagResourceType extends DplanResourceType implements UpdatableD
         Collection $newTaggedInstitutions
     ): Collection {
         return $currentTaggedInstitutions->filter(
-            static fn(Orga $currentOrga): bool => !$newTaggedInstitutions->contains($currentOrga)
+            static fn (Orga $currentOrga): bool => !$newTaggedInstitutions->contains($currentOrga)
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
@@ -200,10 +200,6 @@ class InstitutionTagResourceType extends DplanResourceType implements UpdatableD
      */
     public function delete(object $tag): ResourceChange
     {
-        if (!$this->currentUser->hasPermission('feature_institution_tag_delete')) {
-            throw new InvalidArgumentException('Insufficient permissions');
-        }
-
         $owningOrganisation = $tag->getOwningOrganisation();
         $owningOrganisation->removeOwnInstitutionTag($tag);
         $violations = $this->validator->validate($owningOrganisation);
@@ -226,6 +222,11 @@ class InstitutionTagResourceType extends DplanResourceType implements UpdatableD
         $resourceChange->addEntityToDelete($tag);
 
         return $resourceChange;
+    }
+
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['feature_institution_tag_delete'];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
@@ -154,7 +154,7 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
         $enabled = $this->createAttribute($this->enabled)->filterable();
         $parentId = $this->createAttribute($this->parentId)->aliasedPath($this->parent->id);
         $fileInfo = $this->createAttribute($this->fileInfo)
-                ->readable(true, fn(Elements $element): array => $this->fileService->getInfoArrayFromFileString($element->getFile()));
+                ->readable(true, fn (Elements $element): array => $this->fileService->getInfoArrayFromFileString($element->getFile()));
         $filePathWithHash = $this->createAttribute($this->filePathWithHash)
             ->readable(true, function (Elements $element): ?string {
                 $filePathWithHash = null;
@@ -172,7 +172,7 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
         $title = $this->createAttribute($this->title);
         $text = $this->createAttribute($this->text);
         $children = $this->createToManyRelationship($this->children, true)
-            ->readable(true, static fn(Elements $element): Collection => $element->getChildren()->filter(fn(Elements $elements): bool => $elements->getEnabled()));
+            ->readable(true, static fn (Elements $element): Collection => $element->getChildren()->filter(fn (Elements $elements): bool => $elements->getEnabled()));
         $documents = $this->createToManyRelationship($this->documents, true);
         $index = $this->createAttribute($this->index)->readable(true)->aliasedPath($this->order);
 
@@ -220,7 +220,7 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
             if (!\in_array($index, $properties, true)) {
                 $properties[] = $index;
             }
-            $properties = [...$properties, $this->createAttribute($this->designatedSwitchDate)->readable(false, fn(Elements $category): ?string => $this->formatDate($category->getDesignatedSwitchDate())), $this->createAttribute($this->category)->readable(), $this->createToOneRelationship($this->procedure)->filterable()];
+            $properties = [...$properties, $this->createAttribute($this->designatedSwitchDate)->readable(false, fn (Elements $category): ?string => $this->formatDate($category->getDesignatedSwitchDate())), $this->createAttribute($this->category)->readable(), $this->createToOneRelationship($this->procedure)->filterable()];
         }
 
         return $properties;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
@@ -16,7 +16,6 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\ElementsInterface;
 use DemosEurope\DemosplanAddon\Contracts\ResourceType\UpdatableDqlResourceTypeInterface;
 use DemosEurope\DemosplanAddon\Logic\ResourceChange;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
-use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DeletableDqlResourceTypeInterface;
@@ -292,10 +291,6 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
      */
     public function delete(object $entity): ResourceChange
     {
-        if (!$this->currentUser->hasPermission('feature_admin_element_edit')) {
-            throw new BadRequestException('Deletion of planning document categories is not allowed at all');
-        }
-
         $success = $this->elementService->deleteElement([$entity->getId()]);
         if (!$success) {
             throw new InvalidArgumentException("Deletion of planning document category failed for the given ID '{$entity->getId()}'");
@@ -303,5 +298,10 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
 
         // as the service already flushed the changes, we don't need to return anything in particular
         return new ResourceChange($entity, $this, []);
+    }
+
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['feature_admin_element_edit'];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureNewsResourceType.php
@@ -65,6 +65,11 @@ final class ProcedureNewsResourceType extends AbstractNewsResourceType implement
         return $change;
     }
 
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['area_admin_news'];
+    }
+
     public function getEntityClass(): string
     {
         return News::class;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
@@ -168,4 +168,9 @@ class SignLanguageOverviewVideoResourceType extends DplanResourceType implements
 
         return $resourceChange;
     }
+
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['field_sign_language_overview_video_edit'];
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -328,9 +328,9 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
 
         if ($this->hasAssessmentPermission()) {
             $properties[] = $this->createAttribute($this->documentParentId)
-                ->readable(true, static fn(Statement $statement): ?string => $statement->getDocumentParentId());
+                ->readable(true, static fn (Statement $statement): ?string => $statement->getDocumentParentId());
             $properties[] = $this->createAttribute($this->documentTitle)
-                ->readable(true, static fn(Statement $statement): ?string => $statement->getDocumentTitle());
+                ->readable(true, static fn (Statement $statement): ?string => $statement->getDocumentTitle());
             $properties[] = $this->createAttribute($this->elementId)
                 ->readable(true)->aliasedPath($this->element->id);
             $properties[] = $this->createAttribute($this->elementTitle)
@@ -366,7 +366,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
             'area_admin_submitters'
         )) {
             $properties[] = $this->createAttribute($this->isSubmittedByCitizen)
-                ->readable(false, static fn(Statement $statement): bool => $statement->isSubmittedByCitizen());
+                ->readable(false, static fn (Statement $statement): bool => $statement->isSubmittedByCitizen());
         }
 
         return $properties;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -207,10 +207,6 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
      */
     public function delete(object $entity): ResourceChange
     {
-        if (!$this->currentUser->hasPermission('feature_statement_delete')) {
-            throw new InvalidArgumentException('Insufficient permissions');
-        }
-
         $success = $this->statementResourceTypeService->deleteStatement($entity);
         if (true !== $success) {
             throw new InvalidArgumentException('Deletion request could not be executed.');
@@ -220,6 +216,11 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         $resourceChange->addEntityToDelete($entity);
 
         return $resourceChange;
+    }
+
+    public function getRequiredDeletionPermissions(): array
+    {
+        return ['feature_statement_delete'];
     }
 
     /**


### PR DESCRIPTION
So far to handle JSON:API deletion requests it was required to check permissions inside the `delete` method manually. This however is error-prone, as the necessity is not explicit enough and was in fact already forgotten in `ProcedureNews-` and `SignLanguageOverviewVideo` resource types.

This commit adds a new method
(`getRequiredDeletionPermissions`) that must be implemented by deletable resource types, making the need to define the needed permissions more explicit.

The new method was used in the `ProcedureNews`- and `SignLanguageOverviewVideo` resource types to check for editing permissions, which should be sufficient for their use-cases.

The usage of the new `getRequiredDeletionPermissions` method was added in a way, that prevents the
`BeforeResourceDeletionEvent` event from being dispatched. Until now the event was dispatched even in case of missing permissions, which may potentially have resulted in bugs.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

The adjusted `DeletableDqlResourceTypeInterface` is still in the core, so I assume adjustments of addons are not necessary.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
