### PR TITLE
bug(refs T36230): check response api call

### DIFF
--- a/client/js/components/news/DpNewsAdminList.vue
+++ b/client/js/components/news/DpNewsAdminList.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script>
-import { dpApi, DpBulkEditHeader, DpDataTable, makeFormPost } from '@demos-europe/demosplan-ui'
+import { checkResponse, dpApi, DpBulkEditHeader, DpDataTable, makeFormPost } from '@demos-europe/demosplan-ui'
 import DpNewsItemStatus from './DpNewsItemStatus'
 
 export default {
@@ -185,6 +185,7 @@ export default {
       })
 
       this.updateList()
+        .then(checkResponse)
         .then(() => {
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
         })

--- a/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
+++ b/client/js/components/statement/assessmentTable/DpBulkEditStatement.vue
@@ -368,7 +368,7 @@ export default {
         url: Routing.generate('dplan_assessment_table_assessment_table_statement_bulk_edit_api_action', {
           procedureId: this.procedureId
         }),
-        data: JSON.stringify(payload)
+        data: payload
       })
         .then(checkResponse)
         .then(() => {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36230

Add a check response for DpApi call, so the user does not get a validation message when the api call was not succesfull.

### How to review/test
Verfahren -> Aktuelles -> Toggle Status -> There should be an error message if the api call was not successfull