### PR TITLE
feature (refs T29719): fix for csv exports

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
@@ -23,6 +23,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 
 /**
  * Stellt Adminfunktionen zur Verfügung.
@@ -108,7 +109,10 @@ class DemosPlanAdminController extends BaseController
         }
 
         // set csv Escaper
-        $twig->getExtension('EscaperExtension')->setEscaper('csv', fn ($twigEnv, $string, $charset) => str_replace('"', '""', (string) $string));
+        $twig->getExtension(EscaperExtension::class)->setEscaper(
+            'csv',
+            fn ($twigEnv, $string, $charset) => str_replace('"', '""', (string) $string)
+        );
 
         $response = $this->renderTemplate('@DemosPlanCore/DemosPlanAdmin/statistics.csv.twig', [
             'templateVars' => $templateVars,

--- a/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 
 class DemosPlanReleaseController extends DemosPlanForumBaseController
 {
@@ -834,7 +835,10 @@ class DemosPlanReleaseController extends DemosPlanForumBaseController
         $templateVars['exportDate'] = date('d.m.Y');
 
         // set csv Escaper
-        $twig->getExtension('EscaperExtension')->setEscaper('csv', fn ($twigEnv, $string, $charset) => str_replace('"', '""', (string) $string));
+        $twig->getExtension(EscaperExtension::class)->setEscaper(
+            'csv',
+            fn ($twigEnv, $string, $charset) => str_replace('"', '""', (string) $string)
+        );
 
         $response = $this->renderTemplate('@DemosPlanCore/DemosPlanForum/development_release_export.csv.twig', [
             'templateVars' => $templateVars,


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T29719

Description:
The EscaperExtension can not be found and therefore no csv files can be downloaded.

This is not a fix for the bug described in the ticket - it just fixes csv exports per se

### How to review/test
Try to download the file mentioned in the ticket - should work again.

### Linked PRs:
Fix for the ticket: https://github.com/demos-europe/demosplan-core/pull/1875

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
