### PR TITLE
fix(refs T35059): Catch ununique Titles before sending them to the BE

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
@@ -29,7 +29,8 @@
             v-model="customerContact.title"
             class="u-mb-0_75"
             data-cy="contactTitle"
-            data-dp-validate-error="error.title.required"
+            :pattern="titlesInUsePattern"
+            :data-dp-validate-error="customerContact.title === '' ? 'error.title.required' : 'error.title.unique'"
             :label="{
               text: Translator.trans('customer.contact.title')
             }"
@@ -127,7 +128,13 @@ export default {
   computed: {
     ...mapState('customerContact', {
       contacts: 'items'
-    })
+    }),
+
+    titlesInUsePattern () {
+      return `^(?!(?:${Object.values(this.contacts)
+        .map(contact => contact.attributes.title)
+        .join('|')})$)`
+    }
   },
 
   methods: {

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1033,6 +1033,7 @@ error.phone_or_email.required: "Bitte geben Sie entweder eine gültige E-Mail-Ad
 error.phone.pattern: "Bitte geben Sie gültige Telefonnummer ein."
 error.startdate.required: "Bitte geben Sie ein Startdatum ein"
 error.title.required: "Bitte geben Sie einen Titel ein."
+error.title.unique: "Bitte verwenden Sie einen eindeutigen Titel."
 error.enddate.required: "Bitte geben Sie ein Enddatum ein"
 error.date.endbeforestart: "Das Enddatum kann nicht vor dem Startdatum liegen."
 error.date: "Bitte geben Sie ein Datum ein."


### PR DESCRIPTION
They have to be unique by design. however we can't validate them with a propper error message
 in the Backend, so we check before saving. As a safety net the Be will throw a generic error
 if this check here is insufficient.


**Ticket:** https://yaits.demos-deutschland.de/T35059

As mandatenAdmin Goto `/einstellungen/plattform` and try to create two customerContacts with the same title.  


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
