### PR TITLE
feature (ref 35807): change class KeysAtEndSorter to find excatly pos…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/KeysAtEndSorter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/KeysAtEndSorter.php
@@ -46,13 +46,15 @@ class KeysAtEndSorter implements ArraySorterInterface
         if (0 === count($array)) {
             return $array;
         }
-        foreach ($this->keys as $key) {
-            if (array_key_exists($key, $array)) {
-                $toBePlacedLast = $array[$key];
-                unset($array[$key]);
-                $array[$key] = $toBePlacedLast;
-            }
-        }
+        // Sort array keys based on their position in $this->keys
+        uksort($array, function ($a, $b) {
+            $posA = array_search($a, $this->keys);
+            $posB = array_search($b, $this->keys);
+
+            // If both keys are in $this->keys, compare their positions
+            // If only one key is in $this->keys, prioritize moving it to the end
+            return ($posA && $posB) ? $posA - $posB : ($posB ? -1 : 0);
+        });
 
         return $array;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/KeysAtEndSorter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/KeysAtEndSorter.php
@@ -12,7 +12,6 @@ namespace demosplan\DemosPlanCoreBundle\Logic\AssessmentTable;
 
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use TypeError;
-use function array_key_exists;
 
 /**
  * Class KeysAtEndSorter

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -190,11 +190,13 @@ class ElementsService extends CoreService implements ElementsServiceInterface
             $this->getTopElements($procedureId, [], ['title' => $hiddenTitlesArray, 'deleted' => [false]]);
 
         // return IDs only:
-        return collect(array_merge($mapCategories, $hiddenByConfigCategories))->map(
-            fn ($element) =>
-                /* @var Elements $element */
+        return collect(array_merge($mapCategories, $hiddenByConfigCategories))
+            ->map(
+                fn ($element) =>
+                    /* @var Elements $element */
                 $element->getId()
-        )->toArray();
+            )
+            ->toArray();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1254,8 +1254,8 @@ class StatementService extends CoreService implements StatementServiceInterface
     /**
      * Determines if one of the fields which only can be modified on a manual statement, should be updated.
      *
-     * @param statement|array $statement        - Statement as array or object
-     * @param statement       $currentStatement - current unmodified statement object, to compare with incoming update data
+     * @param Statement|array $statement        - Statement as array or object
+     * @param Statement       $currentStatement - current unmodified statement object, to compare with incoming update data
      *
      * @return bool - true if one of the 'critical' fields should be updated, otherwise false
      */
@@ -2243,8 +2243,12 @@ class StatementService extends CoreService implements StatementServiceInterface
 
         $noManualSortElementsIds = $this->serviceElements->getHiddenElementsIdsForProcedureId($procedureId);
 
+        $this->statementEntityGrouper->sortSubgroupsAtAllLayers(
+            $group,
+            new TitleGroupsSorter()
+        );
         // sorting only needed if there are elements to be moved to the end
-        if (0 < count($noManualSortElementsIds)) {
+        if ($noManualSortElementsIds) {
             // sort hidden elements to end: sort elements not manually sortable in the admin list (because hidden) at the end
             // the sorting is applied to all layers but only the elements layer will be affected as
             // the other two layers do not contain groups with element IDs


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35807

Description: reset KeysAtEndSorter to create right sort of elements. That problem appeared after 
`if ($noManualSortElementsIds) {
            // sort hidden elements to end: sort elements not manually sortable in the admin list (because hidden) at the end
            // the sorting is applied to all layers but only the elements layer will be affected as
            // the other two layers do not contain groups with element IDs
            $this->statementEntityGrouper->sortSubgroupsAtAllLayers(
                $group,
                new KeysAtEndSorter($noManualSortElementsIds)
            );
        }`
because of that, we should change the structure of this class. 

### How to review/test
In UI or Code review

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
