### PR TITLE
bug(refs T34738): Fix user filter sets

### DIFF
--- a/client/js/components/statement/assessmentTable/DpFilterModal.vue
+++ b/client/js/components/statement/assessmentTable/DpFilterModal.vue
@@ -70,7 +70,7 @@
                     class="fa fa-trash"
                     aria-hidden="true" />
                 </a>
-                {{ hasOwnProp(option, 'attributes') ? props.option.attributes.name : '' }}
+                {{ hasOwnProp(props.option, 'attributes') ? props.option.attributes.name : '' }}
               </template>
               <template v-slot:singleLabel="{ props }">
                 {{ hasOwnProp(props.option, 'attributes') ? props.option.attributes.name : '' }}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34738

Since refactoring DpMultiselect option is now a property of props. 


### How to review/test
Verfahren -> Abwägungstabelle -> Filter. You should see the list with user specific filters (first drop down). 