### PR TITLE
chore: fix permission test setup after introducing ProcedureAccessEvaluator

### DIFF
--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -3260,7 +3260,6 @@ class PermissionsTest extends FunctionalTestCase
      * Create a mock testuser.
      *
      * @param array $testCase
-     * @param array $procedure
      *
      * @return User|PHPUnit_Framework_MockObject_MockObject
      */
@@ -3447,7 +3446,6 @@ class PermissionsTest extends FunctionalTestCase
     }
 
     /**
-     * @param array  $procedureArray
      * @param string $procedurePhase
      * @param array  $testCase
      * @param User   $user

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -74,8 +74,6 @@ class PermissionsTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->permissions = $this->getPermissionsInstance();
-
         $testUser = $this->fixtures->getReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
         $procedure = [
             'orgaId'            => $this->userOrgaId,
@@ -117,7 +115,7 @@ class PermissionsTest extends FunctionalTestCase
      *
      * @throws Exception
      */
-    protected function getPermissionsInstance(): Permissions
+    protected function getPermissionsInstance(bool $ownsProcedure, bool $inviteOrgaForDataInput): Permissions
     {
         // reconfigure logger to send messages to STDERR instead of STDOUT
         $logger = new Logger('UnitTest');
@@ -135,7 +133,11 @@ class PermissionsTest extends FunctionalTestCase
         $customerService = static::$container->get(CustomerService::class);
         $addonRegistry = static::$container->get(AddonRegistry::class);
 
-        $procedureAccessEvaluator = self::$container->get(ProcedureAccessEvaluator::class);
+        $tokenMockMethods = [
+            new MockMethodDefinition('isOwningProcedure', $ownsProcedure),
+            new MockMethodDefinition('isAllowedAsDataInputOrga', $inviteOrgaForDataInput),
+        ];
+        $procedureAccessEvaluator = $this->getMock(ProcedureAccessEvaluator::class, $tokenMockMethods);
         /** @var Permissions $permissions */
         $permissions = (new ReflectionClass($permissionsClass))
             ->newInstance(
@@ -3224,6 +3226,7 @@ class PermissionsTest extends FunctionalTestCase
                 $inviteOrgaForDataInput
             );
 
+            $this->permissions = $this->getPermissionsInstance($ownsProcedure, $inviteOrgaForDataInput);
             $this->permissions->setProcedure($procedureMock);
             if (null !== $procedureMock) {
                 $procedureRepositoryMock = $this->setUpProcedureRepositoryForTestCase($procedureMock);


### PR DESCRIPTION
After introducing the ProcedureAccessEvaluator the permission test system was not updated to reflect the change in infrastructure

### How to review/test
run project permissiont test

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
