### PR TITLE
feature (ref 35885): use statement parent id except statement id

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -3019,7 +3019,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
     public function createNonOriginalStatement(array $originalStatementData, Statement $newOriginalStatement): Statement
     {
         $fieldsForUpdateStatement = $this->extractFieldsForUpdateStatement($originalStatementData);
-        $copyOfStatement = $this->statementCopier->copyStatementObjectWithinProcedure($newOriginalStatement, false, true);
+        $copyOfStatement = $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($newOriginalStatement, false, true);
 
         // Some values should only be set on copied statement instead of OriginalStatement itself:
         $this->createVotesOnCreateStatement(

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
@@ -232,7 +232,7 @@ abstract class AbstractStatementResourceType extends DplanResourceType
             $this->createToManyRelationship($this->files)
                 ->readable(false, function (Statement $statement): ?array {
                     // files need to be fetched via Filecontainer
-                    $files = $this->fileService->getEntityFiles(Statement::class, $statement->getId(), 'file');
+                    $files = $this->fileService->getEntityFiles(Statement::class, $statement->getParentId(), 'file');
                     if (0 === count($files)) {
                         return null;
                     }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AbstractStatementResourceType.php
@@ -232,7 +232,7 @@ abstract class AbstractStatementResourceType extends DplanResourceType
             $this->createToManyRelationship($this->files)
                 ->readable(false, function (Statement $statement): ?array {
                     // files need to be fetched via Filecontainer
-                    $files = $this->fileService->getEntityFiles(Statement::class, $statement->getParentId(), 'file');
+                    $files = $this->fileService->getEntityFiles(Statement::class, $statement->getId(), 'file');
                     if (0 === count($files)) {
                         return null;
                     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35885 
https://yaits.demos-deutschland.de/T35896

Description: Because attachment files stored in parent of statement, we should call it except statement. In file container entity, files stored with statement parent ID as an entity_id.

### How to review/test
Browser or code review

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
