### PR TITLE
fix: commit the yarn.lock changes manually

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,7 +1299,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@^0.1.13":
+"@demos-europe/demosplan-ui@^0":
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.13.tgz#2bc369341947e769f17657eb3c761fe9b226b087"
   integrity sha512-EjWFJbk6vD7UdR0KxGUh+tczt2GdeE0aP2pUK/O2HI0McAk8rwp7Sra8VXbPPtmLkNY98qbyoYST/laodrPOTw==


### PR DESCRIPTION
Something got mixed up, so yarn.lock is not in sync with the actual module resolution anymore. if `yarn install` does not result in the current yarn.lock resolutions, it will try to change yarn.lock which fails if `--frozen-lockfile` is set.