### PR TITLE
chore: automatically enable addon during installation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -74,7 +74,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         );
 
         $this->addOption('reinstall', '', InputOption::VALUE_NONE, 'Re-install an addon (useful for debugging)');
-        $this->addOption('enable', '', InputOption::VALUE_NONE, 'Immediately enable addon during installation');
+        $this->addOption('no-enable', '', InputOption::VALUE_NONE, 'Do not immediately enable addon during installation');
         $this->addOption('folder', '', InputOption::VALUE_REQUIRED, 'Folder to read addon zips from', 'addonZips');
     }
 
@@ -87,7 +87,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         $output = new SymfonyStyle($input, $output);
 
         $reinstall = $input->getOption('reinstall');
-        $enable = $input->getOption('enable');
+        $enable = !$input->getOption('no-enable');
         $path = $input->getArgument('path');
         $folder = $input->getOption('folder');
 


### PR DESCRIPTION
This quality of life PR takes the required action in 99% of the installation cases as default and enables the addon immediately after installation. The new option `no-enable` only installs the addon without enabling it

### How to review/test
install an addon via `bin/<project> dplan:addon:install` and choose the addon to install. Then check addons/addons.yaml, whether the addon is activated

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
