### PR TITLE
chore: External orga id from identity provider can be longer than 36 chars

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/08/Version20230830135400.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/08/Version20230830135400.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/08/Version20230830135400.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/08/Version20230830135400.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230830135400 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'External orga id from identity provider can be longer than 36 chars.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _orga CHANGE _o_gw_id _o_gw_id VARCHAR(256) DEFAULT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _orga CHANGE _o_gw_id _o_gw_id VARCHAR(36) DEFAULT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -149,7 +149,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var string|null
      *
-     * @ORM\Column(name="_o_gw_id", type="string", length=36, nullable=true)
+     * @ORM\Column(name="_o_gw_id", type="string", length=256, nullable=true)
      */
     protected $gwId;
     /**


### PR DESCRIPTION
The id of an organization is saved as gw_id to be able to cope with orgachanges. When logging in from external identity providers this id might be longer than 36 chars.

### How to review/test
Login via an idp with an id more than 36 Chars

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
