### PR TITLE
chore: fix leftover from rector that leads to duplicate validation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -278,9 +278,6 @@ class User implements SecurityUserInterface, SamlUserInterface, UuidEntityInterf
     /**
      * @var Collection<int, UserRoleInCustomerInterface>
      *
-     *     @RoleAllowedConstraint()
-     * })
-     *
      * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
      * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
      */


### PR DESCRIPTION
Fix a leftover that was introduced by automatically converting the constraints to php assertions. It lead to duplicate validation of a field and ultimately blocked login via keycloak

### How to review/test
code review or try to login via keycloak locally

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
