### PR TITLE
feature (ref 36035): remove second calling method

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -195,8 +195,6 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 $entity = $this->getEntity($entityIdentifier);
                 $success = $this->statementDeleter->deleteStatementObject($entity);
                 Assert::true($success, "Deletion of statement failed for the given ID '$entityIdentifier'");
-
-                parent::deleteEntity($entityIdentifier);
             }
         );
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36035

Description: remove second call for delete entity in statementResourceType


- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
