### PR TITLE
fix(refs T33843): add gisLayer to master template

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -14,6 +14,8 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\ExportFieldsConfiguration;
+use demosplan\DemosPlanCoreBundle\Entity\Help\ContextualHelp;
+use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
@@ -84,6 +86,26 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         $gisLayerCategoryMaster->setName('rootGisLayer');
         $gisLayerCategoryMaster->setProcedure($procedureMaster);
         $manager->persist($gisLayerCategoryMaster);
+
+        // Create GisLayer for MasterBlueprint
+        $gisLayer = new GisLayer();
+        $gisLayer->setName('basemap');
+        $gisLayer->setUrl('https://sgx.geodatenzentrum.de/wms_basemapde');
+        $gisLayer->setLayers('de_basemapde_web_raster_farbe');
+        $gisLayer->setType('base');
+        $gisLayer->setEnabled(true);
+        $gisLayer->setProcedureId($procedureMaster->getId());
+        $gisLayer->setCategory($gisLayerCategoryMaster);
+        $manager->persist($gisLayer);
+
+        // Create ContextHelp for GisLayer
+        $contextHelp = new ContextualHelp();
+        $contextHelp->setText('');
+        $contextHelp->setKey('gislayer.'.$gisLayer->getId());
+        $manager->persist($contextHelp);
+
+        // Add ContextHelp to GisLayer
+        $gisLayer->setContextualHelp($contextHelp);
 
         // fill master with mandatory standard data to be copied on procedure creation
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33843

To avoid confusion and additional setup time, we add a simple base gisLayer to the master template via prod fixtures. In the future, this layer will be by default available in the master template and all inheriting templates and procedures.

### How to review/test
I have not yet tested this with a new DB! 
