### PR TITLE
feat(refs T34626): adds addon wrapper to core template

### DIFF
--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -10,7 +10,6 @@
 <script>
 import {
   dpApi,
-  AddonWrapper,
   DpButton,
   DpDateRangePicker,
   DpDatetimePicker,
@@ -20,6 +19,7 @@ import {
   DpMultiselect,
   sortAlphabetically
 } from '@demos-europe/demosplan-ui'
+import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import DpEmailList from './DpEmailList'
 import ExportSettings from './ExportSettings'
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -228,6 +228,16 @@
                                 </dp-email-list>
                             </div>
 
+                            {% if hasPermission('field_import_statement_email_addresses') %}
+                                <div class="u-mb">
+                                    {% set addonProps = { 'procedureId': templateVars.proceduresettings.id } %}
+                                    <addon-wrapper
+                                        hook-name="adminstration.edit.extra_fields"
+                                        :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">
+                                    </addon-wrapper>
+                                </div>
+                            {% endif %}
+
                             {% if hasPermission('feature_use_data_input_orga') %}
                                 <div class="u-mb">
                                     <label class="inline-block u-mb-0" for="r_dataInputOrga">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -228,15 +228,13 @@
                                 </dp-email-list>
                             </div>
 
-                            {% if hasPermission('field_import_statement_email_addresses') %}
-                                <div class="u-mb">
-                                    {% set addonProps = { 'procedureId': templateVars.proceduresettings.id } %}
-                                    <addon-wrapper
-                                        hook-name="adminstration.edit.extra_fields"
-                                        :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">
-                                    </addon-wrapper>
-                                </div>
-                            {% endif %}
+                            <div class="u-mb">
+                                {% set addonProps = { 'procedureId': templateVars.proceduresettings.id } %}
+                                <addon-wrapper
+                                    hook-name="adminstration.edit.extra_fields"
+                                    :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">
+                                </addon-wrapper>
+                            </div>
 
                             {% if hasPermission('feature_use_data_input_orga') %}
                                 <div class="u-mb">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34626

This is needed to allow addons to hook into this spot in the procedure settings in all projects. The explanation text is now also in the addons, so I only copied over the addon wrapper itself. I also changed the div class to match the ones around it. Lastly, the import of the AddonWrapper in the DpBasicSettings.vue was outdated and is now fixed.

### How to review/test
I think the addon-permissions are not properly working atm, at least not for me. So just a code review might be easiest.