### PR TITLE
Remove ancient letter spacing

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/_base.dplan.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/_base.dplan.scss
@@ -52,7 +52,6 @@ html.fixtinyfixed {
 body {
     min-height: 100%; // ensures complete display of absolutely positioned flyouts
     background: $dp-color-background-default;
-    letter-spacing: $base-letter-spacing;
     outline: none;
 }
 

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/_settings-fonts.dplan.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/_settings-fonts.dplan.scss
@@ -62,7 +62,6 @@ $base-font-family:
     sans-serif !default;
 
 $base-font-weight:          400 !default;
-$base-letter-spacing:       .02em !default; // is it really a good idea to set _all_ things .02em?
 
 $normal-font-family:        $base-font-family !default;
 $normal-font-weight:        $base-font-weight !default;


### PR DESCRIPTION
In an effort to syncronize the styling of DiPlanBeteiligung and DiPlanPortal, this PR removes the ancient, global `letter-spacing` from demosplan-core. Legibility of the fonts that are used in active projects are not improved by this increased letter-spacing, so there is no reason to have it around.

### How to review/test
Things just should look a little more sense, now.

### Linked PRs
- https://github.com/demos-europe/demosplan-project-teilhabe/pull/40

