### PR TITLE
feature (ref 35950): remove token from twig, because csrf token in em…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
@@ -50,7 +50,7 @@ class DemosPlanMailController extends BaseController
         $mailsCount = $submitterService->getStatementMailAddressesCountForProcedure($procedureId);
 
         $formOptions = [
-            'csrf_protection'    => false,
+            'csrf_protection'    => true,
             'allow_extra_fields' => false,
         ];
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
@@ -31,8 +31,6 @@ class DemosPlanMailController extends BaseController
      *
      * @param string $procedureId
      *
-     * @return Response
-     *
      * @throws Exception
      */
     #[Route(name: 'dplan_procedure_mail_send_all_submitters_view', path: '/verfahren/{procedureId}/mail', methods: ['HEAD', 'GET'])]
@@ -113,7 +111,6 @@ class DemosPlanMailController extends BaseController
      * TODO: add parameterchecks.
      *
      * @param string $key
-     * @param mixed  $value
      */
     protected function saveSerializedInSession($key, $value, Request $request)
     {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_email.html.twig
@@ -7,6 +7,7 @@
     action="{{ path('dplan_procedure_mail_send_all_submitters_send', {'procedureId': templateVars.procedureId}) }}"
     method="post"
     data-dp-validate>
+    <input type="hidden" name="_token" value="{{ templateVars.form._token.vars.value }}" />
 
     <fieldset>
         <legend>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_email.html.twig
@@ -7,7 +7,6 @@
     action="{{ path('dplan_procedure_mail_send_all_submitters_send', {'procedureId': templateVars.procedureId}) }}"
     method="post"
     data-dp-validate>
-    {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
 
     <fieldset>
         <legend>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35950

Description: Because CSRF Token in email form is false (DemosPlanMailController:53), we don't need anymore include CSRF in Twig.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
