### PR TITLE
bug (refs T34564): enable recommendation icon in editor

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -152,7 +152,7 @@
               <i :class="prefixClass('fa fa-puzzle-piece')" />
             </button>
             <button
-              v-if="segment.hasRelationship('tags')"
+              v-if="asyncComponents"
               :class="prefixClass('menubar__button')"
               type="button"
               v-tooltip="Translator.trans('segment.recommendation.insert.similar')"
@@ -229,7 +229,6 @@
           }"
           @click="isFullscreen = !isFullscreen">
           <dp-icon
-            class="inline-block"
             :icon="isFullscreen ? 'compress' : 'expand'"
             aria-hidden="true" />
         </button>
@@ -447,6 +446,7 @@ export default {
 
         return { id: this.segment.relationships.assignee.data.id, name: name, orgaName: orga ? orga.attributes.name : '' }
       } else {
+
         return { id: '', name: '', orgaName: '' }
       }
     },
@@ -823,14 +823,14 @@ export default {
       })
 
     loadAddonComponents('segment.recommendationModal.tab')
-      .then((response) => {
+      .then(response => {
         this.asyncComponents = response
         this.allComponentsLoaded = true
 
         response.forEach(component => {
           this.$options.components[component.name] = window[component.name].default
         })
-      })
+    })
   }
 }
 </script>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -229,6 +229,7 @@
           }"
           @click="isFullscreen = !isFullscreen">
           <dp-icon
+            class="inline-block"
             :icon="isFullscreen ? 'compress' : 'expand'"
             aria-hidden="true" />
         </button>
@@ -830,7 +831,7 @@ export default {
         response.forEach(component => {
           this.$options.components[component.name] = window[component.name].default
         })
-    })
+      })
   }
 }
 </script>


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T34564

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

We shall not check for segment relationships here anymore but if we have an addon enabled. The data prop async components is representing this state hence the check was adjusted accordingly.

(I could not test this locally properly since the segmentation does not work locally atm, however if i checked several existing segments, the icon appears for all of them)

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
