### PR TITLE
feature (refs T34299): disable core permission 'field_statement_polygon'

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -254,7 +254,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
             'field_statement_meta_street',
             'field_statement_meta_submit_name',
             'field_statement_phase',
-            'field_statement_polygon',
             'field_statement_priority',
             'field_statement_status',
             'field_statement_submit_type',


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T34299

Description:
disable core permission 'field_statement_polygon' and restore previous behavior by adding this permission for each project.


### Linked PRs (optional)
Special cases:
https://github.com/demos-europe/demosplan-project-teilhabe/pull/42
https://github.com/demos-europe/demosplan-project-ewm/pull/81
Normal replicas:
https://github.com/demos-europe/demosplan-project-bimschgsh/pull/52
https://github.com/demos-europe/demosplan-project-blp/pull/64
https://github.com/demos-europe/demosplan-project-bobhh/pull/66
https://github.com/demos-europe/demosplan-project-bobsh/pull/46
https://github.com/demos-europe/demosplan-project-diplanbau/pull/162
https://github.com/demos-europe/demosplan-project-diplanbimschg/pull/8
https://github.com/demos-europe/demosplan-project-diplanrog/pull/50
https://github.com/demos-europe/demosplan-project-regio/pull/53
https://github.com/demos-europe/demosplan-project-robobsh/pull/55

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
