### PR TITLE
chore: add helper methods for installed and enabled addons

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
@@ -34,12 +34,28 @@ class AddonRegistry implements ArrayAccess
     public function boot(array $addonInfos = [])
     {
         if ([] !== $this->addonInfos) {
-            AddonException::immutableRegistry();
+            throw AddonException::immutableRegistry();
         }
 
         foreach ($addonInfos as $addonInfo) {
             $this->addonInfos[$addonInfo->getName()] = $addonInfo;
         }
+    }
+
+    /**
+     * @return array<string, AddonInfo>
+     */
+    public function getEnabledAddons(): array
+    {
+        return array_filter($this->getAddonInfos(), fn(AddonInfo $addonInfo) => $addonInfo->isEnabled());
+    }
+
+    /**
+     * @return array<string, AddonInfo>
+     */
+    public function getInstalledAddons(): array
+    {
+        return $this->getAddonInfos();
     }
 
     public function getAddonInfos(): array

--- a/tests/backend/core/Core/Functional/AddonRegistryTest.php
+++ b/tests/backend/core/Core/Functional/AddonRegistryTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use DemosEurope\DemosplanAddon\Permission\PermissionInitializerInterface;
+use demosplan\DemosPlanCoreBundle\Addon\AddonInfo;
+use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
+use demosplan\DemosPlanCoreBundle\Exception\AddonException;
+use Tests\Base\FunctionalTestCase;
+
+class AddonRegistryTest extends FunctionalTestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new AddonRegistry();
+    }
+
+    public function testBootEmpty(): void
+    {
+        $this->sut->boot([]);
+        self::assertEquals([], $this->sut->getAddonInfos());
+    }
+
+    public function testBootMethod(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+        $this->sut->boot($addonInfos);
+        $this->assertEquals($addonInfos, $this->sut->getAddonInfos());
+    }
+
+    public function testGetInstalledAndEnabledAddons(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+
+        $this->sut->boot($addonInfos);
+
+        $installedAddons = $this->sut->getInstalledAddons();
+        $this->assertIsArray($installedAddons);
+
+        $this->assertCount(2, $installedAddons);
+        $this->assertEquals($addonInfos, $installedAddons);
+
+        $enabledAddons = $this->sut->getEnabledAddons();
+        $this->assertIsArray($enabledAddons);
+
+        $this->assertCount(1, $enabledAddons);
+        $this->assertEquals($addonInfos['addon1'], $enabledAddons['addon1']);
+    }
+
+
+    public function testOffsetExists(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+
+        $this->sut->boot($addonInfos);
+
+        $this->assertTrue($this->sut->offsetExists('addon1'));
+        $this->assertTrue($this->sut->offsetExists('addon2'));
+    }
+    public function testOffsetGet(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+
+        $this->sut->boot($addonInfos);
+
+        $this->assertEquals($addonInfos['addon1'], $this->sut->offsetGet('addon1'));
+    }
+    public function testOffsetSet(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+
+        $this->sut->boot($addonInfos);
+        $this->expectException(AddonException::class);
+
+        $this->sut->offsetSet('addon1', 'anything');
+    }
+    public function testOffsetUnset(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+
+        $this->sut->boot($addonInfos);
+        $this->expectException(AddonException::class);
+
+        $this->sut->offsetUnset('addon1');
+    }
+
+    public function testBootImmutable(): void
+    {
+        $addonInfos = $this->getAddonInfoFixture();
+        $this->sut->boot($addonInfos);
+        $this->expectException(AddonException::class);
+        $this->sut->boot($addonInfos);
+    }
+
+    private function getAddonInfoFixture(): array
+    {
+        return [
+            'addon1' =>
+                new AddonInfo(
+                    'addon1', ['enabled' => true],
+                    $this->createMock(PermissionInitializerInterface::class)
+                ),
+            'addon2' =>
+                new AddonInfo(
+                    'addon2', ['enabled' => false],
+                    $this->createMock(PermissionInitializerInterface::class)
+                ),
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds two helper methods to get installed and enabled addons. These ones can be used later on to improve DX and addon handling

### How to review/test
code review, run tests

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
