### PR TITLE
chore: Bump demosplan-ui from 0.2.0 to v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0.2.0",
+    "@demos-europe/demosplan-ui": "^0.2.1",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,10 +1517,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.2.0.tgz#7e2ea895292fe5ad1bb6e70f17a60b048df512d5"
-  integrity sha512-1GFoeoGw68O9/4Dw6HHTRptRa2GFqNg2JaqK2tCHTdl8iQTBPPTzauTp2Q+Ku+7Xo6reGU/SBXKOeQEmhFLeWw==
+"@demos-europe/demosplan-ui@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.2.1.tgz#35b4045741532b1305574b09173ad78b7c15cdd4"
+  integrity sha512-NP1UwRLhzYF3m+e1r23lmKuoJVuovbD6225Xoy/F+J4sSW9PvQYqsles/YBv0tkzTvQki08EHOofhTi7y8d2qw==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@floating-ui/dom" "^1.4.5"


### PR DESCRIPTION
https://github.com/demos-europe/demosplan-ui/blob/main/CHANGELOG.md