### PR TITLE
bug (refs T28095): Change width of label modal

### DIFF
--- a/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
+++ b/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
@@ -10,7 +10,7 @@
 <template>
   <dp-modal
     ref="labelModal"
-    content-classes="width-auto">
+    content-classes="u-1-of-3">
     <template>
       <h3>
         {{ Translator.trans('format') }}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T28095

The modal should not stretch over the whole site's width.

