### PR TITLE
upgrade demosplan-ui to v0.1.15 (release)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@^0":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.14.tgz#28d3cb2599565e7dcc00e35425f373a6906efda9"
-  integrity sha512-7W/YL4vbUpMPoIVqndL5Nw7CzLT0FfW7DsvjtID8MDSWKSXAKHbELKZpnsmyBWil2uVgm0gBMPvm0t3/B4ESPw==
+"@demos-europe/demosplan-ui@0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.15.tgz#2c47b8bb961ecad076391fc434c1e819ed52e9a4"
+  integrity sha512-f/9SLZI/7Zwa66icyq41W+/5O8XWru2r6qdkTSIF+4S0ngvYBqg8w4k53p7Jz6dWwrq+Ya0YJx0sXEbrwZCOGw==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@floating-ui/dom" "^1.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,7 +1299,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@0.1.15":
+"@demos-europe/demosplan-ui@^0":
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.1.15.tgz#2c47b8bb961ecad076391fc434c1e819ed52e9a4"
   integrity sha512-f/9SLZI/7Zwa66icyq41W+/5O8XWru2r6qdkTSIF+4S0ngvYBqg8w4k53p7Jz6dWwrq+Ya0YJx0sXEbrwZCOGw==


### PR DESCRIPTION
**Description:** Upgrade release branch with the new version of demosplan-ui (0.1.15).





