### PR TITLE
Fix(refs:34175): docx export is empty

### DIFF
--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -173,19 +173,15 @@ export default {
     },
 
     selectionContainsUnclaimedFragments () {
-      if (hasPermission('area_statements_fragment')) {
-        return Object.keys(this.selectedElements)
-          .map(id => this.fragments[id] || [])
-          .map(storeFragment => storeFragment.fragments || [])
-          .reduce((acc, fragments) => {
-            return [...acc, ...fragments]
-          })
-          .filter(fragment => {
-            return (fragment.assignee.id !== this.currentUserId) || (fragment.departmentId && fragment.departmentId !== '')
-          }).length > 0
-      } else {
-        return false
-      }
+      return Object.keys(this.selectedElements)
+        .map(id => this.fragments[id] || [])
+        .map(storeFragment => storeFragment.fragments || [])
+        .reduce((acc, fragments) => {
+          return [...acc, ...fragments]
+        })
+        .filter(fragment => {
+          return (fragment.assignee.id !== this.currentUserId) || (fragment.departmentId && fragment.departmentId !== '')
+        }).length > 0
     },
 
     selectionContainsUnclaimedStatements () {
@@ -349,7 +345,7 @@ export default {
         isAllowed = false
       }
 
-      if (this.selectionContainsUnclaimedFragments && hasPermission('area_statements_fragment')) {
+      if (hasPermission('area_statements_fragment') && this.selectionContainsUnclaimedFragments) {
         this.triggerWarning('warning.edit.selection.fragments.not.claimed')
         isAllowed = false
       }

--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -173,15 +173,17 @@ export default {
     },
 
     selectionContainsUnclaimedFragments () {
-      return Object.keys(this.selectedElements)
-        .map(id => this.fragments[id] || [])
-        .map(storeFragment => storeFragment.fragments || [])
-        .reduce((acc, fragments) => {
-          return [...acc, ...fragments]
-        })
-        .filter(fragment => {
-          return (fragment.assignee.id !== this.currentUserId) || (fragment.departmentId && fragment.departmentId !== '')
-        }).length > 0
+      if (hasPermission('area_statements_fragment')) {
+        return Object.keys(this.selectedElements)
+          .map(id => this.fragments[id] || [])
+          .map(storeFragment => storeFragment.fragments || [])
+          .reduce((acc, fragments) => {
+            return [...acc, ...fragments]
+          })
+          .filter(fragment => {
+            return (fragment.assignee.id !== this.currentUserId) || (fragment.departmentId && fragment.departmentId !== '')
+          }).length > 0
+      }
     },
 
     selectionContainsUnclaimedStatements () {

--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -183,6 +183,8 @@ export default {
           .filter(fragment => {
             return (fragment.assignee.id !== this.currentUserId) || (fragment.departmentId && fragment.departmentId !== '')
           }).length > 0
+      } else {
+        return false
       }
     },
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34175

### Description: 

- the computed  `selectionContainsUnclaimedFragments` cannot be used in every project, only in projects where the permission `area_statements_fragment` is activated
- so the error said for this computed function:  `Reduce of empty array with no initial value`

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
