### PR TITLE
chore refs (T33737): Real user object should be stored in Token

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
@@ -66,10 +66,6 @@ final class SecurityUser implements UserInterface, EquatableInterface, PasswordA
 
     public function isEqualTo(UserInterface $user): bool
     {
-        if (!$user instanceof self) {
-            return false;
-        }
-
         if ($this->getRoles() !== $user->getRoles()) {
             return false;
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
@@ -35,6 +35,8 @@ class CurrentUserService implements CurrentUserInterface, CurrentUserProviderInt
 
         if ($user instanceof SecurityUser) {
             $user = $this->userFromSecurityUserProvider->fromSecurityUser($user);
+            // swap real User in token to be used later on when injecting TokenInterface
+            $this->getToken()->setUser($user);
         }
 
         if (!$user instanceof User) {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -139,6 +139,9 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
         $user = $this->userFromSecurityUserProvider->fromToken($token);
         $this->logger->info('User was logged in', ['id' => $user->getId(), 'roles' => $user->getDplanRolesString()]);
 
+        // swap real User in token for the login procedure
+        $token->setUser($user);
+
         // user may be split to two User objects e.g when PublicAgency user needs to have another
         // orga than the planner user (Don't blame me, it's reality)
         $publicAgencyUserId = $request->getSession()->get('session2UserId');


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33737

The SecurityUser should only be used during login process. Afterward it should be swapped with the real user entity so that it could be used later on via injection of the TokenStorage

This is an alternative approach to #1740 to fix the root problem

### How to review/test
Login should work as well as the problem described in ticket

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
