### PR TITLE
fix(refs T33784): fixes sortMethod handling

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/FluentRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FluentRepository.php
@@ -154,7 +154,8 @@ abstract class FluentRepository extends CoreRepository
     public function getEntityByIdentifier(string $id, array $conditions, array $identifierPropertyPath): object
     {
         $identifierCondition = $this->conditionFactory->propertyHasValue($id, $identifierPropertyPath);
-        $entities = $this->getEntities($conditions, [$identifierCondition], 0, 2);
+        $conditions[] = $identifierCondition;
+        $entities = $this->getEntities($conditions, [], 0, 2);
 
         return match (count($entities)) {
             0       => throw new InvalidArgumentException("No matching `{$this->getEntityName()}` entity found."),


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33784

Something must have gone wrong here recently. There is no sortMethod here to be used and the identifier condition is most definitely not a sortMethod. So I added it to the conditions and left the sortMethod empty.

### How to review/test
Publishing any procedure documents will fail without this, but should work with this change.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
