### PR TITLE
F t35878 fix spaces in filenames

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
@@ -32,6 +32,7 @@ use ZipArchive;
 
 use function is_string;
 
+use function Symfony\Component\String\u;
 use const DIRECTORY_SEPARATOR;
 
 class ZipImportService
@@ -134,9 +135,8 @@ class ZipImportService
 
                 $fileInfo = pathinfo($filenameOrig);
 
-                // T5659 only filter filenames for bad chars, do not translit
-                $filename = Utf8::filter($fileInfo['basename']);
-                $dirname = Utf8::filter($fileInfo['dirname']);
+                $filename = u($fileInfo['basename'])->ascii()->replace(' ', '_');
+                $dirname = u($fileInfo['dirname'])->ascii()->replace(' ', '_');
 
                 $user = $this->currentContextProvider->getCurrentUser();
                 $extractDir = $this->getStatementAttachmentImportDir($procedureId, $tempFileFolder, $user);

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
@@ -19,7 +19,6 @@ use demosplan\DemosPlanCoreBundle\Exception\DemosException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
-use Patchwork\Utf8;
 use Psr\Log\LoggerInterface;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
@@ -30,8 +30,8 @@ use Webmozart\Assert\InvalidArgumentException;
 use ZipArchive;
 
 use function is_string;
-
 use function Symfony\Component\String\u;
+
 use const DIRECTORY_SEPARATOR;
 
 class ZipImportService
@@ -41,6 +41,7 @@ class ZipImportService
     private const IMPORT_FILE_TYPES_TO_NOT_BE_SAVED = [
         'xlsx',
     ];
+
     public function __construct(
         private readonly CurrentContextProvider $currentContextProvider,
         private readonly LoggerInterface $logger,
@@ -53,6 +54,7 @@ class ZipImportService
 
     /**
      * @return array<string, File|SplFileInfo> // Filehash => File || FileName => SplFileInfo
+     *
      * @throws InvalidDataException
      * @throws InvalidArgumentException
      */
@@ -66,7 +68,6 @@ class ZipImportService
             if ($this->finder->hasResults()) {
                 /** @var SplFileInfo $file */
                 foreach ($this->finder as $file) {
-
                     $extension = $file->getExtension();
                     $fileNameParts = explode('_', $file->getFilename());
 
@@ -80,17 +81,16 @@ class ZipImportService
 
                     if (in_array($extension, self::IMPORT_FILE_TYPES_TO_NOT_BE_SAVED, true)) {
                         $fileMap[$fileHash] = $file;
-                        } else {
-
-                            $fileMap[$fileHash] = $this->fileService->saveTemporaryFile(
-                                $file->getRealPath(),
-                                $file->getFilename(),
-                                null,
-                                $procedureId,
-                                FileService::VIRUSCHECK_ASYNC,
-                                $this->fileService->createHash()
-                            );
-                        }
+                    } else {
+                        $fileMap[$fileHash] = $this->fileService->saveTemporaryFile(
+                            $file->getRealPath(),
+                            $file->getFilename(),
+                            null,
+                            $procedureId,
+                            FileService::VIRUSCHECK_ASYNC,
+                            $this->fileService->createHash()
+                        );
+                    }
                 }
             }
 
@@ -113,7 +113,6 @@ class ZipImportService
 
             throw new DemosException('statement import failed');
         }
-
     }
 
     /**
@@ -194,9 +193,7 @@ class ZipImportService
         $tmpDir = DemosPlanPath::getTemporaryPath($user->getId().'/'.$procedureId.'/'.$tempFileFolder);
 
         if (!is_dir($tmpDir) && !mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
-            throw new InvalidDataException(
-                'The filename does not exists or is not a directory. Directory was not created'
-            );
+            throw new InvalidDataException('The filename does not exists or is not a directory. Directory was not created');
         }
 
         return $tmpDir;


### PR DESCRIPTION
File names and paths should not contain spaces to avoid errors in file actions like virus scan

https://yaits.demos-deutschland.de/T35878

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
