### PR TITLE
chore refs T35168: css var value might be null as stated in entity

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Validator/ValidCssVarsConstraintValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/ValidCssVarsConstraintValidator.php
@@ -30,9 +30,9 @@ class ValidCssVarsConstraintValidator extends ConstraintValidator
     /**
      * Incoming value is parsed to see if it is valid CSS or blank.
      */
-    private function validateTyped(string $value, ValidCssVarsConstraint $constraint): void
+    private function validateTyped(?string $value, ValidCssVarsConstraint $constraint): void
     {
-        if ('' === $value) {
+        if (null === $value || '' === $value) {
             return;
         }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35168

In a comment in Branding entity it is explicitly stated that value might be null. 

> For future reference: null is for all intents and purposes equivalent to ''. Both mean that there is no set of cssvars.

Hence we need to loosen validation a bit

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
