### PR TITLE
chore: keycloak group role string needs to be configurable

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -330,6 +330,8 @@ parameters:
     oauth_keycloak_client_secret: ''
     oauth_keycloak_auth_server_url: ''
     oauth_keycloak_realm: ''
+    # roles may be granted via keycloak groups
+    keycloak_group_role_string: ''
 
     # Set users with permissions to alter Database
     database_install_user: ""

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -64,7 +64,7 @@ class OzgKeycloakUserDataMapper
         'Redaktion'                         => Role::CONTENT_EDITOR,
         'Privatperson-Angemeldet'           => Role::CITIZEN,
         'Fachliche Leitstelle'              => Role::PROCEDURE_CONTROL_UNIT,
-        'Datenerfassung'                    => Role::PROCEDURE_DATA_INPUT
+        'Datenerfassung'                    => Role::PROCEDURE_DATA_INPUT,
     ];
 
     public function __construct(private readonly CustomerService $customerService, private readonly DepartmentRepository $departmentRepository, private readonly EntityManagerInterface $entityManager, private readonly GlobalConfig $globalConfig, private readonly LoggerInterface $logger, private readonly OrgaRepository $orgaRepository, private readonly OrgaService $orgaService, private readonly OrgaTypeRepository $orgaTypeRepository, private readonly RoleRepository $roleRepository, private readonly UserRepository $userRepository, private readonly UserRoleInCustomerRepository $userRoleInCustomerRepository, private readonly UserService $userService, private readonly ValidatorInterface $validator)

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -426,9 +426,13 @@ class OzgKeycloakUserDataMapper
         $availableRequestedRoles = [];
         foreach ($requestedRoleCodes as $roleCode) {
             if (in_array($roleCode, $this->globalConfig->getRolesAllowed(), true)) {
+                $this->logger->info('try to fetch role entity for role code', [$roleCode]);
                 $availableRequestedRoles[] = $this->roleRepository->findOneBy(['code' => $roleCode]);
+                $this->logger->info('current available requested roles', [$availableRequestedRoles]);
             } else {
+                $this->logger->info('try to fetch role entity for not allowed role code', [$roleCode]);
                 $unavailableRoles[] = $this->roleRepository->findOneBy(['code' => $roleCode]);
+                $this->logger->info('current unavailable requested roles', [$unavailableRoles]);
             }
         }
         if (0 !== count($unavailableRoles)) {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\OzgKeycloakUserDataMapper;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserDataInterface;
 use Doctrine\ORM\EntityManagerInterface;

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -33,8 +33,14 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 
 class OzgKeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntrypointInterface
 {
-    public function __construct(private readonly ClientRegistry $clientRegistry, private readonly EntityManagerInterface $entityManager, private readonly KeycloakUserDataInterface $keycloakUserData, private readonly LoggerInterface $logger, private readonly OzgKeycloakUserDataMapper $ozgKeycloakUserDataMapper, private readonly RouterInterface $router)
-    {
+    public function __construct(
+        private readonly ClientRegistry $clientRegistry,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly KeycloakUserDataInterface $keycloakUserData,
+        private readonly LoggerInterface $logger,
+        private readonly OzgKeycloakUserDataMapper $ozgKeycloakUserDataMapper,
+        private readonly RouterInterface $router
+    ) {
     }
 
     public function supports(Request $request): ?bool

--- a/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject;
 
 use Stringable;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
@@ -52,6 +53,13 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
     protected string $organisationId = '';
     protected string $firstName = '';
     protected string $lastName = '';
+    private readonly string $keycloakGroupRoleString;
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->keycloakGroupRoleString = $parameterBag->get('keycloak_group_role_string');
+    }
+
     public function fill(ResourceOwnerInterface $resourceOwner): void
     {
         $userInformation = $resourceOwner->toArray();
@@ -122,7 +130,7 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
     {
         foreach ($groups as $group) {
             $subGroups = explode('/', $group);
-            if (str_contains($subGroups[1], 'Beteiligung-Berechtigung')) {
+            if (str_contains($subGroups[1], $this->keycloakGroupRoleString)) {
                 $subdomain = strtolower(explode('-', $subGroups[2])[0]);
                 $this->customerRoleRelations[$subdomain][] = $subGroups[3];
             }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
@@ -10,8 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\ValueObject;
 
-use Stringable;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Stringable;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -81,6 +81,7 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
         $this->lock();
         $this->checkMandatoryValuesExist();
     }
+
     /**
      * Checks for existing mandatory data.
      */
@@ -115,6 +116,7 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
             throw new AuthenticationCredentialsNotFoundException(implode(', ', $missingMandatoryValues).'are missing in requestValues');
         }
     }
+
     /**
      * Mapping of roles of customer based on string-comparison.
      * Example of data structure of $groups:
@@ -136,6 +138,7 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
             }
         }
     }
+
     public function __toString(): string
     {
         $customerRoleRelationString = '';


### PR DESCRIPTION
Keycloak group role string needs to be configurable to be able to grant different permissions to different projects.

### How to review/test
Code review or add a new client to keycloak and try to grant different roles as in other client

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
