### PR TITLE
bug(refs T18750): Add min height for editor p tags

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_styled-html.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_styled-html.scss
@@ -38,6 +38,10 @@
         text-transform: uppercase;
     }
 
+    p {
+        min-height: 24px;
+    }
+
     p > a {
         @include keyboard-focus($padded: true);
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T18750

We want empty p tags inside the editor to have the same height as non empty ones for the sake of presentation.

### How to review/test
Verfahren -> Abwägungstabelle -> edit statemente text -> Add some empty lines and save -> the empty lines should be displayed 

