### PR TITLE
f email address is not displayed

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
@@ -32,7 +32,7 @@
                 <div class="justify-center flex">
                     <dp-support-card
                         class="u-pv-0_75 u-ph-0_75 text-left u-mt-2 w-full max-w-sm bg-gray-50"
-                        email="{{ templateVars.customerLoginSupport.eMailAddress.fullAddress|default }}"
+                        email="{{ templateVars.customerLoginSupport.eMailAddress|default }}"
                         phone-number="{{ templateVars.customerLoginSupport.phoneNumber|default }}"
                         :reachability="{ officeHours: '{{ templateVars.customerLoginSupport.text|default }}' }"
                         title="{{ templateVars.customerLoginSupport.title|default }}">


### PR DESCRIPTION
the email property has been adjusted and is a text property now, not anymore a relationship between support contact and email entites.

**Ticket:** https://yaits.demos-deutschland.de/T35795

Description: the email property has been adjusted and is a text property now, not anymore a relationship between support contact and email entites.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
