### PR TITLE
feat: logout from keycloak during local logout

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -68,6 +68,8 @@ security:
             lazy: true
             custom_authenticators: '%demosplan_user_authenticator_service%'
             entry_point: '%demosplan_user_authenticator_service_entry_point%'
+            logout:
+                path: DemosPlan_user_logout
 
 
     password_hashers:

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -324,6 +324,9 @@ parameters:
     oauth_keycloak_client_secret: ''
     oauth_keycloak_auth_server_url: ''
     oauth_keycloak_realm: ''
+    # keycloak logout route like
+    # <url>/realms/<realm>/protocol/openid-connect/logout?post_logout_redirect_uri=<redirect_uri>&client_id=<client_id>
+    oauth_keycloak_logout_route: ''
 
     # Set users with permissions to alter Database
     database_install_user: ""

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
@@ -12,7 +12,6 @@ namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
-use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Exception\EntityIdNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidPostDataException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/BaseController.php
@@ -55,11 +55,6 @@ abstract class BaseController extends AbstractController
     protected $logger;
 
     /**
-     * @var array possible cookies
-     */
-    protected $allowedCookieNames = [PreviousRouteCookie::NAME];
-
-    /**
      * @var MessageBagInterface
      */
     protected $messageBag;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -17,7 +17,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
-use demosplan\DemosPlanCoreBundle\Logic\SessionHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserInterface;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
@@ -277,7 +276,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     }
 
     /**
-     * Logout via security system
+     * Logout via security system.
      */
     #[Route(name: 'DemosPlan_user_logout', path: '/user/logout')]
     public function logoutAction(): void

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -277,48 +277,12 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     }
 
     /**
-     * Ausloggen.
-     *
-     * Ausloggen bedeutet, dass ein Redirect auf die Homepage durchgeführt wird und bei diesem Response gleich
-     * noch der Cookie mit dem ident-Code entwertet wird.
-     *
-     * @DplanPermissions("area_demosplan")
-     *
-     * @param bool $toGateway
-     *
-     * @throws Exception
+     * Logout via security system
      */
     #[Route(name: 'DemosPlan_user_logout', path: '/user/logout')]
-    #[Route(name: 'DemosPlan_user_logout_gateway', path: '/user/logout/gateway', defaults: ['toGateway' => true])]
-    public function logoutAction(
-        ParameterBagInterface $parameterBag,
-        PermissionsInterface $permissions,
-        Request $request,
-        SessionHandler $sessionHandler,
-        $toGateway = false): RedirectResponse
+    public function logoutAction(): void
     {
-        // let SAML handle logout when defined. It does no harm when user is logged in locally
-        if ('' !== $parameterBag->get('saml_idp_slo_url')) {
-            return $this->redirectToRoute('saml_logout');
-        }
-
-        $sessionHandler->logoutUser($request);
-        $response = $this->redirectToRoute('core_home');
-
-        if ($permissions->hasPermission('feature_has_logout_landing_page')) {
-            $response = $this->redirectToRoute('DemosPlan_user_logout_success');
-        }
-
-        if ($toGateway) {
-            $response = $this->redirect($this->globalConfig->getGatewayURL());
-        }
-
-        // clear dplan Cookies
-        foreach ($this->allowedCookieNames as $cookieName) {
-            $response->headers->clearCookie($cookieName);
-        }
-
-        return $response;
+        // special cases are handled by the LogoutSubscriber
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
+
+
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+class LogoutSubscriber implements EventSubscriberInterface
+{
+    private array $allowedCookieNames = [PreviousRouteCookie::NAME];
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly PermissionsInterface $permissions,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [LogoutEvent::class => 'onLogout'];
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        // get the current response, if it is already set by another listener
+        $response = $event->getResponse();
+
+        if (null === $response) {
+            $response = $this->redirectToRoute('core_home');
+        }
+
+        // let SAML handle logout when defined. It does no harm when user is logged in locally.
+        // Needs to be http://localhost/ as it needs to be some kind of url, and it is defined
+        // like this in the parameters_default.yml
+        if ('http://localhost/' !== $this->parameterBag->get('saml_idp_slo_url')) {
+            $this->logger->info('Redirecting to SAML for logout', [$this->parameterBag->get('saml_idp_slo_url')]);
+            $response = $this->redirectToRoute('saml_logout');
+        }
+
+        // let oauth identity provider handle logout when defined
+        if ('' !== $this->parameterBag->get('oauth_keycloak_logout_route')) {
+            $this->logger->info('Redirecting to Keycloak for logout', [$this->parameterBag->get('oauth_keycloak_logout_route')]);
+            $response = $this->redirect($this->parameterBag->get('oauth_keycloak_logout_route'));
+        }
+
+        if ($this->permissions->hasPermission('feature_has_logout_landing_page')) {
+            $response = $this->redirectToRoute('DemosPlan_user_logout_success');
+        }
+
+        // clear dplan Cookies
+        foreach ($this->allowedCookieNames as $cookieName) {
+            $response->headers->clearCookie($cookieName);
+        }
+
+
+        $event->setResponse($response);
+    }
+
+    protected function redirect(string $url): RedirectResponse
+    {
+        return new RedirectResponse($url);
+    }
+
+    protected function redirectToRoute(string $route): RedirectResponse
+    {
+        return $this->redirect($this->urlGenerator->generate($route));
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -1,8 +1,16 @@
 <?php
+
 declare(strict_types=1);
 
-namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
+namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
@@ -61,7 +69,6 @@ class LogoutSubscriber implements EventSubscriberInterface
         foreach ($this->allowedCookieNames as $cookieName) {
             $response->headers->clearCookie($cookieName);
         }
-
 
         $event->setResponse($response);
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34685

Symfony security system is used to log out user instead of building custom logout. Code is mostly only moved to listener, the part with `oauth_keycloak_logout_route` is new. A bug is fixed that caused the part of `saml_idp_slo_url` to always be true.


### How to review/test
code review might be best, normal login should still work

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
