### PR TITLE
fix(refs T34274): Safely generate imprint route

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -31,6 +31,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanCustomerController extends BaseController
@@ -45,7 +46,8 @@ class DemosPlanCustomerController extends BaseController
         CustomerHandler $customerHandler,
         EntityWrapperFactory $wrapperFactory,
         PrefilledResourceTypeProvider $resourceTypeProvider,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        RouterInterface $router
     ): Response {
         try {
             // Using a resource instead of the unrestricted entity is done here to easily notice
@@ -63,6 +65,7 @@ class DemosPlanCustomerController extends BaseController
             $templateVars = [
                 'customer'      => $customerResource,
                 'projectDomain' => $this->getGlobalConfig()->getProjectDomain(),
+                'imprintUrl'    => $router->generate('DemosPlan_misccontent_static_imprint', [], RouterInterface::ABSOLUTE_URL),
             ];
 
             return $this->renderTemplate(

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/customer_settings.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/customer_settings.html.twig
@@ -12,11 +12,9 @@
         </p>
     {% endif %}
 
-    {% set imprintUrl = app.request.schemeAndHttpHost ~ '/impressum' %}
-
     <customer-settings
         current-customer-id="{{ templateVars.customer.id }}"
-        imprint-url="{{ imprintUrl }}"
+        imprint-url="{{ templateVars.imprintUrl }}"
         :init-layer-url="JSON.parse('{{ map.publicBaselayer|json_encode|e('js', 'utf-8') }}')"
         :init-layer="JSON.parse('{{ map.publicBaselayerLayers|json_encode|e('js', 'utf-8') }}')"
         map-attribution="{{ map.mapAttribution }}"


### PR DESCRIPTION
By using Symfony's router to generate the url to be displayed as final imprint url we can be much more sure that the displayed url will be the one users would be expecting there.

**Ticket:** https://yaits.demos-deutschland.de/T34274

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
