### PR TITLE
fix: adapt padding to larger select spacing

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_edit-field.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_edit-field.scss
@@ -33,6 +33,6 @@
     &__editing {
         margin-left: -8px;
         margin-top: math.div(-$inuit-base-spacing-unit--tiny, 2) - 1; // minus one for the border
-        padding-right: 30px; // space for the edit and reset icon
+        padding-right: 40px; // space for the edit and reset icon
     }
 }


### PR DESCRIPTION
This restores a correct spacing between the select element and the save/abort controls.

![image](https://github.com/demos-europe/demosplan-core/assets/40452344/9f36e67e-89cd-457a-b9f3-6babee9d2039)
