### PR TITLE
fix: T35881 fix path to fix reordering of elements

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Elements/RpcElementsListReorderer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Elements/RpcElementsListReorderer.php
@@ -102,7 +102,7 @@ final class RpcElementsListReorderer implements RpcMethodSolverInterface
         }
         $this->jsonSchemaValidator->validate(
             Json::encode($rpcRequest),
-            DemosPlanPath::getConfigPath('config/json-schema/rpc-elements-list-reorder-schema.json')
+            DemosPlanPath::getConfigPath('json-schema/rpc-elements-list-reorder-schema.json')
         );
     }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35881

If you reordering elements in "Planungsdokumente und Planzeichnung", this will not be saved.

This is the case because: getConfigPath builds a path for the config directory, so 'config' is twice in the path, was caused a failure to get the content of a schema json file.

I removed the config in the relative path string. Now the rearrangement should be saved again.

### How to review/test
reorder elements in "Planungsdokumente und Planzeichnung"

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
