### PR TITLE
Fix validation of unique statement.internId per procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -1336,11 +1336,20 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
         return $this->externId;
     }
 
-    public function getInternId(): ?string
+    /**
+     * The usual statement pair (original + non original), makes it tricky to ensure
+     * a unique internId per procedure, because these pair is a kind of a copy.
+     * To ensure the interId is actually unique per procedure, the internId will only be stored
+     * at the original statement.
+     * To reduce the mental load, on getting the internId of a statement, the internId of the related
+     * original statement wil be returned by default.
+     * But in some (technically) cases it can be necessary to get the internId of the current statement,
+     * instead of its parent. This can be done by setting the $gettingFromOriginal to false.
+     */
+    public function getInternId(bool $gettingFromOriginal = true): ?string
     {
-        $original = $this->getOriginal();
-        if (null !== $original) {
-            return $original->getInternId();
+        if ($gettingFromOriginal && null !== $this->getOriginal()) {
+            return $this->getOriginal()->getInternId();
         }
 
         return $this->internId;

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -153,7 +153,7 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
                 $statement[self::PUBLIC_STATEMENT] = $publicStatement;
 
                 $generatedOriginalStatement = $this->createNewOriginalStatement($statement, count($this->generatedStatements), $line, $currentWorksheetTitle);
-                //no validation of $generatedOriginalStatement?
+                // no validation of $generatedOriginalStatement?
 
                 $generatedStatement = $this->createCopy($generatedOriginalStatement);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -153,6 +153,8 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
                 $statement[self::PUBLIC_STATEMENT] = $publicStatement;
 
                 $generatedOriginalStatement = $this->createNewOriginalStatement($statement, count($this->generatedStatements), $line, $currentWorksheetTitle);
+                //no validation of $generatedOriginalStatement?
+
                 $generatedStatement = $this->createCopy($generatedOriginalStatement);
 
                 $constraints = $this->statementValidator->validate($generatedStatement, [Statement::IMPORT_VALIDATION]);

--- a/demosplan/DemosPlanCoreBundle/Validator/PrePersistUniqueInternIdConstraintValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/PrePersistUniqueInternIdConstraintValidator.php
@@ -27,9 +27,6 @@ class PrePersistUniqueInternIdConstraintValidator extends ConstraintValidator
     {
     }
 
-    /**
-     * @param mixed $value
-     */
     public function validate($value, Constraint $constraint): void
     {
         $value = $this->validateType($value, $constraint);
@@ -70,7 +67,7 @@ class PrePersistUniqueInternIdConstraintValidator extends ConstraintValidator
         if (\array_key_exists(Statement::class, $identityMap)) {
             $occupyingStatements = array_filter(
                 $identityMap[Statement::class],
-                static fn(Statement $statement) => !($statement instanceof Segment)
+                static fn (Statement $statement) => !($statement instanceof Segment)
                     && !$statement->isOriginal()
                     && $internId === $statement->getInternId()
                     && $statement->getId() !== $excludeStatement->getId()

--- a/demosplan/DemosPlanCoreBundle/Validator/PrePersistUniqueInternIdConstraintValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/PrePersistUniqueInternIdConstraintValidator.php
@@ -35,7 +35,7 @@ class PrePersistUniqueInternIdConstraintValidator extends ConstraintValidator
         $value = $this->validateType($value, $constraint);
 
         $occupiedInSavedEntities = $this->isIdOccupiedInSavedEntities($value);
-        $occupiedByLoadedEntities = $this->isIdOccupiedByLoadedEntities($value->getInternId(), $value);
+        $occupiedByLoadedEntities = $this->isIdOccupiedByLoadedEntities($value->getInternId(false), $value);
         if ($occupiedInSavedEntities || $occupiedByLoadedEntities) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ internId }}', $value->getInternId())
@@ -89,7 +89,7 @@ class PrePersistUniqueInternIdConstraintValidator extends ConstraintValidator
     private function isIdOccupiedInSavedEntities(Statement $value): bool
     {
         return !$this->statementService->isInternIdUniqueForProcedure(
-            $value->getInternId(),
+            $value->getInternId(false),
             $value->getProcedureId()
         );
     }


### PR DESCRIPTION
**Ticket:** [T35878](https://yaits.demos-deutschland.de/T35878)
Bug of Story:[T33577](https://yaits.demos-deutschland.de/T33577)

statement->getInternId() was always return the internId of the related original statement, which is "correct for the application-logic but leads to wrong results on validate data of a specific statement obviously because the data of a different statement was returned.

### How to review/test
Using the "Beteiligungs-Import" (ZipImport) to import a Zip wich statements also has internIds("Eingangsnummern").
In [T35878](https://yaits.demos-deutschland.de/T35878) is a Zip, which covering this case.

Please merge in case of approve.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
