### PR TITLE
Rename component to use agnostic name

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -551,7 +551,7 @@
                   With tiptap we can set obscure as prop always when the obscure button should be visible in the field,
                   because the permission check (featureObscureText) takes place in tiptap
                   -->
-              <tiptap-edit-text
+              <editable-text
                 class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2 border--right"
                 title="statement"
                 :procedure-id="procedureId"
@@ -570,7 +570,7 @@
                 @field:save="data => saveStatement(data, 'attribute', 'text')"
                 ref="text" /><!--
                 Recommendation text
-             --><tiptap-edit-text
+             --><editable-text
                   class="u-pb-0_25 u-pl-0_5 u-pt-0_25 u-1-of-2"
                   title="recommendation"
                   :procedure-id="procedureId"
@@ -597,7 +597,7 @@
                       class="fa fa-question-circle float-right u-pt-0_125"
                       aria-hidden="true" />
                   </template>
-                </tiptap-edit-text>
+                </editable-text>
             </dl>
           </dp-item-row><!--
          --><div
@@ -742,8 +742,8 @@ import DpClaim from '../DpClaim'
 import DpEditFieldMultiSelect from './DpEditFieldMultiSelect'
 import DpEditFieldSingleSelect from './DpEditFieldSingleSelect'
 import DpItemRow from './ItemRow'
+import EditableText from './EditableText'
 import TableCardFlyoutMenu from '@DpJs/components/statement/assessmentTable/TableCardFlyoutMenu'
-import TiptapEditText from './TiptapEditText'
 
 export default {
   name: 'DpAssessmentTableCard',
@@ -754,8 +754,8 @@ export default {
     DpItemRow,
     DpEditFieldMultiSelect,
     DpEditFieldSingleSelect,
-    TiptapEditText,
     DpFragmentsSwitcher: () => import(/* webpackChunkName: "dp-fragments-switcher" */ './DpFragmentsSwitcher'),
+    EditableText,
     TableCardFlyoutMenu,
     VPopover
   },
@@ -1158,7 +1158,7 @@ export default {
         this.$root.$emit('entity:updated', this.statementId, 'statement')
         return updatedField
       }).then(updatedField => {
-        this.$root.$emit('entityTextSaved:' + this.statementId, { entityId: this.statementId, field: updatedField }) // Used in TiptapEditText.vue to update short and full texts
+        this.$root.$emit('entityTextSaved:' + this.statementId, { entityId: this.statementId, field: updatedField }) // Used in EditableText.vue to update short and full texts
       })
     },
 

--- a/client/js/components/statement/assessmentTable/EditableText.vue
+++ b/client/js/components/statement/assessmentTable/EditableText.vue
@@ -122,7 +122,7 @@ import { Base64 } from 'js-base64'
 import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 
 export default {
-  name: 'TiptapEditText',
+  name: 'EditableText',
 
   components: {
     DpBoilerPlateModal,

--- a/client/js/components/statement/assessmentTable/Fragment.vue
+++ b/client/js/components/statement/assessmentTable/Fragment.vue
@@ -323,7 +323,7 @@ useful info about the component:
       <div class="layout--flush">
 <!--
      --><div class="flex">
-          <tiptap-edit-text
+          <editable-text
             title="fragment.text"
             class="c-styled-html u-mt-0_25 u-pr-0_5 u-1-of-2 u-pb-0_5 border--right"
             :initial-text="fragmentText"
@@ -341,7 +341,7 @@ useful info about the component:
             @field:save="saveFragment"
             ref="text" />
 
-          <tiptap-edit-text
+          <editable-text
             v-if="editableConsiderationAdvice"
             title="fragment.considerationAdvice"
             class="c-styled-html u-mt-0_25 u-1-of-2 u-ph-0_5 u-pb-0_5"
@@ -359,7 +359,7 @@ useful info about the component:
             @field:save="saveFragment"
             ref="considerationAdvice"
             data-cy="considerationAdvice" />
-          <tiptap-edit-text
+          <editable-text
             v-else
             title="fragment.consideration"
             class="u-mt-0_25 u-1-of-2 u-ph-0_5 u-pb-0_5"
@@ -390,8 +390,8 @@ import { Base64 } from 'js-base64'
 import DpClaim from '../DpClaim'
 import DpEditFieldMultiSelect from './DpEditFieldMultiSelect'
 import DpEditFieldSingleSelect from './DpEditFieldSingleSelect'
+import EditableText from './EditableText'
 import TableCardFlyoutMenu from './TableCardFlyoutMenu'
-import TiptapEditText from './TiptapEditText'
 
 export default {
   name: 'DpAssessmentFragment',
@@ -400,8 +400,8 @@ export default {
     DpClaim,
     DpEditFieldMultiSelect,
     DpEditFieldSingleSelect,
+    EditableText,
     TableCardFlyoutMenu,
-    TiptapEditText,
     VPopover
   },
 
@@ -699,7 +699,7 @@ export default {
             })
           }
 
-          // Update short and full texts in TiptapEditText.vue
+          // Update short and full texts in EditableText.vue
           if (field === 'text' || field === 'consideration' || field === 'considerationAdvice') {
             this.$root.$emit('entityTextSaved:' + this.fragmentId, { entityId: this.fragmentId, field: field })
           }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T24040

Tiptap is our current implementation for DpEditor, however it makes no sense to reflect that in the naming of an application specific component.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
