### PR TITLE
fix(refs: T34613): add orga status filter

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -390,6 +390,14 @@ export default {
         }
       }
 
+      filterObject.orgaStatus = {
+        condition: {
+          path: 'statusInCustomers.status',
+          operator: '<>',
+          value: 'rejected'
+        }
+      }
+
       filterObject.namefilter = {
         condition: {
           path: 'name',


### PR DESCRIPTION
<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->
### Ticket:
https://yaits.demos-deutschland.de/T34613

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
### Description:
This PR fixes:
- Rejected orga statuses should be filtered out if the corresponding checkbox has been selected
![image](https://github.com/demos-europe/demosplan-core/assets/91727189/cf7dd029-a66f-468f-8370-e58fd710ea24)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- checkout
- login as support user
- navigate to `/organisation/list`
- select a filter checkbox 
![image](https://github.com/demos-europe/demosplan-core/assets/91727189/6e7b5b65-7e60-48e7-a624-8e6456b5ed46)
- make sure the selected checkbox results in a list where none of the statuses (of the selection) shows a `zurückgewiesen` status here: 
![image](https://github.com/demos-europe/demosplan-core/assets/91727189/03fb1f6a-7025-455b-abd0-d77d5b40dac9)


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
