### PR TITLE
Fix(T34759): add translation key for an empty statement list

### DIFF
--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2872,6 +2872,7 @@ segments.import.error.submitType: "Unbekannte Einreichungsart {value}, valide Ar
 segments.none.yet: "Es sind noch keine Abschnitte vorhanden."
 segments.recommendations.create: "Erwiderungen verfassen"
 segments.recommendations.oracle: "Vorschläge zu inhaltlicher Ähnlichkeit"
+segments.recommendations.oracle.none: "Zu diesem Abschnitt konnten keine ähnlichen Abschnitte mit Erwiderung gefunden werden."
 segments.recommendations.tags: "Vorschläge zu Schlagworten"
 segments.recommendations.tags.none: "Da für diesen Abschnitt keine Schlagworte hinterlegt sind, können keine Erwiderungs-Vorschläge angezeigt werden."
 items.selected.multi.page: |


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34759

**Description:** This PR adds translation key for an empty statement list.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
