### PR TITLE
F t35031 adjust redirect after pdf import

### DIFF
--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -708,9 +708,8 @@ export default {
     redirect () {
       if (hasPermission('area_admin_import')) {
         window.location.href = Routing.generate('DemosPlan_procedure_import', { procedureId: window.dplan.procedureId })
-        // window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedure: window.dplan.procedureId })
       } else {
-        window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedureId: window.dplan.procedureId })
+        window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedure: window.dplan.procedureId })
       }
     },
 

--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -706,10 +706,11 @@ export default {
     },
 
     redirect () {
-      if (hasPermission('area_admin_dashboard')) {
-        window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedure: window.dplan.procedureId })
-      } else {
+      if (hasPermission('area_admin_import')) {
         window.location.href = Routing.generate('DemosPlan_procedure_import', { procedureId: window.dplan.procedureId })
+        // window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedure: window.dplan.procedureId })
+      } else {
+        window.location.href = Routing.generate('DemosPlan_procedure_dashboard', { procedureId: window.dplan.procedureId })
       }
     },
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T35031

Description:
the current redirect conditions always redirected to the procedure_dashboard.
Changed the condition to rather redirect to procedure_import instead if the import permission is granted.

### How to review/test
ewm->import->überprüfen->save
you should be redirected back to the import instead the procedure dashboard.

### Linked PRs (optional)
BE-Part for 'import bestätigen' : - https://github.com/demos-europe/demosplan-addon-demospipes/pull/113

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
