### PR TITLE
fix(refs T34314): Re-Add list styles for proseMirror / fragments

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_edit-field.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_edit-field.scss
@@ -13,6 +13,14 @@
 .c-edit-field {
     position: relative;
 
+    ul {
+        list-style: disc;
+    }
+
+    ol {
+        list-style: decimal;
+    }
+
     &__trigger {
         position: absolute;
         right: 0;

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tiptap.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tiptap.scss
@@ -447,3 +447,13 @@
     }
 }
 
+.ProseMirror {
+    ul {
+        list-style: disc;
+    }
+
+    ol {
+        list-style: decimal;
+    }
+}
+


### PR DESCRIPTION
 **Ticket:** https://yaits.demos-deutschland.de/T34314

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

While moving to tailwind we lost the default styles for ul/ol. Since we only want to add them in placecs, we need them and not globally and then reset them, we have to find all the places where they are lost now. here are two...

--> statement_fragments-list
--> "split statement"

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
