### PR TITLE
Fix(T35897): no layer available after fetch capabilities

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -413,9 +413,12 @@ export default {
 
       externalApi(url)
         .then(response => {
+          return response.text()
+        })
+        .then(text => {
           this.serviceType = hasWMTSType ? 'wmts' : 'wms'
           parser = this.serviceType === 'wmts' ? new WMTSCapabilities() : new WMSCapabilities()
-          this.currentCapabilities = parser.read(response.data)
+          this.currentCapabilities = parser.read(text)
 
           if (this.currentCapabilities !== null) {
             this.version = this.currentCapabilities.version

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -418,7 +418,7 @@ export default {
         .then(text => {
           this.serviceType = hasWMTSType ? 'wmts' : 'wms'
           parser = this.serviceType === 'wmts' ? new WMTSCapabilities() : new WMSCapabilities()
-          this.currentCapabilities = parser.read(text)
+          this.currentCapabilities = parser.read(capabilities)
 
           if (this.currentCapabilities !== null) {
             this.version = this.currentCapabilities.version

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -415,7 +415,7 @@ export default {
         .then(response => {
           return response.text()
         })
-        .then(text => {
+        .then(capabilities => {
           this.serviceType = hasWMTSType ? 'wmts' : 'wms'
           parser = this.serviceType === 'wmts' ? new WMTSCapabilities() : new WMSCapabilities()
           this.currentCapabilities = parser.read(capabilities)


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35897

**Description:** This PR fixes the issue with the fetch request that occurs after refactoring externalApi method from axios to fetch. All processing that depends on the text being read from the URL should be in the final 'then' clause of the fetch.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
