### PR TITLE
bug(refs T35342): Use the correct property for submitter city

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -139,7 +139,7 @@
                     :size="5" />
                   <dp-input
                     id="r_orga_city"
-                    v-model="values.submitter.city"
+                    v-model="values.submitter.ort"
                     class="o-form__group-item"
                     name="r_orga_city"
                     :label="{
@@ -376,13 +376,13 @@ import SimilarStatementSubmitters from '@DpJs/components/procedure/Shared/Simila
 import { v4 as uuid } from 'uuid'
 
 const submitterProperties = {
-  city: '',
   date: '',
   department: '',
   email: '',
   institution: false,
   name: '',
   orga: '',
+  ort: '',
   plz: ''
 }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35342

The property for submitter's city was wrong. We get `ort` from the backend.

