### PR TITLE
Fix(T33788): disabled scrolling after closing the modal window

### DIFF
--- a/client/js/components/statement/assessmentTable/AssignEntityModal.vue
+++ b/client/js/components/statement/assessmentTable/AssignEntityModal.vue
@@ -140,6 +140,7 @@ export default {
 
     handleClose (isOpen) {
       if (!isOpen) {
+        this.$refs.assignModal.preventScroll(false)
         this.setModalProperty({ prop: 'assignEntityModal', val: { ...this.assignEntityModal, show: false } })
       }
     },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T33788

**Description:** This PR addresses the issue where scrolling becomes impossible after closing the modal window. Manually invoke the preventScroll function within the handleClose function.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
