### PR TITLE
chore (refs T34139): fix connection to data services

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
@@ -10,38 +10,29 @@
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 
 class AiApiUser extends FunctionalUser
 {
     final public const AI_API_USER_LOGIN = 'aiapi+internal-users@demosplan';
     final public const AI_API_USER_ID = '00000000-0000-0000-0000-000000000001';
 
-    public function __construct(Customer $customer)
+    public function __construct()
     {
-        parent::__construct();
 
         $this->id = self::AI_API_USER_ID;
         $this->login = self::AI_API_USER_LOGIN;
 
-        $this->functionalOrga = new Orga();
-        $this->functionalOrga->setId(self::ANONYMOUS_USER_ORGA_ID);
-        $this->functionalOrga->setName(self::ANONYMOUS_USER_ORGA_NAME);
-
-        $this->department = new Department();
-        $this->department->setId(self::ANONYMOUS_USER_DEPARTMENT_ID);
-        $this->department->setName(self::ANONYMOUS_USER_DEPARTMENT_NAME);
+        $this->setDefaultOrgaDepartment();
 
         $role = new Role();
-        $role->setCode(Role::API_AI_COMMUNICATOR);
-        $role->setGroupCode(Role::GAICOM);
+        $role->setCode(RoleInterface::API_AI_COMMUNICATOR);
+        $role->setGroupCode(RoleInterface::GAICOM);
 
         $this->setDplanroles([$role]);
 
-        $userRoleInCustomer = new UserRoleInCustomer();
-        $userRoleInCustomer->setUser($this);
-        $userRoleInCustomer->setRole($role);
-        $userRoleInCustomer->setCustomer($customer);
-        $this->roleInCustomers = new ArrayCollection([$userRoleInCustomer]);
+        parent::__construct();
     }
+
+
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use RuntimeException;
 
 class AnonymousUser extends FunctionalUser
@@ -22,17 +23,11 @@ class AnonymousUser extends FunctionalUser
         $this->id = self::ANONYMOUS_USER_ID;
         $this->login = self::ANONYMOUS_USER_LOGIN;
         $this->lastname = self::ANONYMOUS_USER_NAME;
-        $this->functionalOrga = new Orga();
-        $this->functionalOrga->setId(self::ANONYMOUS_USER_ORGA_ID);
-        $this->functionalOrga->setName(self::ANONYMOUS_USER_ORGA_NAME);
-        $this->department = new Department();
-        $this->department->setId(self::ANONYMOUS_USER_DEPARTMENT_ID);
-        $this->department->setName(self::ANONYMOUS_USER_DEPARTMENT_NAME);
-        $this->functionalOrga->setDepartments([$this->department]);
+        $this->setDefaultOrgaDepartment();
 
         $role = new Role();
-        $role->setCode(Role::GUEST);
-        $role->setGroupCode(Role::GGUEST);
+        $role->setCode(RoleInterface::GUEST);
+        $role->setGroupCode(RoleInterface::GGUEST);
 
         $this->setDplanroles([$role]);
 

--- a/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
@@ -47,7 +47,17 @@ class FunctionalUser extends User
 
         parent::__construct();
     }
+    protected function setDefaultOrgaDepartment(): void
+    {
+        $this->functionalOrga = new Orga();
+        $this->functionalOrga->setId(self::ANONYMOUS_USER_ORGA_ID);
+        $this->functionalOrga->setName(self::ANONYMOUS_USER_ORGA_NAME);
 
+        $this->department = new Department();
+        $this->department->setId(self::ANONYMOUS_USER_DEPARTMENT_ID);
+        $this->department->setName(self::ANONYMOUS_USER_DEPARTMENT_NAME);
+        $this->functionalOrga->setDepartments([$this->department]);
+    }
     /**
      * {@inheritDoc}
      */

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/AiApiUserProvider.php
@@ -11,7 +11,6 @@
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Provider;
 
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
-use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -21,7 +20,6 @@ class AiApiUserProvider implements UserProviderInterface
 {
     public function __construct(
         protected readonly UserService $userService,
-        protected readonly CustomerService $customerService
     ) {
     }
 
@@ -55,8 +53,13 @@ class AiApiUserProvider implements UserProviderInterface
         return AiApiUser::class === $class;
     }
 
-    private function getApiUser(): AiApiUser
+    private function getApiUser(): UserInterface
     {
-        return new AiApiUser($this->customerService->getCurrentCustomer());
+        $userEntity = $this->userService->getValidUser(AiApiUser::AI_API_USER_LOGIN);
+        if (!$userEntity) {
+            throw new UserNotFoundException('No AiApiUser found');
+        }
+
+        return $userEntity;
     }
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34139

`AiApiUser` needs to be attached to a database user as it is needed by doctrine actions. Moreover, addon permissions are checked directly via database and therefore a database user needs to exist anyhow

Along the way code duplication in FunctionalUsers is reduced and Addon interfaces used.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
try to import a pdf

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
