### PR TITLE
chore (refs T34808): redirect to distinct error page after idp login error

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Controller\Platform;
 
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
+use demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions as AttributeDplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -149,6 +150,15 @@ class EntrypointController extends BaseController
         $entrypointRoute = $this->entryPointDecider->determinePublicEntrypoint();
 
         return $this->processEntrypointRoute($entrypointRoute);
+    }
+
+    #[AttributeDplanPermissions('area_public_participation')]
+    #[Route(path: '/idp/login/error', name: 'core_login_idp_error', options: ['expose' => true])]
+    public function loginIdpError(): RedirectResponse|Response
+    {
+        return $this->renderTemplate(
+            '@DemosPlanCore/DemosPlanUser/login_idp_error.html.twig',
+        );
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
@@ -187,10 +187,6 @@ class EntrypointController extends BaseController
     /**
      * Public index start page template.
      *
-     * @param string $title Must be empty instead of null to allow
-     *                      URL generation without $orgaSlug somewhere
-     *                      else in the application
-     *
      * @return RedirectResponse|Response|null
      *
      * @throws Exception

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -98,9 +98,10 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
+        $this->logger->warning('Login via Keycloak failed', ['exception' => $exception]);
+        $targetUrl = $this->router->generate('core_login_idp_error');
 
-        return new Response($message, Response::HTTP_FORBIDDEN);
+        return new RedirectResponse($targetUrl);
     }
 
     /**

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
@@ -1,0 +1,10 @@
+{% extends '@DemosPlanCore/DemosPlanCore/base_oeb.html.twig' %}
+
+{% block component_part %}
+
+    <h1>Beim Login ist ein Problem aufgetreten</h1>
+    <p>
+        Möglicherweise sind nicht alle Felder im Identityprovider ausgefüllt. Bitte überprüfen Sie die Einstellungen und kontaktieren
+        Sie bei Fragen den Support.
+    </p>
+{% endblock component_part %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34808

Redirect user to distinct error page after Identityprovider login error to ease the handling and enhancement of the error. This way common twig/vue and symfony mechanisms could be used to build an information page about what happened

### How to review/test
call <projectURL>/idp/login/error

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
