### PR TITLE
feature (refs T35690): deactivate the message-bag entry if not dev environment

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
@@ -10,7 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -24,6 +26,7 @@ class CsrfSubscriber implements EventSubscriberInterface
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly MessageBagInterface $messageBag,
         private readonly LoggerInterface $logger,
+        private readonly GlobalConfigInterface $globalConfig
     ) {
     }
 
@@ -35,10 +38,13 @@ class CsrfSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $environment = $this->globalConfig->getKernelEnvironment();
         $tokenId = $request->request->get('_token');
         if (null === $tokenId) {
-            $this->messageBag->add('dev', 'error.csrf.missing', ['uri' => $request->getRequestUri()]);
             $this->logger->info('CSRF token missing', ['uri' => $request->getRequestUri()]);
+            if (DemosPlanKernel::ENVIRONMENT_DEV === $environment) {
+                $this->messageBag->add('dev', 'error.csrf.missing', ['uri' => $request->getRequestUri()]);
+            }
 
             return;
         }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T35690

Description:
deactivate the message-bag entry for csrf tokens if not on dev environment

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
