### PR TITLE
fix: make icons appear centered within buttons

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -229,6 +229,7 @@
           }"
           @click="isFullscreen = !isFullscreen">
           <dp-icon
+            class="inline-block"
             :icon="isFullscreen ? 'compress' : 'expand'"
             aria-hidden="true" />
         </button>
@@ -259,7 +260,9 @@
           }"
           @click.prevent="showSegmentVersionHistory"
           data-cy="segmentVersionHistory">
-          <dp-icon icon="history" />
+          <dp-icon
+            class="inline-block"
+            icon="history" />
         </button>
 
         <button
@@ -444,7 +447,6 @@ export default {
 
         return { id: this.segment.relationships.assignee.data.id, name: name, orgaName: orga ? orga.attributes.name : '' }
       } else {
-
         return { id: '', name: '', orgaName: '' }
       }
     },
@@ -828,7 +830,7 @@ export default {
         response.forEach(component => {
           this.$options.components[component.name] = window[component.name].default
         })
-    })
+      })
   }
 }
 </script>


### PR DESCRIPTION
This is a minor ui fix. Before, icons within the two upmost buttons were misaligned:
![image](https://github.com/demos-europe/demosplan-core/assets/40452344/283866af-6dba-4a1d-9478-5676a120143c)

This is fixed now:
![image](https://github.com/demos-europe/demosplan-core/assets/40452344/e052a1fc-f916-4487-89db-11d74bd164e9)