### PR TITLE
chore: sort addon tags during install via GitHub

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -485,9 +485,12 @@ class AddonInstallFromZipCommand extends CoreCommand
             function ($tag) {
                 return !str_contains($tag['name'], 'rc');
             }
-        )->map(function ($tag) {
-            return $tag['name'];
-        })->toArray();
+            )->map(function ($tag) {
+                return $tag['name'];
+            })
+            ->reverse()
+            ->values()
+            ->toArray();
 
         if (0 === count($tags)) {
             throw new RuntimeException('No tags found for this repository. Please install the addon via --local');
@@ -497,8 +500,6 @@ class AddonInstallFromZipCommand extends CoreCommand
             'Which tag do you want to install? ',
             $tags
         );
-        $tag = $this->getHelper('question')->ask($input, $output, $question);
-
-        return $tag;
+        return $this->getHelper('question')->ask($input, $output, $question);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -465,7 +465,7 @@ class AddonInstallFromZipCommand extends CoreCommand
             throw new RuntimeException('Could not access repository. Did you create a GitHub personal access token?');
         }
         $existingReposContent = $existingReposResponse->getContent(false);
-        $repositories = array_merge($repositories, JSON::decodeToArray($existingReposContent));
+        $repositories = array_merge($repositories, Json::decodeToArray($existingReposContent));
         if (array_key_exists('link', $existingReposResponse->getHeaders())) {
             $links = explode(',', $existingReposResponse->getHeaders()['link'][0]);
             foreach ($links as $link) {
@@ -485,9 +485,9 @@ class AddonInstallFromZipCommand extends CoreCommand
             function ($tag) {
                 return !str_contains($tag['name'], 'rc');
             }
-            )->map(function ($tag) {
-                return $tag['name'];
-            })
+        )->map(function ($tag) {
+            return $tag['name'];
+        })
             ->reverse()
             ->values()
             ->toArray();
@@ -500,6 +500,7 @@ class AddonInstallFromZipCommand extends CoreCommand
             'Which tag do you want to install? ',
             $tags
         );
+
         return $this->getHelper('question')->ask($input, $output, $question);
     }
 }


### PR DESCRIPTION
Newest tag should be show last as the list will grow over time, and it might be inconvenient to scroll up a lot


### How to review/test
beginn to install an addon via `bin/<project> dplan:addon:install --github` and find the most recent tag in the second step below

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
