### PR TITLE
Fix new phases of procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240130051137.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240130051137.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20240130051137 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T36196: Enhance limit of chars for newly added phases.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _procedure CHANGE _p_phase _p_phase VARCHAR(255) NOT NULL, CHANGE _p_public_participation_phase _p_public_participation_phase VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _procedure CHANGE _p_phase _p_phase VARCHAR(50) NOT NULL, CHANGE _p_public_participation_phase _p_public_participation_phase VARCHAR(20) NOT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240130051137.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240130051137.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -40,7 +50,7 @@ class Version20240130051137 extends AbstractMigration
     private function abortIfNotMysql(): void
     {
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
             "Migration can only be executed safely on 'mysql'."
         );
     }

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -149,7 +149,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="_p_phase", type="string", length=50, nullable=false)
+     * @ORM\Column(name="_p_phase", type="string", nullable=false)
      */
     protected $phase = '';
 
@@ -258,7 +258,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="_p_public_participation_phase", type="string", length=20, nullable=false)
+     * @ORM\Column(name="_p_public_participation_phase", type="string", nullable=false)
      */
     protected $publicParticipationPhase = '';
 


### PR DESCRIPTION
**Ticket:** [T36196](https://yaits.demos-deutschland.de/T36196) ([T33120](https://yaits.demos-deutschland.de/T33120))

Fix error on persist newly created phase key, caused by limitation of length of DB-field.

### How to review/test

Selection of "Erneute frühzeitige Beteiligung Öffentlichkeit" for the public participation phase should not longer lead to an error.

### Linked PRs (optional)
- https://github.com/demos-europe/demosplan-project-blp/pull/82

### Tasks (optional)

- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
