### PR TITLE
fix(refs: T34961): Pass ID as Tooltip container param

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -14,7 +14,7 @@
     :class="{'segment-list-row--assigned': isAssignedToMe, 'fullscreen': isFullscreen}"
     @mouseenter="isHover = true"
     @mouseleave="isHover = false"
-    :id="'segment_' + segment.id">
+    :id="`segment_${segment.id}`">
     <div class="flex flex-col justify-start basis-1/5 u-pt-0_5 u-pl-0_5">
       <v-popover :container="$refs.statementSegment">
         <i
@@ -237,7 +237,7 @@
           data-cy="editorFullscreen"
           :aria-label="Translator.trans('editor.fullscreen')"
           v-tooltip="{
-            container: this.$refs.statementSegment,
+            container: `#segment_${segment.id}`,
             content: Translator.trans('editor.fullscreen')
           }"
           @click="isFullscreen = !isFullscreen">
@@ -253,7 +253,7 @@
           data-cy="segmentEdit"
           :aria-label="Translator.trans('edit')"
           v-tooltip="{
-            container: this.$refs.statementSegment,
+            container: `#segment_${segment.id}`,
             content: Translator.trans('edit')
           }"
           @click="startEditing">
@@ -268,7 +268,7 @@
           type="button"
           :aria-label="Translator.trans('history')"
           v-tooltip="{
-            container: this.$refs.statementSegment,
+            container: `#segment_${segment.id}`,
             content: Translator.trans('history')
           }"
           @click.prevent="showSegmentVersionHistory"
@@ -285,7 +285,7 @@
           type="button"
           :aria-label="Translator.trans('comments')"
           v-tooltip="{
-            container: this.$refs.statementSegment,
+            container: `#segment_${segment.id}`,
             content: Translator.trans('comments')
           }"
           data-cy="segmentComments"
@@ -306,7 +306,7 @@
           type="button"
           :aria-label="Translator.trans('public.participation.relation')"
           v-tooltip="{
-            container: this.$refs.statementSegment,
+            container: `#segment_${segment.id}`,
             content: Translator.trans('public.participation.relation')
           }"
           data-cy="segmentMap"


### PR DESCRIPTION
Pass Id to Tooltipcontainer parameter instead of DOM-Object.
The Tooltip-Directive only can handle querySelectables

**Ticket:** https://yaits.demos-deutschland.de/T34961