### PR TITLE
chore: fix deprecated trim on null

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -2575,9 +2575,9 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     }
 
     /**
-     * @return string|null returns the title of the parent paragraph (the paragraph of the paragraph version)
+     * @return string returns the title of the parent paragraph (the paragraph of the paragraph version)
      */
-    public function getParagraphParentTitle()
+    public function getParagraphParentTitle(): string
     {
         if (null === $this->paragraphParentTitle && $this->paragraph instanceof ParagraphVersion) {
             $parentTitle = null;
@@ -2591,9 +2591,9 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     }
 
     /**
-     * @return string|null returns the title of the parent document (the document of the document version)
+     * @return string returns the title of the parent document (the document of the document version)
      */
-    public function getDocumentParentTitle()
+    public function getDocumentParentTitle(): string
     {
         if (null === $this->documentParentTitle && $this->document instanceof SingleDocumentVersion) {
             $documentTitle = null;
@@ -2603,7 +2603,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
             $this->documentParentTitle = $documentTitle;
         }
 
-        return trim($this->documentParentTitle);
+        return trim($this->documentParentTitle ?? '');
     }
 
     /**
@@ -3946,12 +3946,12 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     public function getParagraphParentTitleOrDocumentParentTitle(): ?string
     {
         $title = $this->getParagraphParentTitle();
-        if (null !== $title && '' !== $title) {
+        if ('' !== $title) {
             return $title;
         }
 
         $title = $this->getDocumentParentTitle();
-        if (null !== $title && '' !== $title) {
+        if ('' !== $title) {
             return $title;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
@@ -1475,9 +1475,9 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface, State
     }
 
     /**
-     * @return string|null returns the title of the parent paragraph (the paragraph of the paragraph version)
+     * @return string returns the title of the parent paragraph (the paragraph of the paragraph version)
      */
-    public function getParagraphParentTitle()
+    public function getParagraphParentTitle(): string
     {
         if (null === $this->paragraphParentTitle && $this->paragraph instanceof ParagraphVersionInterface) {
             $parentTitle = null;
@@ -1487,7 +1487,7 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface, State
             $this->paragraphParentTitle = $parentTitle;
         }
 
-        return trim($this->paragraphParentTitle);
+        return trim($this->paragraphParentTitle ?? '');
     }
 
     /**
@@ -1569,12 +1569,12 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface, State
     public function getParagraphParentTitleOrDocumentParentTitle(): ?string
     {
         $title = $this->getParagraphParentTitle();
-        if (null !== $title && '' !== $title) {
+        if ('' !== $title) {
             return $title;
         }
 
         $title = $this->getDocumentParentTitle();
-        if (null !== $title && '' !== $title) {
+        if ('' !== $title) {
             return $title;
         }
 
@@ -1596,19 +1596,14 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface, State
         return $documentId;
     }
 
-    // @improve T13720
-
-    /**
-     * @return string|null
-     */
-    public function getDocumentParentTitle()
+    public function getDocumentParentTitle(): string
     {
-        $documentTitle = null;
+        $documentTitle = '';
         if ($this->document instanceof SingleDocumentVersionInterface) {
             $documentTitle = $this->document->getSingleDocument()->getTitle();
         }
 
-        return $documentTitle;
+        return trim($documentTitle);
     }
 
     public function setCreated(DateTime $created)


### PR DESCRIPTION
This PR fixes a deprecation on trim on null which made several commands very verbose

### How to review/test
code review and e.g. populate elasticsearch

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
