### PR TITLE
F t36053 files on statement copy

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -2860,6 +2860,9 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         }
     }
 
+    /**
+     * Used on create a manual statement.
+     */
     public function newStatement(array $data, bool $isDataInput = false)
     {
         // tackle legacy structure

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -560,7 +560,11 @@ class StatementService extends CoreService implements StatementServiceInterface
             $this->statementAttributeRepository->copyStatementAttributes($draftStatement, $originalStatement);
 
             // Create a statement copy for the assessment table
-            $assessableStatement = $this->statementCopier->copyStatementObjectWithinProcedure($originalStatement, false);
+            $assessableStatement = $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles(
+                $originalStatement,
+                false,
+                true
+            );
 
             $assessableStatement = $this->postSubmitDraftStatement($assessableStatement, $draftStatement);
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36053

On coping a original statement (due to submit a draftStatement), the related files, were missing on coping the statement from the original statement.

### How to review/test
Create and submit a new statement within attachements/files.
All of them should be appearing on the created original statement as well as on the "normal" statement.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
