### PR TITLE
chore (T34770): allow authenticated ai user to access procedure in hidden phases

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1287,6 +1287,10 @@ feature_platform_public_index_map_settings:
     loginRequired: true
     expose: true
     parent: area_customer_settings
+feature_procedure_api_access:
+    description: 'Enables access to the API for procedures even in hidden procedure phases.'
+    label: 'Enables access to the API for procedures even in hidden procedure phases'
+    loginRequired: true
 feature_procedure_agency_email_addresses:
     description:  |-
         Note that this permission is not consistently used. Twig template overriding may be used instead to adjust

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -12,7 +12,6 @@ namespace demosplan\DemosPlanCoreBundle\Permissions;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Permission\PermissionEvaluatorInterface;
@@ -1047,7 +1046,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     {
         // Prüfe, ob der User ins Verfahren darf
         if (null !== $this->procedure) {
-
             $this->setProcedurePermissions();
 
             $readPermission = $this->hasPermissionsetRead();

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -115,9 +115,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
      */
     private array $addonPermissionCollections = [];
 
-    /**
-     * @param array<non-empty-string, PermissionInitializerInterface> $addonPermissionInitializers
-     */
     public function __construct(
         AddonRegistry $addonRegistry,
         private readonly CustomerService $currentCustomerProvider,
@@ -930,8 +927,8 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     public function hasPermissionsetRead($scope = null): bool
     {
         // Read ist in Write inbegriffen
-        return $this->hasPermissionset(self::PROCEDURE_PERMISSIONSET_READ, $scope) ||
-               $this->hasPermissionset(self::PROCEDURE_PERMISSIONSET_WRITE, $scope);
+        return $this->hasPermissionset(self::PROCEDURE_PERMISSIONSET_READ, $scope)
+               || $this->hasPermissionset(self::PROCEDURE_PERMISSIONSET_WRITE, $scope);
     }
 
     /**
@@ -946,8 +943,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
 
     /**
      * Setzt das initiale Set von kontxtbezogenen Menue-Highlights.
-     *
-     * @param array $context
      */
     protected function initMenuhightlighting(array $context = null): void
     {

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -1047,10 +1047,13 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     {
         // Prüfe, ob der User ins Verfahren darf
         if (null !== $this->procedure) {
+
+            $this->setProcedurePermissions();
+
             $readPermission = $this->hasPermissionsetRead();
             $owns = $this->ownsProcedure();
-            $isAuthenticatedAiUser = $this->user->hasRole(RoleInterface::API_AI_COMMUNICATOR);
-            $hasPermissionToEnter = $readPermission || $owns || $isAuthenticatedAiUser;
+            $apiUserMayAccess = $this->hasPermission('feature_procedure_api_access');
+            $hasPermissionToEnter = $readPermission || $owns || $apiUserMayAccess;
             if (!$hasPermissionToEnter) {
                 // handle guest Exceptions differently as redirects
                 // may be different
@@ -1059,8 +1062,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 }
                 throw new AccessDeniedException('Sie haben nicht die nötigen Rechte, um diese Seite aufzurufen.');
             }
-            // Update die Verfahrensberechtigungen
-            $this->setProcedurePermissions();
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Permissions;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Permission\PermissionEvaluatorInterface;
@@ -1053,7 +1054,8 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         if (null !== $this->procedure) {
             $readPermission = $this->hasPermissionsetRead();
             $owns = $this->ownsProcedure();
-            $hasPermissionToEnter = $readPermission || $owns;
+            $isAuthenticatedAiUser = $this->user->hasRole(RoleInterface::API_AI_COMMUNICATOR);
+            $hasPermissionToEnter = $readPermission || $owns || $isAuthenticatedAiUser;
             if (!$hasPermissionToEnter) {
                 // handle guest Exceptions differently as redirects
                 // may be different


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34770

Authenticated AI user needs to be able to access procedures even if they are in phases with the procedureset hidden (like configuration)

### How to review/test
Try to import a pdf in a hidden internal procedurephase

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
