### PR TITLE
bug(refs T34969): Fix addon hook for maillaine in basic settings

### DIFF
--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -10,7 +10,6 @@
 <script>
 import {
   dpApi,
-  AddonWrapper,
   DpButton,
   DpDateRangePicker,
   DpDatetimePicker,
@@ -20,6 +19,7 @@ import {
   DpMultiselect,
   sortAlphabetically
 } from '@demos-europe/demosplan-ui'
+import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import DpEmailList from './DpEmailList'
 import ExportSettings from './ExportSettings'
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34969

- Hook name changed
- We don't need permission request here, because it is handled in the addon
- Label and tooltip was moved to the addon

### How to review/test
- Install maillaine Addon
- Go to Verfahren -> Grundeinstellungen. You should see "Berechtigte Absenderadressen für den E-Mail-Import" and the button for adding addresses.  

