### PR TITLE
chore: read addon zips from folder during installation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -37,6 +37,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -68,12 +69,13 @@ class AddonInstallFromZipCommand extends CoreCommand
     {
         $this->addArgument(
             'path',
-            InputArgument::REQUIRED,
+            InputArgument::OPTIONAL,
             'Path to zip'
         );
 
         $this->addOption('reinstall', '', InputOption::VALUE_NONE, 'Re-install an addon (useful for debugging)');
         $this->addOption('enable', '', InputOption::VALUE_NONE, 'Immediately enable addon during installation');
+        $this->addOption('folder', '', InputOption::VALUE_REQUIRED, 'Folder to read addon zips from', 'addonZips');
     }
 
     /**
@@ -86,8 +88,23 @@ class AddonInstallFromZipCommand extends CoreCommand
 
         $reinstall = $input->getOption('reinstall');
         $enable = $input->getOption('enable');
+        $path = $input->getArgument('path');
+        $folder = $input->getOption('folder');
 
-        $this->setPaths($input->getArgument('path'));
+        if (null === $path) {
+            $zips = glob(DemosPlanPath::getRootPath($folder).'/*.zip');
+
+            if(!is_array($zips) || count($zips) === 0) {
+                $output->error("No Addon zips found in Folder {$folder}");
+
+                return self::FAILURE;
+            }
+
+            $question = new ChoiceQuestion('Which addon do you want to install? ', $zips);
+            $path = $this->getHelper('question')->ask($input, $output, $question);
+        }
+
+        $this->setPaths($path);
         try {
             $this->initializeAddonsInfrastructure();
         } catch (JsonException|RuntimeException $e) {


### PR DESCRIPTION
A small quality of life PR that reads all (addon) zipfiles located in the default `addonZips` folder during addon installation when no path is given. It then asks for the correct zipfile to install.

### How to review/test
just run `bin/<project> dplan:addon:install` 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
