### PR TITLE
fix(refs T36141): serialize request params

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -836,8 +836,9 @@ export default {
 
           dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), getData, { serialize: true })
             .then(response => {
-              if (response.data.code === 100 && response.data.success) {
-                if (response.data.body !== null) {
+              const parsedData = JSON.parse(response.data)
+              if (parsedData.code === 100 && parsedData.success) {
+                if (parsedData.body !== null) {
                   let popupContent = ''
 
                   //  In Robob, do not show full response body
@@ -853,7 +854,7 @@ export default {
                       popupContent = this.addXMLPartToString(xmlResponse, xmlNeedle, popupContent)
                     }
                   } else {
-                    popupContent = response.data.body
+                    popupContent = parsedData.body
                   }
 
                   if (popupContent.length === 0 || popupContent.match(/<table[^>]*?>[\s\t\n\r↵]*<\/table>/mg) !== null) {

--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -834,7 +834,7 @@ export default {
           //  Add progress indicator (.o-spinner on same element required)
           $popup.find('#popupContent h3').addClass(this.prefixClass('is-progress'))
 
-          dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), getData)
+          dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), getData, { serialize: true })
             .then(response => {
               if (response.data.code === 100 && response.data.success) {
                 if (response.data.body !== null) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36141

As dpApi moved from axios to fetch, params are not added to the request url automagically. As we already have a method to serialize request params of a get request, this can be used.

### How to review/test
Request params for the request described in the ticket should be included again.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
