### PR TITLE
fix: Use correct Option to exclude pacakges from pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,17 +40,17 @@ updates:
         versions:
           - ">= 5"
     groups:
-        babel:
-            patterns:
-                - "@babel/*"
-            # @babel-plugin-* and @babel/eslint have different update cycles and with that
-            # different a versioning. therefore we can't group them with the other babel packages
-            ingnore-patterns:
-                - "@babel/plugin-*"
-                - "@babel/eslint-*"
-        sentry:
-            patterns:
-                - "@sentry/*"
+      babel:
+        patterns:
+          - "@babel/*"
+        # @babel-plugin-* and @babel/eslint have different update cycles and with that
+        # different a versioning. therefore we can't group them with the other babel packages
+        exclude-patterns:
+          - "@babel/plugin-*"
+          - "@babel/eslint-*"
+      sentry:
+        patterns:
+          - "@sentry/*"
     labels:
       - dependencies:yarn
 


### PR DESCRIPTION
I used a not existing option... 
see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups