### PR TITLE
feature (refs T33642): fix faulty new line and out of place empty space

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/send_notification_email_for_unsubmitted_draft_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/send_notification_email_for_unsubmitted_draft_statements.html.twig
@@ -5,7 +5,7 @@
 Hallo {{ templateVars.userFullName }},
 
 im Verfahren "{{ templateVars.procedureName|default('') }}" endet in {{ 'email.text.notification_for_unsubmitted_statement.end_days'|trans({ count: numberOfdays}) }} ({{ templateVars.endDate }}) eine Beteiligungsphase.
-Derzeit haben Sie dort {{ 'email.text.notification_for_unsubmitted_statement.statements'|trans({ count: numberOfdraftStatements })}}.
+Derzeit haben Sie dort {{ 'email.text.notification_for_unsubmitted_statement.statements'|trans({ count: numberOfdraftStatements })|spaceless }}.
 
 Bitte melden Sie sich auf {{ templateVars.projectName }} an und reichen Sie die Stellungnahmen unter nachfolgendem Link ein.
 

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -988,7 +988,7 @@ email.text.notification_for_unsubmitted_statement.end_days: |
         =1 { einem Tag}
         other { # Tagen }
     }
-email.text.notification_for_unsubmitted_statement.statements: |
+email.text.notification_for_unsubmitted_statement.statements: >
     {count, plural,
         =1 { einen noch nicht eingereichten Entwurf einer Stellungnahme }
         other { # noch nicht eingereichte Stellungnahmen-Entwürfe }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T33642

Description:
Fixes a new line feed just before a full stop.
And removes empty spaces surrounding the translation.

### How to review/test
Set a procedure to end for institutions in exactly one week ahead in time.
log in with a member of that orga and write a draft statement.
use the link `http://diplanbau.dplan.local/app_dev.php/maintenance/x7hndcVlpJIH15fEsgNNssd3?frequency=daily` to send the mails and check mailhog.

### Linked PRs (optional)
This PR replaces the prior forgotten old diverged PR https://github.com/demos-europe/demosplan-project-diplanbau/pull/149

other related PR: https://github.com/demos-europe/demosplan-project-diplanbau/pull/175

looks in mailhog:
`Hallo Welcome Page,

im Verfahren "MailTestVerfahrenEndetIn7Tagen" endet in
7 Tagen
(25.10.2023)
eine Beteiligungsphase.
Derzeit haben Sie dort 8 noch nicht eingereichte Stellungnahmen-Entwürfe.

Bitte melden Sie sich an und reichen Sie die Stellungnahmen unter nachfolgendem Link ein.`

old one:
`Hallo Welcome Page,

im Verfahren "MailTestVerfahrenEndetIn7Tagen" endet in
7 Tagen
(25.10.2023)
eine Beteiligungsphase.
Derzeit haben Sie dort 13 noch nicht eingereichte Stellungnahmen-Entwürfe
.

Bitte melden Sie sich an und reichen Sie die Stellungnahmen unter nachfolgendem Link ein.`

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
