### PR TITLE
fix: correct some rather small padding issues

### DIFF
--- a/client/js/components/user/samlLoginForm/SamlLoginForm.vue
+++ b/client/js/components/user/samlLoginForm/SamlLoginForm.vue
@@ -25,7 +25,7 @@
           <!-- This slot is used to pass markup from the twig template into here that is needed for spam protection. -->
           <slot />
 
-          <dp-form-row :class="prefixClass('u-mb-0_75 space-stack-s')">
+          <div :class="prefixClass('u-mb-0_75 space-stack-s')">
             <dp-input
               id="r_useremail"
               data-cy="username"
@@ -58,7 +58,7 @@
               :text="Translator.trans('login')"
               type="submit"
               @click.prevent="submit" />
-          </dp-form-row>
+          </div>
           <a
             :class="prefixClass('o-link--default')"
             data-cy="password_forgot"
@@ -108,14 +108,13 @@
 </template>
 
 <script>
-import { DpButton, DpFormRow, DpInput, dpValidateMixin, prefixClassMixin } from '@demos-europe/demosplan-ui'
+import { DpButton, DpInput, dpValidateMixin, prefixClassMixin } from '@demos-europe/demosplan-ui'
 
 export default {
   name: 'SamlLoginForm',
 
   components: {
     DpButton,
-    DpFormRow,
     DpInput
   },
 

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_form.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_form.scss
@@ -390,7 +390,7 @@ input.disabled {
             // search field and X icon is the same in the top, right, and bottom dimensions.
             // Icon height is set in DpIcon.vue
             &-reset {
-                $icon-height: 16px;
+                $icon-height: 20px;
                 top: calc(50% - (#{$icon-height} / 2));
                 right: calc((#{$element-height} - #{$icon-height}) / 2);
             }


### PR DESCRIPTION
- as the icon in DpResettableInput has changed height, this needs to be adapted in the corresponding css
- DpFormRow applies a padding on each child, which led to a weird button spacing on the login button. this is corrected by simply removing DpFormRow which is not needed here anyway, as the form fields are each on their own line.

### How to review/test
- The X icon in the search field in ewm procedurelist should be aligned correctly
- The "Anmelden" button on the login page should have equal padding to the left and right

### PR Checklist
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
