### PR TITLE
chore: add version to addon list command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/Registrator.php
@@ -104,6 +104,7 @@ final class Registrator
             'installed_at' => Carbon::now()->toIso8601String(),
             // use relative path to be compatible with different environments
             'install_path' => 'addons/vendor/'.$addonName,
+            'version'      => $addonComposerDefinition->getPrettyVersion(),
             'manifest'     => $this->loadManifest($addonName),
         ];
     }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
@@ -39,6 +39,7 @@ class AddonListCommand extends CoreCommand
             $addons[] = [
                 'name'    => $name,
                 'enabled' => $addonLoaded['enabled'] ? 'true' : 'false',
+                'version' => $addonLoaded['version'] ?? '-',
             ];
         }
 
@@ -46,7 +47,7 @@ class AddonListCommand extends CoreCommand
         $table = new Table($output);
 
         // Set the table headers
-        $table->setHeaders(['Name', 'Enabled']);
+        $table->setHeaders(['Name', 'Enabled', 'Version']);
 
         // Add rows to the table
         $table->setRows($addons);

--- a/tests/backend/core/Core/Functional/AddonListCommandTest.php
+++ b/tests/backend/core/Core/Functional/AddonListCommandTest.php
@@ -22,14 +22,22 @@ use Tests\Base\MockMethodDefinition;
 
 class AddonListCommandTest extends FunctionalTestCase
 {
+    /**
+     * @var string|null Field needs to be nullable as it is unset in test setup
+     */
+    private ?string $fieldName = 'Name';
+    private ?string $fieldEnabled = 'Enabled';
+    private ?string $fieldVersion = 'Version';
+
     public function testEmptyList(): void
     {
         $commandTester = $this->executeCommand([]);
 
         // Assert the output
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Name', $output);
-        $this->assertStringContainsString('Enabled', $output);
+        $this->assertStringContainsString($this->fieldName, $output);
+        $this->assertStringContainsString($this->fieldEnabled, $output);
+        $this->assertStringContainsString($this->fieldVersion, $output);
     }
 
     public function testListEnabled(): void
@@ -42,10 +50,12 @@ class AddonListCommandTest extends FunctionalTestCase
 
         // Assert the output
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Name', $output);
-        $this->assertStringContainsString('Enabled', $output);
+        $this->assertStringContainsString($this->fieldName, $output);
+        $this->assertStringContainsString($this->fieldEnabled, $output);
         $this->assertStringContainsString($addonName, $output);
         $this->assertStringContainsString('true', $output);
+        $this->assertStringContainsString($this->fieldVersion, $output);
+        $this->assertStringContainsString('-', $output);
     }
 
     public function testListDisabled(): void
@@ -58,10 +68,26 @@ class AddonListCommandTest extends FunctionalTestCase
 
         // Assert the output
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Name', $output);
-        $this->assertStringContainsString('Enabled', $output);
+        $this->assertStringContainsString($this->fieldName, $output);
+        $this->assertStringContainsString($this->fieldEnabled, $output);
         $this->assertStringContainsString($addonName, $output);
         $this->assertStringContainsString('false', $output);
+        $this->assertStringContainsString($this->fieldVersion, $output);
+        $this->assertStringContainsString('-', $output);
+    }
+
+    public function testListVersion(): void
+    {
+        $addonName = 'demos-europe/demosplan-test-addon';
+        $info = [
+            $addonName => ['enabled' => true, 'version' => '1.0.0'],
+        ];
+        $commandTester = $this->executeCommand($info);
+
+        // Assert the output
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString($this->fieldVersion, $output);
+        $this->assertStringContainsString('1.0.0', $output);
     }
 
     private function executeCommand(array $info): CommandTester


### PR DESCRIPTION
This PR enhances the addon list command to show versions. These are derived from the composer.json file in the addon and saved in addons.yml file during installation

### How to review/test
run `bin/<project> dplan:addon:list` 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
