### PR TITLE
chore: remove useless and misleading Interface

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ValueObject/Statement/DraftStatementListFilters.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Statement/DraftStatementListFilters.php
@@ -96,8 +96,6 @@ class DraftStatementListFilters extends ValueObject
     /**
      * Ignore that ValueObject is not locked.
      * We need to modify on filter change.
-     *
-     * @return mixed
      */
     protected function getProperty(?string $name)
     {

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Statement/DraftStatementListFilters.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Statement/DraftStatementListFilters.php
@@ -10,12 +10,10 @@
 
 namespace demosplan\DemosPlanCoreBundle\ValueObject\Statement;
 
-use demosplan\DemosPlanCoreBundle\Exception\NotYetImplementedException;
 use demosplan\DemosPlanCoreBundle\Exception\ValueObjectException;
 use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
-class DraftStatementListFilters extends ValueObject implements ParameterBagInterface
+class DraftStatementListFilters extends ValueObject
 {
     protected $organisationId = '';
     protected $departmentId = '';
@@ -110,21 +108,6 @@ class DraftStatementListFilters extends ValueObject implements ParameterBagInter
         return $this->{$name};
     }
 
-    public function clear()
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    public function add(array $parameters)
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    public function all(): array
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
     public function get($name)
     {
         $fieldMapping = $this->getFieldMapping();
@@ -133,42 +116,9 @@ class DraftStatementListFilters extends ValueObject implements ParameterBagInter
         return $this->getProperty($property);
     }
 
-    public function remove($name)
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    public function set($name, $value)
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
     public function has($name): bool
     {
         return array_key_exists($name, $this->getFieldMapping());
-    }
-
-    public function resolve()
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    public function resolveValue($value)
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    /**
-     * @return mixed
-     */
-    public function escapeValue($value)
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
-    }
-
-    public function unescapeValue($value): mixed
-    {
-        throw new NotYetImplementedException('Not implemented yet.');
     }
 
     protected function getFieldMapping()


### PR DESCRIPTION
`DraftStatementListFilters` should not implement `ParameterBagInterface` and only use get and has as this is misleading and might even confuse dependency injection

### How to review/test
call to draft statement list should work as before

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
