### PR TITLE
refactor: use fully qualified name for relationships

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/MailSend.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/MailSend.php
@@ -183,7 +183,7 @@ class MailSend implements IntegerIdEntityInterface
     /**
      * @var array
      *
-     * @ORM\OneToMany(targetEntity="MailAttachment", mappedBy="mailSend", cascade={"persist"})
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\MailAttachment", mappedBy="mailSend", cascade={"persist"})
      */
     protected $attachments;
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
@@ -308,8 +308,6 @@ class GisLayer extends CoreEntity implements GisLayerInterface
     /**
      * Set data from DSL.
      *
-     * @param mixed $data
-     *
      * @return GisLayer $this
      */
     public function set($data)

--- a/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
@@ -267,7 +267,7 @@ class GisLayer extends CoreEntity implements GisLayerInterface
      *
      * Many GisLayers has one GisLayerCategory
      *
-     * @ORM\ManyToOne(targetEntity="GisLayerCategory", inversedBy="gisLayers", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory", inversedBy="gisLayers", cascade={"persist"})
      *
      * @ORM\JoinColumn(name="category_id", referencedColumnName="id")
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Boilerplate.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Boilerplate.php
@@ -60,7 +60,7 @@ class Boilerplate extends CoreEntity implements UuidEntityInterface, Boilerplate
      *
      * @var Collection<int,BoilerplateCategoryInterface>
      *
-     * @ORM\ManyToMany(targetEntity="BoilerplateCategory", mappedBy="boilerplates")
+     * @ORM\ManyToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory", mappedBy="boilerplates")
      *
      * @ORM\JoinTable(
      *     name="predefined_texts_categories",
@@ -77,7 +77,7 @@ class Boilerplate extends CoreEntity implements UuidEntityInterface, Boilerplate
      *
      * This Class/Entity is the owning side
      *
-     * @ORM\ManyToOne(targetEntity="BoilerplateGroup", inversedBy="boilerplates")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateGroup", inversedBy="boilerplates")
      *
      * @ORM\JoinColumn(referencedColumnName="id", nullable = true)
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/BoilerplateGroup.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/BoilerplateGroup.php
@@ -60,7 +60,7 @@ class BoilerplateGroup extends CoreEntity implements UuidEntityInterface, Boiler
     /**
      * @var ProcedureInterface
      *
-     * @ORM\ManyToOne(targetEntity="Procedure")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure")
      *
      * @ORM\JoinColumn(referencedColumnName="_p_id", nullable = false, onDelete="CASCADE")
      */
@@ -69,7 +69,7 @@ class BoilerplateGroup extends CoreEntity implements UuidEntityInterface, Boiler
     /**
      * @var Collection<int, BoilerplateInterface
      *
-     * @ORM\OneToMany(targetEntity = "Boilerplate", mappedBy = "group")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate", mappedBy = "group")
      *
      * @ORM\OrderBy({"title" = "ASC"})
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -2150,8 +2150,6 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      * Returns first Survey in the list.
      *
      * @param string $surveyId
-     *
-     * @return Survey
      */
     public function getSurvey($surveyId): ?Survey
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -570,7 +570,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      * Many procedureTypes have one procedure. This is the owning side.
      * (In Doctrine Many have to be the owning side in a ManyToOne relationship.)
      *
-     * @ORM\ManyToOne(targetEntity="ProcedureType", inversedBy="procedures")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType", inversedBy="procedures")
      *
      * @ORM\JoinColumn(nullable=true)
      */
@@ -581,7 +581,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var StatementFormDefinition|null
      *
-     * @ORM\OneToOne(targetEntity="StatementFormDefinition", inversedBy="procedure", cascade={"persist", "remove"})
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition", inversedBy="procedure", cascade={"persist", "remove"})
      *
      * @ORM\JoinColumn(nullable=true)
      */
@@ -592,7 +592,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var ProcedureBehaviorDefinition|null
      *
-     * @ORM\OneToOne(targetEntity="ProcedureBehaviorDefinition", inversedBy="procedure", cascade={"persist", "remove"})
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureBehaviorDefinition", inversedBy="procedure", cascade={"persist", "remove"})
      *
      * @ORM\JoinColumn(nullable=true)
      */
@@ -603,7 +603,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var ProcedureUiDefinition|null
      *
-     * @ORM\OneToOne(targetEntity="ProcedureUiDefinition", inversedBy="procedure", cascade={"persist", "remove"})
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition", inversedBy="procedure", cascade={"persist", "remove"})
      *
      * @ORM\JoinColumn(nullable=true)
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureBehaviorDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureBehaviorDefinition.php
@@ -74,7 +74,7 @@ class ProcedureBehaviorDefinition extends CoreEntity implements UuidEntityInterf
      *
      * @var ProcedureInterface|null
      *
-     * @ORM\OneToOne(targetEntity="Procedure", mappedBy="procedureBehaviorDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure", mappedBy="procedureBehaviorDefinition")
      *
      * @JoinColumn(referencedColumnName="_p_id")
      */
@@ -87,7 +87,7 @@ class ProcedureBehaviorDefinition extends CoreEntity implements UuidEntityInterf
      *
      * @var ProcedureTypeInterface|null
      *
-     * @ORM\OneToOne(targetEntity="ProcedureType", mappedBy="procedureBehaviorDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType", mappedBy="procedureBehaviorDefinition")
      *
      * @JoinColumn() // Without this, Doctrine doesn't add the column to table, so please don't delete.
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureCoupleToken.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureCoupleToken.php
@@ -58,7 +58,7 @@ class ProcedureCoupleToken implements UuidEntityInterface
      *
      * @var Procedure|null
      *
-     * @ORM\OneToOne(targetEntity="Procedure")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure")
      *
      * @ORM\JoinColumn(referencedColumnName="_p_id", nullable=true, unique=true)
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureType.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureType.php
@@ -69,7 +69,7 @@ class ProcedureType extends CoreEntity implements UuidEntityInterface, Procedure
      * @var Collection<int, ProcedureInterface>
      *                                          One procedureType has many procedures. This is the inverse side.
      *
-     * @ORM\OneToMany(targetEntity="Procedure", mappedBy="procedureType", cascade={"persist"})
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure", mappedBy="procedureType", cascade={"persist"})
      *
      * @ORM\OrderBy({"name" = "ASC"})
      */
@@ -91,19 +91,19 @@ class ProcedureType extends CoreEntity implements UuidEntityInterface, Procedure
          */
         private string $description,
         /**
-         * @ORM\OneToOne(targetEntity="StatementFormDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
+         * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
          *
          * @ORM\JoinColumn(referencedColumnName="id", nullable=false)
          */
         private StatementFormDefinition $statementFormDefinition,
         /**
-         * @ORM\OneToOne(targetEntity="ProcedureBehaviorDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
+         * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureBehaviorDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
          *
          * @ORM\JoinColumn(referencedColumnName="id", nullable=false)
          */
         private ProcedureBehaviorDefinition $procedureBehaviorDefinition,
         /**
-         * @ORM\OneToOne(targetEntity="ProcedureUiDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
+         * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition", inversedBy="procedureType", cascade={"persist", "remove"})
          *
          * @ORM\JoinColumn(referencedColumnName="id", nullable=false)
          */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
@@ -75,7 +75,7 @@ class ProcedureUiDefinition extends CoreEntity implements UuidEntityInterface, P
      *
      * @var Procedure|null
      *
-     * @ORM\OneToOne(targetEntity="Procedure", mappedBy="procedureUiDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure", mappedBy="procedureUiDefinition")
      *
      * @JoinColumn(referencedColumnName="_p_id")
      */
@@ -88,7 +88,7 @@ class ProcedureUiDefinition extends CoreEntity implements UuidEntityInterface, P
      *
      * @var ProcedureType|null
      *
-     * @ORM\OneToOne(targetEntity="ProcedureType", mappedBy="procedureUiDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType", mappedBy="procedureUiDefinition")
      *
      * @JoinColumn()
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/StatementFieldDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/StatementFieldDefinition.php
@@ -71,7 +71,7 @@ class StatementFieldDefinition extends CoreEntity implements UuidEntityInterface
          */
         private string $name,
         /**
-         * @ORM\ManyToOne(targetEntity="StatementFormDefinition", inversedBy="fieldDefinitions")
+         * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition", inversedBy="fieldDefinitions")
          *
          * @JoinColumn(referencedColumnName="id", nullable=false)
          */

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/StatementFormDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/StatementFormDefinition.php
@@ -72,7 +72,7 @@ class StatementFormDefinition extends CoreEntity implements UuidEntityInterface,
      * @var Collection<int, StatementFieldDefinition>
      *
      * @ORM\OneToMany(
-     *      targetEntity="StatementFieldDefinition",
+     *      targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFieldDefinition",
      *      mappedBy="statementFormDefinition",
      *      cascade={"persist", "remove"}
      *     )
@@ -90,7 +90,7 @@ class StatementFormDefinition extends CoreEntity implements UuidEntityInterface,
      *
      * @var Procedure|null
      *
-     * @ORM\OneToOne(targetEntity="Procedure", mappedBy="statementFormDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure", mappedBy="statementFormDefinition")
      *
      * @JoinColumn(referencedColumnName="_p_id")
      */
@@ -103,7 +103,7 @@ class StatementFormDefinition extends CoreEntity implements UuidEntityInterface,
      *
      * @var ProcedureType|null
      *
-     * @ORM\OneToOne(targetEntity="ProcedureType", mappedBy="statementFormDefinition")
+     * @ORM\OneToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType", mappedBy="statementFormDefinition")
      *
      * @JoinColumn()
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -854,7 +854,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      *
      * This is the owning side
      *
-     * @ORM\ManyToOne(targetEntity="Statement", inversedBy="cluster")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement", inversedBy="cluster")
      *
      * @ORM\JoinColumn(name="head_statement_id", referencedColumnName="_st_id", nullable = true, onDelete="SET NULL")
      */
@@ -866,7 +866,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      * This should not be persists automatic, because of checking the assignment in updateStatement()!
      * Doctrine-sited persists, would bypass this check!
      *
-     * @ORM\OneToMany(targetEntity="Statement", mappedBy="headStatement", cascade={"merge"})
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement", mappedBy="headStatement", cascade={"merge"})
      *
      * @ORM\OrderBy({"externId" = "ASC"})
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -841,7 +841,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      * This is the user that is currently assigned to this statement. Assigned users are
      * exclusively permitted to change statements
      */
-    protected $assignee = null;
+    protected $assignee;
 
     /**
      * The representative Statement defines the cluster.
@@ -858,7 +858,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      *
      * @ORM\JoinColumn(name="head_statement_id", referencedColumnName="_st_id", nullable = true, onDelete="SET NULL")
      */
-    protected $headStatement = null;
+    protected $headStatement;
 
     /**
      * @var Collection<int, Statement>

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
@@ -102,7 +102,7 @@ class Tag extends CoreEntity implements UuidEntityInterface, TagInterface
      *
      * @ORM\ManyToOne(targetEntity="\demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate", inversedBy="tags")
      */
-    protected $boilerplate = null;
+    protected $boilerplate;
 
     /**
      * Create a Tag-Entity.

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Tag.php
@@ -57,7 +57,7 @@ class Tag extends CoreEntity implements UuidEntityInterface, TagInterface
     /**
      * @var TagTopicInterface
      *
-     * @ORM\ManyToOne(targetEntity="TagTopic", inversedBy="tags", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic", inversedBy="tags", cascade={"persist"})
      *
      * @ORM\JoinColumn(name="_tt_id", referencedColumnName="_tt_id", nullable = false)
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
@@ -194,10 +194,10 @@ class Customer extends CoreEntity implements UuidEntityInterface, CustomerInterf
     public function __construct(/**
      * @ORM\Column(name="_c_name", type="string", length=50, nullable=false)
      */
-    private string $name, /**
+        private string $name, /**
      * @ORM\Column(name="_c_subdomain", type="string", length=50, nullable=false)
      */
-    private string $subdomain, string $mapAttribution = '')
+        private string $subdomain, string $mapAttribution = '')
     {
         $this->mapAttribution = $mapAttribution;
         $this->userRoles = new ArrayCollection();

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Customer.php
@@ -66,13 +66,13 @@ class Customer extends CoreEntity implements UuidEntityInterface, CustomerInterf
     /**
      * @var Collection<int, UserRoleInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="customer")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer", mappedBy="customer")
      */
     protected $userRoles;
     /**
      * @var Collection<int, OrgaStatusInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="OrgaStatusInCustomer", mappedBy="customer")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer", mappedBy="customer")
      */
     protected $orgaStatuses;
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
@@ -66,7 +66,7 @@ class InstitutionTag extends CoreEntity implements UuidEntityInterface, Institut
      *
      * @var Orga
      *
-     * @ORM\ManyToOne(targetEntity="Orga", inversedBy="ownInstitutionTags", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Orga", inversedBy="ownInstitutionTags", cascade={"persist"})
      *
      * @ORM\JoinColumn(referencedColumnName="_o_id", nullable=false)
      */

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -355,7 +355,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var Collection<int,InstitutionTag>
      *
-     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\User", mappedBy="owningOrganisation")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag", mappedBy="owningOrganisation")
      *
      * @ORM\JoinColumn(referencedColumnName="id")
      *

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -312,13 +312,13 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
      * @var Collection<int, AddressBookEntryInterface>
      *                                                 One organisation has many address book entries. This is the inverse side.
      *
-     * @ORM\OneToMany(targetEntity="AddressBookEntry", mappedBy="organisation")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\AddressBookEntry", mappedBy="organisation")
      */
     protected $addressBookEntries;
     /**
      * @var Collection<int, OrgaStatusInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="OrgaStatusInCustomer", mappedBy="orga", cascade={"persist"})
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer", mappedBy="orga", cascade={"persist"})
      */
     protected $statusInCustomers;
     /**
@@ -344,7 +344,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var Collection<int,InstitutionTagInterface>
      *
-     * @ORM\ManyToMany(targetEntity="InstitutionTag", inversedBy="taggedInstitutions", cascade={"persist", "remove"})
+     * @ORM\ManyToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag", inversedBy="taggedInstitutions", cascade={"persist", "remove"})
      *
      * @ORM\JoinTable(
      *     joinColumns={@ORM\JoinColumn(referencedColumnName="_o_id", onDelete="CASCADE")},
@@ -355,7 +355,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var Collection<int,InstitutionTag>
      *
-     * @ORM\OneToMany(targetEntity="InstitutionTag", mappedBy="owningOrganisation")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\User", mappedBy="owningOrganisation")
      *
      * @ORM\JoinColumn(referencedColumnName="id")
      *

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -355,7 +355,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var Collection<int,InstitutionTag>
      *
-     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag", mappedBy="owningOrganisation")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\User", mappedBy="owningOrganisation")
      *
      * @ORM\JoinColumn(referencedColumnName="id")
      *
@@ -1170,9 +1170,9 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
         /** @var OrgaStatusInCustomer $item */
         foreach ($this->getStatusInCustomers() as $item) {
             if (
-                $customer === $item->getCustomer() &&
-                $orgaType === $item->getOrgaType() &&
-                $this === $item->getOrga()
+                $customer === $item->getCustomer()
+                && $orgaType === $item->getOrgaType()
+                && $this === $item->getOrga()
             ) {
                 $exists = true;
             }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/OrgaType.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/OrgaType.php
@@ -55,7 +55,7 @@ class OrgaType extends CoreEntity implements UuidEntityInterface, OrgaTypeInterf
     /**
      * @var Collection<int, OrgaStatusInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="OrgaStatusInCustomer", mappedBy="orgaType")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer", mappedBy="orgaType")
      */
     protected $orgaStatusInCustomers;
 

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
@@ -68,7 +68,7 @@ class Role extends CoreEntity implements UuidEntityInterface, RoleInterface, Str
     /**
      * @var Collection<int, UserRoleInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="role")
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer", mappedBy="role")
      */
     protected $userRoleInCustomers;
 

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -275,7 +275,7 @@ class User implements SamlUserInterface, AddonUserInterface
     /**
      * @var Collection<int, UserRoleInCustomerInterface>
      *
-     * @ORM\OneToMany(targetEntity="UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer", mappedBy="user", cascade={"persist", "remove"})
      */
     #[Assert\All([new Assert\NotNull(), new RoleAllowedConstraint()])]
     #[Assert\NotNull]

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -295,7 +295,7 @@ class User implements SamlUserInterface, AddonUserInterface
     protected $addresses;
 
     /** @var CustomerInterface */
-    protected $currentCustomer = null;
+    protected $currentCustomer;
 
     /**
      * @var Collection<int, SurveyVoteInterface>
@@ -919,7 +919,6 @@ class User implements SamlUserInterface, AddonUserInterface
      * Setzt eine Userflag. Wenn nicht vorhanden, wird sie neu generiert.
      *
      * @param string $flagKey
-     * @param mixed  $flagValue
      */
     protected function setFlagValue($flagKey, $flagValue)
     {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34912

Doctrine relationship require the type of the target entity (e.g. `@ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Orga")`). According to the Doctrine documentation, the string must be given as class-name, which means the fully qualified name is required. Still, Doctrine does some guessing and thus can process the simple name too (e.g. `@ORM\ManyToOne(targetEntity="Orga")`), but the EDT implementation needs to process the `targetEntity` value too and is not capable of this.

To allow EDT to work with the relationship annotations/attributes the simple names are replaced with fully qualified names.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
