### PR TITLE
fix(refs T35369) Display contact cards for none admins

### DIFF
--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -8,8 +8,7 @@ All rights reserved
 </license>
 
 <template>
-  <div
-    class="space-inset-m bg-color--blue-light-3">
+  <div class="space-inset-m bg-color--blue-light-3">
     <h2 class="font-normal color--black">
       {{ Translator.trans('support.heading') }}
     </h2>
@@ -19,17 +18,19 @@ All rights reserved
     <p>
       {{ Translator.trans('support.contact.advice') }}
     </p>
-    <h3 class="u-mt-0_75">
+    <h3
+      v-if="contacts.length > 0"
+      class="u-mt-0_75">
       {{ Translator.trans('support') }}
     </h3>
     <ul
       class="u-mb-0_75"
-      :class="{ 'grid lg:grid-cols-3 gap-3': visibleContacts.length !== 1 }">
+      :class="{ 'grid lg:grid-cols-3 gap-3': contacts.length !== 1 }">
       <li
-        v-for="contact in visibleContacts"
+        v-for="contact in contacts"
         :key="contact.id"
         class="space-inset-m bg-color--white"
-        :class="{ 'lg:w-8/12': visibleContacts.length === 1 }">
+        :class="{ 'lg:w-8/12': contacts.length === 1 }">
         <dp-support-card
           :title="contact.attributes.title"
           :email="contact.attributes.eMailAddress"
@@ -74,11 +75,7 @@ export default {
   computed: {
     ...mapState('customerContact', {
       contacts: 'items'
-    }),
-
-    visibleContacts () {
-      return Object.values(this.contacts).filter(contact => contact.attributes.visible)
-    }
+    })
   },
 
   methods: {
@@ -94,7 +91,6 @@ export default {
           'title',
           'phoneNumber',
           'text',
-          'visible',
           'eMailAddress'
         ].join()
       }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35369


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

If You don't have the Permission to edit customer contacts,
the api doesn't return `visible` as attribute since you only
receive visible contacts. That means it doesn't work to filter
by that state and it's not only unnecessary but results in empty lists.


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

as "Mandanten admin" create some entities in "inhaltlicher support" (`/einstellungen/plattform`). set some to visible and other to not-visible.
Log out. check if You only see the visible ones on the page `/informationen`


### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
