### PR TITLE
bug(refs T34708): Fix moving list items

### DIFF
--- a/client/js/components/map/admin/DpAdminLayerListItem.vue
+++ b/client/js/components/map/admin/DpAdminLayerListItem.vue
@@ -633,7 +633,7 @@ export default {
       set (value) {
         this.setChildrenFromCategory({
           categoryId: this.element.id,
-          data: value,
+          data: value.newOrder,
           orderType: 'treeOrder',
           parentOrder: this.layer.attributes.treeOrder
         })

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -139,7 +139,7 @@ const LayersStore = {
         const categories = []
         const layers = []
 
-        data.data.newOrder.forEach((el, idx) => {
+        data.data.forEach((el, idx) => {
           set(el.attributes, data.orderType, (data.parentOrder * 100) + (idx + 1))
           if (data.orderType === 'treeOrder') {
             if (el.type === 'GisLayerCategory') {

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -139,7 +139,7 @@ const LayersStore = {
         const categories = []
         const layers = []
 
-        data.data.forEach((el, idx) => {
+        data.data.newOrder.forEach((el, idx) => {
           set(el.attributes, data.orderType, (data.parentOrder * 100) + (idx + 1))
           if (data.orderType === 'treeOrder') {
             if (el.type === 'GisLayerCategory') {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34708

We need to set the value as `newOrder` here to be able to set the children in `client/js/store/map/Layers.js:142`.

### How to review/test
Go to Verfahren -> Planungsdokumente und Planzeichnung -> Kartenebenen definieren and create some folders and layers. You should be able to move the layer and folders and nest them. 