### PR TITLE
chore: use base container for ci tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,12 +24,12 @@ def cancelPreviousBuilds() {
 
 def _dockerExecAsUser(String command, String containerName) {
     sh "echo $containerName"
-    return String.format('docker exec --user $(whoami) %s /bin/zsh -c "%s"', containerName, command)
+    return String.format('docker exec --user $(whoami) %s /bin/bash -c "%s"', containerName, command)
 }
 
 def _dockerExecAsRoot(String command, String containerName) {
     sh "echo $containerName"
-    return String.format('docker exec %s /bin/zsh -c "%s"', containerName, command)
+    return String.format('docker exec %s /bin/bash -c "%s"', containerName, command)
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,13 +48,12 @@ pipeline {
         }
         stage('Preparations') {
             steps {
-                sh '''grep -A3 'development:' /etc/dp/containers.yml | tail -n1 | awk '{ print $2}' | sed 's/"//g' > dockertag'''
                 withCredentials([usernamePassword(credentialsId: 'Docker', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                sh '''docker login --username $USERNAME --password $PASSWORD && docker pull demosdeutschland/demosplan-development:$(cat dockertag) '''
+                sh '''docker login --username $USERNAME --password $PASSWORD && docker pull demosdeutschland/demosplan-base:latest'''
                 }
                 script{
                     containerName = "testContainer" + env.BRANCH_NAME + env.BUILD_NUMBER
-                    commandDockerRun = 'docker run --cpus=1 -d --name ' + containerName + ' -v ${PWD}:/srv/www -v /var/cache/demosplanCI/:/srv/www/.cache/ --env CURRENT_HOST_USERNAME=$(whoami) --env CURRENT_HOST_USERID=$(id -u $(whoami)) demosdeutschland/demosplan-development:$(cat dockertag)'
+                    commandDockerRun = 'docker run --cpus=1 -d --name ' + containerName + ' -v ${PWD}:/srv/www -v /var/cache/demosplanCI/:/srv/www/.cache/ --env CURRENT_HOST_USERNAME=$(whoami) --env CURRENT_HOST_USERID=$(id -u $(whoami)) demosdeutschland/demosplan-base:latest'
                     commandExecYarn =  _dockerExecAsRoot('yarn install --prefer-offline --frozen-lockfile', containerName)
                     commandExecComposer = _dockerExecAsRoot('composer install --no-interaction', containerName)
                     sh "mkdir -p .cache"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,9 @@ def cancelPreviousBuilds() {
 //containerName = ""
 
 def _dockerExecAsUser(String command, String containerName) {
-    sh "echo $containerName"
-    return String.format('docker exec --user $(whoami) %s /bin/bash -c "%s"', containerName, command)
+    _dockerExecAsRoot(command, containerName)
+    //sh "echo $containerName"
+    //return String.format('docker exec --user $(whoami) %s /bin/bash -c "%s"', containerName, command)
 }
 
 def _dockerExecAsRoot(String command, String containerName) {
@@ -59,7 +60,7 @@ pipeline {
                     sh "mkdir -p .cache"
                     sh "echo ${PWD}"
                     sh "$commandDockerRun"
-                    sh "sleep 10"
+                    //sh "sleep 10"
                     sh "$commandExecYarn"
                     sh "$commandExecComposer"
 


### PR DESCRIPTION
Use the new shiny more lightweight demosplan-base container for ci tests. This will (hopefully) reduce memory and cpu footprint on the ci workers

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
