### PR TITLE
chore (refs T33736, T33711): Fix SecurityUser in session

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/DemosPlanResponseListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/DemosPlanResponseListener.php
@@ -10,13 +10,14 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventListener;
 
-use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\User\SecurityUser;
 use demosplan\DemosPlanCoreBundle\Logic\TransformMessageBagService;
-use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
+use demosplan\DemosPlanCoreBundle\Security\Authentication\Provider\SecurityUserProvider;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Custom Eventlistener
@@ -24,27 +25,29 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
  */
 class DemosPlanResponseListener
 {
-    /** @var GlobalConfigInterface */
-    protected $globalConfig;
-
     public function __construct(
-        GlobalConfig $globalConfig,
+        private readonly SecurityUserProvider $securityUserProvider,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly TransformMessageBagService $transformMessageBagService
     ) {
-        $this->globalConfig = $globalConfig;
     }
 
-    /**
-     * Perform search task and orga branding.
-     */
     public function onKernelResponse(ResponseEvent $event)
     {
-        // handle Messages on Redirects
+        $this->handleMessagesOnRedirects($event);
+        $this->xhrResponsesNeedToGetMessagesIntoData($event);
+        $this->transformTokenUserObjectToSecurityUserObject();
+    }
+
+    private function handleMessagesOnRedirects(ResponseEvent $event): void
+    {
         if (Response::HTTP_FOUND === $event->getResponse()->getStatusCode()) {
             $this->transformMessageBagService->transformMessageBagToFlashes();
         }
+    }
 
-        // Xhr Responses need to get messages into data
+    private function xhrResponsesNeedToGetMessagesIntoData(ResponseEvent $event): void
+    {
         if ($event->getResponse() instanceof JsonResponse) {
             $responseContent = Json::decodeToArray($event->getResponse()->getContent());
             $messageBagMessages = $this->transformMessageBagService->transformMessageBagToResponseFormat();
@@ -66,5 +69,35 @@ class DemosPlanResponseListener
                 $event->getResponse()->setStatusCode(Response::HTTP_OK);
             }
         }
+    }
+
+    /**
+     * Authentication is done with the special SecurityUser, not with the User
+     * entity. One of the reasons is that the objects gets serialized
+     * in the session between requests and the doctrine entity with all its dependencies
+     * may be huge to serialize. Therefore, we use the special SecurityUser that has only
+     * those properties that are needed for authorization. During the request it
+     * is swapped by the User entity {@see SecurityUserProvider::refreshUser()}.
+     */
+    private function transformTokenUserObjectToSecurityUserObject(): void
+    {
+        // unauthenticated requests do not have a token
+        $existingToken = $this->tokenStorage->getToken();
+        if (null === $existingToken) {
+            return;
+        }
+
+        // subrequests may already have SecurityUser as user
+        // once be got rid of the subrequests triggered in twig by `render()` calls,
+        // this can be removed
+        if ($existingToken->getUser() instanceof SecurityUser) {
+            return;
+        }
+
+        $securityUser = $this->securityUserProvider->getSecurityUser(
+            $existingToken->getUser()?->getLogin() ?? ''
+        );
+
+        $existingToken->setUser($securityUser);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
@@ -21,7 +21,6 @@ use demosplan\DemosPlanCoreBundle\Exception\EntityIdNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanCoreBundle\Exception\NotYetImplementedException;
 use demosplan\DemosPlanCoreBundle\Repository\EntityContentChangeRepository;
-use demosplan\DemosPlanCoreBundle\Security\Authentication\Provider\UserFromSecurityUserProvider;
 use demosplan\DemosPlanCoreBundle\Types\UserFlagKey;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
@@ -56,7 +55,6 @@ class EntityContentChangeService extends CoreService
     protected $tokenStorage;
 
     public function __construct(
-        private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider,
         private readonly EntityContentChangeRepository $entityContentChangeRepository,
         private readonly EntityHelper $entityHelper,
         private readonly Environment $twig,
@@ -822,12 +820,10 @@ class EntityContentChangeService extends CoreService
     protected function determineChanger(bool $isReviewer): ?object
     {
         $token = $this->getTokenStorage()->getToken();
+        if ($token instanceof TokenInterface && $token->getUser() instanceof User) {
+            $user = $token->getUser();
 
-        if ($token instanceof TokenInterface) {
-            $user = $this->userFromSecurityUserProvider->fromToken($token);
-            if ($user instanceof User) {
-                return $isReviewer ? $user->getDepartment() : $user;
-            }
+            return $isReviewer ? $user->getDepartment() : $user;
         }
 
         return null;

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
@@ -33,10 +33,12 @@ class CurrentUserService implements CurrentUserInterface, CurrentUserProviderInt
     {
         $user = $this->getToken()->getUser();
 
+        // This might occur when user is fetched from session after
+        // it has been replaced by the SecurityUser. One example is the
+        // collection of data for the symfony toolbar
         if ($user instanceof SecurityUser) {
-            $user = $this->userFromSecurityUserProvider->fromSecurityUser($user);
-            // swap real User in token to be used later on when injecting TokenInterface
-            $this->getToken()->setUser($user);
+
+            return $this->userFromSecurityUserProvider->fromSecurityUser($user);
         }
 
         if (!$user instanceof User) {

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CurrentUserService.php
@@ -25,17 +25,20 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class CurrentUserService implements CurrentUserInterface, CurrentUserProviderInterface
 {
-    public function __construct(private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider, private readonly PermissionsInterface $permissions, private readonly TokenStorageInterface $tokenStorage)
-    {
+    public function __construct(
+        private readonly PermissionsInterface $permissions,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider
+    ) {
     }
 
     public function getUser(): User
     {
         $user = $this->getToken()->getUser();
 
-        // This might occur when user is fetched from session after
-        // it has been replaced by the SecurityUser. One example is the
-        // collection of data for the symfony toolbar
+        // This might occur when user is fetched from session after it has been
+        // replaced by the SecurityUser. One example is the collection of data
+        // for the symfony toolbar
         if ($user instanceof SecurityUser) {
 
             return $this->userFromSecurityUserProvider->fromSecurityUser($user);

--- a/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
@@ -533,15 +533,12 @@ class UserRepository extends FluentRepository implements ArrayInterface, ObjectI
 
     /**
      * @param User $user
-     *
-     * @throws ORMException
-     * @throws OptimisticLockException
      */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword(UserInterface $user, string $newHashedPassword): void
     {
         // set the new encoded password on the User object
-        $user->setPassword($newEncodedPassword);
-        $user->setAlternativeLoginPassword($newEncodedPassword);
+        $user->setPassword($newHashedPassword);
+        $user->setAlternativeLoginPassword($newHashedPassword);
 
         // execute the queries on the database
         $this->getEntityManager()->flush();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -12,23 +12,18 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Event\RequestValidationWeakEvent;
 use demosplan\DemosPlanCoreBundle\EventDispatcher\TraceableEventDispatcher;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperInterface;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
-use demosplan\DemosPlanCoreBundle\Security\Authentication\Provider\UserFromSecurityUserProvider;
-use demosplan\DemosPlanCoreBundle\Validator\PasswordValidator;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -37,8 +32,6 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class DplanAuthenticator extends AbstractAuthenticator
 {
@@ -79,7 +72,6 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
 
 
     public function __construct(
-        private readonly UserFromSecurityUserProvider $userFromSecurityUserProvider,
         UserMapperInterface $authenticator,
         LoggerInterface $logger,
         MessageBagInterface $messageBag,
@@ -135,12 +127,12 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
             return new RedirectResponse($this->urlGenerator->generate($this->verificationRoute));
         }
 
-        // get real User from SecurityUser that was saved in token
-        $user = $this->userFromSecurityUserProvider->fromToken($token);
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            $this->logger->error('user not found', ['user' => $user]);
+            throw new AuthenticationException('User not found');
+        }
         $this->logger->info('User was logged in', ['id' => $user->getId(), 'roles' => $user->getDplanRolesString()]);
-
-        // swap real User in token for the login procedure
-        $token->setUser($user);
 
         // user may be split to two User objects e.g when PublicAgency user needs to have another
         // orga than the planner user (Don't blame me, it's reality)

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use demosplan\DemosPlanCoreBundle\Entity\User\SecurityUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\OzgKeycloakUserDataMapper;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserDataInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -63,7 +63,7 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
                     $this->logger->info('doctrine transaction commit.');
                     $request->getSession()->set('userId', $user->getId());
 
-                    return new SecurityUser($user);
+                    return new User($user);
                 } catch (Exception $e) {
                     $this->entityManager->getConnection()->rollBack();
                     $this->logger->info('doctrine transaction rollback.');

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -63,7 +63,7 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
                     $this->logger->info('doctrine transaction commit.');
                     $request->getSession()->set('userId', $user->getId());
 
-                    return new User($user);
+                    return $user;
                 } catch (Exception $e) {
                     $this->entityManager->getConnection()->rollBack();
                     $this->logger->info('doctrine transaction rollback.');

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -23,14 +23,14 @@ class AiApiUserProvider implements UserProviderInterface
     ) {
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $username
-     */
-    public function loadUserByUsername($username): UserInterface
+    public function loadUserByUsername(string $username): UserInterface
     {
-        if (AiApiUser::AI_API_USER_LOGIN !== $username) {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        if (AiApiUser::AI_API_USER_LOGIN !== $identifier) {
             throw new UserNotFoundException('Invalid username');
         }
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -34,7 +34,7 @@ class AiApiUserProvider implements UserProviderInterface
             throw new UserNotFoundException('Invalid username');
         }
 
-        return $this->userService->getValidUser($username);
+        return $this->getApiUser();
     }
 
     /**
@@ -45,7 +45,7 @@ class AiApiUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $user;
+        return $this->getApiUser();
     }
 
     /**
@@ -53,8 +53,13 @@ class AiApiUserProvider implements UserProviderInterface
      *
      * @param string $class
      */
-    public function supportsClass($class): string
+    public function supportsClass($class): bool
     {
-        return AiApiUser::class;
+        return AiApiUser::class === $class;
+    }
+
+    private function getApiUser(): AiApiUser
+    {
+        return new AiApiUser($this->customerService->getCurrentCustomer());
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -50,12 +50,7 @@ class AiApiUserProvider implements UserProviderInterface
         return $this->getApiUser();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $class
-     */
-    public function supportsClass($class): bool
+    public function supportsClass(string $class): bool
     {
         return AiApiUser::class === $class;
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Provider;
 
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -19,7 +20,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class AiApiUserProvider implements UserProviderInterface
 {
     public function __construct(
-        protected readonly UserService $userService
+        protected readonly UserService $userService,
+        protected readonly CustomerService $customerService
     ) {
     }
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
@@ -22,19 +22,19 @@ class ApiUserProvider implements UserProviderInterface
     {
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $login
-     */
-    public function loadUserByUsername($login): UserInterface
+    public function loadUserByUsername(string $username): UserInterface
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
     {
         // avoid database call if anonymous user calls API
-        if (User::ANONYMOUS_USER_NAME === $login) {
+        if (User::ANONYMOUS_USER_NAME === $identifier) {
             return new AnonymousUser();
         }
 
-        $user = $this->userService->findDistinctUserByEmailOrLogin($login);
+        $user = $this->userService->findDistinctUserByEmailOrLogin($identifier);
 
         if (!$user instanceof User) {
             $user = new AnonymousUser();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
@@ -48,7 +48,7 @@ class ApiUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $user;
+        return $this->loadUserByIdentifier($user->getLogin());
     }
 
     /**
@@ -56,8 +56,8 @@ class ApiUserProvider implements UserProviderInterface
      *
      * @param string $class
      */
-    public function supportsClass($class): string
+    public function supportsClass($class): bool
     {
-        return User::class;
+        return User::class === $class;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
@@ -51,12 +51,7 @@ class ApiUserProvider implements UserProviderInterface
         return $this->loadUserByIdentifier($user->getUserIdentifier());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $class
-     */
-    public function supportsClass($class): bool
+    public function supportsClass(string $class): bool
     {
         return User::class === $class;
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
@@ -48,7 +48,7 @@ class ApiUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $this->loadUserByIdentifier($user->getLogin());
+        return $this->loadUserByIdentifier($user->getUserIdentifier());
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
@@ -44,12 +44,7 @@ class SamlUserProvider implements UserProviderInterface
         return $this->loadUserByIdentifier($user->getUserIdentifier());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $class
-     */
-    public function supportsClass($class): bool
+    public function supportsClass(string $class): bool
     {
         return User::class === $class;
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
@@ -24,9 +24,9 @@ class SamlUserProvider implements UserProviderInterface
     {
     }
 
-    public function loadUserByUsername($login): UserInterface
+    public function loadUserByUsername(string $username): UserInterface
     {
-        return $this->loadUserByIdentifier((string) $login);
+        return $this->loadUserByIdentifier($username);
     }
 
     public function loadUserByIdentifier(string $identifier): UserInterface

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
@@ -41,7 +41,7 @@ class SamlUserProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $user;
+        return $this->loadUserByIdentifier($user->getLogin());
     }
 
     /**
@@ -49,8 +49,8 @@ class SamlUserProvider implements UserProviderInterface
      *
      * @param string $class
      */
-    public function supportsClass($class): string
+    public function supportsClass($class): bool
     {
-        return User::class;
+        return User::class === $class;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SamlUserProvider.php
@@ -41,7 +41,7 @@ class SamlUserProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $this->loadUserByIdentifier($user->getLogin());
+        return $this->loadUserByIdentifier($user->getUserIdentifier());
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
@@ -64,7 +64,7 @@ class SecurityUserProvider implements UserProviderInterface, PasswordUpgraderInt
 
     public function upgradePassword(UserInterface $user, string $newHashedPassword): void
     {
-        $userEntity = $this->loadUserByLogin($user->getUsername());
+        $userEntity = $this->loadUserByLogin($user->getUserIdentifier());
         $this->userRepository->upgradePassword($userEntity, $newHashedPassword);
     }
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
@@ -1,4 +1,4 @@
-{%  if app.user.loggedIn == true and hasPermission('area_combined_participation_area') %}
+{%  if currentUser.loggedIn == true and hasPermission('area_combined_participation_area') %}
     {% set extendTwig = '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 {% else %}
     {% set extendTwig = '@DemosPlanCore/DemosPlanCore/base_oeb.html.twig' %}
@@ -33,8 +33,8 @@
             link: path('DemosPlan_procedure_public_detail', {'procedure': procedure}) ~ '#_procedureDetailsDocumentlist',
             link_caption: 'plandocuments.all'|trans,
             width_css: {
-                col1: app.user.loggedIn == true ? 'u-1-of-1' : 'width-map-toolbar',
-                col2: app.user.loggedIn == true ? 'u-1-of-1' : 'width-map-canvas'
+                col1: currentUser.loggedIn == true ? 'u-1-of-1' : 'width-map-toolbar',
+                col2: currentUser.loggedIn == true ? 'u-1-of-1' : 'width-map-canvas'
             },
             cssClasses: '',
             content_heading: 'plandocuments'|trans ~ ': '  ~ getProcedureName(proceduresettings),
@@ -44,7 +44,7 @@
     {% endblock page_header %}
 
     {# content #}
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ app.user.id|default }}">
+    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
         <div id="scParagraph" class="{{ 'o-page__padded'|prefixClass }}">
 
             {% if templateVars.list.documentlistToc|default([])|length > 0 %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -99,12 +99,12 @@
     {% if isMapEnabled %}
         <dp-public-detail
             :is-map-enabled="{{ isMapEnabled ? 'true' : 'false' }}"
-            user-id="{{ app.user.id|default }}"
+            user-id="{{ currentUser.id|default }}"
             procedure-id="{{ procedure }}"
             inline-template>
     {% else %}
         <dp-public-detail-no-map
-            user-id="{{ app.user.id|default }}"
+            user-id="{{ currentUser.id|default }}"
             procedure-id="{{ procedure }}"
             inline-template>
     {% endif %}
@@ -509,7 +509,7 @@
                                         {{ 'survey.explanation.evaluation'|trans }}
                                     {% elseif templateVars.survey.status == 'completed' %}
                                         {{ 'survey.explanation.finished'|trans }}
-                                    {% elseif app.user.loggedIn == true and hasPermission('feature_surveyvote_may_vote') %}
+                                    {% elseif currentUser.loggedIn == true and hasPermission('feature_surveyvote_may_vote') %}
                                         {% if templateVars.survey.userCanVote == true %}
                                             {{ 'survey.explanation.loggedin'|trans }}
                                         {% else %}
@@ -534,8 +534,8 @@
                      --><div class="{{ 'layout__item width-map-canvas u-pl-0_5-lap-up u-pr-0_5-lap-up'|prefixClass }}">
                             <dp-public-survey
                                 use-css-prefix
-                                :is-logged-in="Boolean({{ app.user.loggedIn }})"
-                                user-id="{{ app.user.id }}"
+                                :is-logged-in="Boolean({{ currentUser.loggedIn }})"
+                                user-id="{{ currentUser.id }}"
                                 :survey="JSON.parse('{{ templateVars.survey|default([])|json_encode|e('js', 'utf-8') }}')">
                             </dp-public-survey>
                         </div>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
@@ -1,7 +1,7 @@
 {% extends '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 
 {% block demosplanbundlecontent %}
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ app.user.id|default }}"><div>
+    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}"><div>
 
     {% set owndraftText = "text.statements.owndraft"|trans %}
     {% set permissionSubmit = 'feature_statements_released_group_submit' %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_released_group.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_released_group.html.twig
@@ -20,7 +20,7 @@
         %}
     {% endblock %}
 
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ app.user.id|default }}">
+    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
 
     <div class="o-page__padded--spaced u-pv">
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33736
**Ticket:** https://yaits.demos-deutschland.de/T33711

Authentication is done with the special SecurityUser, not with the User
entity. One of the reasons is that the objects gets serialized
in the session between requests and the doctrine entity with all its dependencies
may be huge to serialize. Therefore, we use the special SecurityUser that has only
those properties that are needed for authorization. During the request it
is swapped by the User entity.

During this PR we discovered that the implementation of `supportsClass` need to return a boolean but returned a string, which eventually worked beforehand. Likewise, a sub request does not reliably provide the current user for `app.user` in twig, `currentUser` is always available.

### How to review/test
Copy a statement or follow the descriptions in the tickets

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
