### PR TITLE
feat (refs T34644): remove subdomains_allowed

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1290,16 +1290,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.8",
+            "version": "v0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "93c3263b46a03640588f8a64e30d6e719f04b37d"
+                "reference": "4e525a92abc965f9833f2c86f7eb4f044e3fa856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/93c3263b46a03640588f8a64e30d6e719f04b37d",
-                "reference": "93c3263b46a03640588f8a64e30d6e719f04b37d",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/4e525a92abc965f9833f2c86f7eb4f044e3fa856",
+                "reference": "4e525a92abc965f9833f2c86f7eb4f044e3fa856",
                 "shasum": ""
             },
             "require": {
@@ -1337,9 +1337,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.8"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.9"
             },
-            "time": "2023-08-24T13:04:55+00:00"
+            "time": "2023-09-14T09:30:54+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -456,8 +456,7 @@ parameters:
     # This parameter may be used to map some external URL to an internal customer like
     # planungsportal.brandenburg.de: bb.bauleitplanung-online.de
     subdomain_map: []
-    # Defines which subdomains (aka customers) are allowed in current project
-    subdomains_allowed: ['sh']
+
 
     ai_service_salt: ""
     ai_service_post_url: ""

--- a/config/parameters_test.yml
+++ b/config/parameters_test.yml
@@ -7,9 +7,5 @@ parameters:
     fileservice_filepath: "/tmp/uploads"
     doctrine.dbal.connection_factory.class: Liip\TestFixturesBundle\Factory\ConnectionFactory
     subdomain: 'hindsight'
-    subdomains_allowed:
-        - 'sh'
-        - 'hindsight'
-        - 'brandenburg'
     project_prefix: 'dplan_test'
     honeypot_disabled: true

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
@@ -531,10 +531,6 @@ class GlobalConfig implements GlobalConfigInterface
     protected $subdomain;
     /** @var array<string,string> */
     protected $subdomainMap;
-    /**
-     * @var array<int,string>
-     */
-    protected $subdomainsAllowed;
     // End bauleitplanung-online
 
     /** @var array */
@@ -812,7 +808,6 @@ class GlobalConfig implements GlobalConfigInterface
             $this->setSubdomain($parameterBag->get('subdomain'));
         }
         $this->subdomainMap = $parameterBag->get('subdomain_map');
-        $this->subdomainsAllowed = $parameterBag->get('subdomains_allowed');
 
         // set shared folder
         $this->sharedFolder = $parameterBag->get('is_shared_folder');
@@ -1678,11 +1673,6 @@ class GlobalConfig implements GlobalConfigInterface
     public function setSubdomain(string $subdomain): void
     {
         $this->subdomain = $subdomain;
-    }
-
-    public function getSubdomainsAllowed(): array
-    {
-        return $this->subdomainsAllowed;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Services/SubdomainHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Services/SubdomainHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Services;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -23,8 +24,11 @@ class SubdomainHandler implements SubdomainHandlerInterface
      */
     protected $logger;
 
-    public function __construct(GlobalConfigInterface $globalConfig, LoggerInterface $logger)
-    {
+    public function __construct(
+        GlobalConfigInterface $globalConfig,
+        LoggerInterface $logger,
+        private readonly CustomerRepository $customerRepository
+    ) {
         $this->globalConfig = $globalConfig;
         $this->logger = $logger;
     }
@@ -43,8 +47,13 @@ class SubdomainHandler implements SubdomainHandlerInterface
         $urlSubdomain = $this->getUrlSubdomain($request);
         $this->logger->debug('Subdomain', [$urlSubdomain]);
 
-        if (in_array($urlSubdomain, $this->globalConfig->getSubdomainsAllowed(), true)) {
+        try {
+            $customer = $this->customerRepository->findCustomerBySubdomain($urlSubdomain);
+            $this->logger->debug('Customer found', [$customer->getSubdomain()]);
+
             return $urlSubdomain;
+        } catch (\Exception $e) {
+            $this->logger->warning('Customer not found', [$e->getMessage()]);
         }
 
         return $this->getGlobalConfig()->getSubdomain();

--- a/tests/backend/core/Procedure/Functional/SubdomainHandlerTest.php
+++ b/tests/backend/core/Procedure/Functional/SubdomainHandlerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Procedure\Functional;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use demosplan\DemosPlanCoreBundle\Services\SubdomainHandler;
+use demosplan\DemosPlanCoreBundle\Services\SubdomainHandlerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Base\FunctionalTestCase;
+
+class SubdomainHandlerTest extends FunctionalTestCase
+{
+    private const TESTDOMAIN = 'test';
+
+    private SubdomainHandlerInterface $subdomainHandler;
+
+    private GlobalConfigInterface $globalConfig;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->globalConfig = $this->getContainer()->get(GlobalConfigInterface::class);
+        $this->subdomainHandler = new SubdomainHandler(
+            $this->globalConfig, new NullLogger(),
+            $this->createMock(CustomerRepository::class)
+        );
+    }
+
+    private function getTestRequest($url): Request
+    {
+        $request = Request::create($url);
+        $request->server->set('REQUEST_URI', $url);
+
+        return $request;
+    }
+
+    public function testGetUrlSubdomain(): void
+    {
+        $defaultTestSubdomain = self::TESTDOMAIN;
+        $this->globalConfig->setSubdomain($defaultTestSubdomain);
+
+        $this->setCustomerNotFoundRepository();
+
+        $url = 'http://blp.dplan.local';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        static::assertEquals('blp', $this->subdomainHandler->getUrlSubdomain($request));
+
+        $url = 'http://blp.dplan.local/app_dev.php/verfahren/verwalten';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        static::assertEquals('blp', $this->subdomainHandler->getUrlSubdomain($request));
+
+        $url = 'http://blp-dev';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertSubdomainEmpty($request);
+        $url = 'http://blp-dev/app_dev.php/dplan/login';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertSubdomainEmpty($request);
+        $url = 'http://blp-dev/dplan/login';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertSubdomainEmpty($request);
+        $url = 'http://www.blp-dev/dplan/login';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertSubdomainEmpty($request);
+
+        $this->setCustomerFoundRepository();
+
+        $url = 'http://www.test.blp.dplan.local/app_dev.php/verfahren/verwalten';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertUrlSubdomainEquals(self::TESTDOMAIN, $request);
+        $url = 'http://test.blp.dplan.local/app_dev.php/verfahren/verwalten';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertUrlSubdomainEquals(self::TESTDOMAIN, $request);
+        $url = 'http://www.test.blp.dplan.local/app_dev.php/verfahren/verwalten';
+        $request = $this->getTestRequest($url);
+        $this->assertSubdomainEquals(self::TESTDOMAIN, $request);
+        $this->assertUrlSubdomainEquals(self::TESTDOMAIN, $request);
+
+    }
+
+    private function assertSubdomainEquals(string $expected, Request $request): void
+    {
+        static::assertEquals($expected, $this->subdomainHandler->getSubdomain($request));
+    }
+
+    private function assertSubdomainEmpty(Request $request): void
+    {
+        static::assertEmpty($this->subdomainHandler->getUrlSubdomain($request));
+    }
+
+    private function assertUrlSubdomainEquals(string $expected, Request $request): void
+    {
+        static::assertEquals($expected, $this->subdomainHandler->getUrlSubdomain($request));
+    }
+
+    private function setCustomerNotFoundRepository(): void
+    {
+        $mock = $this->getMockBuilder(CustomerRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->method('findCustomerBySubdomain')
+            ->willThrowException(new CustomerNotFoundException());
+        $this->subdomainHandler = new SubdomainHandler(
+            $this->globalConfig, new NullLogger(),
+            $mock
+        );
+    }
+
+    private function setCustomerFoundRepository(): void
+    {
+        $mock = $this->getMockBuilder(CustomerRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->subdomainHandler = new SubdomainHandler(
+            $this->globalConfig, new NullLogger(),
+            $mock
+        );
+    }
+}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34644

subdomains_allowed was an attempt not to take over all malicious subdomains. The approach is unfortunately too static and can be replaced by searching for the subdomain in the customer table. If the entry exists, the subdomain can be used.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
