### PR TITLE
fix: Type-o in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
                 - "@babel/plugin-*"
                 - "@babel/eslint-*"
         sentry:
-            pattern:
+            patterns:
                 - "@sentry*"
     labels:
       - dependencies:yarn


### PR DESCRIPTION
its tiny

for interested Persons https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file