### PR TITLE
F adjust methods parameters und returntypes

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePerson.php
@@ -147,7 +147,7 @@ class ProcedurePerson implements UuidEntityInterface, ProcedurePersonInterface
             : "$this->streetName $this->streetNumber";
     }
 
-    public function getStreetName(bool $withStreetNumber = false): ?string
+    public function getStreetName(): ?string
     {
         return $this->streetName;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -92,7 +92,7 @@ class SegmentsExporter
         );
     }
 
-    public function getSimilarStatementSubmitters(Statement $statement)
+    public function getSimilarStatementSubmitters(Statement $statement): string
     {
         $submitterStrings = [];
         foreach ($statement->getSimilarStatementSubmitters() as $submitter) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -69,10 +69,23 @@ class SegmentsExporter
         $section = $phpWord->addSection($this->styles['globalSection']);
         $this->addHeader($section, $procedure);
         $this->addStatementInfo($section, $statement);
+        $this->addSimilarStatementSubmitters($section,$statement);
         $this->addSegments($section, $statement);
         $this->addFooter($section, $statement);
 
         return IOFactory::createWriter($phpWord);
+    }
+
+    public function addSimilarStatementSubmitters(Section $section, Statement $statement): void
+    {
+        $SimilarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $this->getSimilarStatementSubmitters($statement)]);
+        $section->addText(
+            $SimilarStatementSubmittersText,
+            $this->styles['globalFont'],
+            $this->styles['globalSection']
+        );
+
+        $section->addTextBreak(2);
     }
 
     protected function addHeader(Section $section, Procedure $procedure): void
@@ -158,13 +171,6 @@ class SegmentsExporter
         $row6 = $table->addRow();
         $this->addSegmentCell($row6, $orgaInfoHeader->getNextHeader(), $this->styles['statementInfoTextCell']);
         $this->addSegmentCell($row6, '', $this->styles['statementInfoEmptyCell']);
-
-        $similarStatementSubmitters = $this->getSimilarStatementSubmitters($statement);
-        if ('' !== $similarStatementSubmitters) {
-            $statementSimilarSubmittersRow = $table->addRow();
-            $statementSimilarSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $similarStatementSubmitters]);
-            $this->addSegmentCell($statementSimilarSubmittersRow, $statementSimilarSubmittersText, $this->styles['statementInfoTextCell']);
-        }
 
         $section->addTextBreak(2);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -69,7 +69,7 @@ class SegmentsExporter
         $section = $phpWord->addSection($this->styles['globalSection']);
         $this->addHeader($section, $procedure);
         $this->addStatementInfo($section, $statement);
-        $this->addSimilarStatementSubmitters($section,$statement);
+        $this->addSimilarStatementSubmitters($section, $statement);
         $this->addSegments($section, $statement);
         $this->addFooter($section, $statement);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -78,9 +78,9 @@ class SegmentsExporter
 
     public function addSimilarStatementSubmitters(Section $section, Statement $statement): void
     {
-        $SimilarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $this->getSimilarStatementSubmitters($statement)]);
+        $similarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $this->getSimilarStatementSubmitters($statement)]);
         $section->addText(
-            $SimilarStatementSubmittersText,
+            $similarStatementSubmittersText,
             $this->styles['globalFont'],
             $this->styles['globalSection']
         );


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T43766

Description: 
- add new method 'addSimilarStatementSubmitters' : it to add a new section which contain the  Similar Statement Submitters section
- adjust methods return types and remove uneeded parameters


Delete the checkbox if it doesn't apply/isn't necessary.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
