### PR TITLE
feature (refs T35857): adjust userSettings E-mail notification checkbox state for first visitors

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -361,13 +361,17 @@ class DemosPlanUserController extends BaseController
 
         // get User settings
         $templateVars['emailNotificationReleasedStatement'] = false;
+        // by default coordinator gets mails, if not explicitly denied
+        if ($user->hasRole(Role::PUBLIC_AGENCY_COORDINATION)) {
+            $templateVars['emailNotificationReleasedStatement'] = true;
+        }
 
         $settings = $contentService->getSettings(
             'emailNotificationReleasedStatement',
             SettingsFilter::whereUser($user)->lock(),
             false
         );
-        // by default coordinator gets mails, if not explicitly denied
+
         if (is_array($settings) && 1 === count($settings)) {
             $templateVars['emailNotificationReleasedStatement'] = $settings[0]->getContentBool();
         }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T35857

Description:
adjust userSettings E-mail notification checkbox state for first visitors
of the settings-page

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
