### PR TITLE
chore: add data user role to fixtures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
@@ -13,9 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadCategoryData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadCategoryData.php
@@ -13,7 +13,6 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\Category;
 use Doctrine\Persistence\ObjectManager;
 
-
 class LoadCategoryData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMailTemplateData.php
@@ -13,9 +13,6 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\Entity\MailTemplate;
 use Doctrine\Persistence\ObjectManager;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
 class LoadMailTemplateData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
@@ -14,7 +14,6 @@ use demosplan\DemosPlanCoreBundle\Entity\MigrationVersions;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Finder\Finder;
 
-
 class LoadMigrationVersionData extends ProdFixture
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadMigrationVersionData.php
@@ -14,9 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\MigrationVersions;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Finder\Finder;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadMigrationVersionData extends ProdFixture
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -28,7 +28,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-
 class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
 {
     /** @var TranslatorInterface */

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -28,9 +28,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
 {
     /** @var TranslatorInterface */

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
@@ -16,9 +16,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadProcedureTypeData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureTypeData.php
@@ -16,7 +16,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureUiDefinition;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\StatementFormDefinition;
 use Doctrine\Persistence\ObjectManager;
 
-
 class LoadProcedureTypeData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -14,9 +14,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use Doctrine\Persistence\ObjectManager;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadRolesData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -14,7 +14,6 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use Doctrine\Persistence\ObjectManager;
 
-
 class LoadRolesData extends ProdFixture
 {
     public function load(ObjectManager $manager): void

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use Doctrine\Persistence\ObjectManager;
 
@@ -22,118 +23,124 @@ class LoadRolesData extends ProdFixture
     {
         $roles = [
             [
-                'code'      => Role::PLANNING_AGENCY_ADMIN,
+                'code'      => RoleInterface::PLANNING_AGENCY_ADMIN,
                 'name'      => 'Fachplaner-Admin',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::PLANNING_AGENCY_WORKER,
+                'code'      => RoleInterface::PLANNING_AGENCY_WORKER,
                 'name'      => 'Fachplaner-Sachbearbeiter',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::HEARING_AUTHORITY_ADMIN,
+                'code'      => RoleInterface::HEARING_AUTHORITY_ADMIN,
                 'name'      => 'Anhörungsbehörde-Admin',
                 'groupCode' => 'GHEAUT',
                 'groupName' => 'Anhörungsbehörde',
             ],
             [
-                'code'      => Role::HEARING_AUTHORITY_WORKER,
+                'code'      => RoleInterface::HEARING_AUTHORITY_WORKER,
                 'name'      => 'Anhörungsbehörde-Sachbearbeiter',
                 'groupCode' => 'GHEAUT',
                 'groupName' => 'Anhörungsbehörde',
             ],
             [
-                'code'      => Role::PRIVATE_PLANNING_AGENCY,
+                'code'      => RoleInterface::PRIVATE_PLANNING_AGENCY,
                 'name'      => 'Fachplaner-Planungsbüro',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::PLANNING_SUPPORTING_DEPARTMENT,
+                'code'      => RoleInterface::PLANNING_SUPPORTING_DEPARTMENT,
                 'name'      => 'Fachplaner-Fachbehörde',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::PUBLIC_AGENCY_COORDINATION,
+                'code'      => RoleInterface::PUBLIC_AGENCY_COORDINATION,
                 'name'      => 'TöB-Koordinator',
-                'groupCode' => Role::GPSORG,
+                'groupCode' => RoleInterface::GPSORG,
                 'groupName' => 'Institution',
             ],
             [
-                'code'      => Role::PUBLIC_AGENCY_WORKER,
+                'code'      => RoleInterface::PUBLIC_AGENCY_WORKER,
                 'name'      => 'TöB-Sachbearbeiter',
-                'groupCode' => Role::GPSORG,
+                'groupCode' => RoleInterface::GPSORG,
                 'groupName' => 'Institution',
             ],
             [
-                'code'      => Role::CITIZEN,
+                'code'      => RoleInterface::CITIZEN,
                 'name'      => 'Bürger',
-                'groupCode' => Role::GCITIZ,
+                'groupCode' => RoleInterface::GCITIZ,
                 'groupName' => 'Bürgergruppe',
             ],
             [
-                'code'      => Role::PROSPECT,
+                'code'      => RoleInterface::PROSPECT,
                 'name'      => 'Interessent',
-                'groupCode' => Role::GINTPA,
+                'groupCode' => RoleInterface::GINTPA,
                 'groupName' => 'Interessent',
             ],
             [
-                'code'      => Role::GUEST,
+                'code'      => RoleInterface::GUEST,
                 'name'      => 'Gast',
-                'groupCode' => Role::GGUEST,
+                'groupCode' => RoleInterface::GGUEST,
                 'groupName' => 'Gast',
             ],
             [
-                'code'      => Role::PLATFORM_SUPPORT,
+                'code'      => RoleInterface::PLATFORM_SUPPORT,
                 'name'      => 'Verfahrenssupport',
-                'groupCode' => Role::GTSUPP,
+                'groupCode' => RoleInterface::GTSUPP,
                 'groupName' => 'Verfahrenssupport',
             ],
             [
-                'code'      => Role::ORGANISATION_ADMINISTRATION,
+                'code'      => RoleInterface::ORGANISATION_ADMINISTRATION,
                 'name'      => 'Fachplaner-Masteruser',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::BOARD_MODERATOR,
+                'code'      => RoleInterface::BOARD_MODERATOR,
                 'name'      => 'Moderator',
-                'groupCode' => Role::GMODER,
+                'groupCode' => RoleInterface::GMODER,
                 'groupName' => 'Moderator',
             ],
             [
-                'code'      => Role::PLANNING_AGENCY_ADMIN,
+                'code'      => RoleInterface::PLANNING_AGENCY_ADMIN,
                 'name'      => 'Fachplaner-Admin',
-                'groupCode' => Role::GLAUTH,
+                'groupCode' => RoleInterface::GLAUTH,
                 'groupName' => 'Kommune',
             ],
             [
-                'code'      => Role::CONTENT_EDITOR,
+                'code'      => RoleInterface::CONTENT_EDITOR,
                 'name'      => 'Redakteur',
-                'groupCode' => Role::GTEDIT,
+                'groupCode' => RoleInterface::GTEDIT,
                 'groupName' => 'Redakteur',
             ],
             [
-                'code'      => Role::PROCEDURE_CONTROL_UNIT,
+                'code'      => RoleInterface::PROCEDURE_CONTROL_UNIT,
                 'name'      => 'Fachliche Leitstelle',
-                'groupCode' => Role::GFALST,
+                'groupCode' => RoleInterface::GFALST,
                 'groupName' => 'Fachliche Leitstelle',
             ],
             [
-                'code'      => Role::PROCEDURE_DATA_INPUT,
+                'code'      => RoleInterface::PROCEDURE_DATA_INPUT,
                 'name'      => 'Datenerfassung',
-                'groupCode' => Role::GDATA,
+                'groupCode' => RoleInterface::GDATA,
                 'groupName' => 'Datenerfassung',
             ],
             [
-                'code'      => Role::CUSTOMER_MASTER_USER,
+                'code'      => RoleInterface::CUSTOMER_MASTER_USER,
                 'name'      => 'Mandanten-Masteruser',
-                'groupCode' => Role::CUSTOMERMASTERUSERGROUP,
+                'groupCode' => RoleInterface::CUSTOMERMASTERUSERGROUP,
                 'groupName' => 'Mandant',
+            ],
+            [
+                'code'      => RoleInterface::API_AI_COMMUNICATOR,
+                'name'      => 'AI API Communicator',
+                'groupCode' => RoleInterface::GAICOM,
+                'groupName' => 'Data',
             ],
         ];
 

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -26,9 +26,7 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ObjectManager;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 class LoadUserData extends ProdFixture implements DependentFixtureInterface
 {
     public function __construct(

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -26,7 +26,6 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ObjectManager;
 
-
 class LoadUserData extends ProdFixture implements DependentFixtureInterface
 {
     public function __construct(

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
@@ -13,7 +13,6 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
-
 abstract class ProdFixture extends DemosFixture implements FixtureGroupInterface
 {
     /**

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/ProdFixture.php
@@ -13,9 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\DataFixtures\ORM\ProdData;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\DemosFixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 
-/**
- * @deprecated loading fixture data via Foundry-Factories instead
- */
+
 abstract class ProdFixture extends DemosFixture implements FixtureGroupInterface
 {
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30599

The prod fixtures need to provide a role for the data user so that a user could be created. Moreover, the prod fixtures are not deprecated, this is cleaned up as well.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
