### PR TITLE
chore: add option to enable addon during installation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
@@ -15,6 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\Addon;
 use ArrayAccess;
 use DemosEurope\DemosplanAddon\Permission\PermissionInitializerInterface;
 use demosplan\DemosPlanCoreBundle\Exception\AddonException;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * This is the central information repository about all addons installed on this system and their configuration.
@@ -31,6 +32,9 @@ class AddonRegistry implements ArrayAccess
         $this->addonInfos = [];
     }
 
+    /**
+     * @param Definition[] $addonInfos
+     */
     public function boot(array $addonInfos = [])
     {
         if ([] !== $this->addonInfos) {

--- a/demosplan/DemosPlanCoreBundle/Addon/Composer/PackageInformation.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/Composer/PackageInformation.php
@@ -43,11 +43,9 @@ final class PackageInformation
             return;
         }
 
-        $packageListPath = include_once $installedPackagesPath;
-
-        if (true === $packageListPath) {
-            return;
-        }
+        // we want to include the file again as we want to refresh the information
+        // and reload the packages
+        $packageListPath = include $installedPackagesPath;
 
         if (!array_key_exists('versions', $packageListPath)) {
             return;

--- a/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
@@ -40,17 +40,15 @@ final class Registrator
      * Checks if a given composer definition is a correct representation of an addon.
      * If so and if that addon is not yet installed, it will be added to the list of installed addons.
      */
-    public function register(PackageInterface $addonComposerDefinition): string
+    public function register(PackageInterface $addonComposerDefinition, bool $enabled = false): string
     {
         if (PackageInformation::ADDON_COMPOSER_TYPE !== $addonComposerDefinition->getType()) {
             throw AddonException::invalidType($addonComposerDefinition->getName(), $addonComposerDefinition->getType());
         }
 
-        // if addon is not in registry, then add it
-        if (!$this->isRegistered($addonComposerDefinition->getName())) {
-            $this->packageInformation->reloadPackages();
-            $this->doRegister($addonComposerDefinition);
-        }
+        // always refresh the package information and re-register, as it may have changed in addon
+        $this->packageInformation->reloadPackages();
+        $this->doRegister($addonComposerDefinition, $enabled);
 
         $this->refreshAddonsYaml();
 
@@ -80,12 +78,12 @@ final class Registrator
         return array_key_exists($addonName, $this->addons);
     }
 
-    private function doRegister(PackageInterface $addonComposerDefinition): void
+    private function doRegister(PackageInterface $addonComposerDefinition, bool $enabled = false): void
     {
         $addonName = $addonComposerDefinition->getName();
 
         $this->addons[$addonName] = [
-            'enabled'      => false,
+            'enabled'      => $enabled,
             'installed_at' => Carbon::now()->toIso8601String(),
             // use relative path to be compatible with different environments
             'install_path' => 'addons/vendor/'.$addonName,

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -156,7 +156,7 @@ class AddonInstallFromZipCommand extends CoreCommand
             $output->error($e->getMessage());
             // this hint may be removed in symfony6 when we can update the efrane/console-additions
             // to a version bigger than 0.7, as the batch will not swallow the exception anymore
-            $output->info('If you have no clue why this happened, you may try to install ' .
+            $output->info('If you have no clue why this happened, you may try to install '.
                 'the addon manually by performing
                 `composer bin addons update --prefer-lowest -a -o`');
         }
@@ -291,8 +291,8 @@ class AddonInstallFromZipCommand extends CoreCommand
 
         $composerContent = Json::decodeToArray(file_get_contents($this->addonsDirectory.'composer.json'));
 
-        if (!array_key_exists('require', $composerContent) ||
-            !array_key_exists($addonName, $composerContent['require'])) {
+        if (!array_key_exists('require', $composerContent)
+            || !array_key_exists($addonName, $composerContent['require'])) {
             $composerContent['require'][$addonName] = $addonVersion;
             file_put_contents(
                 $this->addonsDirectory.'composer.json',

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -291,7 +291,8 @@ class AddonInstallFromZipCommand extends CoreCommand
 
         $composerContent = Json::decodeToArray(file_get_contents($this->addonsDirectory.'composer.json'));
 
-        if (!array_key_exists($addonName, $composerContent['require'])) {
+        if (!array_key_exists('require', $composerContent) ||
+            !array_key_exists($addonName, $composerContent['require'])) {
             $composerContent['require'][$addonName] = $addonVersion;
             file_put_contents(
                 $this->addonsDirectory.'composer.json',

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -134,15 +134,17 @@ class AddonInstallFromZipCommand extends CoreCommand
             return Command::FAILURE;
         }
 
-        // If composer update went well, add the addon to the registry
-        $name = $this->installer->register($packageDefinition);
-
         try {
+            // If composer update went well, add the addon to the registry
+            $name = $this->installer->register($packageDefinition, $enable);
+
+            $kernel = $this->getApplication()->getKernel();
+            $environment = $kernel->getEnvironment();
             $activeProject = $this->getApplication()->getKernel()->getActiveProject();
 
             $batchReturn = Batch::create($this->getApplication(), $output)
-                ->addShell(["bin/{$activeProject}", 'cache:clear'])
-                ->addShell(["bin/{$activeProject}", 'dplan:addon:build-frontend', $name])
+                ->addShell(["bin/{$activeProject}", 'cache:clear', '-e', $environment])
+                ->addShell(["bin/{$activeProject}", 'dplan:addon:build-frontend', $name, '-e', $environment])
                 ->run();
 
             if (0 === $batchReturn) {

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -73,6 +73,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         );
 
         $this->addOption('reinstall', '', InputOption::VALUE_NONE, 'Re-install an addon (useful for debugging)');
+        $this->addOption('enable', '', InputOption::VALUE_NONE, 'Immediately enable addon during installation');
     }
 
     /**
@@ -84,6 +85,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         $output = new SymfonyStyle($input, $output);
 
         $reinstall = $input->getOption('reinstall');
+        $enable = $input->getOption('enable');
 
         $this->setPaths($input->getArgument('path'));
         try {

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -148,10 +148,17 @@ class AddonInstallFromZipCommand extends CoreCommand
                 ->run();
 
             if (0 === $batchReturn) {
+                $output->success("Addon {$name} successfully installed");
+
                 return Command::SUCCESS;
             }
         } catch (Exception $e) {
             $output->error($e->getMessage());
+            // this hint may be removed in symfony6 when we can update the efrane/console-additions
+            // to a version bigger than 0.7, as the batch will not swallow the exception anymore
+            $output->info('If you have no clue why this happened, you may try to install ' .
+                'the addon manually by performing
+                `composer bin addons update --prefer-lowest -a -o`');
         }
 
         return Command::FAILURE;


### PR DESCRIPTION
Addons may be enabled during installation by using the option `--enable`.
Along the way some improvements in the installation process where introduced, you may review commit wise.

I voted against tests in this specific case as the commands main task is to cope with infrastructure and configuration.

### How to review/test
code review or install an addon and enable it directly

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
