### PR TITLE
Mark LoadData classes as deprecated

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadCategoryData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadCategoryData extends ProdFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\MailTemplate;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadMailTemplateData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\MailTemplate;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadMailTemplateData extends ProdFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
@@ -15,7 +15,7 @@ use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Finder\Finder;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadMigrationVersionData extends ProdFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
@@ -14,6 +14,9 @@ use demosplan\DemosPlanCoreBundle\Entity\MigrationVersions;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Finder\Finder;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadMigrationVersionData extends ProdFixture
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -28,6 +28,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
 {
     /** @var TranslatorInterface */

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -29,7 +29,7 @@ use Doctrine\Persistence\ObjectManager;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureTypeData extends ProdFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureTypeData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadRolesData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadRolesData extends ProdFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -27,7 +27,7 @@ use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadUserData extends ProdFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -26,6 +26,9 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadUserData extends ProdFixture implements DependentFixtureInterface
 {
     public function __construct(

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 abstract class ProdFixture extends DemosFixture implements FixtureGroupInterface
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 abstract class ProdFixture extends DemosFixture implements FixtureGroupInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
@@ -14,9 +14,8 @@ use demosplan\DemosPlanCoreBundle\Entity\User\AddressBookEntry;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadAddressBookEntryData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadAddressBookEntryData.php
@@ -14,6 +14,10 @@ use demosplan\DemosPlanCoreBundle\Entity\User\AddressBookEntry;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadAddressBookEntryData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadBoilerplateData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadBoilerplateData.php
@@ -19,7 +19,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadBoilerplateData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadBoilerplateData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadBoilerplateData.php
@@ -18,6 +18,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadBoilerplateData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCategoryData.php
@@ -15,7 +15,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadCategoryData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCategoryData.php
@@ -14,6 +14,9 @@ use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadCategoryData extends TestFixture
 {
     final public const TEST_CATEGORY_FAQ = 'testCategoryFaq';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadConsultationTokenData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadConsultationTokenData.php
@@ -17,6 +17,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\ConsultationToken;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadConsultationTokenData extends TestFixture implements DependentFixtureInterface
 {
     final public const CONSULTATION_TOKEN = 'consultationToken';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadConsultationTokenData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadConsultationTokenData.php
@@ -18,7 +18,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadConsultationTokenData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadContextualHelpData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadContextualHelpData.php
@@ -14,6 +14,9 @@ use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\Help\ContextualHelp;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadContextualHelpData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadContextualHelpData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadContextualHelpData.php
@@ -15,7 +15,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Help\ContextualHelp;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadContextualHelpData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadCustomerData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadCustomerData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadCustomerData extends TestFixture
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadDraftStatementData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadDraftStatementData.php
@@ -22,7 +22,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadDraftStatementData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadDraftStatementData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadDraftStatementData.php
@@ -21,6 +21,9 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadDraftStatementData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadElementsData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadElementsData.php
@@ -21,7 +21,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadElementsData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadElementsData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadElementsData.php
@@ -20,6 +20,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocumentVersion;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadElementsData extends TestFixture implements DependentFixtureInterface
 {
     final public const TEST_ELEMENT_1 = 'testElement1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadEntityContentChangeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadEntityContentChangeData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadEntityContentChangeData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadEntityContentChangeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadEntityContentChangeData.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadEntityContentChangeData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFaqData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFaqData.php
@@ -17,6 +17,9 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadFaqData extends TestFixture implements DependentFixtureInterface
 {
     final public const FAQ_GUEST = 'testFaqGuest';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFaqData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFaqData.php
@@ -18,7 +18,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadFaqData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFileData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFileData.php
@@ -19,6 +19,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadFileData extends TestFixture implements DependentFixtureInterface
 {
     final public const PDF_TEST_FILE = 'testFile';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFileData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadFileData.php
@@ -20,7 +20,7 @@ use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadFileData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadForumData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadForumData.php
@@ -20,6 +20,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Forum\ForumThread;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadForumData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadForumData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadForumData.php
@@ -21,7 +21,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadForumData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadGlobalContentData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadGlobalContentData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadGlobalContentData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadGlobalContentData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadGlobalContentData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\GlobalContent;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadGlobalContentData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadLocationData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadLocationData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Municipality;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\PriorityArea;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadLocationData extends TestFixture
 {
     final public const COUNTY_1 = 'County1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadLocationData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadLocationData.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\PriorityArea;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadLocationData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMailData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMailData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\MailSend;
 use demosplan\DemosPlanCoreBundle\Entity\MailTemplate;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadMailData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMailData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMailData.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Entity\MailTemplate;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadMailData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadManualListSortData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadManualListSortData.php
@@ -15,7 +15,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadManualListSortData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadManualListSortData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadManualListSortData.php
@@ -14,6 +14,9 @@ use demosplan\DemosPlanCoreBundle\Entity\ManualListSort;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadManualListSortData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMapData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMapData.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadMapData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMapData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMapData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadMapData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMasterToebData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMasterToebData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\MasterToeb;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadMasterToebData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMasterToebData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadMasterToebData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\User\MasterToeb;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadMasterToebData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadNewsData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadNewsData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\News\News;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadNewsData extends TestFixture implements DependentFixtureInterface
 {
     final public const TEST_SINGLE_NEWS_1 = 'testSingleNews1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadNewsData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadNewsData.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadNewsData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadOpenGeoDbData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadOpenGeoDbData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\OpenGeoDbShortTable;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadOpenGeoDbData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadOpenGeoDbData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadOpenGeoDbData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\OpenGeoDbShortTable;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadOpenGeoDbData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureBehaviorDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureBehaviorDefinitionData.php
@@ -15,7 +15,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureBehaviorDefinitionData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureBehaviorDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureBehaviorDefinitionData.php
@@ -14,6 +14,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureBehaviorDefinition;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureBehaviorDefinitionData extends TestFixture implements DependentFixtureInterface
 {
     // for procedureTypes

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
@@ -43,6 +43,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureData extends TestFixture implements DependentFixtureInterface
 {
     final public const TESTPROCEDURE = 'testProcedure';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureData.php
@@ -44,7 +44,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -18,7 +18,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedurePersonData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedurePersonData.php
@@ -17,6 +17,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePerson;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedurePersonData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureProposalData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureProposalData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureProposal;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureProposalData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureProposalData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureProposalData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureProposal;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureProposalData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureSubscriptionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureSubscriptionData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureSubscription;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureSubscriptionData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureSubscriptionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureSubscriptionData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureSubscriptionData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureTypeData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Exception\ExclusiveProcedureOrProcedureTypeExc
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureTypeData extends TestFixture implements DependentFixtureInterface
 {
     final public const _1 = 'testProcedureType1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureTypeData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureTypeData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureUiDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureUiDefinitionData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadProcedureUiDefinitionData extends TestFixture
 {
     // for procedureTypes

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureUiDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadProcedureUiDefinitionData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadProcedureUiDefinitionData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadReportData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadReportData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadReportData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadReportData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadReportData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadReportData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSegmentData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSegmentData.php
@@ -17,6 +17,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Workflow\Place;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadSegmentData extends TestFixture implements DependentFixtureInterface
 {
     final public const SEGMENT_BULK_EDIT_1 = 'segmentTestTagsBulkEdit1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSegmentData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSegmentData.php
@@ -18,7 +18,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadSegmentData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSettingData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSettingData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Setting;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadSettingData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSettingData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSettingData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadSettingData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementAttributeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementAttributeData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementAttribute;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadStatementAttributeData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementAttributeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementAttributeData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementAttribute;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadStatementAttributeData extends TestFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
@@ -32,7 +32,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadStatementData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementData.php
@@ -31,6 +31,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadStatementData extends TestFixture implements DependentFixtureInterface
 {
     protected $manager;

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementFormDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementFormDefinitionData.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadStatementFormDefinitionData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementFormDefinitionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementFormDefinitionData.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadStatementFormDefinitionData extends TestFixture
 {
     // for procedureTypes

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementVoteData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementVoteData.php
@@ -16,7 +16,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadStatementVoteData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementVoteData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadStatementVoteData.php
@@ -15,6 +15,9 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadStatementVoteData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyData.php
@@ -17,6 +17,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadSurveyData extends TestFixture implements DependentFixtureInterface
 {
     final public const PARK_SURVEY = 'parkSurvey';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyData.php
@@ -18,7 +18,7 @@ use Doctrine\Persistence\ObjectManager;
 use Exception;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadSurveyData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyVoteData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyVoteData.php
@@ -17,6 +17,9 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadSurveyVoteData extends TestFixture implements DependentFixtureInterface
 {
     final public const SURVEY_PARK_POSITIVE1 = 'surveyParkPositive1';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyVoteData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadSurveyVoteData.php
@@ -18,7 +18,7 @@ use Doctrine\Persistence\ObjectManager;
 use Exception;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadSurveyVoteData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadTagData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadTagData.php
@@ -16,6 +16,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadTagData extends TestFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadTagData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadTagData.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadTagData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -25,7 +25,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadUserData extends TestFixture
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadUserData.php
@@ -24,6 +24,9 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadUserData extends TestFixture
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadWorkflowPlaceData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadWorkflowPlaceData.php
@@ -18,7 +18,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 class LoadWorkflowPlaceData extends TestFixture implements DependentFixtureInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadWorkflowPlaceData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/LoadWorkflowPlaceData.php
@@ -17,6 +17,9 @@ use demosplan\DemosPlanCoreBundle\Entity\Workflow\Place;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 class LoadWorkflowPlaceData extends TestFixture implements DependentFixtureInterface
 {
     final public const PLACE_REPLY = 'reply';

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/TestFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/TestFixture.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
 /**
- * @deprecated Loading fixture data via Foundry-Factories instead.
+ * @deprecated loading fixture data via Foundry-Factories instead
  */
 abstract class TestFixture extends DemosFixture implements FixtureGroupInterface
 {

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/TestFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/TestData/TestFixture.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
+/**
+ * @deprecated Loading fixture data via Foundry-Factories instead.
+ */
 abstract class TestFixture extends DemosFixture implements FixtureGroupInterface
 {
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34038

Mark LoadData classes as deprecated due to new availability of FoundryFactories.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
