### PR TITLE
T17360: fix generate statement command as functional user has no id

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/FactoryBase.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/FactoryBase.php
@@ -11,7 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\DataGenerator\CustomFactory;
 
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
-use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\DataProviderException;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
@@ -141,7 +141,7 @@ abstract class FactoryBase implements FactoryInterface
      */
     public function configure(...$options): void
     {
-        $this->user = new FunctionalUser();
+        $this->user = new AnonymousUser();
 
         $this->permissions->initPermissions($this->user);
 

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/FactoryBase.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/FactoryBase.php
@@ -95,8 +95,6 @@ abstract class FactoryBase implements FactoryInterface
      * the necessity of persisting them or requirements to create tehm.
      *
      * @param int $amount
-     *
-     * @return mixed
      */
     public function create($amount = 1)
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
@@ -114,6 +114,11 @@ class FunctionalUser extends User
             if ($role instanceof Role) {
                 $this->dplanRoles->add($role);
             }
+            if (is_string($role)) {
+                $roleEntity = new Role();
+                $roleEntity->setCode($role);
+                $this->dplanRoles->add($roleEntity);
+            }
         }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
@@ -47,6 +47,7 @@ class FunctionalUser extends User
 
         parent::__construct();
     }
+
     protected function setDefaultOrgaDepartment(): void
     {
         $this->functionalOrga = new Orga();
@@ -58,33 +59,22 @@ class FunctionalUser extends User
         $this->department->setName(self::ANONYMOUS_USER_DEPARTMENT_NAME);
         $this->functionalOrga->setDepartments([$this->department]);
     }
-    /**
-     * {@inheritDoc}
-     */
+
     public function isNewUser(): bool
     {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function isProfileCompleted(): bool
     {
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getRoleBySubdomain(string $subdomain): string
     {
         return Role::GUEST;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOrga(): Orga
     {
         return $this->functionalOrga;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T17360

Statements could not be generated any more as validation has tightened

### How to review/test
run bin/<project> dplan:data:generate:statement

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
