### PR TITLE
chore refs T35309: add csrf protection listener

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
+
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class CsrfSubscriber implements EventSubscriberInterface
+{
+
+    public function __construct(
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly MessageBagInterface $messageBag,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if($request->isMethod('GET')) {
+            return;
+        }
+
+        $tokenId = $request->request->get('_token');
+        if(null === $tokenId) {
+            $this->messageBag->add('dev', 'error.csrf.missing', ['uri' => $request->getRequestUri()]);
+            $this->logger->info('CSRF token missing', ['uri' => $request->getRequestUri()]);
+
+            return;
+        }
+
+        $token = $this->csrfTokenManager->getToken($tokenId);
+        if ($token instanceof CsrfToken && $this->csrfTokenManager->isTokenValid($token)) {
+            // all clear, token is set and valid
+            return;
+        }
+
+        $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri(), 'token' => $token ?? 'null']);
+
+    }
+
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest'],
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
@@ -49,7 +49,7 @@ class CsrfSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri(), 'token' => $token ?? 'null']);
+        $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri(), 'token' => $tokenId]);
     }
 
     public static function getSubscribedEvents(): array

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class CsrfSubscriber implements EventSubscriberInterface
 {
-
     public function __construct(
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly MessageBagInterface $messageBag,
@@ -32,12 +31,12 @@ class CsrfSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if($request->isMethod('GET')) {
+        if ($request->isMethod('GET')) {
             return;
         }
 
         $tokenId = $request->request->get('_token');
-        if(null === $tokenId) {
+        if (null === $tokenId) {
             $this->messageBag->add('dev', 'error.csrf.missing', ['uri' => $request->getRequestUri()]);
             $this->logger->info('CSRF token missing', ['uri' => $request->getRequestUri()]);
 
@@ -51,9 +50,7 @@ class CsrfSubscriber implements EventSubscriberInterface
         }
 
         $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri(), 'token' => $token ?? 'null']);
-
     }
-
 
     public static function getSubscribedEvents(): array
     {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/csrf.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/csrf.html.twig
@@ -1,0 +1,6 @@
+{#
+Please include this hidden input in every html form to protect against CSRF attacks.
+Just use {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }} in your form.
+Token is checked in the CsrfSubscriber.
+#}
+<input name="_token" type="hidden" value="{{ csrf_token('csrf') }}">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -55,6 +55,7 @@
         novalidate>
         <input name="action" type="hidden" value="newsedit">
         <input name="r_ident" type="hidden" value="{% if news.ident is defined %}{{ news.ident }}{% endif %}">
+        {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
 
         {% set currentState = '0' %}
         {% set defaultNewState = '1' %}

--- a/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
+++ b/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
@@ -20,6 +29,7 @@ class CsrfSubscriberTest extends FunctionalTestCase
     private ?CsrfTokenManagerInterface $csrfTokenManager;
     private ?MessageBagInterface $messageBag;
     private ?LoggerInterface $logger;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
+++ b/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\EventSubscriber\CsrfSubscriber;
+use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\Base\FunctionalTestCase;
+
+class CsrfSubscriberTest extends FunctionalTestCase
+{
+    private ?CsrfTokenManagerInterface $csrfTokenManager;
+    private ?MessageBagInterface $messageBag;
+    private ?LoggerInterface $logger;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $this->messageBag = $this->createMock(MessageBagInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    /**
+     * @dataProvider dataProviderMethod
+     */
+    public function testOnKernelRequestWithValidToken($method): void
+    {
+        // Set up a valid token
+        $validToken = new CsrfToken('token_id', 'valid_token');
+        $this->csrfTokenManager->expects($this->once())
+            ->method('getToken')
+            ->with('valid_token')
+            ->willReturn($validToken);
+
+        $this->csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with($validToken)
+            ->willReturn(true);
+
+        // Create a subscriber with the mocked dependencies
+        $subscriber = new CsrfSubscriber($this->csrfTokenManager, $this->messageBag, $this->logger);
+
+        // Create a request event with a request and a valid token
+        $request = new Request([], ['_token' => 'valid_token'], [], [], [], ['REQUEST_URI' => '/some-uri', 'REQUEST_METHOD' => $method]);
+        $event = new RequestEvent($this->createMock(KernelInterface::class), $request, 1);
+
+        // Call the onKernelRequest method
+        $subscriber->onKernelRequest($event);
+
+        // Assert that no messages were added to the message bag
+        $this->messageBag->expects($this->never())->method('add');
+
+        // Assert that the logger was not called for a valid token
+        $this->logger->expects($this->never())->method('info');
+    }
+
+    /**
+     * @dataProvider dataProviderMethod
+     */
+    public function testOnKernelRequestWithMissingToken($method): void
+    {
+        $messageBag = new MessageBag($this->createMock(TranslatorInterface::class));
+        $messages = $messageBag->get()->get('dev')->count();
+        $this->assertEquals(0, $messages);
+
+        // Create a subscriber with the mocked dependencies
+        $subscriber = new CsrfSubscriber($this->csrfTokenManager, $messageBag, $this->logger);
+
+        // Create a request event with a request and a missing token
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/some-uri', 'REQUEST_METHOD' => $method]);
+        $event = new RequestEvent($this->createMock(KernelInterface::class), $request, 1);
+
+        // Call the onKernelRequest method
+        $subscriber->onKernelRequest($event);
+
+        $messages = $messageBag->get()->get('dev')->count();
+        $this->assertEquals(1, $messages);
+    }
+
+    public function testOnKernelGetRequestWithMissingToken(): void
+    {
+        $messageBag = new MessageBag($this->createMock(TranslatorInterface::class));
+        // get messages to ensure that they are empty
+        $messageBag->get();
+        $subscriber = new CsrfSubscriber($this->csrfTokenManager, $messageBag, $this->logger);
+        // Create a request event with a request and a missing token
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/some-uri', 'REQUEST_METHOD' => 'GET']);
+        $event = new RequestEvent($this->createMock(KernelInterface::class), $request, 1);
+        $subscriber->onKernelRequest($event);
+        $messages = $messageBag->get('messages')->count();
+        $this->assertEquals(0, $messages);
+    }
+
+    public function dataProviderMethod(): array
+    {
+        return [
+            ['POST'],
+            ['PUT'],
+            ['DELETE'],
+            ['PATCH'],
+            ['OPTIONS'],
+            ['HEAD'],
+        ];
+    }
+}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1019,6 +1019,7 @@ error.annotated.statement.boxes.already.being.reviewed: "Dieses Dokument wird ak
 error.annotated.statement.text.already.being.reviewed: "Der Import wird aktuell durch {user} geprüft."
 error.annotated.statement.not.being.reviewed: "Das Dokument wird nicht überprüft."
 error.api.generic: "Während der Verarbeitung der Anfrage ist ein Fehler aufgetreten."
+error.csrf.missing: "Der CSRF-Token fehlt. Bitte @DemosPlanCore/DemosPlanCore/includes/csrf.html.twig in dem Formular zur Route {uri} importieren."
 error.procedure.token.creation: "Fehler beim Generieren des Verfahrenstokens."
 error.procedure.token.not.found: "Der eingegebene Token konnte nicht gefunden werden."
 error.procedure.token.already.used: "Der eingegebene Token wurde bereits verwendet."


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35309

All HTML post forms must be provided with csrf protection. 
protection. On the one hand this is best practice, on the other hand it is required by the BSI and by customers.

After this PR all forms must include `{{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}`. Initially only a dev message is triggered, later on the check could be activated

### How to review/test
run tests, post any form and see the dev message. Adding or editing a procedure news should not trigger the message

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
