### PR TITLE
feature (refs T33839): Datenerasser kann nicht stn frei schalten

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -588,6 +588,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             $this->enablePermissions([
                 'area_statement_data_input_orga',  // Create new submitted statements
                 'feature_procedure_get_base_data',  // receive basic procedure data
+                'field_statement_public_allowed'
             ]);
 
             $this->disablePermissions([

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -588,7 +588,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             $this->enablePermissions([
                 'area_statement_data_input_orga',  // Create new submitted statements
                 'feature_procedure_get_base_data',  // receive basic procedure data
-                'field_statement_public_allowed'
+                'field_statement_public_allowed',
             ]);
 
             $this->disablePermissions([

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -1185,12 +1185,12 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         return match ($operator) {
             'AND' => array_reduce(
                 $permissions,
-                fn(bool $carry, string $permission) => $carry && $this->hasPermission($permission),
+                fn (bool $carry, string $permission) => $carry && $this->hasPermission($permission),
                 true
             ),
             'OR' => array_reduce(
                 $permissions,
-                fn(bool $carry, string $permission) => $carry || $this->hasPermission($permission),
+                fn (bool $carry, string $permission) => $carry || $this->hasPermission($permission),
                 false
             ),
             default => throw PermissionException::invalidPermissionCheckOperator($operator),

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -588,7 +588,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             $this->enablePermissions([
                 'area_statement_data_input_orga',  // Create new submitted statements
                 'feature_procedure_get_base_data',  // receive basic procedure data
-                'field_statement_public_allowed',  // Publish statements
             ]);
 
             $this->disablePermissions([


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33839

 Description: Unset the Permission **field_statement_public_allowed** from **Datenerfassung** Role

### How to review/test
Code review or browser

### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #https://github.com/demos-europe/demosplan-project-diplanrog/pull/35

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

