### PR TITLE
feature (ref 35482): statement interface instead of segment interface

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -15,6 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Segment;
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -87,7 +88,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
                 $segmentsOrStatements = $statement->getSegmentsOfStatement();
             }
             foreach ($segmentsOrStatements as $segmentOrStatement) {
-                $exportData[] = $this->covertIntoExportableArray($segmentOrStatement);
+                $exportData[] = $this->convertIntoExportableArray($segmentOrStatement);
             }
         }
 
@@ -264,7 +265,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
      *
      * @throws ReflectionException
      */
-    private function covertIntoExportableArray(SegmentInterface $segmentOrStatement): array
+    private function convertIntoExportableArray(StatementInterface $segmentOrStatement): array
     {
         $exportData = $this->entityHelper->toArray($segmentOrStatement);
         $exportData['meta'] = $this->entityHelper->toArray($exportData['meta']);

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -14,7 +14,6 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Segment;
 
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35482

Description: 

- use statementInterface instead of segmentInterface: 
  the parameter 'segmentOrStatement' could be a segment or a statement.  The Segment entity is already a child of StatementInterface otherwise the Statement entity implement not the Segment Interface that's why we have to use the parent class here to make both entities valid.  
- adjust name of method: method name was false

### How to review/test
test with export file or code review

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-project-ewm/pull/98

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
