### PR TITLE
feat: introduce addon list command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonManifestCollectionWrapper.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonManifestCollectionWrapper.php
@@ -1,14 +1,25 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace demosplan\DemosPlanCoreBundle\Addon;
 
 /**
  * Helper class to be able to test Classes that use the static method
- * AddonManifestCollection::load()
+ * AddonManifestCollection::load().
  */
-class AddonManifestCollectionWrapper {
-    public function load(): array {
+class AddonManifestCollectionWrapper
+{
+    public function load(): array
+    {
         return AddonManifestCollection::load();
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonManifestCollectionWrapper.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonManifestCollectionWrapper.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Addon;
+
+/**
+ * Helper class to be able to test Classes that use the static method
+ * AddonManifestCollection::load()
+ */
+class AddonManifestCollectionWrapper {
+    public function load(): array {
+        return AddonManifestCollection::load();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Addon;
+
+use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class AddonListCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:addon:list';
+
+    public function __construct(
+        private readonly AddonManifestCollectionWrapper $addonManifestCollectionWrapper,
+        ParameterBagInterface $parameterBag,
+        string $name = null
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('List installed addons');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $addons = [];
+        $addonsLoaded = $this->addonManifestCollectionWrapper->load();
+
+        foreach ($addonsLoaded as $name => $addonLoaded) {
+            $addons[] = [
+                'name' => $name,
+                'enabled' => $addonLoaded['enabled'] ? 'true' : 'false',
+            ];
+        }
+
+        // Create a Table instance
+        $table = new Table($output);
+
+        // Set the table headers
+        $table->setHeaders(['Name', 'Enabled']);
+
+        // Add rows to the table
+        $table->setRows($addons);
+
+        // Render the table
+        $table->render();
+
+        return self::SUCCESS;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
@@ -37,7 +37,7 @@ class AddonListCommand extends CoreCommand
 
         foreach ($addonsLoaded as $name => $addonLoaded) {
             $addons[] = [
-                'name' => $name,
+                'name'    => $name,
                 'enabled' => $addonLoaded['enabled'] ? 'true' : 'false',
             ];
         }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class AddonListCommand extends CoreCommand
 {
     protected static $defaultName = 'dplan:addon:list';
+    protected static $defaultDescription = 'List installed addons';
 
     public function __construct(
         private readonly AddonManifestCollectionWrapper $addonManifestCollectionWrapper,
@@ -27,11 +28,6 @@ class AddonListCommand extends CoreCommand
         string $name = null
     ) {
         parent::__construct($parameterBag, $name);
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('List installed addons');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/backend/core/Core/Functional/AddonListCommandTest.php
+++ b/tests/backend/core/Core/Functional/AddonListCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Addon\AddonListCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+use Tests\Base\MockMethodDefinition;
+
+class AddonListCommandTest  extends FunctionalTestCase
+{
+    public function testEmptyList(): void
+    {
+        $commandTester = $this->executeCommand([]);
+
+        // Assert the output
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Name', $output);
+        $this->assertStringContainsString('Enabled', $output);
+
+    }
+
+    public function testListEnabled(): void
+    {
+
+        $addonName = 'demos-europe/demosplan-test-addon';
+        $info = [
+            $addonName => ['enabled' => true,]
+        ];
+        $commandTester = $this->executeCommand($info);
+
+        // Assert the output
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Name', $output);
+        $this->assertStringContainsString('Enabled', $output);
+        $this->assertStringContainsString($addonName, $output);
+        $this->assertStringContainsString('true', $output);
+
+    }
+    public function testListDisabled(): void
+    {
+
+        $addonName = 'demos-europe/demosplan-test-addon';
+        $info = [
+            $addonName => ['enabled' => false,]
+        ];
+        $commandTester = $this->executeCommand($info);
+
+        // Assert the output
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Name', $output);
+        $this->assertStringContainsString('Enabled', $output);
+        $this->assertStringContainsString($addonName, $output);
+        $this->assertStringContainsString('false', $output);
+
+    }
+
+    private function executeCommand(array $info): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+
+        $tokenMockMethods = [
+            new MockMethodDefinition('load', $info),
+        ];
+        $addonManifestCollectionWrapper = $this->getMock(AddonManifestCollectionWrapper::class, $tokenMockMethods);
+
+        $application->add(
+            new AddonListCommand(
+                $addonManifestCollectionWrapper,
+                $this->createMock(ParameterBagInterface::class),
+                null
+            )
+        );
+
+        $command = $application->find(AddonListCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        // Execute the command
+        $commandTester->execute([]);
+        return $commandTester;
+    }
+}
+

--- a/tests/backend/core/Core/Functional/AddonListCommandTest.php
+++ b/tests/backend/core/Core/Functional/AddonListCommandTest.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
@@ -11,7 +20,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Tests\Base\FunctionalTestCase;
 use Tests\Base\MockMethodDefinition;
 
-class AddonListCommandTest  extends FunctionalTestCase
+class AddonListCommandTest extends FunctionalTestCase
 {
     public function testEmptyList(): void
     {
@@ -21,15 +30,13 @@ class AddonListCommandTest  extends FunctionalTestCase
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('Name', $output);
         $this->assertStringContainsString('Enabled', $output);
-
     }
 
     public function testListEnabled(): void
     {
-
         $addonName = 'demos-europe/demosplan-test-addon';
         $info = [
-            $addonName => ['enabled' => true,]
+            $addonName => ['enabled' => true],
         ];
         $commandTester = $this->executeCommand($info);
 
@@ -39,14 +46,13 @@ class AddonListCommandTest  extends FunctionalTestCase
         $this->assertStringContainsString('Enabled', $output);
         $this->assertStringContainsString($addonName, $output);
         $this->assertStringContainsString('true', $output);
-
     }
+
     public function testListDisabled(): void
     {
-
         $addonName = 'demos-europe/demosplan-test-addon';
         $info = [
-            $addonName => ['enabled' => false,]
+            $addonName => ['enabled' => false],
         ];
         $commandTester = $this->executeCommand($info);
 
@@ -56,7 +62,6 @@ class AddonListCommandTest  extends FunctionalTestCase
         $this->assertStringContainsString('Enabled', $output);
         $this->assertStringContainsString($addonName, $output);
         $this->assertStringContainsString('false', $output);
-
     }
 
     private function executeCommand(array $info): CommandTester
@@ -81,7 +86,7 @@ class AddonListCommandTest  extends FunctionalTestCase
         $commandTester = new CommandTester($command);
         // Execute the command
         $commandTester->execute([]);
+
         return $commandTester;
     }
 }
-


### PR DESCRIPTION
This PR provides a Command to list all installed addons.

An AddonManifestCollectionWrapper needed to be created as static methods are not testable.
In this case it is valid to have AddonManifestCollection::load static, as it is needed during kernel boot

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
code review or run `bin/<project> dplan:addon:list` 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
