### PR TITLE
Fix(T34174): issue with lists and their numbering

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_at.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_at.scss
@@ -192,6 +192,14 @@ $at-icon-row-width: math.round($inuit-base-spacing-unit * 1.3);
     &__focus-border {
         box-shadow: 0 0 0 3px $dp-color-neutral-light-1;
     }
+
+    ul {
+        list-style: disc;
+    }
+
+    ol {
+        list-style: decimal;
+    }
 }
 
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34174

**Description:** This PR fixes the issue with lists and their numbering by adding styling for both `ul` and `ol` tags in the AT (Abwägungstabelle). The problem was that the initial value for `ol` did not work as expected, displaying bullets instead of numbers. As a solution, this PR sets the appropriate styling for each tag to resolve the numbering problem.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
