### PR TITLE
Fix(T35990): badge position

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -131,7 +131,7 @@
                   :text="Translator.trans('segment.oracle.tooltip')" />
                 <dp-badge
                   v-if="activeId === 'oracleRec'"
-                  class="absolute right-12"
+                  class="absolute right-4"
                   size="smaller"
                   :text="Translator.trans('segment.oracle.beta')"
                   v-tooltip="Translator.trans('segment.oracle.beta.tooltip')" />


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35990

**Description:** The badge component had excessive space on the right. It was changed from 320px to 24px.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
