### PR TITLE
refactor(refs T31187): move DpDashboardTaskCard to demosplan

### DIFF
--- a/client/js/bundles/procedure/administrationDashboard.js
+++ b/client/js/bundles/procedure/administrationDashboard.js
@@ -11,8 +11,9 @@
  * This is the entry point for administration_dashboard.html.twig
  */
 
-import { DpContextualHelp, DpDashboardTaskCard } from '@demos-europe/demosplan-ui'
+import { DpContextualHelp } from '@demos-europe/demosplan-ui'
 import AddonWrapper from '../../../../client/js/components/addon/AddonWrapper'
+import DpDashboardTaskCard from '@DpJs/components/procedure/DpDashboardTaskCard'
 import DpStatementSegmentsStatusCharts from '@DpJs/components/procedure/charts/DpStatementSegmentsStatusCharts'
 import DpSurveyChart from '@DpJs/components/procedure/survey/DpSurveyChart'
 import { initialize } from '@DpJs/InitVue'

--- a/client/js/components/procedure/DpDashboardTaskCard.vue
+++ b/client/js/components/procedure/DpDashboardTaskCard.vue
@@ -1,0 +1,110 @@
+<template>
+  <dp-card
+    :heading="Translator.trans('tasks.my')">
+    <div class="u-mt">
+      <span v-cleanhtml="Translator.trans('segments.assigned.now', { count: assignedSegmentCount })" />
+    </div>
+    <div
+      class="text--right u-mt"
+      v-if="assignedSegmentCount !== 0">
+      <dp-button
+        :href="userFilteredSegmentUrl"
+        :text="Translator.trans('tasks.view')" />
+    </div>
+  </dp-card>
+</template>
+
+<script>
+import { checkResponse, CleanHtml, dpApi, DpButton, DpCard } from '@demos-europe/demosplan-ui'
+export default {
+  name: 'DpDashboardTaskCard',
+
+  components: {
+    DpButton,
+    DpCard
+  },
+
+  directives: {
+    cleanhtml: CleanHtml
+  },
+
+  props: {
+    currentUserId: {
+      type: String,
+      required: true
+    },
+
+    procedureId: {
+      type: String,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      assignedSegmentCount: 0,
+      userHash: ''
+    }
+  },
+
+  computed: {
+    userFilteredSegmentUrl () {
+      return Routing.generate('dplan_segments_list', { procedureId: this.procedureId }) + '/' + this.userHash
+    }
+  },
+
+  mounted () {
+    // Filter by current user as assignee and current procedure
+    const filterQuery = {
+      [this.currentUserId]: {
+        condition: {
+          path: 'assignee',
+          value: this.currentUserId
+        }
+      },
+      sameProcedure: {
+        condition: {
+          path: 'parentStatement.procedure.id',
+          value: this.procedureId
+        }
+      }
+    }
+
+    // Get count of segments assigned to the current user
+    const segmentUrl = Routing.generate('api_resource_list', { resourceType: 'StatementSegment' })
+    dpApi.get(segmentUrl, { filter: filterQuery }, { serialize: true }).then(response => {
+      this.assignedSegmentCount = response.data.data.length
+    })
+
+    /*
+     * It is currently difficult to get the default filter hash but a filter hash is needed to retrieve an updated hash.
+     * Therefore, we place a get request to the default segment list route. The backend will respond with a 302 status
+     * code redirecting to the default filter hash. The 302 is handled by the browser and axios will receive the
+     * redirected response. The redirected response will contain the default filter hash, which can then be extracted
+     * and used to obtain an updated filter hash.
+     */
+    dpApi.get(Routing.generate('dplan_segments_list', { procedureId: this.procedureId }))
+      .then(response => {
+        const redirectUrl = response.request.responseURL
+        const splitUrl = redirectUrl.split('/')
+        const queryHash = splitUrl[splitUrl.length - 1]
+        const filterData = {
+          filter: {
+            ...filterQuery
+          },
+          searchPhrase: ''
+        }
+
+        // Get the actual filter hash
+        const url = Routing.generate('dplan_rpc_segment_list_query_update', { queryHash })
+        dpApi.patch(url, {}, filterData)
+          .then(response => checkResponse(response))
+          .then(response => {
+            if (response) {
+              this.userHash = response
+            }
+          })
+      })
+  }
+}
+</script>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T31187

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
The component is too specific to keep in demosplan-ui

### Linked PRs (optional)
Removes `DpDashboardTaskCard.vue` from `demosplan-ui`:
- https://github.com/demos-europe/demosplan-ui/pull/445

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
