### PR TITLE
F T35528 make support contact work the same support email

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
@@ -159,10 +159,10 @@ export default {
         type: 'CustomerContact',
         attributes: {
           title: this.customerContact.title,
-          phoneNumber: this.customerContact.phoneNumber ? this.customerContact.phoneNumber : null,
-          text: this.customerContact.text ? this.customerContact.text : null,
+          phoneNumber: this.customerContact.phoneNumber ?? null,
+          text: this.customerContact.text ?? null,
           visible: this.customerContact.visible,
-          eMailAddress: this.customerContact.eMailAddress ? this.customerContact.eMailAddress : null
+          eMailAddress: this.customerContact.eMailAddress ?? null
         }
       }
 
@@ -197,7 +197,7 @@ export default {
     },
 
     resetForm () {
-      this.customerContact = emptyCustomer
+      this.customerContact = { ...emptyCustomer }
       this.updating = false
     },
 
@@ -207,9 +207,9 @@ export default {
       this.updating = true
       this.customerContact = {
         title: currentData.title,
-        phoneNumber: currentData.phoneNumber ? currentData.phoneNumber : '',
-        eMailAddress: currentData.eMailAddress ? currentData.eMailAddress : '',
-        text: currentData.text ? currentData.text : '',
+        phoneNumber: currentData.phoneNumber ?? '',
+        eMailAddress: currentData.eMailAddress ?? '',
+        text: currentData.text ?? '',
         visible: currentData.visible,
         id: id
       }

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20231129120204 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T: the email address property have to be of type a string, not any more a relation to EmailAddress and with no unique constraint.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql('TRUNCATE support_contact');
+        $this->addSql('ALTER TABLE support_contact DROP FOREIGN KEY FK_8C8C0928B08E074E');
+        $this->addSql('DROP INDEX IDX_8C8C0928B08E074E ON support_contact');
+        $this->addSql('ALTER TABLE support_contact CHANGE email_address email_address VARCHAR(255)');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql('ALTER TABLE support_contact CHANGE email_address email_address CHAR(36) DEFAULT NULL');
+        $this->addSql('ALTER TABLE support_contact ADD CONSTRAINT FK_8C8C0928B08E074E FOREIGN KEY (email_address) REFERENCES email_address (id)');
+        $this->addSql('CREATE INDEX IDX_8C8C0928B08E074E ON support_contact (email_address)');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2023/11/Version20231129120204.php
@@ -23,7 +23,7 @@ class Version20231129120204 extends AbstractMigration
         $this->addSql('TRUNCATE support_contact');
         $this->addSql('ALTER TABLE support_contact DROP FOREIGN KEY FK_8C8C0928B08E074E');
         $this->addSql('DROP INDEX IDX_8C8C0928B08E074E ON support_contact');
-        $this->addSql('ALTER TABLE support_contact CHANGE email_address email_address VARCHAR(255)');
+        $this->addSql('ALTER TABLE support_contact CHANGE email_address email_address VARCHAR(255) NULL');
     }
 
     /**
@@ -32,6 +32,7 @@ class Version20231129120204 extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->abortIfNotMysql();
+        $this->addSql('TRUNCATE support_contact');
         $this->addSql('ALTER TABLE support_contact CHANGE email_address email_address CHAR(36) DEFAULT NULL');
         $this->addSql('ALTER TABLE support_contact ADD CONSTRAINT FK_8C8C0928B08E074E FOREIGN KEY (email_address) REFERENCES email_address (id)');
         $this->addSql('CREATE INDEX IDX_8C8C0928B08E074E ON support_contact (email_address)');

--- a/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
@@ -15,7 +15,6 @@ namespace demosplan\DemosPlanCoreBundle\Entity\User;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Constraint\SupportContactConstraint;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
-use demosplan\DemosPlanCoreBundle\Entity\EmailAddress;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 use Gedmo\Timestampable\Traits\TimestampableEntity;

--- a/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
@@ -67,7 +67,7 @@ class SupportContact extends CoreEntity implements UuidEntityInterface
     private ?string $phoneNumber;
 
     /**
-     * @ORM\Column(type="string", length=255, name="email_address")
+     * @ORM\Column(type="string", length=255, name="email_address", nullable=true)
      */
     #[Assert\Email(mode: 'strict')]
     private ?string $eMailAddress;

--- a/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
@@ -67,16 +67,10 @@ class SupportContact extends CoreEntity implements UuidEntityInterface
     private ?string $phoneNumber;
 
     /**
-     * @ORM\ManyToOne(
-     *     targetEntity="demosplan\DemosPlanCoreBundle\Entity\EmailAddress",
-     *     cascade={"persist"})
-     *
-     * @ORM\JoinColumn(name="email_address",
-     *     referencedColumnName="id",
-     *     nullable = true)
+     * @ORM\Column(type="string", length=255, name="email_address")
      */
-    #[Assert\Valid]
-    private ?EmailAddress $eMailAddress;
+    #[Assert\Email(mode: 'strict')]
+    private ?string $eMailAddress;
 
     /**
      * @ORM\Column(name="text", type="text", nullable=true)
@@ -110,7 +104,7 @@ class SupportContact extends CoreEntity implements UuidEntityInterface
         string $supportType,
         ?string $title,
         ?string $phoneNumber,
-        ?EmailAddress $emailAddress,
+        ?string $emailAddress,
         ?string $text,
         ?Customer $customer,
         bool $visible = false
@@ -154,12 +148,12 @@ class SupportContact extends CoreEntity implements UuidEntityInterface
         $this->phoneNumber = $phoneNumber;
     }
 
-    public function getEMailAddress(): ?EmailAddress
+    public function getEMailAddress(): ?string
     {
         return $this->eMailAddress;
     }
 
-    public function setEMailAddress(?EmailAddress $eMailAddress): void
+    public function setEMailAddress(?string $eMailAddress): void
     {
         $this->eMailAddress = $eMailAddress;
     }

--- a/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
@@ -66,10 +66,8 @@ class EmailAddressRepository extends FluentRepository implements EmailAddressRep
             .' FROM email_address AS e'
             .' LEFT JOIN procedure_agency_extra_email_address  AS p  ON p.email_address_id = e.id'
             .' LEFT JOIN maillane_allowed_sender_email_address AS m  ON m.email_address_id = e.id'
-            .' LEFT JOIN support_contact                      AS sc ON sc.email_address = e.id'
             .' WHERE p.procedure_id   IS NULL'
             .' AND   m.procedure_id   IS NULL'
-            .' AND   sc.email_address IS NULL'
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerContactResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerContactResourceType.php
@@ -35,7 +35,7 @@ use Webmozart\Assert\Assert;
  * @property-read End                      $phoneNumber
  * @property-read End                      $text
  * @property-read End                      $visible
- * @property-read EmailAddressResourceType $eMailAddress
+ * @property-read End                      $eMailAddress
  * @property-read CustomerResourceType     $customer
  */
 class CustomerContactResourceType extends DplanResourceType implements CreatableDqlResourceTypeInterface, DeletableDqlResourceTypeInterface, UpdatableDqlResourceTypeInterface
@@ -52,8 +52,7 @@ class CustomerContactResourceType extends DplanResourceType implements Creatable
             $this->createAttribute($this->title)->readable()->initializable(),
             $this->createAttribute($this->phoneNumber)->readable()->initializable(),
             $this->createAttribute($this->text)->readable()->initializable(),
-            $this->createAttribute($this->eMailAddress)->aliasedPath($this->eMailAddress->fullAddress)->readable()->initializable(),
-        ];
+            $this->createAttribute($this->eMailAddress)->readable()->initializable(),        ];
 
         if ($this->hasManagementPermission()) {
             $properties[] = $this->createAttribute($this->visible)->readable()->filterable()->initializable();
@@ -116,20 +115,12 @@ class CustomerContactResourceType extends DplanResourceType implements Creatable
     {
         $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
 
-        // create/get email address
-        $providedEmailAddress = $properties[$this->eMailAddress->getAsNamesInDotNotation()];
-        if (null !== $providedEmailAddress) {
-            $emailAddressEntity = $this->emailAddressService->getOrCreateEmailAddress($providedEmailAddress);
-        } else {
-            $emailAddressEntity = null;
-        }
-
         // create support contact
         $contact = new SupportContact(
             SupportContact::SUPPORT_CONTACT_TYPE_DEFAULT,
             $properties[$this->title->getAsNamesInDotNotation()],
             $properties[$this->phoneNumber->getAsNamesInDotNotation()],
-            $emailAddressEntity,
+            $properties[$this->eMailAddress->getAsNamesInDotNotation()],
             $properties[$this->text->getAsNamesInDotNotation()],
             $currentCustomer,
             $properties[$this->visible->getAsNamesInDotNotation()],
@@ -141,16 +132,10 @@ class CustomerContactResourceType extends DplanResourceType implements Creatable
         // validate entities
         $this->resourceTypeService->validateObject($contact);
         $this->resourceTypeService->validateObject($currentCustomer);
-        if (null !== $emailAddressEntity) {
-            $this->resourceTypeService->validateObject($emailAddressEntity);
-        }
 
         // build resource change
         $change = new ResourceChange($contact, $this, $properties);
         $change->addEntityToPersist($contact);
-        if (null !== $emailAddressEntity) {
-            $change->addEntityToPersist($emailAddressEntity);
-        }
 
         return $change;
     }
@@ -210,24 +195,7 @@ class CustomerContactResourceType extends DplanResourceType implements Creatable
         $updater = new PropertiesUpdater($properties);
         $updater->ifPresent($this->title, $contact->setTitle(...));
         $updater->ifPresent($this->phoneNumber, $contact->setPhoneNumber(...));
-        $updater->ifPresent(
-            $this->eMailAddress,
-            function (?string $fullEMailAddress) use ($contact, $resourceChange): void {
-                if (null === $fullEMailAddress) {
-                    $contact->setEMailAddress(null);
-                } else {
-                    $emailAddress = $contact->getEMailAddress();
-                    if (null === $emailAddress) {
-                        $emailAddress = $this->emailAddressService->getOrCreateEmailAddress($fullEMailAddress);
-                        $resourceChange->addEntityToPersist($emailAddress);
-                        $contact->setEMailAddress($emailAddress);
-                    } else {
-                        $emailAddress->setFullAddress($fullEMailAddress);
-                    }
-                    $this->resourceTypeService->validateObject($emailAddress);
-                }
-            }
-        );
+        $updater->ifPresent($this->eMailAddress, $contact->setEMailAddress(...));
         $updater->ifPresent($this->text, $contact->setText(...));
         $updater->ifPresent($this->visible, $contact->setVisible(...));
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35528

Description: 
- Using the EmailAddress causes many issues which do not meet the users expectations ( use the same emails for many support contact ). that's why the email address property have to be of type a string, not any more a relation to EmailAddress and with no unique constraint.
- The entity 'SupportContact' and the table 'support_contact' are adjusted.
- The resource Types a re adjusted.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
