### PR TITLE
fix(refs:T36011): the resourceType was incorrect

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -241,7 +241,7 @@ export default {
     },
 
     claimSegment (segment) {
-      const dataToUpdate = { ...segment, ...{ relationships: { ...segment.relationships, ...{ assignee: { data: { type: 'User', id: this.currentUser.id } } } } } }
+      const dataToUpdate = { ...segment, ...{ relationships: { ...segment.relationships, ...{ assignee: { data: { type: 'AssignableUser', id: this.currentUser.id } } } } } }
       this.setSegment({ ...dataToUpdate, id: segment.id, group: null })
 
       const payload = {
@@ -251,7 +251,7 @@ export default {
           relationships: {
             assignee: {
               data: {
-                type: 'User',
+                type: 'AssignableUser',
                 id: this.currentUser.id
               }
             }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36011

### Description:
- the type was incorrect, so the segment was unclaimable 

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
