### PR TITLE
chore: modernize frontcontrollers to match symfony 5.x

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -3,7 +3,7 @@
 parameters:
     locale: "de"
     salt: "JddLn]@xP.NmGGW@&pkv?cBW,tZc5@/GaAENL?/_N@pY,%2z},CZEmnCE(E_RsGRR?+*N}*# UgRS,j[)gkELxS)2wk2@B_v]?r@q,7hS(Za?9]R{*"
-    secret: "IAmOnlyTheDefaultSecretSoChangeMeInProjects"
+    #secret: "IAmOnlyTheDefaultSecretSoChangeMeInProjects"
 
     # logging strategy for monolog, can be either "rotating_file" or "stream"
     logging_strategy: "rotating_file"

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -3,6 +3,7 @@
 parameters:
     locale: "de"
     salt: "JddLn]@xP.NmGGW@&pkv?cBW,tZc5@/GaAENL?/_N@pY,%2z},CZEmnCE(E_RsGRR?+*N}*# UgRS,j[)gkELxS)2wk2@B_v]?r@q,7hS(Za?9]R{*"
+    secret: "IAmOnlyTheDefaultSecretSoChangeMeInProjects"
 
     # logging strategy for monolog, can be either "rotating_file" or "stream"
     logging_strategy: "rotating_file"

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -3,7 +3,6 @@
 parameters:
     locale: "de"
     salt: "JddLn]@xP.NmGGW@&pkv?cBW,tZc5@/GaAENL?/_N@pY,%2z},CZEmnCE(E_RsGRR?+*N}*# UgRS,j[)gkELxS)2wk2@B_v]?r@q,7hS(Za?9]R{*"
-    #secret: "IAmOnlyTheDefaultSecretSoChangeMeInProjects"
 
     # logging strategy for monolog, can be either "rotating_file" or "stream"
     logging_strategy: "rotating_file"

--- a/demosplan/DemosPlanCoreBundle/Application/FrontController.php
+++ b/demosplan/DemosPlanCoreBundle/Application/FrontController.php
@@ -45,7 +45,6 @@ final class FrontController
      */
     public static function bootstrap(): void
     {
-
         (new Dotenv())->bootEnv(DemosPlanPath::getRootPath('.env'));
 
         // Add the Addon autoloader to the spl autoload stack

--- a/demosplan/DemosPlanCoreBundle/Application/FrontController.php
+++ b/demosplan/DemosPlanCoreBundle/Application/FrontController.php
@@ -56,7 +56,7 @@ final class FrontController
      *
      * @throws Exception
      */
-    public static function console(string $activeProject, bool $deprecatedFrontcontroller = false): void
+    public static function bootstrapConsole(): ArgvInput
     {
         if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
@@ -88,6 +88,13 @@ final class FrontController
                 Debug::enable();
             }
         }
+
+        return $input;
+    }
+
+    public static function console(string $activeProject, bool $deprecatedFrontcontroller = false): void
+    {
+        $input = self::bootstrapConsole();
 
         // Add the Addon autoloader to the spl autoload stack
         AddonAutoloading::register();

--- a/tests/backend/core-application/app/config/config_test.yml
+++ b/tests/backend/core-application/app/config/config_test.yml
@@ -23,6 +23,7 @@ parameters:
     database_host: ''
     database_user: ''
     database_password: ''
+    secret: "IAmOnlyTheDefaultSecretSoChangeMeInProjects"
 
     roles_allowed:
         - !php/const demosplan\DemosPlanCoreBundle\Entity\User\Role::BOARD_MODERATOR

--- a/tests/backend/core-application/src/Application/FrontController.php
+++ b/tests/backend/core-application/src/Application/FrontController.php
@@ -29,7 +29,6 @@ class FrontController
      */
     public static function console()
     {
-
         if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
         }
@@ -65,8 +64,5 @@ class FrontController
         $application = new ConsoleApplication($kernel, false);
 
         $application->run($input);
-
-
-
     }
 }

--- a/tests/backend/core-application/src/Application/FrontController.php
+++ b/tests/backend/core-application/src/Application/FrontController.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Tests\CoreApplication\Application;
 
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
-use Exception;
 use demosplan\DemosPlanCoreBundle\Application\FrontController as BasicFrontController;
+use Exception;
 
 class FrontController
 {

--- a/tests/backend/core-application/src/Application/FrontController.php
+++ b/tests/backend/core-application/src/Application/FrontController.php
@@ -13,12 +13,8 @@ declare(strict_types=1);
 namespace Tests\CoreApplication\Application;
 
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Exception;
-use LogicException;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
+use demosplan\DemosPlanCoreBundle\Application\FrontController as BasicFrontController;
 
 class FrontController
 {
@@ -29,36 +25,7 @@ class FrontController
      */
     public static function console()
     {
-        if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-            echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
-        }
-
-        set_time_limit(0);
-
-        require DemosPlanPath::getRootPath('vendor/autoload.php');
-
-        if (!class_exists(ConsoleApplication::class) || !class_exists(Dotenv::class)) {
-            throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
-        }
-
-        $input = new ArgvInput();
-        if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
-            putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
-        }
-
-        if ($input->hasParameterOption('--no-debug', true)) {
-            putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
-        }
-
-        (new Dotenv())->bootEnv(DemosPlanPath::getRootPath('.env'));
-
-        if ($_SERVER['APP_DEBUG']) {
-            umask(0000);
-
-            if (class_exists(Debug::class)) {
-                Debug::enable();
-            }
-        }
+        $input = BasicFrontController::bootstrapConsole();
 
         $kernel = new DemosPlanTestKernel(DemosPlanTestKernel::TEST_PROJECT_NAME, 'test', (bool) $_SERVER['APP_DEBUG']);
         $application = new ConsoleApplication($kernel, false);

--- a/tests/backend/core-application/src/Application/FrontController.php
+++ b/tests/backend/core-application/src/Application/FrontController.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 namespace Tests\CoreApplication\Application;
 
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Exception;
+use LogicException;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 
 class FrontController
@@ -26,18 +29,44 @@ class FrontController
      */
     public static function console()
     {
-        set_time_limit(0);
 
-        $input = new ArgvInput();
-        $debug = '0' !== getenv('SYMFONY_DEBUG') && !$input->hasParameterOption('--no-debug', true);
-
-        if ($debug) {
-            Debug::enable();
+        if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+            echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
         }
 
-        $kernel = new DemosPlanTestKernel(DemosPlanTestKernel::TEST_PROJECT_NAME, 'test', $debug);
+        set_time_limit(0);
+
+        require DemosPlanPath::getRootPath('vendor/autoload.php');
+
+        if (!class_exists(ConsoleApplication::class) || !class_exists(Dotenv::class)) {
+            throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+        }
+
+        $input = new ArgvInput();
+        if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+            putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+        }
+
+        if ($input->hasParameterOption('--no-debug', true)) {
+            putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+        }
+
+        (new Dotenv())->bootEnv(DemosPlanPath::getRootPath('.env'));
+
+        if ($_SERVER['APP_DEBUG']) {
+            umask(0000);
+
+            if (class_exists(Debug::class)) {
+                Debug::enable();
+            }
+        }
+
+        $kernel = new DemosPlanTestKernel(DemosPlanTestKernel::TEST_PROJECT_NAME, 'test', (bool) $_SERVER['APP_DEBUG']);
         $application = new ConsoleApplication($kernel, false);
 
         $application->run($input);
+
+
+
     }
 }


### PR DESCRIPTION
Reimplement changes of https://github.com/symfony/recipes/pull/724/files to our customized frontcontrollers


### How to review/test
Browsercalls as well as commands should work as before

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
