### PR TITLE
chore: set user and group for generated cache and log files to current user

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",
+        "ext-posix": "*",
         "ext-simplexml": "*",
         "ext-soap": "*",
         "ext-sockets": "*",

--- a/tests/backend/bootstrap.php
+++ b/tests/backend/bootstrap.php
@@ -9,11 +9,20 @@
  */
 
 use demosplan\DemosPlanCoreBundle\Application\FrontController;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 
 require dirname(__DIR__, 2).'/vendor/autoload.php';
 
 // set user and group for generated cache and log files to current user
-posix_setuid(1001);
-posix_setgid(1001);
+$userId = 1001;
+$tmpDir = DemosPlanPath::getTemporaryPath('dplan');
+if (!mkdir($tmpDir) && !is_dir($tmpDir)) {
+    throw new \RuntimeException(
+        sprintf('Directory "%s" was not created', $tmpDir)
+    );
+}
+chown($tmpDir, $userId);
+posix_setuid($userId);
+posix_setgid($userId);
 
 FrontController::bootstrap();

--- a/tests/backend/bootstrap.php
+++ b/tests/backend/bootstrap.php
@@ -17,9 +17,7 @@ require dirname(__DIR__, 2).'/vendor/autoload.php';
 $userId = 1001;
 $tmpDir = DemosPlanPath::getTemporaryPath('dplan');
 if (!mkdir($tmpDir) && !is_dir($tmpDir)) {
-    throw new \RuntimeException(
-        sprintf('Directory "%s" was not created', $tmpDir)
-    );
+    throw new \RuntimeException(sprintf('Directory "%s" was not created', $tmpDir));
 }
 chown($tmpDir, $userId);
 posix_setuid($userId);

--- a/tests/backend/bootstrap.php
+++ b/tests/backend/bootstrap.php
@@ -12,4 +12,8 @@ use demosplan\DemosPlanCoreBundle\Application\FrontController;
 
 require dirname(__DIR__, 2).'/vendor/autoload.php';
 
+// set user and group for generated cache and log files to current user
+posix_setuid(1001);
+posix_setgid(1001);
+
 FrontController::bootstrap();


### PR DESCRIPTION
As phpstorm runs tests via docker (compose) as root user file permissions are screwed up that leads to error when visiting the browser after performing a project test

### How to review/test
core review or visit the browser after performing a project test

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
