### PR TITLE
chore: change composer php constraint syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "EUPL-1.2",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.1 || ^8.2",
+        "php": "^8.1, ^8.2",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",


### PR DESCRIPTION
Composer version constraints can be built in multiple ways. The current `||` could not be interpreted correctly by phpstorm to automatically set the php version. It might be a bug there, but changing the constraint from logical or to and does not make any harm, so I think we could support here and change the way we define the constraint.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
