### PR TITLE
bug(refs T34691): Fix wrong trans key

### DIFF
--- a/client/js/components/procedure/basicSettings/ExportSettings.vue
+++ b/client/js/components/procedure/basicSettings/ExportSettings.vue
@@ -18,7 +18,7 @@
       class="u-mb"
       :label="{
         bold: true,
-        text: Translator.trans('select.all')
+        text: Translator.trans('aria.select.all')
       }"
       @change="toggleAll" />
     <div class="inline-block u-pr align-top u-1-of-4-wide u-1-of-2-desk u-1-of-2-lap u-1-of-1-palm u-mb">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34691

There was a wrong trans key used for selecting all elements. 

### How to review/test
Verfahren -> Grundeinstellunge -> Daten im Export. There should be the correct translation for selecting all elements.