### PR TITLE
fix(refs: T34709): adjust button placement on public detail document view

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_elements_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_elements_list.html.twig
@@ -83,7 +83,7 @@
                                         </dp-video-player>
                                     {% else %}
                                         {# Simple download link that is also read out by screen readers #}
-                                        <div class="{{ 'elements__file-name elements__grid-grow'|prefixClass }}">
+                                        <div class="{{ 'elements__file-name flow-root'|prefixClass }}">
                                             <a
                                                 class="{{ 'o-link--default break-words'|prefixClass }}"
                                                 target="_blank"
@@ -98,20 +98,19 @@
                                                     </span>
                                                 {% endif %}
                                             </a>
+                                            {# Additional download button to emphasize download action - hidden for screen readers #}
+                                            {% if element.file|getFile('mimeType') not in videoFormats %}
+                                                <a
+                                                    class="{{ 'elements__button btn btn--secondary btn--outline u-1-of-1-lap-down float-right'|prefixClass }}"
+                                                    target="_blank"
+                                                    rel="noopener"
+                                                    href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': element.file|getFile('hash') }) }}"
+                                                    aria-hidden="true"
+                                                    tabindex="-1">
+                                                    {{ 'download'|trans }}
+                                                </a>
+                                            {% endif %}
                                         </div>
-
-                                        {# Additional download button to emphasize download action - hidden for screen readers #}
-                                        {% if element.file|getFile('mimeType') not in videoFormats %}
-                                            <a
-                                                class="{{ 'elements__button btn btn--secondary btn--outline u-1-of-1-lap-down'|prefixClass }}"
-                                                target="_blank"
-                                                rel="noopener"
-                                                href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': element.file|getFile('hash') }) }}"
-                                                aria-hidden="true"
-                                                tabindex="-1">
-                                                {{ 'download'|trans }}
-                                            </a>
-                                        {% endif %}
                                     {% endif %}
                                 </li>
                             {% endif %}


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T34709

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- The button was not properly included in the corresponding warpper component
- The class `elements__grid-grow` prevent a proper adjustment of the button hence was replaced with `flow-root` to easily adjust the download button at the end of the container
- The download button class list was added float-right to align it

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- checkout
- find a plan with planning documents
- navigate to the procedure's public detail view and make sure the download buttons are consistently aligned in relation to each other:
![image](https://github.com/demos-europe/demosplan-core/assets/91727189/570b6171-ac11-4560-a610-fa8524c69ee8)


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
