### PR TITLE
Fix(T33137): accessible notifications

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -455,7 +455,7 @@
               name="r_useName"
               data-cy="submitPublicly"
               value="1"
-              @change="val => setStatementData({r_useName: '1'})"
+              @change="val => setPrivacyPreference({r_useName: '1'})"
               :checked="formData.r_useName === '1'"
               :label="{
                 text: Translator.trans('statement.detail.form.personal.post_publicly')
@@ -482,7 +482,7 @@
               id="r_useName_0"
               name="r_useName"
               value="0"
-              @change="val => setStatementData({r_useName: '0'})"
+              @change="val => setPrivacyPreference({ r_useName: '0' })"
               :checked="formData.r_useName === '0'"
               :label="{
                 text: Translator.trans('statement.detail.form.personal.post_anonymously')
@@ -885,6 +885,8 @@ export default {
   },
 
   computed: {
+    ...mapState('notify', ['messages']),
+
     ...mapState('publicStatement', {
       initFormDataJSON: 'initForm',
       initDraftStatements: 'initDraftStatements',
@@ -962,6 +964,8 @@ export default {
   },
 
   methods: {
+    ...mapMutations('notify', ['remove']),
+
     ...mapMutations('publicStatement', [
       'addUnsavedDraft',
       'clearDraftState',
@@ -987,11 +991,11 @@ export default {
       }
 
       const invalidFields = this.dpValidate.invalidFields[formId]
-      const fieldDescriptions = invalidFields.map(field => {
+      const uniqueFieldDescriptions = Array.from(new Set(invalidFields.map(field => {
         const fieldId = field.getAttribute('id')
         return `<li>${Translator.trans(fieldDescriptionsForErrors[fieldId])}</li>`
-      })
-      return `<p>${Translator.trans('error.in.fields')}</p><ul class="u-mb-0 u-ml">${fieldDescriptions.join('')}</ul>`
+      })))
+      return `<p>${Translator.trans('error.in.fields')}</p><ul class="u-mb-0 u-ml">${uniqueFieldDescriptions.join('')}</ul>`
     },
 
     fieldIsActive (fieldKey) {
@@ -1342,6 +1346,13 @@ export default {
         .then(() => {
           this.isLoading = false
         })
+    },
+
+    setPrivacyPreference (data) {
+      this.setStatementData(data)
+      this.messages.forEach(message => {
+        this.remove(message)
+      })
     },
 
     writeDraftStatementIdToSession (draftStatementId) {

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -482,7 +482,7 @@
               id="r_useName_0"
               name="r_useName"
               value="0"
-              @change="val => setPrivacyPreference({ r_useName: '0' })"
+              @change="val => setPrivacyPreference({r_useName: '0'})"
               :checked="formData.r_useName === '0'"
               :label="{
                 text: Translator.trans('statement.detail.form.personal.post_anonymously')
@@ -1184,6 +1184,12 @@ export default {
       this.setStatementData(elementFields)
     },
 
+    removeNotificationsFromStore () {
+      this.messages.forEach(message => {
+        this.remove(message)
+      })
+    },
+
     removeUnsavedFile (file) {
       const indexToRemove = this.unsavedFiles.findIndex(el => el.hash === file.hash)
       this.unsavedFiles.splice(indexToRemove, 1)
@@ -1350,9 +1356,7 @@ export default {
 
     setPrivacyPreference (data) {
       this.setStatementData(data)
-      this.messages.forEach(message => {
-        this.remove(message)
-      })
+      this.removeNotificationsFromStore()
     },
 
     writeDraftStatementIdToSession (draftStatementId) {

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
@@ -83,7 +83,7 @@
           name="r_getEvaluation"
           :disabled="statement.r_useName === '0'"
           @change="val => setStatementData({r_getEvaluation: 'snailmail'})"
-          :checked="statement.r_getEvaluation === 'snailmail'"
+          :checked="statement.r_getEvaluation === 'snailmail' && statement.r_getFeedback === 'on'"
           :label="{
             text: Translator.trans('statement.form.personal.require_answer_post')
           }"
@@ -93,12 +93,12 @@
           v-show="statement.r_useName !== '0'"
           :class="prefixClass('layout__item u-1-of-1-palm u-1-of-2 u-mt-0_5 ')"
           :disabled="statement.r_useName === '0'"
-          :required="statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" /><!--
+          :required="statement.r_getFeedback === 'on' && statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" /><!--
      --><form-group-postal-and-city
           v-show="statement.r_useName !== '0'"
           :class="prefixClass('layout__item u-1-of-1-palm u-1-of-2 u-mt-0_5 ')"
           :disabled="statement.r_useName === '0'"
-          :required="statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" />
+          :required="statement.r_getFeedback === 'on' && statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" />
       </div>
     </div>
   </div>

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupPostalAndCity.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupPostalAndCity.vue
@@ -15,7 +15,7 @@
         autocomplete="postal-code"
         data-cy="postalCode"
         :class="prefixClass('layout__item')"
-        data-dp-validate-if="#r_useName_1"
+        data-dp-validate-if="#r_getEvaluation_snailmail, #r_useName_1"
         :disabled="disabled"
         :label="{
           text: Translator.trans('postalcode')


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33137

**Description:** This PR fixes the notification issue and enhances accessibility by:

- resolving the problem of duplicating invalid fields
- removing all notifications/errors after clicking on _'Ich möchte anonym Stellung nehmen.'_
- introducing a `'statement.r_getFeedback === 'on''` check for required fields, which validates the fields only when the `'getFeedback'` field is activated."

**Linked PRs**
[PR](https://github.com/demos-europe/demosplan-ui/pull/622) in demosplan-ui

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
