### PR TITLE
chore: show addons to build frontend for. Allow env to be passed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -10,6 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Composer\Console\Input\InputOption;
+use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
 use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -17,6 +19,8 @@ use EFrane\ConsoleAdditions\Batch\Batch;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class AddonBuildFrontendCommand extends CoreCommand
@@ -31,19 +35,33 @@ class AddonBuildFrontendCommand extends CoreCommand
     protected function configure()
     {
         $this->setDescription('Build frontend assets for an addon');
-        $this->addArgument('addon-name', InputArgument::REQUIRED, 'Addon name, du\'h.');
+        $this->addArgument('addon-name', InputArgument::OPTIONAL, 'Addon name, du\'h.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln("Building frontend assets for {$input->getArgument('addon-name')}");
+        $output = new SymfonyStyle($input, $output);
+        $addonName = $input->getArgument('addon-name');
+        $env = $input->getOption('env');
 
-        $addonInfo = $this->registry[$input->getArgument('addon-name')];
+        if(null === $addonName) {
+            $enabledAddons = $this->registry->getEnabledAddons();
+            if(0 === count($enabledAddons)) {
+                $output->warning('No addons enabled, nothing to do.');
+                return self::SUCCESS;
+            }
+            $question = new ChoiceQuestion('Which addon do you want to build the assets for? ', array_keys($enabledAddons));
+            $addonName = $this->getHelper('question')->ask($input, $output, $question);
+        }
+
+        $output->writeln("Building frontend assets for {$addonName}");
+
+        $addonInfo = $this->registry[$addonName];
 
         $addonPath = DemosPlanPath::getRootPath($addonInfo->getInstallPath());
         $consoleReturn = Batch::create($this->getApplication(), $output)
             ->addShell(['yarn', 'install', '--frozen-lockfile'], $addonPath)
-            ->addShell(['yarn', 'prod'], $addonPath)
+            ->addShell(['yarn', $env], $addonPath)
             ->run();
 
         return 0 === $consoleReturn ? self::SUCCESS : self::FAILURE;

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -10,8 +10,6 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
-use Composer\Console\Input\InputOption;
-use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
 use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -44,10 +42,11 @@ class AddonBuildFrontendCommand extends CoreCommand
         $addonName = $input->getArgument('addon-name');
         $env = $input->getOption('env');
 
-        if(null === $addonName) {
+        if (null === $addonName) {
             $enabledAddons = $this->registry->getEnabledAddons();
-            if(0 === count($enabledAddons)) {
+            if (0 === count($enabledAddons)) {
                 $output->warning('No addons enabled, nothing to do.');
+
                 return self::SUCCESS;
             }
             $question = new ChoiceQuestion('Which addon do you want to build the assets for? ', array_keys($enabledAddons));


### PR DESCRIPTION
DX PR to allow frontend assets to be build for a specific addon in a given environment. Might be useful to specifically build addon assets in dev mode. Moreover when the addon name is skipped all enabled addons are suggested to be chosen of

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
