### PR TITLE
chore: lock ol to same version that masterportal uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "lscache": "^1.3.2",
-    "ol": "~7.5.1",
+    "ol": "7.3.0",
     "plyr": "^3.7.8",
     "portal-vue": "^2.1.7",
     "proj4": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6848,15 +6848,6 @@ object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-ol-mapbox-style@^10.1.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/ol-mapbox-style/-/ol-mapbox-style-10.6.0.tgz#89ac864160a374d936a59f7d1c969d4dc1d0a46b"
-  integrity sha512-s86QhCoyyKVRsYkvPzzdWd///bhYh3onWrBq4lNXnCd9G/hS6AoK023kn4zlDESVlTBDTWLz8vhOistp0M3TXA==
-  dependencies:
-    "@mapbox/mapbox-gl-style-spec" "^13.23.1"
-    mapbox-to-css-font "^2.4.1"
-    ol "^7.3.0"
-
 ol-mapbox-style@^9.2.0:
   version "9.2.4"
   resolved "https://registry.yarnpkg.com/ol-mapbox-style/-/ol-mapbox-style-9.2.4.tgz#d7d47208b83576455dd28531eb2e3d9b4e71493f"
@@ -6873,17 +6864,6 @@ ol@7.3.0:
     earcut "^2.2.3"
     geotiff "^2.0.7"
     ol-mapbox-style "^9.2.0"
-    pbf "3.2.1"
-    rbush "^3.0.1"
-
-ol@^7.3.0, ol@~7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/ol/-/ol-7.5.1.tgz#76e7a8b2cabf36124ce3123d22af08e7c4e86087"
-  integrity sha512-CFXDhO8YdQt7I+zwrGYSONo/ZM2oLr7vUvxqpLEUyy+USaQjUeE8L6FBOWIPboopGVhnSVYd5hdEirn9ifKBZQ==
-  dependencies:
-    earcut "^2.2.3"
-    geotiff "^2.0.7"
-    ol-mapbox-style "^10.1.0"
     pbf "3.2.1"
     rbush "^3.0.1"
 


### PR DESCRIPTION
To not include two versions of Openlayers within our build, we have to lock it to the version used by masterportalapi.

The [Openlayers Upgrade notes](https://github.com/openlayers/openlayers/blob/v7.5.0/changelog/upgrade-notes.md) imply that we can roll back without losing important stuff... the other question is, do we really want to lock to the masterportalapi here?

<details>
   <summary>Ergebnisse des Prod Builds mit --analyze</summary>
Before:

![image_480](https://github.com/demos-europe/demosplan-core/assets/40452344/35ac0977-55f4-4a04-b15f-4b52c08df468)

After:

![image_480](https://github.com/demos-europe/demosplan-core/assets/40452344/0e465d1b-783b-4c94-9555-29aaa5ee217f)
</details>