### PR TITLE
fix(refs T33908):  Prevent map from panning/zooming out of extent

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -1767,7 +1767,6 @@ export default {
     },
 
     redrawMap () {
-      const map = this.map
       this.map.updateSize()
       this.map.getView().fit(this.initialExtent, this.map.getSize())
     },
@@ -1910,7 +1909,6 @@ export default {
         extent: this.maxExtent,
         minResolution: resolutions[(resolutions.length - 1)],
         maxResolution: resolutions[0],
-        constrainOnlyCenter: true,
         constrainResolution: true
       })
     },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33908

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

use set extent to stay within the allowed area of the map
The delete flag has the effect, that the panning and zoomout in the map handles the mapExtent diffferently than our expectations.


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

as FP-A set the "Kartenbegrenzung" to a narrow space. (/verfahren/<procedure-id>/verwalten/globaleGisEinstellungen)
then goto the public Detail and try to zoom out / pan out that area. That should not work anymore

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
