### PR TITLE
refactor: avoid entity wrapping for twig

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -717,7 +717,6 @@ class DemosPlanProcedureController extends BaseController
     public function newProcedureAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
-        EntityWrapperFactory $wrapperFactory,
         FormFactoryInterface $formFactory,
         MasterTemplateService $masterTemplateService,
         Request $request,
@@ -794,7 +793,7 @@ class DemosPlanProcedureController extends BaseController
         $this->writeErrorsIntoMessageBag($form->getErrors(true));
 
         $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp('procedure.new');
-        $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, false, $wrapperFactory);
+        $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, false);
         $templateVars = $this->procedureServiceOutput->fillTemplateVars($templateVars);
         $templateVars['masterTemplateId'] = $masterTemplateService->getMasterTemplateId();
 
@@ -819,7 +818,6 @@ class DemosPlanProcedureController extends BaseController
     public function newProcedureTemplateAction(
         Breadcrumb $breadcrumb,
         CurrentUserInterface $currentUser,
-        EntityWrapperFactory $wrapperFactory,
         FormFactoryInterface $formFactory,
         MasterTemplateService $masterTemplateService,
         Request $request,
@@ -896,7 +894,7 @@ class DemosPlanProcedureController extends BaseController
         $this->writeErrorsIntoMessageBag($form->getErrors(true));
 
         $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp('procedure.master.new');
-        $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, true, $wrapperFactory);
+        $templateVars = $this->addProcedureTypesToTemplateVars($templateVars, true);
         $templateVars = $this->procedureServiceOutput->fillTemplateVars($templateVars);
         $templateVars['masterTemplateId'] = $masterTemplateService->getMasterTemplateId();
 
@@ -2771,8 +2769,7 @@ class DemosPlanProcedureController extends BaseController
      */
     protected function addProcedureTypesToTemplateVars(
         array $templateVars,
-        bool $isProcedureTemplate,
-        WrapperFactoryInterface $wrapperFactory
+        bool $isProcedureTemplate
     ): array {
         // procedure types are completely irrelevant in procedure templates (Blaupausen), so no need
         // to pass the variable if it's a procedure template (Blaupause)
@@ -2785,10 +2782,7 @@ class DemosPlanProcedureController extends BaseController
         }
 
         $nameSorting = $this->sortMethodFactory->propertyAscending($this->procedureTypeResourceType->name);
-        $entities = $this->procedureTypeResourceType->listEntities([], [$nameSorting]);
-        $procedureTypeResources = array_map(fn (object $entity) => $wrapperFactory->createWrapper($entity, $this->procedureTypeResourceType), $entities);
-
-        $templateVars['procedureTypes'] = $procedureTypeResources;
+        $templateVars['procedureTypes'] = $this->procedureTypeResourceType->listEntities([], [$nameSorting]);
 
         return $templateVars;
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
@@ -52,13 +52,13 @@ class DemosPlanProcedureTypeController extends BaseController
     public function procedureTypeListAction(
         ProcedureTypeService $procedureTypeService): Response
     {
-        $procedureTypeResources = $procedureTypeService->getAllProcedureTypeResources();
+        $procedureTypes = $procedureTypeService->getAllProcedureTypes();
 
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanProcedure/administration_procedure_type_list.html.twig',
             [
                 'templateVars' => [
-                    'procedureTypes' => $procedureTypeResources,
+                    'procedureTypes' => $procedureTypes,
                 ],
                 'title'        => 'procedure.types',
             ]
@@ -81,7 +81,7 @@ class DemosPlanProcedureTypeController extends BaseController
         TranslatorInterface $translator
     ): Response {
         $template = '@DemosPlanCore/DemosPlanProcedure/administration_procedure_type_edit.html.twig';
-        $procedureTypeResources = $procedureTypeService->getAllProcedureTypeResources();
+        $procedureTypes = $procedureTypeService->getAllProcedureTypes();
 
         $form = $this->getForm(
             $formFactory,
@@ -104,7 +104,7 @@ class DemosPlanProcedureTypeController extends BaseController
             $template,
             [
                 'templateVars' => [
-                    'procedureTypes' => $procedureTypeResources,
+                    'procedureTypes' => $procedureTypes,
                     'isCreate'       => true,
                 ],
                 'form'         => $form->createView(),
@@ -136,7 +136,7 @@ class DemosPlanProcedureTypeController extends BaseController
         }
 
         // List of ProcedureTypes
-        $procedureTypeResources = $procedureTypeService->getAllProcedureTypeResources();
+        $procedureTypes = $procedureTypeService->getAllProcedureTypes();
         /** @var ProcedureType $procedureTypeEntity */
         $procedureTypeEntity = $procedureTypeResourceType->getEntityAsReadTarget($procedureTypeId);
         $procedureTypeResource = $entityWrapperFactory->createWrapper($procedureTypeEntity, $procedureTypeResourceType);
@@ -165,7 +165,7 @@ class DemosPlanProcedureTypeController extends BaseController
             [
                 'templateVars' => [
                     'procedureTypeId' => $procedureTypeId,
-                    'procedureTypes'  => $procedureTypeResources,
+                    'procedureTypes'  => $procedureTypes,
                     'isCreate'        => true,
                 ],
                 'form'         => $form->createView(),

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureTypeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureTypeService.php
@@ -21,9 +21,7 @@ use demosplan\DemosPlanCoreBundle\Exception\ExclusiveProcedureOrProcedureTypeExc
 use demosplan\DemosPlanCoreBundle\Exception\ResourceNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
-use demosplan\DemosPlanCoreBundle\Logic\EntityWrapperFactory;
 use demosplan\DemosPlanCoreBundle\Logic\ResourcePersister;
-use demosplan\DemosPlanCoreBundle\Logic\TwigableWrapperObject;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedureBehaviorDefinitionRepository;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedureRepository;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedureTypeRepository;
@@ -45,7 +43,6 @@ use Symfony\Component\HttpFoundation\Request;
 class ProcedureTypeService extends CoreService implements ProcedureTypeServiceInterface
 {
     public function __construct(
-        private readonly EntityWrapperFactory $entityWrapperFactory,
         private readonly ProcedureBehaviorDefinitionRepository $procedureBehaviorDefinitionRepository,
         private readonly ProcedureRepository $procedureRepository,
         private readonly ProcedureTypeRepository $procedureTypeRepository,
@@ -430,20 +427,19 @@ class ProcedureTypeService extends CoreService implements ProcedureTypeServiceIn
     }
 
     /**
-     * @return array<int, TwigableWrapperObject>
+     * @return array<int, ProcedureType>
      *
      * @throws PathException
      */
-    public function getAllProcedureTypeResources(): array
+    public function getAllProcedureTypes(): array
     {
         if (!$this->procedureTypeResourceType->isAvailable()) {
             throw AccessException::typeNotAvailable($this->procedureTypeResourceType);
         }
 
         $nameSorting = $this->sortMethodFactory->propertyAscending($this->procedureTypeResourceType->name);
-        $entities = $this->procedureTypeResourceType->listEntities([], [$nameSorting]);
 
-        return array_map(fn (object $entity): TwigableWrapperObject => $this->entityWrapperFactory->createWrapper($entity, $this->procedureTypeResourceType), $entities);
+        return $this->procedureTypeResourceType->listEntities([], [$nameSorting]);
     }
 
     public function getProcedureTypeByName(string $name): ?ProcedureType


### PR DESCRIPTION
A previous attempt to pass objects into
twig files that use the same properties
as the resources returned by the generic
web API did not establish itself. The
attempt is thus rolled back,
simplifying code logic.

As the `ProcedureTypeResourceType` does
not apply any aliases or special
property permissions, no adjustment of
the twig files is necessary.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
