### PR TITLE
feat(refs: T35297): prevent link from being purged from gfi response

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
@@ -255,7 +255,7 @@ class GetFeatureInfo
                 $return = preg_replace('|<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>|mi', '', $return);
                 // Ersetze h2 durch h4
                 $return = preg_replace('|h2>|', 'h4>', $return);
-                $return = strip_tags($return, '<h4><table><tr><th><td><strong><b>');
+                $return = strip_tags($return, '<h4><table><tr><th><td><strong><b><a>');
             }
         }
 

--- a/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
@@ -293,11 +293,11 @@ class GetFeatureInfo
                 break;
             case 'vorranggebietId':
                 $featureInfoUrl = $this->getUrl2();
-//                http://geodienstewindstage.bob-sh.de/robob/services/wms_vorranggebiete
+                //                http://geodienstewindstage.bob-sh.de/robob/services/wms_vorranggebiete
 
                 $query['LAYERS'] = $this->getUrl2Layer();
                 $query['QUERY_LAYERS'] = $this->getUrl2Layer();
-//                vorranggebiete,potentialflaechen
+                //                vorranggebiete,potentialflaechen
 
                 $versionString = $this->getUrl2VersionString();
                 // ""
@@ -381,8 +381,6 @@ class GetFeatureInfo
     /** Setze den Request ab.
      * @param string $path
      * @param array  $data
-     *
-     * @return mixed
      *
      * @throws Exception
      */


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
https://yaits.demos-deutschland.de/T35297

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- The gfi response contains a link to a pdf which should be accessible from the UI directly. This commit prevents the purging of a clickable link in the resulting html like table response

![image](https://github.com/demos-europe/demosplan-core/assets/91727189/c1e57d40-560b-416f-8e2c-a724e33e7184)


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
In the corresponding PR is a full depth how-to-test section.



### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

regio-PR #(https://github.com/demos-europe/demosplan-project-regio/pull/87)
### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
