### PR TITLE
bug (refs T34273): Add prop selection controls to filter modal

### DIFF
--- a/client/js/components/statement/assessmentTable/FilterModalSelectItem.vue
+++ b/client/js/components/statement/assessmentTable/FilterModalSelectItem.vue
@@ -30,6 +30,7 @@
             multiple
             :name="filterItem.attributes.name + '_multiselect'"
             :options="availableOptions"
+            selection-controls
             track-by="label"
             :value="selected"
             @close="updateFilterOptions"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34273

We need to give true for selection controls to show the beforeList slot.

### How to review/test
To test this locally, you need to install the linked demospipes version and update demosplan-ui. 

Verfahren -> Stellungnahmen -> Aufteilen -> Abschnitt bearbeiten -> Click in Schlagwort suchen. There should be the option "Schlagwort oder Thema anlegen" and this should work. 