### PR TITLE
fix(refs T33737): use correct user for assignee check

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssignService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssignService.php
@@ -13,12 +13,15 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
+use demosplan\DemosPlanCoreBundle\Security\Authentication\Provider\UserFromSecurityUserProvider;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class AssignService extends CoreService
 {
-    public function __construct(private readonly TokenStorageInterface $tokenStorage)
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider)
     {
     }
 
@@ -58,7 +61,7 @@ class AssignService extends CoreService
         if (!$token instanceof TokenInterface) {
             return false;
         }
-        $user = $token->getUser();
+        $user = $this->userFromSecurityUserProvider->fromToken($token);
         if (!$user instanceof User) {
             return false;
         }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33737

There has been a rework of the token storage as well as the used user entity to move our application closer to Symfony standards. In that process, the token storage now returns a securityUser instead of the regular user entity. So we need to get the corresponding user entity via the UserFromSecurityUserProvider to restore the logic.

### How to review/test
Without this fix, a user wont be able to edit a statement even when they are the assignee. With this fix it should work as intended.

