### PR TITLE
fix(refs T31372): Add confirm message to confirm mstn (#1529)

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the package demosplan.
  *
- * (c) 2010-present DEMOS E-Partizipation GmbH, for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -210,6 +210,10 @@ class DemosPlanAssessmentController extends BaseController
                 }
 
                 if ($newStatement instanceof Statement) {
+                    $this->getMessageBag()->add(
+                        'confirm', 'confirm.statement.new', ['externId' => $newStatement->getExternId()]
+                    );
+
                     return $this->redirectToRoute(
                         'DemosPlan_statement_new_submitted',
                         ['procedureId' => $procedureId]


### PR DESCRIPTION
Add Missing Confirmmassge when creating a manual STN

(cherry picked from commit 7abdf5a027ad949c1940437a2d93d703654c1337)

**Ticket:** https://yaits.demos-deutschland.de/T31372


