### PR TITLE
chore (refs T32796): fix faulty unique index on procedure_message.procedure_id

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/09/Version20230925135949.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/09/Version20230925135949.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230925135949 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T32796: fix faulty unique index on procedure_message.procedure_id';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE procedure_message DROP FOREIGN KEY FK_E7F5DA961624BCD2');
+        $this->addSql('ALTER TABLE procedure_message DROP INDEX UNIQ_E7F5DA961624BCD2');
+        $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 FOREIGN KEY (procedure_id) REFERENCES _procedure (_p_id)');
+    }
+
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+            $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 UNIQUE INDEX UNIQ_E7F5DA961624BCD2 (procedure_id)');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/09/Version20230925135949.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/09/Version20230925135949.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -25,7 +35,6 @@ class Version20230925135949 extends AbstractMigration
         $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 FOREIGN KEY (procedure_id) REFERENCES _procedure (_p_id)');
     }
 
-
     /**
      * @throws Exception
      */
@@ -33,7 +42,7 @@ class Version20230925135949 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-            $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 UNIQUE INDEX UNIQ_E7F5DA961624BCD2 (procedure_id)');
+        $this->addSql('ALTER TABLE procedure_message ADD CONSTRAINT FK_E7F5DA961624BCD2 UNIQUE INDEX UNIQ_E7F5DA961624BCD2 (procedure_id)');
     }
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32796

procedure_id was modeled as a unique foreign key which does not make sense as we need to be able to save multiple messages to one procedure

### How to review/test
code review or modify procedure twice

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
