### PR TITLE
fix(refs: T34571): Display Tooltip ontop of popover

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -167,7 +167,10 @@
               v-if="asyncComponents"
               :class="prefixClass('menubar__button')"
               type="button"
-              v-tooltip="Translator.trans('segment.recommendation.insert.similar')"
+              v-tooltip="{
+                content: Translator.trans('segment.recommendation.insert.similar'),
+                classes: 'u-z-super'
+              }"
               @click.stop="toggleRecommendationModal">
               <i :class="prefixClass('fa fa-lightbulb-o')" />
             </button>
@@ -463,7 +466,6 @@ export default {
 
         return { id: this.segment.relationships.assignee.data.id, name: name, orgaName: orga ? orga.attributes.name : '' }
       } else {
-
         return { id: '', name: '', orgaName: '' }
       }
     },
@@ -832,7 +834,7 @@ export default {
           this.selectedPlace = this.places.find(place => place.id === this.segment.relationships.place.data.id) || this.places[0]
         }
       })
-    this.fetchAssignableUsers({ include: 'department', sort: 'lastname' })
+    this.fetchAssignableUsers({ include: 'orga', sort: 'lastname' })
       .then(() => {
         if (this.segment.relationships?.assignee?.data?.id) {
           this.selectedAssignee = this.assignableUsers.find(user => user.id === this.segment.relationships.assignee.data.id)


### PR DESCRIPTION
when a tooltip is used within a popover,
we have to overwrite the default z-index-class

 **Ticket:** https://yaits.demos-deutschland.de/T34571


:warning:  **due to local problems, I couldn't test the fix locally**



<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->


As FPA 
goto `/verfahren/<procedure-id>/<statement-id>/abschnitte

respond to a segment and open the bulp-modal for "similar segments". Hover over the robot.





### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
