### PR TITLE
chore: remove useless non-existing migration

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
@@ -52,6 +52,8 @@ class MigrateCommand extends CoreCommand
         $commands = [
             "dplan:migrations:cache --env={$env}",
             "doctrine:migrations:sync-metadata-storage {$db} --env={$env}",
+            // delete migration named "on" that was created by initial database creation
+            "doctrine:migrations:version on --delete {$db} --env={$env} ",
         ];
 
         $migrationsConfigurationPath = DemosPlanPath::getProjectPath('app/config/project_migrations.yml');


### PR DESCRIPTION
Small quality of life improvement: A migration named "on" is saved into a database when generating a new database based on fixtures, probably due to a bug in doctrine. This version is removed from the list of executed versions to avoid confusion.


### How to review/test
code revoew or create a new database based on fixtures and see migrations list. After running `bin/<project> dplan:doctrine:migrations` it should be gone. 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
