### PR TITLE
chore: restore orga/department change verify page

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -19,6 +19,7 @@ use demosplan\DemosPlanCoreBundle\Event\RequestValidationWeakEvent;
 use demosplan\DemosPlanCoreBundle\EventDispatcher\TraceableEventDispatcher;
 use demosplan\DemosPlanCoreBundle\Validator\PasswordValidator;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
+use demosplan\DemosPlanUserBundle\Logic\UserMapperDataportGateway;
 use demosplan\DemosPlanUserBundle\Logic\UserMapperInterface;
 use demosplan\DemosPlanUserBundle\Logic\UserService;
 use Exception;
@@ -162,10 +163,10 @@ abstract class DplanAuthenticator extends AbstractAuthenticator
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $firewallName): Response
     {
         // verification pages need to be loaded before logging user in
-        if (null !== $this->verificationRoute) {
+        if ($this->userMapper instanceof UserMapperDataportGateway && null !== $this->userMapper->getVerificationRoute()) {
             $this->logger->info('User Orga/Department needs to be verified');
 
-            return new RedirectResponse($this->urlGenerator->generate($this->verificationRoute));
+            return new RedirectResponse($this->urlGenerator->generate($this->userMapper->getVerificationRoute()));
         }
 
         /** @var User $user */

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/DplanAuthenticator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * This file is part of the package demosplan.
  *
- * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34763

If it is not possible to automatically recognise whether an organisation or department has been changed, the user is redirected to a page on which this must be specified. This PR fixes the mechanism behind it.

### How to review/test
code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
