### PR TITLE
feat (refs T35632): duplicate csrf token usage leads to error

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_boilerplate.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_boilerplate.html.twig
@@ -21,7 +21,7 @@
                 <input name="action" type="hidden" value="boilerplateedit">
                 <input name="r_ident" type="hidden" value="{{ form.vars.value.id }}">
                 <input type="hidden" name="_token" value="{{ form._token.vars.value }}" />
-                {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
+
 
                 <label class="layout__item u-1-of-4" for="r_title">
                     {{ "title"|trans }}*

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
@@ -25,7 +25,6 @@
             <input type="hidden" value="{% if proceduresettings.ident is defined %}{{ proceduresettings.ident }}{% endif %}" name="r_ident">
             <input type="hidden" value="{% if templateVars.internalPhases.1 is defined %}{{ templateVars.internalPhases.1.key }}{% endif %}" name="r_phase">
             <input type="hidden" value="edit" name="action">
-            {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
 
             <label>
                 {{ "name"|trans }}*


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35632

In some cases csrf token is already set in BE via symfony forms.
For this cases the additional csrf in template is removed with this PR.

### How to review/test
Creation of Boilerplatetext and procedure template should work with this PR and should not without this one.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
