### PR TITLE
Fix(T34841): issue with displaying the icons

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -737,9 +737,6 @@ export default {
     },
 
     toggleRecommendationModal () {
-      if (this.asyncComponents[0]) {
-        this.activeId = this.asyncComponents[0].options.id
-      }
       this.$refs.recommendationModal.toggle()
     },
 
@@ -852,6 +849,7 @@ export default {
     loadAddonComponents('segment.recommendationModal.tab')
       .then(response => {
         this.asyncComponents = response
+        this.activeId = response[0].options.id || ''
         this.allComponentsLoaded = true
 
         response.forEach(component => {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -737,6 +737,9 @@ export default {
     },
 
     toggleRecommendationModal () {
+      if (this.asyncComponents[0]) {
+        this.activeId = this.asyncComponents[0].options.id
+      }
       this.$refs.recommendationModal.toggle()
     },
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34841

**Description:** This PR fixes an issue with two icons in the modal window. They were not being displayed because the `activeId` was only updated after clicking on the tab. Therefore, set the `activeId` value when clicking on the `toggleRecommendationModal` button.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
