### PR TITLE
feat (T35051): implement the FileInfoInterface and adjust composer lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1290,16 +1290,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.9",
+            "version": "v0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "4e525a92abc965f9833f2c86f7eb4f044e3fa856"
+                "reference": "c476528a5f260d592a27c4b0cb063509c96ff59d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/4e525a92abc965f9833f2c86f7eb4f044e3fa856",
-                "reference": "4e525a92abc965f9833f2c86f7eb4f044e3fa856",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/c476528a5f260d592a27c4b0cb063509c96ff59d",
+                "reference": "c476528a5f260d592a27c4b0cb063509c96ff59d",
                 "shasum": ""
             },
             "require": {
@@ -1337,9 +1337,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.9"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.10"
             },
-            "time": "2023-09-14T09:30:54+00:00"
+            "time": "2023-10-25T15:15:29+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/ValueObject/FileInfo.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/FileInfo.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\ValueObject;
 
+use DemosEurope\DemosplanAddon\Contracts\ValueObject\FileInfoInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 
 /**
@@ -21,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
  * @method string         getAbsolutePath()
  * @method Procedure|null getProcedure()
  */
-class FileInfo extends ValueObject
+class FileInfo extends ValueObject implements FileInfoInterface
 {
     /**
      * @var string


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35051

demosplan-addon has a new version (v.0.10). This version contains the FileInfoInterface. This PR implements the interface to
the corresponding value object and adjusts the composer.lock.

### How to review/test
code review

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
