### PR TITLE
Fix sentry pattern for dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,7 @@ updates:
                 - "@babel/eslint-*"
         sentry:
             patterns:
-                - "@sentry*"
+                - "@sentry/*"
     labels:
       - dependencies:yarn
 


### PR DESCRIPTION
Maybe dependabot is confused by the slash in @sentry package names.