### PR TITLE
fix(refs T34144): Make Request syncronouse again

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -602,17 +602,21 @@ export default {
 
       if (serviceType === 'wmts') {
         const layerArray = Array.isArray(layer.attributes.layers) ? layer.attributes.layers : layer.attributes.layers.split(',')
-        const url = this.addGetCapabilityParamToUrl(layer.attributes.url)
-        externalApi(url)
-          .then(response => {
-            const result = this.parser.read(response.data)
+        url = this.addGetCapabilityParamToUrl(layer.attributes.url)
+        $.ajax({
+          dataType: 'xml',
+          url: url || '',
+          async: false,
+          success: response => {
+            const result = this.parser.read(response)
             options = optionsFromCapabilities(result, {
               layer: layerArray[0] || '',
               matrixSet: layer.attributes.tileMatrixSet
             })
 
             source = new WMTS({ ...options, layers: layerArray })
-          })
+          }
+        })
       } else if (serviceType === 'wms') {
         // @TODO find out why 'SERVICE=WMS&' is added twice to url
         url = layer.attributes.url ? layer.attributes.url : null


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34144

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

we tried to remove jQuery here and replaced ajax with (under the hood) axios.
(@see 43ad166fab54583ac4147b19071b3ab815381925)

that didn't work out because axios doesn't have a syncronous flag like ajax. Without that, we run into a stacked trap of race conditions which can't be resolved easily without rebuilding huge parts of this file.

Since I don't have a better solution, I roleback the changes from once.


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

https://diplanrog-dev.demos-europe.eu/verfahren/f96129bb-56c2-4b62-96e4-f52628adefc6/public/detail -> "test layer" should load. (there should appear getMap-Requests from https://geodienstelandesplanungstage.bob-sh.de/mapproxy/lep)

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
