### PR TITLE
F t35348 error message when adding text while editing sections

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcBulkEditor/RpcSegmentsBulkEditor.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcBulkEditor/RpcSegmentsBulkEditor.php
@@ -132,11 +132,14 @@ class RpcSegmentsBulkEditor implements RpcMethodSolverInterface
                     }
                     $resultSegments = [...$resultSegments, ...$segments];
                     $resultResponse[] = $this->generateMethodResult($rpcRequest);
-                } catch (InvalidArgumentException|InvalidSchemaException|UserNotAssignableException) {
+                } catch (InvalidArgumentException|InvalidSchemaException|UserNotAssignableException $e) {
+                    $this->logger->error('Problem while segments bulk editing', ['Exception' => $e]);
                     $resultResponse[] = $this->errorGenerator->invalidParams($rpcRequest);
-                } catch (AccessDeniedException|UserNotFoundException) {
+                } catch (AccessDeniedException|UserNotFoundException $e) {
+                    $this->logger->error('Problem while segments bulk editing', ['Exception' => $e]);
                     $resultResponse[] = $this->errorGenerator->accessDenied($rpcRequest);
-                } catch (Exception) {
+                } catch (Exception $e) {
+                    $this->logger->error('Problem while segments bulk editing', ['Exception' => $e]);
                     $resultResponse[] = $this->errorGenerator->serverError($rpcRequest);
                 }
             }

--- a/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
@@ -116,8 +116,8 @@ class SegmentRepository extends FluentRepository
 
         $qb = $this->getEntityManager()->createQueryBuilder();
         $value = $attach
-            ? $qb->expr()->concat('segment.recommendation', $recommendationText)
-            : $recommendationText;
+            ? $qb->expr()->concat('segment.recommendation', ':recommendationText')
+            : ':recommendationText';
 
         $query = $qb
             ->update(Segment::class, 'segment')
@@ -125,6 +125,7 @@ class SegmentRepository extends FluentRepository
             ->where($qb->expr()->in('segment.id', $segmentIds))
             ->andWhere('segment.procedure = :procedureId')
             ->setParameter('procedureId', $procedureId)
+            ->setParameter('recommendationText', $recommendationText)
             ->getQuery();
 
         $query->execute();


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35348

Description: 
The error message when adding text while editing sections suggests that there's a syntax error in your DQL (Doctrine Query Language) query. It expects a closing parenthesis but got an other character instead. This usually occurs due to malformed DQL. The $recommendationText variable might contain a value that is breaking the query syntax that's why we have to bind it to make sure that if the content of this variable is supposed to be a string literal in the query, it is properly escaped or handled.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
