### PR TITLE
f_T35396 fix assignee filter

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2497,6 +2497,10 @@ field_required_procedure_end_date:
     label: 'require procedure end date'
     expose: true
     loginRequired: true
+field_segment_assignee_filter:
+    description: 'Allow assignee facet search in segments of current procedure.'
+    label: 'Filter segment list by assignee'
+    loginRequired: true
 field_send_final_email:
     label: 'Schlussmitteilung versenden'
     loginRequired: true

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
@@ -15,7 +15,6 @@ namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use EDT\PathBuilding\End;
-use EDT\Querying\Contracts\PathsBasedInterface;
 
 /**
  * @template-extends DplanResourceType<Department>

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/DepartmentResourceType.php
@@ -39,7 +39,10 @@ final class DepartmentResourceType extends DplanResourceType
             // Managing users includes access to their departments
             'area_manage_users',
             // Departments are included in the response when fragments are updated
-            'feature_statements_fragment_edit'
+            'feature_statements_fragment_edit',
+            // Resource is needed for segments filtering :In the case when segments are filtered by assignee,
+            // the department resource type has to be available because user are grouped by departments
+            'field_segment_assignee_filter'
         );
     }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35396

Description: 
The departement resource type is not available while filter segments by assignee. A new permission was added to make the departement resource type available while segment by assignee filter


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
