### PR TITLE
feature (ref 26430): chnage method of route from get to post

### DIFF
--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -262,7 +262,7 @@ export default {
 
     exportProcedures (event) {
       if (dpconfirm(Translator.trans('check.entries.marked.export'))) {
-        this.$refs.procedureForm.method = 'get'
+        this.$refs.procedureForm.method = 'post'
         this.$refs.procedureForm.action = Routing.generate('DemosPlan_procedures_export')
       } else {
         event.preventDefault()

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -262,7 +262,7 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
         path: '/verfahren/export',
         name: 'DemosPlan_procedures_export',
         options: ['expose' => true],
-        methods: ['GET']
+        methods: ['POST']
     )]
     public function exportProceduresAction(ExportService $exportService, Request $request): Response
     {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T26430

Description: Change the method of route from GET to POST, because of the error 401 (Long URL) for export all of procedures

### How to review/test
export all procedures in UI or Code review

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
