### PR TITLE
fix (refs T33736, T33711): SecurityUser needs to provide real salt

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SecurityUser.php
@@ -24,6 +24,7 @@ final class SecurityUser implements UserInterface, EquatableInterface, PasswordA
     private readonly ?string $password;
     private readonly array  $roles;
     private readonly ?string $login;
+    private readonly ?string $salt;
 
     public function __construct(User $user)
     {
@@ -32,6 +33,7 @@ final class SecurityUser implements UserInterface, EquatableInterface, PasswordA
         $this->password = $user->getPassword();
         $this->login = $user->getLogin();
         $this->roles = $user->getDplanRolesArray();
+        $this->salt = $user->getSalt();
     }
 
     public function getRoles(): array
@@ -46,7 +48,7 @@ final class SecurityUser implements UserInterface, EquatableInterface, PasswordA
 
     public function getSalt(): ?string
     {
-        return null;
+        return $this->salt;
     }
 
     public function getUsername(): string


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33711
**Ticket:** https://yaits.demos-deutschland.de/T33736

Salt is deprecated in symfony 5.4 but still used to compare whether user changed during login as a safety measure. As long as this feature is used by symfony we need to provide the salt, as older users might still have the salt field filled

After merging #1769 it occurred that some users could not login any more. These where the ones with a salt set. 

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Set a salt to a user (like Walter West in test database) and try to login

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
