### PR TITLE
Fix(T34793): segment id performance 

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -201,7 +201,7 @@
               v-if="hasPermission('feature_read_source_statement_via_api')"
               :class="{'is-disabled': getOriginalPdfAttachmentHashBySegment(rowData) === null}"
               target="_blank"
-              :href="Routing.generate('core_file_procedure', { hash: getOriginalPdfAttachmentHashBySegment(rowData), procedureId: procedureId })"
+              :href="Routing.generate('core_file', { hash: getOriginalPdfAttachmentHashBySegment(rowData) })"
               rel="noopener noreferrer">
               {{ Translator.trans('original.pdf') }}
             </a>
@@ -246,7 +246,9 @@ import {
   DpFlyout,
   DpLoading,
   DpPager,
+  dpRpc,
   DpStickyElement,
+  hasOwnProp,
   tableSelectAllItems,
   VPopover
 } from '@demos-europe/demosplan-ui'
@@ -521,10 +523,7 @@ export default {
           // Get all segments (without pagination) to save them in localStorage for bulk editing
           this.fetchSegmentIds({
             filter: filter,
-            search: payload.search,
-            fields: {
-              StatementSegment: ['id'].join()
-            }
+            search: payload.search
           })
         })
         .finally(() => {
@@ -532,11 +531,14 @@ export default {
         })
     },
 
-    async fetchSegmentIds (payload) {
-      const response = await dpApi.get(Routing.generate('api_resource_list', { resourceType: 'StatementSegment' }), payload, { serialize: true })
-      const allSegments = response.data.data.map(segment => segment.id)
-      this.storeAllSegments(allSegments)
-      this.allItemsCount = allSegments.length
+    fetchSegmentIds (payload) {
+      return dpRpc('segment.load.id', payload)
+        .then(response => checkResponse(response))
+        .then(response => {
+          const allSegments = (hasOwnProp(response, 0) && response[0].result) ? response[0].result : []
+          this.storeAllSegments(allSegments)
+          this.allItemsCount = allSegments.length
+        })
     },
 
     getTagsBySegment (id) {

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -201,7 +201,7 @@
               v-if="hasPermission('feature_read_source_statement_via_api')"
               :class="{'is-disabled': getOriginalPdfAttachmentHashBySegment(rowData) === null}"
               target="_blank"
-              :href="Routing.generate('core_file', { hash: getOriginalPdfAttachmentHashBySegment(rowData) })"
+              :href="Routing.generate('core_file_procedure', { hash: getOriginalPdfAttachmentHashBySegment(rowData), procedureId: procedureId })"
               rel="noopener noreferrer">
               {{ Translator.trans('original.pdf') }}
             </a>

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcBulkEditor/RpcSegmentIdLoader.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcBulkEditor/RpcSegmentIdLoader.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Segment\RpcBulkEditor;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Logic\Rpc\RpcMethodSolverInterface;
+use DemosEurope\DemosplanAddon\Validator\JsonSchemaValidator;
+use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
+use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\SearchParams;
+use demosplan\DemosPlanCoreBundle\Logic\Rpc\RpcErrorGenerator;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementSegmentResourceType;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\JsonApi\RequestHandling\JsonApiSortingParser;
+use EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser;
+use Exception;
+use Psr\Log\LoggerInterface;
+use stdClass;
+use Webmozart\Assert\Assert;
+
+class RpcSegmentIdLoader implements RpcMethodSolverInterface
+{
+    final public const SEGMENT_ID_LOAD = 'segment.load.id';
+
+    public function __construct(
+        protected readonly DqlConditionFactory $conditionFactory,
+        protected readonly DrupalFilterParser $drupalFilterParser,
+        protected readonly JsonSchemaValidator $jsonValidator,
+        protected readonly StatementSegmentResourceType $segmentResourceType,
+        protected readonly JsonApiSortingParser $sortingParser,
+        protected readonly JsonApiEsService $jsonApiEsService,
+        protected readonly LoggerInterface $logger,
+        protected RpcErrorGenerator $errorGenerator
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return self::SEGMENT_ID_LOAD === $method;
+    }
+
+    public function execute(?ProcedureInterface $procedure, $rpcRequests): array
+    {
+        $expectedProcedureId = $procedure?->getId();
+        Assert::stringNotEmpty($expectedProcedureId);
+
+        $rpcRequests = is_object($rpcRequests)
+            ? [$rpcRequests]
+            : $rpcRequests;
+
+        $resultResponse = [];
+        foreach ($rpcRequests as $rpcRequest) {
+            try {
+                $params = $rpcRequest->params;
+
+                $conditions = $this->getConditions($params, $expectedProcedureId);
+                if (isset($params->sort)) {
+                    $sortMethods = $this->sortingParser->createFromQueryParamValue($params->sort);
+                } else {
+                    $sortMethods = [];
+                }
+                $segmentIdentifiers = $this->segmentResourceType->listEntityIdentifiers($conditions, $sortMethods);
+                $searchParams = SearchParams::createOptional(isset($params->search) ? $this->toArray($params->search) : []);
+                if ($searchParams instanceof SearchParams) {
+                    $elasticsearchResult = $this->jsonApiEsService->getEsFilteredResult(
+                        $this->segmentResourceType,
+                        $segmentIdentifiers,
+                        $searchParams,
+                        [] === $sortMethods,
+                        null
+                    );
+                    $esResultArrays = $this->jsonApiEsService->toLegacyResultES($elasticsearchResult);
+                    $segmentIdentifiers = array_column($esResultArrays, 'id');
+                }
+
+                $resultResponse[] = $this->generateMethodResult($rpcRequest, $segmentIdentifiers);
+            } catch (Exception $exception) {
+                $this->logger->error('Error while loading segment IDs', ['exception' => $exception]);
+                $resultResponse[] = $this->errorGenerator->serverError($rpcRequest);
+            }
+        }
+
+        return $resultResponse;
+    }
+
+    /**
+     * @param list<non-empty-string> $segmentIds
+     */
+    public function generateMethodResult(object $rpcRequest, array $segmentIds): object
+    {
+        $result = new stdClass();
+        $result->jsonrpc = '2.0';
+        $result->result = $segmentIds;
+        $result->id = $rpcRequest->id;
+
+        return $result;
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function validateRpcRequest(object $rpcRequest): void
+    {
+        $params = $rpcRequest->params;
+        if (property_exists($params, 'sort')) {
+            Assert::stringNotEmpty($params->sort);
+        }
+        if (property_exists($params, 'filter')) {
+            Assert::isArray($params->filter);
+        }
+        if (property_exists($params, 'search')) {
+            Assert::isArray($params->searh);
+        }
+    }
+
+    private function getConditions(stdClass $params, string $procedureId)
+    {
+        $drupalFilter = $this->toArray($params->filter);
+        $conditions = null === $drupalFilter || [] === $drupalFilter
+            ? []
+            : $this->drupalFilterParser->parseFilter($drupalFilter);
+        $conditions[] = $this->conditionFactory->propertyHasValue(
+            $procedureId,
+            $this->segmentResourceType->parentStatement->procedure->id
+        );
+
+        return $conditions;
+    }
+
+    private function toArray(stdClass $object): array
+    {
+        return json_decode(json_encode($object), true);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
+++ b/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
@@ -61,7 +61,7 @@ trait ElasticsearchQueryTrait
      */
     private function areSortsAvailable(array $sorts, array $availableSorts): bool
     {
-        $getSortname = fn($sort) => $sort->getName();
+        $getSortname = fn ($sort) => $sort->getName();
 
         $availableSortNames = array_map($getSortname, $availableSorts);
         $sortNames = array_map($getSortname, $sorts);
@@ -86,9 +86,9 @@ trait ElasticsearchQueryTrait
      * @param Index|null    $index   if set this will be used instead of {@link index}
      */
     public function getElasticsearchResult(
-              $esQuery,
-              $limit = -1,
-              $page = 1,
+        $esQuery,
+        $limit = -1,
+        $page = 1,
         Index $index = null): array
     {
         $result = [];
@@ -488,7 +488,7 @@ trait ElasticsearchQueryTrait
      *
      * @param array $elasticsearchResult
      */
-    protected function toLegacyResultES($elasticsearchResult): array
+    public function toLegacyResultES($elasticsearchResult): array
     {
         $list = [];
         // avoid undefined index
@@ -507,8 +507,6 @@ trait ElasticsearchQueryTrait
      * Konvertiere das Ergebnis aus Elasticsearch zu Legacy.
      *
      * @param array $hit
-     *
-     * @return mixed
      */
     protected function convertElasticsearchHitToLegacy($hit)
     {
@@ -539,7 +537,7 @@ trait ElasticsearchQueryTrait
         foreach ($filters as $filter) {
             $labelMap = array_key_exists($filter->getName(), $labelMaps) ? $labelMaps[$filter->getName()] : [];
             $filterValues = $this->generateFilterValues($aggregationsFilterResult[$filter->getName()], $labelMap);
-            $filterValues = collect($filterValues)->sortBy(fn($filterValue) =>
+            $filterValues = collect($filterValues)->sortBy(fn ($filterValue) =>
                 /* @var FilterValue $filterValue */
                 $filterValue->getLabel())->toArray();
             if ($filter->hasNoAssignmentSelectOption()) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34793

**Description:** 

BE: Creates a new RPC route.
FE: Adjusts the request/response for the RPC route in the `SegmentsList` component.

Here is a discussion in [Slack](https://demosdeutschland.slack.com/archives/CUZTNDTUH/p1695659882787459)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
