### PR TITLE
bug(refs T35883): Remove unnecessary title prop

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_split_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_split_statement.html.twig
@@ -11,8 +11,7 @@
         'procedureId': procedure,
         'statementId': statementId,
         'statementExternId': statementExternId,
-        'procedureName': procedureName,
-        'title': title
+        'procedureName': procedureName
         }
     %}
     <addon-wrapper


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35883

We don't need the title in the addon. It is only used as page title. If we include it as a prop, the title is added automatically as an attribute to the outer div of the addon component and displayed as tooltip on hover, because the component has no title prop.

### How to review/test
Verfahren -> STN aufteilen -> The statement text shouldn't show a tooltip on hover