### PR TITLE
bug: Only show office hours if there are office hours

### DIFF
--- a/client/js/components/support/DpSupportCard.vue
+++ b/client/js/components/support/DpSupportCard.vue
@@ -25,20 +25,22 @@ All rights reserved
     <p
       v-if="email"
       v-text="email" />
-    <div
-      v-if="reachability.service">
-      <h4
-        class="u-mt-0_75 font-semibold"
-        v-text="reachability.service" />
-      <p v-cleanhtml="reachability.officeHours" />
-      <span
-        class="color--grey-light font-size-smaller"
-        v-text="reachability.exception" />
-    </div>
-    <div
-      v-else
-      v-cleanhtml="reachability.officeHours"
-      class="u-mt-0_75 lg:mt-2" />
+    <template v-if="reachability.officeHours">
+      <div
+        v-if="reachability.service">
+        <h4
+          class="u-mt-0_75 font-semibold"
+          v-text="reachability.service" />
+        <p v-cleanhtml="reachability.officeHours" />
+        <span
+          class="color--grey-light font-size-smaller"
+          v-text="reachability.exception" />
+      </div>
+      <div
+        v-else
+        v-cleanhtml="reachability.officeHours"
+        class="u-mt-0_75 lg:mt-2" />
+    </template>
   </section>
 </template>
 <script>


### PR DESCRIPTION
Show office hours only if there are office hours to avoid console errors. Appeared if you create a contact without office hours (the big text field). 

![check](https://github.com/demos-europe/demosplan-core/assets/101879352/78a4b77c-a112-44f2-a1c6-824c68add8bf)

