### PR TITLE
chore: bump demosplan-ui v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0.3.3",
+    "@demos-europe/demosplan-ui": "^0.3.4",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,10 +1365,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.3.3.tgz#aeb1191b860b5fd6b5f32823df19ef963daf2efb"
-  integrity sha512-YDBJOheHL55LSsh8GfenRdBekY5EcPc8LM3IpHikcco/MkJ1+gziiHpwodeckprqqss8JsbgIRhR7nCangsO3g==
+"@demos-europe/demosplan-ui@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.3.4.tgz#de2ca8687dbf52d634fe674931f8c6965d904791"
+  integrity sha512-5oqnXPLvKPEqiEDGDuymGXsqJzhHkyb9IqWULHJu1u1278+FO2zFF3RxJevZzFEb15Tisv71t3zJ5F4wlJ66ew==
   dependencies:
     "@braintree/sanitize-url" "^7.0.0"
     "@floating-ui/dom" "^1.4.5"


### PR DESCRIPTION
This PR bumps the `demosplan-u`i to the current version 0.3.4