### PR TITLE
chore (refs T34581): Define Entity to ensure field length

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Sessions.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Sessions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * This entity is only used to create the table for the session handler.
+ * It is not actively used in the application.
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="sessions")
+ * @ORM\Table(indexes={@ORM\Index(name="sessions_sess_lifetime_idx", columns={"sess_lifetime"})})
+ */
+class Sessions
+{
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="binary", length=128, nullable=false)
+     */
+    private string $sess_id;
+
+    /**
+     * @ORM\Column(type="blob", nullable=false, options={"fixed" = true, "length" = 16777215})
+     */
+    private $sess_data;
+
+    /**
+     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true})
+     */
+    private $sess_lifetime;
+
+    /**
+     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true})
+     */
+    private $sess_time;
+
+}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T3458

The data in the session table is no longer stored as a medium blob but as a blob by symfony default. This entity is defined to help doctrine to create the correct field size during database setup.

As a side effect this PR reduces the number of entries that are generated during doctrine migrations diff

### How to review/test
create a new database (be sure to change the database name before!) with `bin/<project> dplan:db:init --create-database` and find a sessions table. 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
