### PR TITLE
chore: update headers to match http2 standard

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Application/Header.php
+++ b/demosplan/DemosPlanCoreBundle/Application/Header.php
@@ -14,7 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Application;
 
 class Header
 {
-    final public const FILE_HASH = 'X-Demosplan-File-Hash';
-    final public const FILE_ID = 'X-Demosplan-File-Id';
-    final public const PROCEDURE_ID = 'X-Demosplan-Procedure-Id';
+    final public const FILE_HASH = 'x-demosplan-file-hash';
+    final public const FILE_ID = 'x-demosplan-file-id';
+    final public const PROCEDURE_ID = 'x-demosplan-procedure-id';
 }

--- a/demosplan/DemosPlanCoreBundle/Application/Header.php
+++ b/demosplan/DemosPlanCoreBundle/Application/Header.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Application;
 
 /**
  * Should be lowercase.
+ *
  * @see https://httpwg.org/specs/rfc7540.html#HttpHeaders
  */
 class Header

--- a/demosplan/DemosPlanCoreBundle/Application/Header.php
+++ b/demosplan/DemosPlanCoreBundle/Application/Header.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Application;
 
+/**
+ * Should be lowercase.
+ * @see https://httpwg.org/specs/rfc7540.html#HttpHeaders
+ */
 class Header
 {
     final public const FILE_HASH = 'x-demosplan-file-hash';


### PR DESCRIPTION
http2 Standard needs headers to be lowercase. We should adopt this standard. https://httpwg.org/specs/rfc7540.html#HttpHeaders

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
