### PR TITLE
fix(refs T35941): enable editor to update after save

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -563,7 +563,11 @@
                     With tiptap we can set obscure as prop always when the obscure button should be visible in the field,
                     because the permission check (featureObscureText) takes place in tiptap
                     -->
+                <dp-loading
+                  v-if="reloadStatementEditor"
+                  class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2 border--right" />
                 <editable-text
+                  v-else
                   class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2 border--right"
                   title="statement"
                   :procedure-id="procedureId"
@@ -584,7 +588,11 @@
                 <!--
                   Recommendation text
                -->
+                <dp-loading
+                  v-if="reloadRecommendationEditor"
+                  class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2" />
                 <editable-text
+                  v-else
                   class="u-pb-0_25 u-pl-0_5 u-pt-0_25 u-1-of-2"
                   title="recommendation"
                   :procedure-id="procedureId"
@@ -751,7 +759,7 @@
 </template>
 
 <script>
-import { dpApi, formatDate, hasOwnProp, VPopover } from '@demos-europe/demosplan-ui'
+import { dpApi, DpLoading, formatDate, hasOwnProp, VPopover } from '@demos-europe/demosplan-ui'
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
 import { Base64 } from 'js-base64'
 import DpClaim from '../DpClaim'
@@ -770,6 +778,7 @@ export default {
     DpItemRow,
     DpEditFieldMultiSelect,
     DpEditFieldSingleSelect,
+    DpLoading,
     DpFragmentsSwitcher: () => import(/* webpackChunkName: "dp-fragments-switcher" */ './DpFragmentsSwitcher'),
     EditableText,
     TableCardFlyoutMenu,
@@ -809,7 +818,9 @@ export default {
       tab: this.$store.state.assessmentTable.currentTableView === 'fragments' ? 'fragments' : 'statement',
       updatingClaimState: false,
       fragmentsLoading: false,
-      placeholderStatementId: null
+      placeholderStatementId: null,
+      reloadRecommendationEditor: false,
+      reloadStatementEditor: false
     }
   },
 
@@ -1086,6 +1097,14 @@ export default {
       return payload
     },
 
+    reloadEditorOnSave (fieldName, value) {
+      if (fieldName === 'text') {
+        this.reloadStatementEditor = value
+      } else if (fieldName === 'recommendation') {
+        this.reloadRecommendationEditor = value
+      }
+    },
+
     resetRelatedFields () {
       if (this.elementHasParagraphs && this.$refs.paragraph) {
         this.resetSelectedParagraph()
@@ -1113,6 +1132,7 @@ export default {
      * @param fieldName {String} - the name of the property as sent to BE
      */
     saveStatement (data, propType, fieldName) {
+      this.reloadEditorOnSave(fieldName, true)
       const payload = this.preparePayload(data, propType, fieldName)
       this.$emit('statement:updated')
       //  ##### Fire store action #####
@@ -1179,6 +1199,8 @@ export default {
 
         // Used in DpVersionHistory to update items in version history sidebar
         this.$root.$emit('entity:updated', this.statementId, 'statement')
+        this.reloadEditorOnSave(fieldName, false)
+
         return updatedField
       }).then(updatedField => {
         this.$root.$emit('entityTextSaved:' + this.statementId, { entityId: this.statementId, field: updatedField }) // Used in EditableText.vue to update short and full texts

--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -774,12 +774,12 @@ export default {
 
   components: {
     DpClaim,
-    DpFragmentList: () => import(/* webpackChunkName: "dp-fragment-list" */ './DpFragmentList'),
-    DpItemRow,
     DpEditFieldMultiSelect,
     DpEditFieldSingleSelect,
-    DpLoading,
+    DpFragmentList: () => import(/* webpackChunkName: "dp-fragment-list" */ './DpFragmentList'),
     DpFragmentsSwitcher: () => import(/* webpackChunkName: "dp-fragments-switcher" */ './DpFragmentsSwitcher'),
+    DpItemRow,
+    DpLoading,
     EditableText,
     TableCardFlyoutMenu,
     VPopover


### PR DESCRIPTION
### Ticket:
https://yaits.demos-deutschland.de/T35941

### Description:
The reactivity was an issue when updating a statement or recommendation text, the change was only visible when re-loading the page hence the component will be forced to remount with the updated data. It was not possible to establish a proper reactivity with the statement or recommendation store objects due to a lot of internal processing of the texts. Since this problem disappears when the component remounts (e.g. on page reload) I decided it would be a valid solution 

- Enhances the behavior of the component after statement text or recommendation text has been adjusted
- Adds a loading spinner when updating one of the editors
- Adds styling to loading spinner to keep the design and not break the view while loading

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- checkout branch
- navigate to A-table in regio project as FPA user
- change statement or recommendation text via editor, save and make sure everything works without a page reload
![image](https://github.com/demos-europe/demosplan-core/assets/91727189/e74341d9-c91b-41e9-83c7-12187928be37)

Delete the checkbox if it doesn't apply/isn't necessary.
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
