### PR TITLE
feat: when used as a library the project path differs

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Utilities/DemosPlanPath.php
+++ b/demosplan/DemosPlanCoreBundle/Utilities/DemosPlanPath.php
@@ -87,6 +87,10 @@ class DemosPlanPath
      */
     public static function getProjectPath(string $path = ''): string
     {
+        if(self::isInstalledAsLib()) {
+            return dirname(self::getRootPath(), 3).DIRECTORY_SEPARATOR.$path;
+        }
+
         $projectPath = self::$projectPathFromConfig;
 
         return self::getRootPath("{$projectPath}/{$path}");
@@ -102,6 +106,11 @@ class DemosPlanPath
         return '' !== $path
             ? self::getRootPath('tests').'/'.$path
             : self::getRootPath('tests');
+    }
+
+    public static function isInstalledAsLib(): bool
+    {
+        return !is_dir(self::getRootPath('vendor'));
     }
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34629

dplan may be used as a library. In this case the path to the project root needs to be adjusted.

### How to review/test
code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
