### PR TITLE
refactor: Declare fields when fetching orgas and use the proper rels

### DIFF
--- a/client/js/bundles/user/listOrgas.js
+++ b/client/js/bundles/user/listOrgas.js
@@ -38,7 +38,7 @@ const presetStoreModules = {
           }
         }
       },
-      include: ['customer.branding', 'currentSlug', 'customers', 'statusInCustomers'].join(),
+      include: ['customer.branding', 'currentSlug', 'statusInCustomers'].join(),
       group: 'pending'
     }
   }]

--- a/client/js/bundles/user/listOrgas.js
+++ b/client/js/bundles/user/listOrgas.js
@@ -24,7 +24,7 @@ const components = {
   DpEditor
 }
 
-const apiStores = ['orga', 'customer']
+const apiStores = ['customer', 'orga']
 const presetStoreModules = {
   orga: [{
     name: 'pending',
@@ -38,7 +38,7 @@ const presetStoreModules = {
           }
         }
       },
-      include: ['branding', 'currentSlug', 'customers', 'statusInCustomers'].join(),
+      include: ['customer.branding', 'currentSlug', 'customers', 'statusInCustomers'].join(),
       group: 'pending'
     }
   }]

--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -168,6 +168,48 @@ import {
 import { mapActions, mapState } from 'vuex'
 import DpOrganisationListItem from './DpOrganisationListItem'
 
+const orgaFields = {
+  StatusInCustomer: [
+    'customer',
+    'status'
+  ].join(),
+  Customer: [
+    'name',
+    'subdomain'
+  ].join(),
+  Orga: [
+    'ccEmail2',
+    'city',
+    'competence',
+    'contactPerson',
+    'copy',
+    'copySpec',
+    'currentSlug',
+    'dataProtection',
+    'emailNotificationEndingPhase',
+    'emailNotificationNewStatement',
+    'email2',
+    'houseNumber',
+    'imprint',
+    'isPlanningOrganisation',
+    'name',
+    'participationEmail',
+    'phone',
+    'postalcode',
+    'registrationStatuses',
+    'reviewerEmail',
+    'showlist',
+    'showname',
+    'state',
+    'street',
+    'submissionType',
+    'types'
+  ].join(),
+  CurrentSlug: [
+    'name'
+  ].join()
+}
+
 export default {
   name: 'DpOrganisationList',
 
@@ -362,7 +404,8 @@ export default {
         },
         sort: 'name',
         filter: filterObject,
-        include: ['currentSlug', 'customers', 'statusInCustomers'].join()
+        fields: orgaFields,
+        include: ['currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
       })
         .then(() => { this.isLoading = false })
     },
@@ -374,6 +417,7 @@ export default {
         page: {
           number: page
         },
+        fields: orgaFields,
         sort: 'name',
         filter: {
           namefilter: {
@@ -384,7 +428,7 @@ export default {
             }
           }
         },
-        include: ['branding', 'currentSlug', 'customers', 'statusInCustomers'].join()
+        include: ['currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
       })
         .then(() => {
           this.pendingOrganisationsLoading = false
@@ -403,8 +447,9 @@ export default {
         page: {
           number: page
         },
+        fields: orgaFields,
         sort: 'name',
-        include: ['currentSlug', 'customers'].join()
+        include: ['currentSlug', 'orgasInCustomer.customer'].join()
       })
         .then(() => {
           this.pendingOrganisationsLoading = false
@@ -449,7 +494,7 @@ export default {
 
   mounted () {
     this.pendingOrganisationList({
-      include: ['currentSlug', 'customers'].join()
+      include: ['currentSlug', 'orgasInCustomer.customer'].join()
     }).then(() => {
       this.getItemsByPage()
     }).then(() => {
@@ -460,7 +505,7 @@ export default {
       this.isLoading = true
       this.pendingOrgs = {}
       this.pendingOrganisationList({
-        include: ['currentSlug', 'customers'].join()
+        include: ['currentSlug', 'orgasInCustomer.customer'].join()
       }).then(() => {
         this.getItemsByPage()
       })

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
@@ -24,8 +24,6 @@ use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use Doctrine\Common\Collections\Collection;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\PathBuilding\End;
-use EDT\Querying\Contracts\FunctionInterface;
-use EDT\Querying\Contracts\PathsBasedInterface;
 use Tightenco\Collect\Support\Collection as TightencoCollection;
 
 /**
@@ -168,7 +166,7 @@ final class OrgaResourceType extends DplanResourceType
             $this->createAttribute($this->id)->sortable()->filterable()->readable(true),
             $this->createAttribute($this->name)->sortable()->filterable()->readable(true),
             $this->createAttribute($this->ccEmail2)->readable(true),
-            $this->createAttribute($this->city)->readable(true, static fn(Orga $orga): string => $orga->getCity()),
+            $this->createAttribute($this->city)->readable(true, static fn (Orga $orga): string => $orga->getCity()),
             $this->createAttribute($this->imprint)->readable(true),
             $this->createAttribute($this->dataProtection)->readable(true),
             $this->createAttribute($this->competence)->readable(true),
@@ -177,24 +175,24 @@ final class OrgaResourceType extends DplanResourceType
             $this->createAttribute($this->copySpec)->aliasedPath($this->paperCopySpec)->readable(true),
             $this->createAttribute($this->email2)->readable(true),
             $this->createAttribute($this->participationEmail)->aliasedPath($this->email2)->readable(true),
-            $this->createAttribute($this->phone)->readable(true, static fn(Orga $orga): string => $orga->getPhone()),
+            $this->createAttribute($this->phone)->readable(true, static fn (Orga $orga): string => $orga->getPhone()),
             $this->createAttribute($this->emailNotificationEndingPhase)->readable(true, $this->getEmailNotificationEndingPhase(...)),
             $this->createAttribute($this->emailNotificationNewStatement)->readable(true, $this->getEmailNotificationNewStatement(...)),
-            $this->createAttribute($this->postalcode)->readable(true, static fn(Orga $orga): string => $orga->getPostalcode()),
+            $this->createAttribute($this->postalcode)->readable(true, static fn (Orga $orga): string => $orga->getPostalcode()),
             $this->createAttribute($this->reviewerEmail)->aliasedPath($this->emailReviewerAdmin)->readable(true),
             $this->createAttribute($this->showlist)->readable(true),
             $this->createAttribute($this->showname)->readable(true),
-            $this->createAttribute($this->state)->readable(true, static fn(Orga $orga): string => $orga->getState()),
-            $this->createAttribute($this->street)->readable(true, static fn(Orga $orga): string => $orga->getStreet()),
-            $this->createAttribute($this->houseNumber)->readable(true, static fn(Orga $orga): string => $orga->getHouseNumber()),
-            $this->createAttribute($this->submissionType)->readable(true, static fn(Orga $orga): string => $orga->getSubmissionType()),
-            $this->createAttribute($this->types)->readable(true, fn(Orga $orga): array => $orga->getTypes($this->globalConfig->getSubdomain())),
+            $this->createAttribute($this->state)->readable(true, static fn (Orga $orga): string => $orga->getState()),
+            $this->createAttribute($this->street)->readable(true, static fn (Orga $orga): string => $orga->getStreet()),
+            $this->createAttribute($this->houseNumber)->readable(true, static fn (Orga $orga): string => $orga->getHouseNumber()),
+            $this->createAttribute($this->submissionType)->readable(true, static fn (Orga $orga): string => $orga->getSubmissionType()),
+            $this->createAttribute($this->types)->readable(true, fn (Orga $orga): array => $orga->getTypes($this->globalConfig->getSubdomain())),
             $this->createAttribute($this->registrationStatuses)->readable(true, $this->getRegistrationStatuses(...)),
             $this->createToOneRelationship($this->currentSlug, true)->readable(true),
-            $this->createToManyRelationship($this->customers)->readable(false, static fn(Orga $orga): Collection => $orga->getCustomers()),
-            $this->createToManyRelationship($this->departments)->readable(false, static fn(Orga $orga): TightencoCollection => $orga->getDepartments()),
+            $this->createToManyRelationship($this->customers)->readable(false, static fn (Orga $orga): Collection => $orga->getCustomers()),
+            $this->createToManyRelationship($this->departments)->readable(false, static fn (Orga $orga): TightencoCollection => $orga->getDepartments()),
             $this->createAttribute($this->isPlanningOrganisation)->readable(true,
-                fn(Orga $orga): bool => $orga->hasType(OrgaType::MUNICIPALITY, $this->globalConfig->getSubdomain())
+                fn (Orga $orga): bool => $orga->hasType(OrgaType::MUNICIPALITY, $this->globalConfig->getSubdomain())
                     || $orga->hasType(OrgaType::PLANNING_AGENCY, $this->globalConfig->getSubdomain())
                     || $orga->hasType(OrgaType::HEARING_AUTHORITY_AGENCY, $this->globalConfig->getSubdomain())
             ),
@@ -235,9 +233,9 @@ final class OrgaResourceType extends DplanResourceType
     {
         $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
         $acceptedOrgaTypes = $orga->getStatusInCustomers()
-            ->filter(static fn(OrgaStatusInCustomer $orgaStatus): bool => OrgaStatusInCustomer::STATUS_ACCEPTED === $orgaStatus->getStatus())
-            ->filter(static fn(OrgaStatusInCustomer $orgaStatus): bool => $orgaStatus->getCustomer() === $currentCustomer)
-            ->map(static fn(OrgaStatusInCustomer $orgaStatus): OrgaType => $orgaStatus->getOrgaType())->getValues();
+            ->filter(static fn (OrgaStatusInCustomer $orgaStatus): bool => OrgaStatusInCustomer::STATUS_ACCEPTED === $orgaStatus->getStatus())
+            ->filter(static fn (OrgaStatusInCustomer $orgaStatus): bool => $orgaStatus->getCustomer() === $currentCustomer)
+            ->map(static fn (OrgaStatusInCustomer $orgaStatus): OrgaType => $orgaStatus->getOrgaType())->getValues();
 
         return $this->roleService->getGivableRoles($acceptedOrgaTypes);
     }
@@ -246,7 +244,7 @@ final class OrgaResourceType extends DplanResourceType
     {
         return $this->getRegistration($orga)
             ->map(
-                static fn(OrgaStatusInCustomer $orgaStatusInCustomer) => [
+                static fn (OrgaStatusInCustomer $orgaStatusInCustomer) => [
                     OrgaResourceType::REGISTRATION_STATUSES_STATUS    => $orgaStatusInCustomer->getStatus(),
                     OrgaResourceType::REGISTRATION_STATUSES_TYPE      => $orgaStatusInCustomer->getOrgaType()->getName(),
                     OrgaResourceType::REGISTRATION_STATUSES_SUBDOMAIN => $orgaStatusInCustomer->getCustomer()->getSubdomain(),
@@ -287,7 +285,7 @@ final class OrgaResourceType extends DplanResourceType
         $orgaStatuses = $orga->getStatusInCustomers();
         if (!$this->currentUser->hasPermission('area_manage_orgas_all')) {
             $orgaStatuses = $orgaStatuses
-                ->filter(static fn(OrgaStatusInCustomer $orgaStatusInCustomer) => $orgaStatusInCustomer->getCustomer()->getSubdomain() === $currentCustomer->getSubdomain());
+                ->filter(static fn (OrgaStatusInCustomer $orgaStatusInCustomer) => $orgaStatusInCustomer->getCustomer()->getSubdomain() === $currentCustomer->getSubdomain());
         }
 
         return $orgaStatuses;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
@@ -215,7 +215,7 @@ final class OrgaResourceType extends DplanResourceType
 
         // OrgaStatusInCustomer @organisation-list filtering for orga
         if ($this->currentUser->hasPermission('area_organisations')) {
-            $statusInCustomers->sortable()->filterable();
+            $statusInCustomers->sortable()->filterable()->readable();
         } else {
             $statusInCustomers->readable(false, $this->getRegistration(...));
         }


### PR DESCRIPTION
- we don't want to access the customer directly from the orga. Its deprecated
- and we should define explicitly which fields we want to get from the Backend
- even if that means listing all fields.

As Mandaten-Admin / Support The Page `/organisation/list` should work like before but without the purple warnings

