### PR TITLE
refactor: prepare access conditions for EDT ^0.18

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -276,7 +276,6 @@ class User implements SamlUserInterface, AddonUserInterface
      * @var Collection<int, UserRoleInCustomerInterface>
      *
      * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
-     * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
      */
     #[Assert\All([new Assert\NotNull(), new RoleAllowedConstraint()])]
     #[Assert\NotNull]

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -677,7 +677,12 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
      */
     public function getAccessCondition(): PathsBasedInterface
     {
-        return $this->conditionFactory->allConditionsApply(...$this->getAccessConditions());
+        $accessConditions = $this->getAccessConditions();
+        if ([] === $accessConditions) {
+            return $this->conditionFactory->true();
+        }
+
+        return $this->conditionFactory->allConditionsApply(...$accessConditions);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/ResourceType/DplanResourceType.php
@@ -50,6 +50,7 @@ use EDT\PathBuilding\PropertyAutoPathTrait;
 use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PaginationException;
 use EDT\Querying\Contracts\PathException;
+use EDT\Querying\Contracts\PathsBasedInterface;
 use EDT\Querying\Contracts\PropertyPathInterface;
 use EDT\Querying\Contracts\SortMethodFactoryInterface;
 use EDT\Querying\Contracts\SortMethodInterface;
@@ -664,6 +665,19 @@ abstract class DplanResourceType extends CachingResourceType implements Iterator
         $conditions[] = $this->schemaPathProcessor->processAccessCondition($this);
 
         return $conditions;
+    }
+
+    /**
+     * @return list<ClauseFunctionInterface<bool>>
+     */
+    abstract protected function getAccessConditions(): array;
+
+    /**
+     * @deprecated use and implement {@link DplanResourceType::getAccessConditions()} instead
+     */
+    public function getAccessCondition(): PathsBasedInterface
+    {
+        return $this->conditionFactory->allConditionsApply(...$this->getAccessConditions());
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -96,6 +96,7 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\TransactionRequiredException;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\DqlQuerying\SortMethodFactories\SortMethodFactory;
 use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PathException;
@@ -612,7 +613,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     }
 
     /**
-     * @return array<int, FunctionInterface<bool>>
+     * @return list<ClauseFunctionInterface<bool>>
      */
     public function getAdminProcedureConditions(bool $template, User $user): array
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementClusterService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementClusterService.php
@@ -112,13 +112,11 @@ class StatementClusterService extends CoreService
     public function getClustersOfProcedure(string $procedureId)
     {
         $sortMethods = $this->clusterStatementResourceType->getDefaultSortMethods();
-        $conditions = [
-            $this->clusterStatementResourceType->getAccessCondition(),
-            $this->conditionFactory->propertyHasValue(
-                $procedureId,
-                $this->clusterStatementResourceType->procedure->id
-            ),
-        ];
+        $conditions = $this->clusterStatementResourceType->getAccessConditions();
+        $conditions[] = $this->conditionFactory->propertyHasValue(
+            $procedureId,
+            $this->clusterStatementResourceType->procedure->id
+        );
 
         return $this->statementRepository->getEntities($conditions, $sortMethods);
     }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminProcedureResourceType.php
@@ -141,14 +141,15 @@ final class AdminProcedureResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('area_admin_procedures');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        $conditions = $this->procedureService->getAdminProcedureConditions(
+        $adminProcedureConditions = $this->procedureService->getAdminProcedureConditions(
             false,
             $this->currentUser->getUser()
         );
-        $conditions[] = $this->procedureResourceType->getResourceTypeCondition();
 
-        return $this->conditionFactory->allConditionsApply(...$conditions);
+        $resourceTypeConditions = $this->procedureResourceType->getResourceTypeConditions();
+
+        return array_merge($adminProcedureConditions, $resourceTypeConditions);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -71,7 +71,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         return $this->currentUser->hasPermission('feature_user_list');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $conditions = [
             // always get non-deleted users only
@@ -102,7 +102,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             );
         }
 
-        return $this->conditionFactory->allConditionsApply(...$conditions);
+        return $conditions;
     }
 
     public function getQuery(): AbstractQuery

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AgencyEmailAddressResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AgencyEmailAddressResourceType.php
@@ -52,9 +52,9 @@ final class AgencyEmailAddressResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AssignableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AssignableUserResourceType.php
@@ -47,12 +47,12 @@ final class AssignableUserResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('feature_json_api_user');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $currentProcedure = $this->currentProcedureService->getProcedure();
         if (null === $currentProcedure) {
             // you need a procedure to know who can be an assignee
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $authorizedUsers = $this->procedureService->getAuthorizedUsers($currentProcedure->getId());
@@ -63,10 +63,10 @@ final class AssignableUserResourceType extends DplanResourceType
         }
         if (0 < count($authorizedUsers)) {
             // only return users that are on the list of authorized users
-            return $this->conditionFactory->propertyHasAnyOfValues($authorizedUserIds, $this->id);
+            return [$this->conditionFactory->propertyHasAnyOfValues($authorizedUserIds, $this->id)];
         }
 
-        return $this->conditionFactory->false();
+        return [$this->conditionFactory->false()];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/BoilerplateGroupResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/BoilerplateGroupResourceType.php
@@ -51,9 +51,9 @@ final class BoilerplateGroupResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/BoilerplateResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/BoilerplateResourceType.php
@@ -52,17 +52,17 @@ final class BoilerplateResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('area_admin_boilerplates');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $procedure->getId(),
             $this->procedure->id
-        );
+        )];
     }
 
     public function getDefaultSortMethods(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/BrandingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/BrandingResourceType.php
@@ -74,8 +74,8 @@ class BrandingResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ClaimResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ClaimResourceType.php
@@ -61,8 +61,8 @@ final class ClaimResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ClusterStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ClusterStatementResourceType.php
@@ -53,14 +53,14 @@ final class ClusterStatementResourceType extends AbstractStatementResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    public function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyIsNotNull($this->original),
             $this->conditionFactory->propertyHasValue(true, $this->clusterStatement),
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
@@ -70,7 +70,7 @@ final class ClusterStatementResourceType extends AbstractStatementResourceType
             // statement placeholders are not considered actual statement resources
             $this->conditionFactory->propertyIsNull($this->movedStatement),
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->procedure->id)
-        );
+        ];
     }
 
     public function getDefaultSortMethods(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ConsultationTokenResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ConsultationTokenResourceType.php
@@ -49,17 +49,17 @@ final class ConsultationTokenResourceType extends DplanResourceType implements U
         return $this->currentUser->hasPermission('area_admin_consultations');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $procedure->getId(),
             $this->originalStatement->procedure->id
-        );
+        )];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ContextualHelpResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ContextualHelpResourceType.php
@@ -51,9 +51,9 @@ final class ContextualHelpResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CountyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CountyResourceType.php
@@ -49,9 +49,9 @@ final class CountyResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerResourceType.php
@@ -66,9 +66,9 @@ final class CustomerResourceType extends DplanResourceType
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
@@ -48,9 +48,9 @@ final class DepartmentResourceType extends DplanResourceType
         return 'Department';
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/EmailAddressResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/EmailAddressResourceType.php
@@ -49,9 +49,9 @@ class EmailAddressResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/EmailResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/EmailResourceType.php
@@ -39,9 +39,9 @@ final class EmailResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->false();
+        return [$this->conditionFactory->false()];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/FaqCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/FaqCategoryResourceType.php
@@ -53,8 +53,8 @@ class FaqCategoryResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->false();
+        return [$this->conditionFactory->false()];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/FaqResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/FaqResourceType.php
@@ -64,14 +64,14 @@ class FaqResourceType extends DplanResourceType implements UpdatableDqlResourceT
         return $this->currentUser->hasPermission('area_admin_faq');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $customer = $this->currentCustomerService->getCurrentCustomer();
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $customer->getId(),
             $this->faqCategory->customer->id
-        );
+        )];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
@@ -64,9 +64,9 @@ final class FileResourceType extends DplanResourceType implements FileResourceTy
      * the file is used if access should be restricted. Also note that this property is
      * checked when the actual file bytes are requested.
      */
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->propertyHasValue(false, $this->deleted);
+        return [$this->conditionFactory->propertyHasValue(false, $this->deleted)];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerCategoryResourceType.php
@@ -59,9 +59,9 @@ final class GisLayerCategoryResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('area_map_participation_area');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -89,9 +89,9 @@ final class GisLayerResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsCategoryResourceType.php
@@ -50,12 +50,12 @@ class GlobalNewsCategoryResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             $this->conditionFactory->propertyHasValue(true, $this->enabled)
-        );
+        ];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GlobalNewsResourceType.php
@@ -87,9 +87,9 @@ final class GlobalNewsResourceType extends AbstractNewsResourceType implements D
     /**
      * @throws PathException
      */
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->propertyHasValue(false, $this->deleted);
+        return [$this->conditionFactory->propertyHasValue(false, $this->deleted)];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/HashedQueryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/HashedQueryResourceType.php
@@ -57,8 +57,8 @@ class HashedQueryResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/HeadStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/HeadStatementResourceType.php
@@ -36,9 +36,9 @@ final class HeadStatementResourceType extends AbstractStatementResourceType
         return $this->currentUser->hasAllPermissions('area_admin_assessmenttable', 'feature_statement_cluster');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isDirectlyAccessible(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
@@ -98,18 +98,18 @@ class InstitutionTagResourceType extends DplanResourceType implements UpdatableD
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $userOrga = $this->currentUser->getUser()->getOrga();
 
         if (null === $userOrga) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $userOrga->getId(),
             $this->owningOrganisation->id
-        );
+        )];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitableInstitutionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitableInstitutionResourceType.php
@@ -65,11 +65,11 @@ final class InvitableInstitutionResourceType extends DplanResourceType implement
             || $this->currentUser->hasPermission('feature_institution_tag_read');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $customer = $this->currentCustomerService->getCurrentCustomer();
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             $this->conditionFactory->propertyHasValue(
                 OrgaStatusInCustomer::STATUS_ACCEPTED,
@@ -87,7 +87,7 @@ final class InvitableInstitutionResourceType extends DplanResourceType implement
                 $customer->getId(),
                 $this->statusInCustomers->customer->id
             ),
-        );
+        ];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
@@ -67,18 +67,18 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
      * @throws PathException
      * @throws CustomerNotFoundException
      */
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $customer = $this->currentCustomerService->getCurrentCustomer();
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
         $invitedOrgaIds = $procedure->getOrganisation()->map(
             static fn (Orga $orga): string => $orga->getId()
         );
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             $this->conditionFactory->propertyHasValue(true, $this->showlist),
             $this->conditionFactory->propertyHasValue(
@@ -102,7 +102,7 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
                 $invitedOrgaIds->toArray(),
                 $this->id
             ),
-        );
+        ];
     }
 
     public function getDefaultSortMethods(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/MasterToebResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/MasterToebResourceType.php
@@ -43,9 +43,9 @@ final class MasterToebResourceType extends DplanResourceType
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/MunicipalityResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/MunicipalityResourceType.php
@@ -66,9 +66,9 @@ final class MunicipalityResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaStatusInCustomerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaStatusInCustomerResourceType.php
@@ -27,12 +27,12 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class OrgaStatusInCustomerResourceType extends DplanResourceType
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $this->currentCustomerService->getCurrentCustomer()->getId(),
             $this->customer->id
-        );
+        )];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaTypeResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaTypeResourceType.php
@@ -26,12 +26,12 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class OrgaTypeResourceType extends DplanResourceType
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $this->currentCustomerService->getCurrentCustomer()->getId(),
             $this->orgaStatusInCustomers->customer->id
-        );
+        )];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OriginalStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OriginalStatementResourceType.php
@@ -51,20 +51,20 @@ final class OriginalStatementResourceType extends DplanResourceType implements O
         return $event->isOriginalStatementeAvailable() || $this->currentUser->hasPermission('feature_json_api_original_statement');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             $this->conditionFactory->propertyIsNull($this->original->id),
             $this->conditionFactory->propertyIsNull($this->headStatement->id),
             $this->conditionFactory->propertyIsNull($this->movedStatement),
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->procedure->id)
-        );
+        ];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphResourceType.php
@@ -50,9 +50,9 @@ final class ParagraphResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphVersionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphVersionResourceType.php
@@ -50,9 +50,9 @@ final class ParagraphVersionResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
@@ -57,18 +57,18 @@ final class PlaceResourceType extends DplanResourceType implements UpdatableDqlR
         return $this->currentUser->hasPermission('area_statement_segmentation');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         // for now all places can be read by anyone if they are available
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $procedure->getId(),
             $this->procedure->id
-        );
+        )];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanningDocumentCategoryResourceType.php
@@ -24,6 +24,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use Doctrine\Common\Collections\Collection;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\PathBuilding\End;
 use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PathException;
@@ -92,11 +93,11 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
      * Especially orga specific settings (possibly feature_admin_element_authorisations)
      * and visibility for citizens and public agencies need to be considered.
      */
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $adminConditions = [
@@ -116,7 +117,7 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
 
         $ownsProcedure = $this->procedureAccessEvaluator->isOwningProcedure($this->currentUser->getUser(), $procedure);
         if ($ownsProcedure && $this->currentUser->hasPermission('feature_admin_element_edit')) {
-            return $this->conditionFactory->allConditionsApply(...$adminConditions);
+            return $adminConditions;
         }
 
         $publicConditions = $adminConditions;
@@ -133,13 +134,13 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
         // without owning the procedure and administration permissions users are only
         // allowed to see enabled elements
         $publicConditions[] = $this->conditionFactory->propertyHasValue(true, $this->enabled);
-        $publicConditions[] = $this->createNestingCondition();
+        $nestingConditions = $this->createNestingConditions();
 
-        return $this->conditionFactory->allConditionsApply(...$publicConditions);
+        return array_merge($publicConditions, $nestingConditions);
     }
 
     /**
-     * Like {@link PlanningDocumentCategoryResourceType::getAccessCondition} we need to limit
+     * Like {@link PlanningDocumentCategoryResourceType::getAccessConditions} we need to limit
      * access here too. Who is allowed to access properties like {@link $fileInfo} or
      * {@link $filePathWithHash}, who is not?
      *
@@ -260,11 +261,11 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
      * approach and check each potential parent individually, resulting in a large query with
      * many joins for large values of {@link Elements::MAX_PARENTS_COUNT}.
      *
-     * @return FunctionInterface<bool>
+     * @return list<ClauseFunctionInterface<bool>>
      *
      * @throws PathException
      */
-    private function createNestingCondition(): FunctionInterface
+    private function createNestingConditions(): array
     {
         $conditions = [];
         $parentPath = $this->parent;
@@ -281,7 +282,7 @@ final class PlanningDocumentCategoryResourceType extends DplanResourceType imple
             $parentPath = $parentPath->parent;
         }
 
-        return $this->conditionFactory->allConditionsApply(...$conditions);
+        return $conditions;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PriorityAreaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PriorityAreaResourceType.php
@@ -76,9 +76,9 @@ final class PriorityAreaResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureBehaviorDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureBehaviorDefinitionResourceType.php
@@ -33,23 +33,23 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class ProcedureBehaviorDefinitionResourceType extends DplanResourceType implements UpdatableDqlResourceTypeInterface
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $currentProcedure = $this->currentProcedureService->getProcedure();
         if (null === $currentProcedure) {
             // if the user provided no procedure it must be a one with the permission to
             // access the list of ProcedureTypes and should be restricted to ProcedureBehaviorDefinitions
             // that are connected to a ProcedureType (and thus not connected to a Procedure)
-            return $this->conditionFactory->allConditionsApply(
+            return [
                 $this->conditionFactory->propertyIsNull($this->procedure),
                 $this->conditionFactory->propertyIsNotNull($this->procedureType)
-            );
+            ];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $currentProcedure->getId(),
             $this->procedure->id
-        );
+        )];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureNewsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureNewsResourceType.php
@@ -90,17 +90,17 @@ final class ProcedureNewsResourceType extends AbstractNewsResourceType implement
         return $this->currentUser->hasPermission('area_admin_news');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->pId),
             $this->conditionFactory->propertyHasValue(false, $this->deleted)
-        );
+        ];
     }
 
     public function isCreatable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureSettingsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureSettingsResourceType.php
@@ -54,8 +54,8 @@ class ProcedureSettingsResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
@@ -53,12 +53,12 @@ final class ProcedureTemplateResourceType extends DplanResourceType
         ];
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $userOrga = $this->currentUser->getUser()->getOrga();
         if (null === $userOrga) {
             // users without organisation get no access to any procedure templates
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $masterTemplateSubCondition = $this->conditionFactory->propertyHasValue(true, $this->masterTemplate);
@@ -66,17 +66,17 @@ final class ProcedureTemplateResourceType extends DplanResourceType
             // not the unique master template
             $this->conditionFactory->propertyHasValue(false, $this->masterTemplate),
             // created by the users organisation (ie.: the current user is in the owning organisation of the template)
-            $this->conditionFactory->propertyHasValue($userOrga->getId(), $this->owningOrganisation->id)
+            $this->conditionFactory->propertyHasValue($userOrga->getId(), $this->orga->id)
         );
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             // a deleted template is not a valid template resource
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             // templates are never actual procedures
             $this->conditionFactory->propertyHasValue(true, $this->master),
             // the template must be either the unique master template or a "normal" template
             $this->conditionFactory->anyConditionApplies($masterTemplateSubCondition, $normalTemplateSubCondition)
-        );
+        ];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTypeResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTypeResourceType.php
@@ -33,9 +33,9 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class ProcedureTypeResourceType extends DplanResourceType implements UpdatableDqlResourceTypeInterface
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureUiDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureUiDefinitionResourceType.php
@@ -35,23 +35,23 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class ProcedureUiDefinitionResourceType extends DplanResourceType implements UpdatableDqlResourceTypeInterface
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $currentProcedure = $this->currentProcedureService->getProcedure();
         if (null === $currentProcedure) {
             // if the user provided no procedure it must be a one with the permission to
             // access the list of ProcedureTypes and should be restricted to ProcedureUiDefinitions
             // that are connected to a ProcedureType (and thus not connected to a Procedure)
-            return $this->conditionFactory->allConditionsApply(
+            return [
                 $this->conditionFactory->propertyIsNull($this->procedure),
-                $this->conditionFactory->propertyIsNotNull($this->procedureType)
-            );
+                $this->conditionFactory->propertyIsNotNull($this->procedureType),
+            ];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $currentProcedure->getId(),
             $this->procedure->id
-        );
+        )];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
@@ -78,21 +78,21 @@ class ReportEntryResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $customer = $this->currentCustomerService->getCurrentCustomer();
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->identifier),
             $this->conditionFactory->propertyHasAnyOfValues($this->getGroups(), $this->group),
             $this->conditionFactory->propertyHasAnyOfValues($this->getCategories(), $this->category),
             $this->conditionFactory->propertyHasValue($customer->getId(), $this->customer->id),
-        );
+        ];
     }
 
     public function getDefaultSortMethods(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/RoleResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/RoleResourceType.php
@@ -53,14 +53,14 @@ final class RoleResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $projectRoleCodes = $this->globalConfig->getRolesAllowed();
 
-        return $this->conditionFactory->propertyHasAnyOfValues(
+        return [$this->conditionFactory->propertyHasAnyOfValues(
             $projectRoleCodes,
             $this->code
-        );
+        )];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SegmentCommentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SegmentCommentResourceType.php
@@ -67,10 +67,10 @@ final class SegmentCommentResourceType extends DplanResourceType implements Crea
         return $this->currentUser->hasPermission('feature_segment_comment_create');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         // if a segment can be accessed then all its comments can be read
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isCreatable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SignLanguageOverviewVideoResourceType.php
@@ -61,9 +61,9 @@ class SignLanguageOverviewVideoResourceType extends DplanResourceType implements
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->allConditionsApply(
+        return [
             // for now the access to SignLanguageOverviewVideos is limited to the ones uploaded
             // in the current customer
             $this->conditionFactory->propertyHasValue(
@@ -75,8 +75,8 @@ class SignLanguageOverviewVideoResourceType extends DplanResourceType implements
             $this->conditionFactory->propertiesEqual(
                 $this->id->getAsNames(),
                 $this->customerContext->signLanguageOverviewVideos->id->getAsNames()
-            )
-        );
+            ),
+        ];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SimilarStatementSubmitterResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SimilarStatementSubmitterResourceType.php
@@ -96,16 +96,16 @@ final class SimilarStatementSubmitterResourceType extends DplanResourceType impl
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $procedureId = $procedure->getId();
 
-        return $this->conditionFactory->propertyHasValue($procedureId, $this->procedure->id);
+        return [$this->conditionFactory->propertyHasValue($procedureId, $this->procedure->id)];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
@@ -61,13 +61,13 @@ final class SingleDocumentResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         if ($this->currentUser->hasPermission('area_admin_single_document')) {
-            return $this->conditionFactory->true();
+            return [];
         }
 
-        return $this->conditionFactory->propertyHasValue(true, $this->visible);
+        return [$this->conditionFactory->propertyHasValue(true, $this->visible)];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SlugResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SlugResourceType.php
@@ -49,9 +49,9 @@ final class SlugResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementAttachmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementAttachmentResourceType.php
@@ -66,11 +66,11 @@ final class StatementAttachmentResourceType extends DplanResourceType implements
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         // The access to an attachment is allowed only if access to the corresponding
         // statement is granted.
-        return $this->statementResourceType->buildAccessCondition($this->statement, true);
+        return $this->statementResourceType->buildAccessConditions($this->statement, true);
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFieldDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFieldDefinitionResourceType.php
@@ -33,9 +33,9 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class StatementFieldDefinitionResourceType extends DplanResourceType implements UpdatableDqlResourceTypeInterface
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
         // todo: allow accessFilter by modelling bidirectional relationship of between StatementFieldDefinition and StatementFormDefinition
         // to ensure related ProcedureType and ProcedureType is available here
     }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFormDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFormDefinitionResourceType.php
@@ -25,7 +25,7 @@ use EDT\Querying\Contracts\PathsBasedInterface;
  */
 final class StatementFormDefinitionResourceType extends DplanResourceType
 {
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedureTypeEditAllowed = $this->currentUser->hasPermission('area_procedure_type_edit');
 
@@ -33,24 +33,24 @@ final class StatementFormDefinitionResourceType extends DplanResourceType
         // then allow access to those StatementFormDefinition
         // that are not connected to a specific procedure.
         if ($procedureTypeEditAllowed) {
-            return $this->conditionFactory->allConditionsApply(
+            return [
                 $this->conditionFactory->propertyIsNotNull($this->procedureType),
-                $this->conditionFactory->propertyIsNull($this->procedure)
-            );
+                $this->conditionFactory->propertyIsNull($this->procedure),
+            ];
         }
 
         // If no edit permission for ProcedureType and not authenticated for any procedure, deny any reads.
         $currentProcedure = $this->currentProcedureService->getProcedure();
         if (null === $currentProcedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         // If no edit permission for ProcedureType, allow access to StatementFormDefinitions
         // connected to the given Procedure.
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue($currentProcedure->getId(), $this->procedure->id),
             $this->conditionFactory->propertyIsNull($this->procedureType)
-        );
+        ];
     }
 
     public function getEntityClass(): string

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentResourceType.php
@@ -159,18 +159,18 @@ final class StatementFragmentResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->procedure->id),
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->statement->procedure->id),
-            $this->conditionFactory->propertyHasValue(false, $this->deleted),
+            $this->conditionFactory->propertyHasValue(false, $this->deleted), // FIXME: cdr: this should not work, there is no `deleted` property in `StatementFragment` nor is `deleted` set up as alias in this resource type
             $this->conditionFactory->propertyHasValue(false, $this->statement->deleted)
-        );
+        ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentResourceType.php
@@ -169,7 +169,6 @@ final class StatementFragmentResourceType extends DplanResourceType
         return [
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->procedure->id),
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->statement->procedure->id),
-            $this->conditionFactory->propertyHasValue(false, $this->deleted), // FIXME: cdr: this should not work, there is no `deleted` property in `StatementFragment` nor is `deleted` set up as alias in this resource type
             $this->conditionFactory->propertyHasValue(false, $this->statement->deleted)
         ];
     }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentsElementsResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementFragmentsElementsResourceType.php
@@ -52,9 +52,9 @@ final class StatementFragmentsElementsResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementMetaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementMetaResourceType.php
@@ -48,9 +48,9 @@ final class StatementMetaResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->false();
+        return [$this->conditionFactory->false()];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -29,9 +29,8 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementResourceTypeService;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryStatement;
 use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\PathBuilding\End;
-use EDT\Querying\Contracts\FunctionInterface;
-use EDT\Querying\Contracts\PathsBasedInterface;
 use Elastica\Index;
 
 /**
@@ -75,9 +74,9 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         return 'Statement';
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->buildAccessCondition($this);
+        return $this->buildAccessConditions($this);
     }
 
     /**
@@ -95,13 +94,13 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
      * prefixed with `statement`, as this is the name of the relationship from the
      * {@link StatementAttachmentResourceType} to the {@link StatementResourceType}.
      *
-     * @return FunctionInterface<bool>
+     * @return list<ClauseFunctionInterface<bool>>
      */
-    public function buildAccessCondition(StatementResourceType $pathStartResourceType, bool $allowOriginals = false): FunctionInterface
+    public function buildAccessConditions(StatementResourceType $pathStartResourceType, bool $allowOriginals = false): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $configuredProcedures = $procedure
@@ -134,7 +133,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
             $conditions[] = $this->conditionFactory->propertyIsNotNull($pathStartResourceType->original->id);
         }
 
-        return $this->conditionFactory->allConditionsApply(...$conditions);
+        return $conditions;
     }
 
     public function updateObject(object $object, array $properties): ResourceChange

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementSegmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementSegmentResourceType.php
@@ -85,11 +85,11 @@ final class StatementSegmentResourceType extends DplanResourceType implements Up
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         $procedureId = $procedure->getId();
@@ -102,10 +102,10 @@ final class StatementSegmentResourceType extends DplanResourceType implements Up
             ->filterNonOwnedProcedureIds($currentUser, ...$allowedProcedures);
         $procedureIds[] = $procedureId;
 
-        return $this->conditionFactory->propertyHasAnyOfValues(
+        return [$this->conditionFactory->propertyHasAnyOfValues(
             $procedureIds,
-            $this->parentStatement->procedure->id
-        );
+            $this->parentStatementOfSegment->procedure->id
+        )];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SurveyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SurveyResourceType.php
@@ -55,9 +55,9 @@ final class SurveyResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SurveyVoteResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SurveyVoteResourceType.php
@@ -57,9 +57,9 @@ final class SurveyVoteResourceType extends DplanResourceType
         return false;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/TagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/TagResourceType.php
@@ -57,18 +57,18 @@ final class TagResourceType extends DplanResourceType implements CreatableDqlRes
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
             // there is currently no use case in which all tags for all procedures need to be requested
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $procedure->getId(),
             $this->topic->procedure->id
-        );
+        )];
     }
 
     public function isCreatable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
@@ -56,18 +56,18 @@ final class TagTopicResourceType extends DplanResourceType implements CreatableD
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
             // there is currently no use case in which all tags for all procedures need to be requested
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->propertyHasValue(
+        return [$this->conditionFactory->propertyHasValue(
             $procedure->getId(),
             $this->procedure->id
-        );
+        )];
     }
 
     public function isCreatable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/UserFilterSetResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/UserFilterSetResourceType.php
@@ -64,17 +64,17 @@ class UserFilterSetResourceType extends DplanResourceType
         return true;
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         $user = $this->currentUser->getUser();
         $procedure = $this->currentProcedureService->getProcedure();
         if (null === $procedure) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
-        return $this->conditionFactory->allConditionsApply(
+        return [
             $this->conditionFactory->propertyHasValue($user->getId(), $this->user->id),
             $this->conditionFactory->propertyHasValue($procedure->getId(), $this->procedure->id)
-        );
+        ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
@@ -144,11 +144,11 @@ final class UserResourceType extends DplanResourceType implements UpdatableDqlRe
         );
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
         // Without this permission users can use their own User resource only.
         if ($this->currentUser->hasPermission('area_manage_users')) {
-            return $this->conditionFactory->true();
+            return [];
         }
         $currentProcedure = $this->currentProcedureService->getProcedure();
         $user = $this->currentUser->getUser();
@@ -158,10 +158,10 @@ final class UserResourceType extends DplanResourceType implements UpdatableDqlRe
         if ($userAuthorized) {
             // allow access to all users when working inside a procedure to request assignees of statements or segments
             // TODO: split into AssigneeResourceType to differentiate between claiming and normal (more restricted) user accesses
-            return $this->conditionFactory->true();
+            return [];
         }
 
-        return $this->conditionFactory->propertyHasValue($user->getId(), $this->id);
+        return [$this->conditionFactory->propertyHasValue($user->getId(), $this->id)];
     }
 
     public function isReferencable(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/UserRoleInCustomerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/UserRoleInCustomerResourceType.php
@@ -39,9 +39,9 @@ final class UserRoleInCustomerResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('feature_json_api_user');
     }
 
-    public function getAccessCondition(): PathsBasedInterface
+    protected function getAccessConditions(): array
     {
-        return $this->conditionFactory->true();
+        return [];
     }
 
     public function isReferencable(): bool


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
In EDT ^0.18 the following changes took place:

1. The `getAccessCondition` method was renamed to
 `getAccessConditions` and must now return an array of conditions
  (of which all must match for access to be granted). This
  simplifies the further handling of conditions in EDT.
2. Condition paths used in `getAccessConditions` MUST NOT use
  aliases. Aliases allow to expose properties via the JSON:API
  that may have different names or reside in different entities
  than the backing entity. However, this is not needed for the
  access conditions and unnecessarily complicated path handling
  in EDT in the past.
3. As retrieval of resources is now done in the resource type
  itself, `getAccessConditions` does not need to be set to `public`
  visibility anymore, reducing the surface area and complexity of
  resource types. The only exception is the `StatementCluster`
  resource type, which was kept `public` for now.

The dplan core resource types were adjusted accordingly to prepare
for the actual EDT ^0.18 update, while keeping compatibility to
the current version. The necessary changes in the (upcoming) actual
dependency update are thus further reduced.

### How to review/test

I suggest to do a code review via IDE (focusing on the points above) and test inside a project.
I only briefly tested EWM locally (procedure-/statement-/segment-list). If more extensive tests uncover any bugs they are easy to fix.

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
