### PR TITLE
fix(T35874): add white space wrapping for the procedure name

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -109,7 +109,7 @@
                         {# Name of procedure #}
                         <div class="flow-root border--top">
                             {% if proceduresettings.name|default != '' %}
-                                <span class="o-hellip--nowrap color--grey inline-block u-pt-0_5 u-mb-0_25 u-pr-2">
+                                <span class="color--grey inline-block u-pt-0_5 u-mb-0_25">
                                     {{ proceduresettings.name|default }}
                                 </span>
                             {% else %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35874

**Description:** This PR fixes an issue where the procedure name is long or the screen width is small, allowing the name to wrap onto the next line.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
