### PR TITLE
feat: allow rabbitmq_dsn to be overridden by env var

### DIFF
--- a/.env
+++ b/.env
@@ -14,18 +14,19 @@
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
-###> symfony/framework-bundle ###
-APP_ENV=dev
-APP_SECRET=7c3c6ba97270803aa3f2113c25c4984d
+###> demos/demosplan ###
 APP_TEST_SHARD=test
-#TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-#TRUSTED_HOSTS='^(localhost|example\.com)$'
-
 OAUTH_KEYCLOAK_CLIENT_ID=keycloak_id
 OAUTH_KEYCLOAK_CLIENT_SECRET=keycloak_secret
 OAUTH_KEYCLOAK_AUTH_SERVER_URL=localhost
 OAUTH_KEYCLOAK_REALM=main
+###< demos/demosplan ###
 
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=7c3c6ba97270803aa3f2113c25c4984d
+#TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+#TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###
 
 ###> symfony/mailer ###
@@ -56,7 +57,8 @@ JWT_PASSPHRASE=0699e1b59a14e6fec876c06cb8279190
 ###< lexik/jwt-authentication-bundle ###
 
 ###> php-amqplib/rabbitmq-bundle ###
-# You need to define RABBITMQ_URL in your .env.local
+# You need to define RABBITMQ_DSN in your .env.local
+RABBITMQ_DSN=amqp://:@localhost:5672/%2f
 ###< php-amqplib/rabbitmq-bundle ###
 
 ###> sentry/sentry-symfony ###

--- a/config/packages/old_sound_rabbit_mq.yaml
+++ b/config/packages/old_sound_rabbit_mq.yaml
@@ -2,7 +2,7 @@
 old_sound_rabbit_mq:
     connections:
         default:
-            url: '%env(string:default:rabbitmq_dsn:RABBITMQ_URL)%'
+            url: '%rabbitmq_dsn%'
             lazy:     true
             connection_timeout: 3
             read_write_timeout: 3

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -159,8 +159,8 @@ parameters:
     # route to tex2pdf service without trailing slash
     tex2pdf_url: ""
 
-    #RabbitMQ setting with default values
-    rabbitmq_dsn: "amqp://:@localhost:5672/%2f"
+    #RabbitMQ setting like amqp://:@localhost:5672/%2f
+    rabbitmq_dsn: "%env(string:RABBITMQ_DSN)%"
     rabbitmq_routing_disabled: false
 
     # Route to docxImporter without trailing slash


### PR DESCRIPTION
We need to be able to use environment variables during deployment to set configurations. This is also suggested as a [symfony best practice](https://symfony.com/doc/current/configuration.html#config-env-vars)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
