### PR TITLE
B(T35949): adjustments in core for DpApi method

### DIFF
--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -236,7 +236,7 @@ export default {
           procedureId: this.procedureId,
           include: ['assignee', 'statements'].join()
         }),
-        data: JSON.stringify(payload)
+        data: payload
       })
         .then(checkResponse)
         .then(response => {

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -47,7 +47,7 @@ export default function AssessmentTable () {
 
     return dpApi({
       method: 'POST',
-      data: JSON.stringify(inputFields),
+      data: inputFields,
       responseType: 'json',
       url: Routing.generate(
         'dplan_api_procedure_update_filter_hash',

--- a/client/js/lib/statement/AssessmentTableOriginal.js
+++ b/client/js/lib/statement/AssessmentTableOriginal.js
@@ -34,7 +34,7 @@ export default function AssessmentTableOriginal () {
 
     return dpApi({
       method: 'POST',
-      data: JSON.stringify(inputFields),
+      data: inputFields,
       responseType: 'json',
       url: Routing.generate('dplan_api_procedure_update_original_filter_hash', { procedureId })
     }).then(checkResponse)


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35949, https://yaits.demos-deutschland.de/T35898

**Description:** [After refactoring the DpApi method](https://github.com/demos-europe/demosplan-ui/pull/506), which now includes stringification of the body, some adjustments are needed in the core since body `stringify()` is no longer required there.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
