### PR TITLE
feature (refs T34758): Rename KeyCloak role-map 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
@@ -161,10 +161,10 @@ class SegmentController extends BaseController
                     $route,
                     compact('procedureId')
                 );
-            } catch (MissingDataException) {
+            } catch (MissingDataException $e) {
                 $this->getMessageBag()->add('error', 'error.missing.data',
                     ['%fileName%' => $fileName]);
-            } catch (Exception) {
+            } catch (Exception $e) {
                 $this->getMessageBag()->add(
                     'error',
                     'statements.import.error.document.unexpected',

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -49,7 +49,7 @@ class OzgKeycloakUserDataMapper
 {
     private KeycloakUserDataInterface $ozgKeycloakUserData;
     private const ROLETITLE_TO_ROLECODE = [
-        // 'Mandanten Administration'          => Role::ORGANISATION_ADMINISTRATION,
+        'Mandanten Administration'          => Role::CUSTOMER_MASTER_USER,
         'Organisationsadministration'       => Role::ORGANISATION_ADMINISTRATION,
         'Fachplanung Planungsbüro'          => Role::PRIVATE_PLANNING_AGENCY,
         // 'Verfahrens-Planungsbüro'           => Role::PRIVATE_PLANNING_AGENCY,
@@ -60,7 +60,6 @@ class OzgKeycloakUserDataMapper
         'Institutions Koordination'         => Role::PUBLIC_AGENCY_COORDINATION,
         'Institutions Sachbearbeitung'      => Role::PUBLIC_AGENCY_WORKER,
         'Support'                           => Role::PLATFORM_SUPPORT,
-        'Plattform Administration'          => Role::CUSTOMER_MASTER_USER,
         'Redaktion'                         => Role::CONTENT_EDITOR,
         'Privatperson-Angemeldet'           => Role::CITIZEN,
         'Fachliche Leitstelle'              => Role::PROCEDURE_CONTROL_UNIT,

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -130,10 +130,10 @@ class OzgKeycloakUserDataMapper
         // and an existing user could be found using the given user attributes:
         // If the organisations are different - the assumption is that the user wants to change the orga.
         $moveUserToAnotherOrganisation =
-            null !== $existingUser &&
-            null !== $existingOrga &&
-            null !== $existingUser->getOrga() &&
-            $existingUser->getOrga()->getId() !== $existingOrga->getId();
+            null !== $existingUser
+            && null !== $existingOrga
+            && null !== $existingUser->getOrga()
+            && $existingUser->getOrga()->getId() !== $existingOrga->getId();
 
         if ($moveUserToAnotherOrganisation) {
             $this->detachUserFromOrgaAndDepartment($existingUser);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T34758

Description:
Rename KeyCloak role-map to use 'Mandanten' instead of 'Plattform'
as identifier for Role::CUSTOMER_MASTER_USER

left-over commit - not topic related in SegmentController:
Adds an Exception variable to catch clauses in order to get info about what happened.


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
