### PR TITLE
fix (refs T36081): remove unnecessary quoting

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/SegmentRepository.php
@@ -114,9 +114,6 @@ class SegmentRepository extends CoreRepository
             return;
         }
 
-        // wrap the given text in quotes so the DB handles it as string instead of an expression
-        $recommendationText = "'$recommendationText'";
-
         $qb = $this->getEntityManager()->createQueryBuilder();
         $value = $attach
             ? $qb->expr()->concat('segment.recommendation', ':recommendationText')


### PR DESCRIPTION
Pre-T35348 the text was passed directly into the DQL query, which required quoting it. After the corresponding fix that passes the text value as DQL parameter, this quoting is no longer necessary and in fact results in quotes added to the text itself.

<!-- **Ticket:** https://yaits.demos-deutschland.de/Txxyyzz -->

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
