### PR TITLE
fix(T36027): issue with elements in the OriginalStatementsTableItem component

### DIFF
--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -241,16 +241,15 @@ export default {
 
     element () {
       let elementTitle = ''
+      const element = this.statement.elementId ? this.elements.find((el) => el.id === this.statement.elementId) : null
 
-      if (hasOwnProp(this.statement, 'elements') && this.statement.elements.title !== '') {
-        elementTitle = this.statement.elements.title
+      if (element) {
+        elementTitle = element.title
         if (hasOwnProp(this.statement, 'document') && this.statement.document.title !== '') {
           elementTitle += ` / ${this.statement.document.title}`
         }
       } else {
-        const element = this.statement.elementId ? this.elements.find((el) => el.id === this.statement.elementId) : null
-
-        elementTitle = element ? element.title : Translator.trans('notspecified')
+        elementTitle = Translator.trans('notspecified')
       }
 
       if (hasOwnProp(this.statement, 'paragraph')) {

--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -243,7 +243,7 @@ export default {
       let elementTitle = ''
       const element = this.statement.elementId ? this.elements.find((el) => el.id === this.statement.elementId) : null
 
-      if (element) {
+      if (element && hasOwnProp(element, 'title')) {
         elementTitle = element.title
         if (hasOwnProp(this.statement, 'document') && this.statement.document.title !== '') {
           elementTitle += ` / ${this.statement.document.title}`

--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -243,7 +243,7 @@ export default {
       let elementTitle = ''
       const element = this.statement.elementId ? this.elements.find((el) => el.id === this.statement.elementId) : null
 
-      if (element && hasOwnProp(element, 'title')) {
+      if (element && element.title !== '') {
         elementTitle = element.title
         if (hasOwnProp(this.statement, 'document') && this.statement.document.title !== '') {
           elementTitle += ` / ${this.statement.document.title}`


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36027

**Description:** Refactor the code to follow the same logic as in the `DpAssessmentTableCard` component (`line: 469 - 470`):
 utilize `statement.elementId` to identify the corresponding element in the elements list from the `assessmentTable` store.

`statement.elements` often lacks a value, either being an empty array or containing only one item. This adjustment is made to minimize the use of IF checks as well.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
