### PR TITLE
chore (refs T34194): fix anonymous user login

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
@@ -20,7 +20,7 @@ class AnonymousUser extends FunctionalUser
     public function __construct()
     {
         $this->id = self::ANONYMOUS_USER_ID;
-        $this->login = self::ANONYMOUS_USER_NAME;
+        $this->login = self::ANONYMOUS_USER_LOGIN;
         $this->lastname = self::ANONYMOUS_USER_NAME;
         $this->functionalOrga = new Orga();
         $this->functionalOrga->setId(self::ANONYMOUS_USER_ORGA_ID);

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/ApiUserProvider.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Provider;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface as AddonContractUserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
@@ -30,7 +31,7 @@ class ApiUserProvider implements UserProviderInterface
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
         // avoid database call if anonymous user calls API
-        if (User::ANONYMOUS_USER_NAME === $identifier) {
+        if (AddonContractUserInterface::ANONYMOUS_USER_LOGIN === $identifier) {
             return new AnonymousUser();
         }
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Provider;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface as AddonContractUserInterface;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\SecurityUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
@@ -70,6 +72,12 @@ class SecurityUserProvider implements UserProviderInterface, PasswordUpgraderInt
 
     private function loadUserByLogin(string $login): User
     {
+        // avoid database call for anonymous user
+        if (AddonContractUserInterface::ANONYMOUS_USER_LOGIN === $login) {
+
+           return new AnonymousUser();
+        }
+
         $userEntity = $this->userRepository->findOneBy(['login' => $login]);
         if (!$userEntity) {
             throw new UserNotFoundException(sprintf('No user found for "%s"', $login));

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
@@ -17,7 +17,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\SecurityUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
@@ -74,8 +73,7 @@ class SecurityUserProvider implements UserProviderInterface, PasswordUpgraderInt
     {
         // avoid database call for anonymous user
         if (AddonContractUserInterface::ANONYMOUS_USER_LOGIN === $login) {
-
-           return new AnonymousUser();
+            return new AnonymousUser();
         }
 
         $userEntity = $this->userRepository->findOneBy(['login' => $login]);


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T3419

The login field of the AnonymousUser was set to its user name which lead to confusion during the jwt authentication for not logged in users. The `SecurityUserProvider` searches for the login of a user and could not find anything if username is given

### How to review/test
reproducer is given in ticket

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
