### PR TITLE
fix(refs T33917): fixes the lookup of available projections

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -275,8 +275,6 @@ export default {
     },
 
     extractDataFromWMSCapabilities () {
-      const isProjectionInOptions = this.findProjectionInOptions
-
       // Show available layers in layers dropdown
       if (Array.isArray(this.currentCapabilities.Capability.Layer.Layer)) {
         this.addLayerToOptions(this.currentCapabilities.Capability.Layer.Layer, 'Name')
@@ -294,7 +292,7 @@ export default {
             projectionsFromSource: availableCRS.join(', '),
             availableProjectionsFromSystem: this.availableProjections.join(', ')
           }))
-        } else if (isProjectionInOptions === false) {
+        } else if (this.findProjectionInOptions() === false) {
           this.projection = this.projectionOptions[0].value
         }
       }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33917

The lookup if the current projection is actually in the list of available projections happened before the available projections were properly filtered. Now it happens after, which should fix this bug after newly saving the gis layer.
Proper credit: I was just the hands while @salisdemos was directing me.

### How to review/test
With a current database, you can try to reproduce the bug in the linked ticket with/without this fix. Otherwise a code review might be enough.