### PR TITLE
feature (refs T35088): regard DateTime Objects when calculating changes to procedures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Event\Procedure;
 
+use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureUpdatedEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
@@ -49,6 +50,15 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
     private function determineModifiedValues(object $oldObject, object $newObject): array
     {
         $modifiedValues = [];
+
+        if ($oldObject instanceof DateTime && $newObject instanceof DateTime) {
+            if ($oldObject->getTimestamp() !== $newObject->getTimestamp()) {
+                $modifiedValues['old'] = $oldObject;
+                $modifiedValues['new'] = $newObject;
+            }
+
+            return $modifiedValues;
+        }
 
         $reflectionClass = new ReflectionClass($oldObject);
         $properties = $reflectionClass->getProperties();


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T35088

Description:
DateTime objects were not taken into account when calculating the changes via a reflectionClass - as DateTime properties are private. Implemented a special treatment for DateTime objects.

### How to review/test
Install addon -> change any startDate / endDate of a procedure and check the procedure_message table for a new entry.

### Linked PRs (optional)
other missing relevant procedure properties regarding an update were added here: https://github.com/demos-europe/demosplan-addon-xbeteiligung-async/pull/13

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
