### PR TITLE
Fix:(T34286) incorrect time in the statement versions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/DraftStatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/DraftStatementRepository.php
@@ -47,6 +47,7 @@ class DraftStatementRepository extends FluentRepository implements ArrayInterfac
             ->setParameter('draftStatementId', $draftStatementId)
             ->setParameter('organisationId', $organisationId)
             ->orderBy('draftStatementVersion.versionDate', 'DESC')
+            ->orderBy('draftStatementVersion.lastModifiedDate', 'DESC')
             ->getQuery();
 
         try {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/versions_of_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/versions_of_statement.html.twig
@@ -1,8 +1,8 @@
 {% extends '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 {% block demosplanbundlecontent %}
 
-{% set lastIndex = templateVars.draftStatementVersions|length - 1 %}
 {% set draftStatementVersions =  templateVars.draftStatementVersions %}
+{% set lastIndex = draftStatementVersions|length - 1 %}
 
     {% block title_text %}
         {#  pageheader - display procedure title + nav link #}
@@ -24,15 +24,15 @@
         class="o-page__padded--spaced u-pv"
         data-cy="versionsStatementContainer">
 
-        {% if templateVars.draftStatementVersions is defined and  templateVars.draftStatementVersions|length > 0 %}
+        {% if draftStatementVersions is defined and  draftStatementVersions|length > 0 %}
 
-            {% for index, statement in templateVars.draftStatementVersions if index < lastIndex %}
+            {% for index, statement in draftStatementVersions if index < lastIndex %}
                 <h2>{{ "date"|trans }}: {{ statement.versionDate|dplanDate('d.m.Y | H:i') }}</h2>
                 {{ statement.text|wysiwyg }}
             {% endfor %}
 
-            <h2>{{ "date"|trans }}: {{ templateVars.draftStatementVersions[lastIndex].createdDate|dplanDate('d.m.Y | H:i') }}</h2>
-            {{ templateVars.draftStatementVersions[lastIndex].text|wysiwyg }}
+            <h2>{{ "date"|trans }}: {{ draftStatementVersions[lastIndex].createdDate|dplanDate('d.m.Y | H:i') }}</h2>
+            {{ draftStatementVersions[lastIndex].text|wysiwyg }}
         {% else %}
             <p>
                 {{ "explanation.versions"|trans }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/versions_of_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/versions_of_statement.html.twig
@@ -1,6 +1,9 @@
 {% extends '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 {% block demosplanbundlecontent %}
 
+{% set lastIndex = templateVars.draftStatementVersions|length - 1 %}
+{% set draftStatementVersions =  templateVars.draftStatementVersions %}
+
     {% block title_text %}
         {#  pageheader - display procedure title + nav link #}
         {% include '@DemosPlanCore/DemosPlanCore/includes/pageheader.html.twig' with {
@@ -22,10 +25,14 @@
         data-cy="versionsStatementContainer">
 
         {% if templateVars.draftStatementVersions is defined and  templateVars.draftStatementVersions|length > 0 %}
-            {% for statement in templateVars.draftStatementVersions %}
-                <h2>{{ "date"|trans }}: {{ statement.versionDate|default()|dplanDate('d.m.Y | H:i') }}</h2>
+
+            {% for index, statement in templateVars.draftStatementVersions if index < lastIndex %}
+                <h2>{{ "date"|trans }}: {{ statement.versionDate|dplanDate('d.m.Y | H:i') }}</h2>
                 {{ statement.text|wysiwyg }}
             {% endfor %}
+
+            <h2>{{ "date"|trans }}: {{ templateVars.draftStatementVersions[lastIndex].createdDate|dplanDate('d.m.Y | H:i') }}</h2>
+            {{ templateVars.draftStatementVersions[lastIndex].text|wysiwyg }}
         {% else %}
             <p>
                 {{ "explanation.versions"|trans }}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34286

**Description:** This PR fixes the problem with dates in the statement versions. It employs the `createdDate` for the last item within the `draftStatementVersions` array to display the `createdDate` instead of using `versionDate`.

- issue with sorting by `createdDate` has also been resolved (BE)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
