### PR TITLE
bug (refs T34613): Fix filter orga status

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -420,7 +420,6 @@ export default {
 
     fetchAllOrganisations (page) {
       this.isLoading = true
-      console.log('here')
 
       this.list({
         page: {

--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -382,19 +382,19 @@ export default {
               memberOf: 'orgaType'
             }
           }
+
+          filterObject.orgaStatus = {
+            condition: {
+              path: 'statusInCustomers.status',
+              operator: '<>',
+              value: 'rejected'
+            }
+          }
         }
       })
       filterObject.orgaType = {
         group: {
           conjunction: 'OR'
-        }
-      }
-
-      filterObject.orgaStatus = {
-        condition: {
-          path: 'statusInCustomers.status',
-          operator: '<>',
-          value: 'rejected'
         }
       }
 
@@ -420,6 +420,7 @@ export default {
 
     fetchAllOrganisations (page) {
       this.isLoading = true
+      console.log('here')
 
       this.list({
         page: {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34613

Only filter for orga status if the filter is active. Otherwise we want all orgas. 

### How to review/test
- login as support user
- navigate to `/organisation/list`
- select a filter checkbox 
- make sure the selected checkbox results in a list where none of the statuses (of the selection) shows a `zurückgewiesen` status
- remove filter -> make sure all orgas are shown, especially the ones that were filtered out before with the status "zurückgewiesen"

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/2373

