### PR TITLE
feat (refs T30599): allow addons to have their own DoctrineMigrations

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonDoctrineMigrationsPass.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonDoctrineMigrationsPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Addon;
+
+use DemosEurope\DemosplanAddon\Utilities\AddonPath;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AddonDoctrineMigrationsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $addons = AddonManifestCollection::load();
+        // Check if the Doctrine Migrations bundle is registered
+        if (!$container->has('doctrine.migrations.configuration')) {
+            return;
+        }
+
+        // Get the MigrationConfiguration service definition
+        $migrationConfigurationDefinition = $container->getDefinition('doctrine.migrations.configuration');
+
+        foreach ($addons as $config) {
+            // check if the addon has a DoctrineMigrations directory
+            $migrationsPath = AddonPath::getRootPath($config['install_path'] . '/src/DoctrineMigrations');
+            if (!is_dir($migrationsPath)) {
+                continue;
+            }
+            // fetch the namespace from the mandatory entry point configuration
+            $baseNamespace = substr($config['manifest']['entry'], 0, strrpos($config['manifest']['entry'], '\\'));
+            // add the migrations directory to the MigrationConfiguration service
+            $migrationConfigurationDefinition->addMethodCall('addMigrationsDirectory', [$baseNamespace.'\\DoctrineMigrations', $migrationsPath]);
+        }
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Application;
 
 use demosplan\DemosPlanCoreBundle\Addon\AddonBundleGenerator;
+use demosplan\DemosPlanCoreBundle\Addon\AddonDoctrineMigrationsPass;
 use demosplan\DemosPlanCoreBundle\Addon\LoadAddonInfoCompilerPass;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler\DeploymentStrategyLoaderPass;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler\DumpGraphContainerPass;
@@ -276,6 +277,7 @@ class DemosPlanKernel extends Kernel
         $container->addCompilerPass(new OptionsLoaderPass(), PassConfig::TYPE_AFTER_REMOVING, 0);
         if ('test' !== $this->getEnvironment()) {
             $container->addCompilerPass(new LoadAddonInfoCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+            $container->addCompilerPass(new AddonDoctrineMigrationsPass());
         }
     }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30599

When a folder src/DoctrineMigrations exists in the addon it is added to the doctrine migrations path. The namespace of the migration needs to match the psr4 addon namespace

### How to review/test
create a Migration in src/DoctrineMigrations and run bin/<project> doctrine:migrations:status and you should see the migration

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
