### PR TITLE
feature (T28333) : add new error message for wrong selected xls impor…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -2405,11 +2405,15 @@ class DemosPlanStatementController extends BaseController
                 $this->getMessageBag()->add('error', 'error.missing.data',
                     ['fileName' => $fileName]);
             } catch (UnexpectedWorksheetNameException $exception) {
-                $this->getMessageBag()->add('error', 'error.worksheet.name',
-                    [
-                        'worksheetTitle' => $exception->getIncomingTitle(),
-                        'expectedTitles' => $exception->getExpectedTitles(),
-                    ]);
+                if ($exception->getIncomingTitle() == 'Abschnitte') {
+                    $this->getMessageBag()->add('error', 'error.wrong.selected.importer');
+                } else {
+                    $this->getMessageBag()->add('error', 'error.worksheet.name',
+                        [
+                            'worksheetTitle' => $exception->getIncomingTitle(),
+                            'expectedTitles' => $exception->getExpectedTitles(),
+                        ]);
+                }
             } catch (RowAwareViolationsException $error) {
                 $this->getMessageBag()->add('error', 'statements.import.error.document.summary', ['doc' => $fileName]);
                 $this->getMessageBag()->add('error', 'statements.import.error.line.summary', ['lineNr' => $error->getRow()]);

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -2405,7 +2405,7 @@ class DemosPlanStatementController extends BaseController
                 $this->getMessageBag()->add('error', 'error.missing.data',
                     ['fileName' => $fileName]);
             } catch (UnexpectedWorksheetNameException $exception) {
-                if ($exception->getIncomingTitle() == 'Abschnitte') {
+                if ('Abschnitte' == $exception->getIncomingTitle()) {
                     $this->getMessageBag()->add('error', 'error.wrong.selected.importer');
                 } else {
                     $this->getMessageBag()->add('error', 'error.worksheet.name',

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -2405,7 +2405,7 @@ class DemosPlanStatementController extends BaseController
                 $this->getMessageBag()->add('error', 'error.missing.data',
                     ['fileName' => $fileName]);
             } catch (UnexpectedWorksheetNameException $exception) {
-                if ('Abschnitte' == $exception->getIncomingTitle()) {
+                if ('Abschnitte' === $exception->getIncomingTitle()) {
                     $this->getMessageBag()->add('error', 'error.wrong.selected.importer');
                 } else {
                     $this->getMessageBag()->add('error', 'error.worksheet.name',

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1229,7 +1229,7 @@ error.userStory.voting.reset: "Ihre Bewertung konnte nicht zurückgesetzt werden
 error.userStory.voting: "Die Bewertung konnte nicht gespeichert werden."
 error.without.authorization: "Sie sind zu dieser Aktion nicht autorisiert."
 error.worksheet.name: "Bitte wählen Sie einen gültigen Titel ({expectedTitles}) für das Arbeitsblatt {worksheetTitle}."
-error.wrong.selected.importer: "Sie haben ein Segment importiert. Bitte wählen Sie die Option Abschnitte importieren und importieren Sie Ihre Datei erneut."
+error.wrong.selected.importer: "Sie haben die Option Stellungnahmen importieren genutzt um Abschnitte zu importieren. Bitte wählen Sie die korrekte Option aus und importieren Sie Ihre Datei erneut."
 error.wrong.password: "Falsches Passwort"
 error: "Fehler"
 error.internal: "Ein interner Fehler ist aufgetreten"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1229,6 +1229,7 @@ error.userStory.voting.reset: "Ihre Bewertung konnte nicht zurückgesetzt werden
 error.userStory.voting: "Die Bewertung konnte nicht gespeichert werden."
 error.without.authorization: "Sie sind zu dieser Aktion nicht autorisiert."
 error.worksheet.name: "Bitte wählen Sie einen gültigen Titel ({expectedTitles}) für das Arbeitsblatt {worksheetTitle}."
+error.wrong.selected.importer: "Sie haben ein Segment importiert. Bitte wählen Sie die Option Abschnitte importieren und importieren Sie Ihre Datei erneut."
 error.wrong.password: "Falsches Passwort"
 error: "Fehler"
 error.internal: "Ein interner Fehler ist aufgetreten"


### PR DESCRIPTION
**Ticket:** [https://yaits.demos-deutschland.de/Txxyyzz -->](https://yaits.demos-deutschland.de/T28333)

Description: If users import Segment-XLS file to statement field, They receive a wrong error message. 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
