### PR TITLE
bug(refs T34442): Only center map again if there are features

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
@@ -188,9 +188,11 @@ export default {
     segmentId (newVal) {
       if (newVal) {
         this.setInitDrawings()
-        this.$nextTick(() => {
-          this.setCenterAndExtent()
-        })
+        if (this.featuresObject.features.length > 0) {
+          this.$nextTick(() => {
+            this.setCenterAndExtent()
+          })
+        }
       }
     }
   },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34442

If there are no features (aka drawings) in the map, we shouldn't try to get the extent of these features. 

### How to review/test
Go to Verfahren -> Abschnitte -> Erwiderungen verfassen -> Ortsbezug. There should be no warnings in the console when opening the map with no drawings. 
