### PR TITLE
feat (refs T27469): Filter by unassigned segments.

### DIFF
--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -239,6 +239,8 @@ export default {
 
     /**
      * Construct the query object to be passed into vuex-json-api call.
+     * if the id is unassigned, then set the operator to IS NULL so that only segments with assignee null are taking.
+     * That is because the BE uses Elastic Search to make the filtering
      */
     filter () {
       const filter = {}
@@ -247,7 +249,7 @@ export default {
           condition: {
             path: this.path,
             value: id,
-            operator: this.operator
+            operator: id === "unassigned"? "IS NULL" : this.operator
           }
         }
       })
@@ -399,6 +401,11 @@ export default {
                 this.$set(this.itemsObject, el.id, el)
               }
             })
+
+            // If the current filter is assignee, display amount of Segments that have assignee as null. That is given by the field missingResourcesSum
+            if (result.data[0].attributes.path === 'assignee') {
+              this.$set(this.itemsObject, "unassigned", { attributes: { count: result.data[0].attributes.missingResourcesSum , label: Translator.trans('not.assigned'), ungrouped : true,  selected: result.meta['unassigned_selected']} , id: "unassigned", type: "AggregationFilterItem", ungrouped : true})
+            }
           }
         })
         .catch(err => console.log(err))

--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -403,8 +403,18 @@ export default {
             })
 
             // If the current filter is assignee, display amount of Segments that have assignee as null. That is given by the field missingResourcesSum
-            if (result.data[0].attributes.path === 'assignee') {
-              this.$set(this.itemsObject, "unassigned", { attributes: { count: result.data[0].attributes.missingResourcesSum , label: Translator.trans('not.assigned'), ungrouped : true,  selected: result.meta['unassigned_selected']} , id: "unassigned", type: "AggregationFilterItem", ungrouped : true})
+             if (result.data[0].attributes.path === 'assignee') {
+              this.$set(this.itemsObject, 'unassigned', {
+                attributes: {
+                  count: result.data[0].attributes.missingResourcesSum,
+                  label: Translator.trans('not.assigned'),
+                  ungrouped: true,
+                  selected: result.meta.unassigned_selected
+                },
+                id: 'unassigned',
+                type: 'AggregationFilterItem',
+                ungrouped: true
+              })
             }
           }
         })

--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -249,7 +249,7 @@ export default {
           condition: {
             path: this.path,
             value: id,
-            operator: id === "unassigned"? "IS NULL" : this.operator
+            operator: id === 'unassigned' ? 'IS NULL' : this.operator
           }
         }
       })

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcSegmentFacetsProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcSegmentFacetsProvider.php
@@ -79,6 +79,17 @@ class RpcSegmentFacetsProvider implements RpcMethodSolverInterface
                 $item = $this->resourceService->makeCollection($aggregationFilterType, AggregationFilterTypeTransformer::class);
                 $jsonArray = $this->resourceService->getFractal()->createData($item)->toArray();
                 $jsonArray['meta']['count'] = $apiListResult->getResultCount();
+
+                /**
+                 * When the user selects a filter, the BE uses ElasticSearch facets to create the filters and answers back the FE with the given filter id and the property selected = true (see here demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Facet\FacetFactory.php method createAggregationFilterItems)
+                 * When filtering for assignee NULL, there is no id, consequently there is not Facet for this filter.
+                 * Because NULL filters lack an id, the BE can't inform the FE that this filter (assignee == NULL) has been selected.
+                 * To address this, we include information about the NULL filter in the meta (metadata) of the RPC request: $jsonArray['meta']['unassigned_selected']
+                 * This way, the FE is notified that a NULL filter for a assignee is selected, even though it doesn't have an id.
+                 */
+
+                $jsonArray['meta']['unassigned_selected'] = property_exists($rpcRequest->params->filter, 'unassigned');
+
                 $resultResponse[] = $this->generateMethodResult($rpcRequest, $jsonArray);
             } catch (InvalidArgumentException|InvalidSchemaException) {
                 $resultResponse[] = $this->errorGenerator->invalidParams($rpcRequest);

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcSegmentFacetsProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/RpcSegmentFacetsProvider.php
@@ -80,7 +80,7 @@ class RpcSegmentFacetsProvider implements RpcMethodSolverInterface
                 $jsonArray = $this->resourceService->getFractal()->createData($item)->toArray();
                 $jsonArray['meta']['count'] = $apiListResult->getResultCount();
 
-                /**
+                /*
                  * When the user selects a filter, the BE uses ElasticSearch facets to create the filters and answers back the FE with the given filter id and the property selected = true (see here demosplan\DemosPlanCoreBundle\Logic\ApiRequest\Facet\FacetFactory.php method createAggregationFilterItems)
                  * When filtering for assignee NULL, there is no id, consequently there is not Facet for this filter.
                  * Because NULL filters lack an id, the BE can't inform the FE that this filter (assignee == NULL) has been selected.


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27469

Description:
It is possible to filter by unassigned segments. This needs adjustments in the FE and in the BE.
The BE uses Elastic Search with Facets to group by assignee ids. Given that filtering segments by assignee = NULL is not possible using Facets, there is the need of the FE to send a particular filter using "IS NULL".
The BE is supposed to tell FE what filter was selected based on the assignee id. Given that there is not assigneeId, a new meta field was introduced in the RPC request to let the FE know that unassigned filter was selected.

### How to review/test
- Go to Regio > select a Prcoedure (Verfahren), and then Abschnitten
- Select Bearbeiter*in filter (in each filter should be the number of segmenter corresponding to the filter)
-- Select an assignee
-- Select Nicht zugewiesen (this is the new feature)
- Click on Anwenden and see if the segments are displayed properly

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Update documentation
- [x] Move the tickets on the board accordingly
