### PR TITLE
feature (refs T35367): Used the same logic to format the authoredDate as pdfExporter does

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
@@ -527,6 +527,12 @@ class AssessmentTableServiceOutput
      */
     public function replaceAuthoredDateOfStatementMeta(array $statement): array
     {
+        $statement['meta']['authoredDate'] = '';
+        if (isset($statement['submitDateString'])) {
+            $this->logger->debug('Use submitDate: '.$statement['submitDateString']);
+
+            $statement['meta']['authoredDate'] = $statement['submitDateString'];
+        }
         if (isset($statement['meta']['authoredDate'])
             && 100000 < $statement['meta']['authoredDate']
             && 3 < strlen((string) $statement['meta']['authoredDate'])
@@ -538,11 +544,6 @@ class AssessmentTableServiceOutput
             $this->logger->debug('authoredDate (formatted): '.date('d.m.Y', $date));
 
             $statement['meta']['authoredDate'] = date('d.m.Y', $date);
-        }
-        if (isset($statement['submitDateString'])) {
-            $this->logger->debug('Use submitDate: '.$statement['submitDateString']);
-
-            $statement['meta']['authoredDate'] = $statement['submitDateString'];
         }
 
         return $statement;

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -14,7 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Segment;
 
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -87,7 +87,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
                 $segmentsOrStatements = $statement->getSegmentsOfStatement();
             }
             foreach ($segmentsOrStatements as $segmentOrStatement) {
-                $exportData[] = $this->covertIntoExportableArray($segmentOrStatement);
+                $exportData[] = $this->convertIntoExportableArray($segmentOrStatement);
             }
         }
 
@@ -264,7 +264,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
      *
      * @throws ReflectionException
      */
-    private function covertIntoExportableArray(SegmentInterface $segmentOrStatement): array
+    private function convertIntoExportableArray(StatementInterface $segmentOrStatement): array
     {
         $exportData = $this->entityHelper->toArray($segmentOrStatement);
         $exportData['meta'] = $this->entityHelper->toArray($exportData['meta']);


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T35367

Description:
The exported xls file contained a unix timestamp instead of a readable
formatted date string. This change formats this value so it is the same as the other date value
present within the export (d.m.Y)

### How to review/test
get an up to date regio db, check out branch and download the xls statement(s) as described within the ticket.
The date value should look like `01.11.2023` instead of the unix timeStamp - lokal exampleExport:
[Abwägungstabelle-10-11-2023-14 07.xlsx](https://github.com/demos-europe/demosplan-core/files/13320402/Abwagungstabelle-10-11-2023-14.07.xlsx)

### Linked Prs:
this Pr replaces https://github.com/demos-europe/demosplan-core/pull/2304

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

