### PR TITLE
Allow dots in selectors for purgeCss

### DIFF
--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -80,7 +80,7 @@ if (config.cssPurge.enabled) {
       content: config.cssPurge.paths,
       defaultExtractor (content) {
         const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '')
-        return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/.]+/g) || []
+        return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/.[\]]+/g) || []
       },
       safelist: config.cssPurge.safelist
     }

--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -80,7 +80,7 @@ if (config.cssPurge.enabled) {
       content: config.cssPurge.paths,
       defaultExtractor (content) {
         const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '')
-        return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g) || []
+        return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/.]+/g) || []
       },
       safelist: config.cssPurge.safelist
     }


### PR DESCRIPTION
As tailwind uses the dot for selector names, we have to tell that to purgeCss.