### PR TITLE
F t35807 no feature for sorting planning documents

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -190,11 +190,14 @@ class ElementsService extends CoreService implements ElementsServiceInterface
             $this->getTopElements($procedureId, [], ['title' => $hiddenTitlesArray, 'deleted' => [false]]);
 
         // return IDs only:
-        return collect(array_merge($mapCategories, $hiddenByConfigCategories))->map(
-            fn ($element) =>
-                /* @var Elements $element */
+        return collect(array_merge($mapCategories, $hiddenByConfigCategories))
+            ->sort(fn($elementA, $elementB) => strcasecmp($elementA->getTitle(),$elementB->getTitle()))
+            ->map(
+                fn ($element) =>
+                    /* @var Elements $element */
                 $element->getId()
-        )->toArray();
+            )
+            ->toArray();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -195,7 +195,7 @@ class ElementsService extends CoreService implements ElementsServiceInterface
             ->map(
                 fn ($element) =>
                     /* @var Elements $element */
-                $element->getId()
+                    $element->getId()
             )
             ->toArray();
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2243,6 +2243,10 @@ class StatementService extends CoreService implements StatementServiceInterface
 
         $noManualSortElementsIds = $this->serviceElements->getHiddenElementsIdsForProcedureId($procedureId);
 
+        $this->statementEntityGrouper->sortSubgroupsAtAllLayers(
+            $group,
+            new TitleGroupsSorter()
+        );
         // sorting only needed if there are elements to be moved to the end
         if (0 < count($noManualSortElementsIds)) {
             // sort hidden elements to end: sort elements not manually sortable in the admin list (because hidden) at the end


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35807

### Description: 

- the planning categories and their subgroups are not sorted
- actually its not a bug, its a feature, because sorting was not implemented for planning categories and their subgroups

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
