### PR TITLE
Harden file downloads

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -62,7 +62,7 @@ class FileController extends BaseController
     /**
      * @throws Exception
      */
-    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, ?string $procedureId = null): Response
+    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, string $procedureId = null): Response
     {
         $fs = new Filesystem();
         // @improve T14122

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -36,7 +36,7 @@ class FileController extends BaseController
     public function fileAction(FileService $fileService, string $hash)
     {
         try {
-            return $this->prepareResponseWithHash($fileService, $hash);
+            return $this->prepareResponseWithHash($fileService, $hash, true);
         } catch (Exception $e) {
             $this->getLogger()->info('Could not serve file: ', [$e]);
             throw new NotFoundHttpException();

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/includes/item/files.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/includes/item/files.html.twig
@@ -16,7 +16,7 @@
                                 class="u-pr-0_5 o-hellip"
                                 target="_blank"
                                 rel="noopener"
-                                href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                                href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': statement.procedure.id }) }}">
                                 {{ file|getFile('name') }}
                             </a>
                         {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_cluster_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_cluster_detail_statement_data.html.twig
@@ -525,7 +525,7 @@
                                     title="{{ file|getFile('name') }}"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                                    href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': statement.procedure.id }) }}">
                                     <i class="fa fa-file-o"></i> {{ file|getFile('name') }}
                                 </a>
                             {% else %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement.html.twig
@@ -189,7 +189,7 @@
                                                         title="{{ file|getFile('name') }}"
                                                         target="_blank"
                                                         rel="noopener"
-                                                        href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                                                        href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': statement.procedure.id }) }}">
                                                         <i class="fa fa-file-o" aria-hidden="true"></i> {{ file|getFile('name') }}
                                                     </a>
                                                     {% set fileContainer = templateVars['fileHashToFileContainerMapping'][file|getFile('hash')]|default(false) %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -1143,7 +1143,7 @@
                                     title="{{ source_stn.file.name|default }}"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    href="{{ path("core_file", { 'hash': source_stn.file.hash|default }) }}">
+                                    href="{{ path("core_file_procedure", { 'hash': source_stn.file.hash|default, 'procedureId': procedure }) }}">
                                     <i class="fa fa-file-o"></i> {{ source_stn.file.filename|default }}
                                 </a>
                                 {% if not readonly %}
@@ -1211,7 +1211,7 @@
                                             title="{{ file|getFile('name') }}"
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                                            href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': procedure }) }}">
                                             <i class="fa fa-file-o"></i> {{ file|getFile('name') }}
                                         </a>
                                         {% if not readonly %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -39,8 +39,13 @@
                 </p>
                 <div class="u-mb-0_5">
                     {% if gislayer.legend is defined and gislayer.legend != '' %}
+                        {#
+                            global gis layer can use core_file_procedure as check for procedure
+                            is automatically skipped, when no procedure is saved at the file.
+                            It is better to use core_file_procedure here as it checks the procedure permissions and declines the access to the file via this route.
+                        #}
                         <a
-                            href="{{ path("core_file", { 'hash': gislayer.legend|getFile('hash') }) }}"
+                            href="{{ path("core_file_procedure", { 'hash': gislayer.legend|getFile('hash'), 'procedureId': procedure }) }}"
                             target="_blank"
                             rel="noopener">
                             <i class="fa fa-file-o"></i>
@@ -158,7 +163,7 @@
                         </p>
                         <div class="u-mb-0_5">
                             <a
-                                href="{{ path("core_file", { 'hash': gislayer.legend|getFile('hash') }) }}"
+                                href="{{ path("core_file_procedure", { 'hash': gislayer.legend|getFile('hash'), 'procedureId': procedure }) }}"
                                 target="_blank"
                                 rel="noopener">
                                 <i class="fa fa-file-o"></i>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
@@ -70,6 +70,7 @@
                 </p>
                 <div class="u-mb-0_5">
                     <a
+                        {# a global gis layer can not us core_file_procedure as no procedure is defined #}
                         href="{{ path("core_file", { 'hash': gislayer.legend|getFile('hash') }) }}"
                         target="_blank"
                         rel="noopener">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
@@ -40,7 +40,7 @@
                                     class="o-hellip"
                                     target="_blank"
                                     rel="noopener"
-                                    href="{{ path("core_file", { 'hash': templateVars.procedure.settings.planDrawPDF|getFile('hash') }) }}">
+                                    href="{{ path("core_file_procedure", { 'hash': templateVars.procedure.settings.planDrawPDF|getFile('hash'), 'procedureId': procedure }) }}">
                                     {{ templateVars.procedure.settings.planDrawPDF|getFile('name') }}
                                 </a>
                                 <p>
@@ -63,7 +63,7 @@
                                     class="o-hellip"
                                     target="_blank"
                                     rel="noopener"
-                                    href="{{ path("core_file", { 'hash': templateVars.procedure.settings.planPDF|getFile('hash') }) }}">
+                                    href="{{ path("core_file_procedure", { 'hash': templateVars.procedure.settings.planPDF|getFile('hash'), 'procedureId': procedure }) }}">
                                     {{ templateVars.procedure.settings.planPDF|getFile('name') }}
                                 </a>
                                 <p>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -875,7 +875,7 @@
                                             <a
                                                 target="_blank"
                                                 rel="noopener"
-                                                href="{{ path("core_file", { 'hash': proceduresettings.settings.pictogram|getFile('hash') }) }}">
+                                                href="{{ path("core_file_procedure", { 'hash': proceduresettings.settings.pictogram|getFile('hash'), 'procedureId': procedure }) }}">
                                                 {{ proceduresettings.settings.pictogram|getFile('name') }}
                                             </a>
                                         {% else %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
@@ -170,7 +170,7 @@
                         <a
                             target="_blank"
                             rel="noopener"
-                            href="{{ path("core_file", { 'hash': proceduresettings.settings.pictogram|getFile('hash') }) }}">
+                            href="{{ path("core_file_procedure", { 'hash': proceduresettings.settings.pictogram|getFile('hash'), 'procedureId': procedure }) }}">
                             {{ proceduresettings.settings.pictogram|getFile('name') }}
                         </a>
                     {% else %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/public_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/public_statement.html.twig
@@ -170,7 +170,7 @@
                             class="{{ 'u-ml-0_25 u-mb-0_25 inline-block'|prefixClass }}"
                             target="_blank"
                             rel="noopener"
-                            href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                            href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': procedure }) }}">
                             <i class="{{ 'fa fa-download u-mr-0_25'|prefixClass }}"></i>
                             {{ 'file.download' | trans }}
                             {% if (file|getFile('size')|length > 0) %}
@@ -182,7 +182,7 @@
                             class="{{ 'btn btn--secondary float-right u-ml-0_125'|prefixClass }}"
                             target="_blank"
                             rel="noopener"
-                            href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                            href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': procedure }) }}">
                             {{ 'download'|trans }}
                         </a>
                     </li>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/DemosPlanAssessment/view_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/DemosPlanAssessment/view_statement.html.twig
@@ -467,7 +467,7 @@
                                             title="{{ source_stn.file.name|default('original.pdf'|trans) }}"
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            href="{{ path("core_file", { 'hash': source_stn.file.hash|default }) }}">
+                                            href="{{ path("core_file_procedure", { 'hash': source_stn.file.hash|default, 'procedureId': procedure  }) }}">
                                             {{ source_stn.file.name|default('original.pdf'|trans) }}
                                         </a>
                                     {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/listentry_content.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/listentry_content.html.twig
@@ -83,7 +83,7 @@
                 <a
                     target="_blank"
                     rel="noopener"
-                    href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}">
+                    href="{{ path("core_file_procedure", { 'hash': file|getFile('hash'), 'procedureId': procedure }) }}">
                     {{ file|getFile('name') }}
                 </a><br>
             {% endfor %}


### PR DESCRIPTION
For improved security we should use `core_file_procedure` instead of `core_file` whenever possible. I checked the remaining calls of `core_file` and adjusted them if they are in procedure context. I tested all the cases in the interface

### How to review/test
code review or check the cases in the interface

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
