### PR TITLE
allow strike-through in pdf

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -262,8 +262,6 @@ class LatexExtension extends ExtensionBase
      * Process Table.
      *
      * @param string $text
-     *
-     * @return mixed
      */
     public function processTable($text)
     {

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -13,13 +13,12 @@ namespace demosplan\DemosPlanCoreBundle\Twig\Extension;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Exception;
-
-use function preg_quote;
-use function preg_replace;
-
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Twig\TwigFilter;
+
+use function preg_quote;
+use function preg_replace;
 
 /**
  * Wysiwyg-Editor.
@@ -31,100 +30,54 @@ class LatexExtension extends ExtensionBase
      */
     protected $fileService;
 
-    final public const HTMLTOREPLACE = [
-        '\\',
-        '{',
-        '}',
-        '[',
-        ']',
-        '<u>',
-        '<del>',
-        '<i>',
-        '<em>',
-        '<strong>',
-        '<b>',
-        '<ins>',
-        '</u>',
-        '</del>',
-        '</i>',
-        '</em>',
-        '</strong>',
-        '</b>',
-        '<ul>',
-        '</ul>',
-        '<ol>',
-        '</ol>',
-        '<li>',
-        '</li>',
-        '´',
-        '`',
-        '&',
-        '$',
-        '<span>',
-        '</span>',
-        "' ",
-        "'",
-        '&#039; ',
-        '&#039;',
-        '§',
-        '" ',
-        '"',
-        '#',
-        '_',
-        '€',
-        '%',
-        '^',
-        '█',
-        '­',
-        '</ins>',
-    ];
-
-    final public const REPLACEBYLATEX = [
-        '\textbackslash~',
-        '\{',
-        '\}',
-        '\lbrack~',
-        '\rbrack~',
-        '\uline{',
-        '\sout{',
-        '{\itshape ',
-        '{\itshape ',
-        '{\bfseries ',
-        '{\bfseries ',
-        '',
-        '}',
-        '}',
-        '}',
-        '}',
-        '}',
-        '}',
-        '\begin{itemize}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
-        '\end{itemize}',
-        '\begin{enumerate}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
-        '\end{enumerate}',
-        '\item ',
-        '',
-        '\textquoteright ',
-        '\textquoteleft ',
-        '\&',
-        '\$',
-        '',
-        '',
-        '\textquoteright~',
-        '\textquoteright ',
-        '\textquoteright~',
-        '\textquoteright ',
-        '\S~',
-        '\dq~',
-        '\dq ',
-        '\#',
-        '\_',
-        '\texteuro~',
-        '\%',
-        '\textasciicircum~',
-        '\ding{122}',
-        '\-',
-        '',
+    final public const HTML_TO_LATEX = [
+        '\\'        => '\textbackslash~',
+        '{'         => '\{',
+        '}'         => '\}',
+        '['         => '\lbrack~',
+        ']'         => '\rbrack~',
+        '<u>'       => '\uline{',
+        '</u>'      => '}',
+        '<del>'     => '\sout{',
+        '</del>'    => '}',
+        '<s>'       => '\sout{',
+        '</s>'      => '}',
+        '<i>'       => '{\itshape ',
+        '</i>'      => '}',
+        '<em>'      => '{\itshape ',
+        '</em>'     => '}',
+        '<strong>'  => '{\bfseries ',
+        '</strong>' => '}',
+        '<b>'       => '{\bfseries ',
+        '</b>'      => '}',
+        '<ins>'     => '',
+        '<ul>'      => '\begin{itemize}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
+        '</ul>'     => '\end{itemize}',
+        '<ol>'      => '\begin{enumerate}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
+        '</ol>'     => '\end{enumerate}',
+        '<li>'      => '\item ',
+        '</li>'     => '',
+        '´'         => '\textquoteright ',
+        '`'         => '\textquoteleft ',
+        '&'         => '\&',
+        '$'         => '\$',
+        '<span>'    => '',
+        '</span>'   => '',
+        "' "        => '\textquoteright~',
+        "'"         => '\textquoteright ',
+        '&#039; '   => '\textquoteright~',
+        '&#039;'    => '\textquoteright ',
+        '§'         => '\S~',
+        '" '        => '\dq~',
+        '"'         => '\dq ',
+        '#'         => '\#',
+        '_'         => '\_',
+        '€'         => '\texteuro~',
+        '%'         => '\%',
+        '^'         => '\textasciicircum~',
+        '█'         => '\ding{122}',
+        '­'         => '\-',
+        '</ins>'    => '',
     ];
 
     public function __construct(ContainerInterface $container, FileService $serviceFile, private readonly LoggerInterface $logger)
@@ -237,7 +190,7 @@ class LatexExtension extends ExtensionBase
             // Alle anderen Tags beseitigen
             $text = strip_tags(
                 $text,
-                '<p><table><tr><td><tcs2><tcs><tcs3><tcs4><tcs5><tcs6><th><br><ol><strike><u><del><i><ol><ul><li><b><strong><em><span><ins>'
+                '<p><table><tr><td><tcs2><tcs><tcs3><tcs4><tcs5><tcs6><th><br><ol><strike><u><s><del><i><ol><ul><li><b><strong><em><span><ins>'
             );
 
             // remove <ins> title attribute
@@ -253,7 +206,7 @@ class LatexExtension extends ExtensionBase
             $text = str_replace("\r", '', $text);
 
             // Latex-Umbau
-            $text = str_replace(self::HTMLTOREPLACE, self::REPLACEBYLATEX, $text);
+            $text = str_replace(array_keys(self::HTML_TO_LATEX), self::HTML_TO_LATEX, $text);
             if (false !== stripos($text, '<table')) {
                 $text = $this->processTable($text);
             }

--- a/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
+++ b/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
@@ -431,8 +431,8 @@ class LatexExtensionTest extends UnitTestCase
 
     public function testKeyWordReplacement(): void
     {
-        $html = LatexExtension::HTMLTOREPLACE;
-        $latex = LatexExtension::REPLACEBYLATEX;
+        $html = array_keys(LatexExtension::HTML_TO_LATEX);
+        $latex = LatexExtension::HTML_TO_LATEX;
 
         self::assertCount(count($html), $latex);
 
@@ -450,5 +450,33 @@ class LatexExtensionTest extends UnitTestCase
         $partsExpectedToBeEqual = preg_replace($pattern, '', [$ul, $ol]);
         self::assertCount(2, $partsExpectedToBeEqual);
         self::assertSame($partsExpectedToBeEqual[0], $partsExpectedToBeEqual[1]);
+    }
+
+    public function testStrikeTagReplacement(): void
+    {
+        $text = '<p>test</p><p></p><p><strong>bold</strong></p><p><em>kursiv</em></p><p><u>unterstrichen</u></p><p><s>durchgestrichen</s></p><p><mark title="markierter Text">markiert</mark></p><p><dp-obscure>geschwärzt</dp-obscure></p>';
+
+        self::assertStringContainsString('<s>', $text);
+        self::assertStringContainsString('</s>', $text);
+        self::assertStringNotContainsString('<del>', $text);
+        self::assertStringNotContainsString('</del>', $text);
+
+        $handledText = $this->sut->latexFilter($text);
+
+        self::assertStringContainsString('\sout{', $handledText);
+    }
+
+    public function testDeletionTagReplacement(): void
+    {
+        $text = '<p>test</p><p></p><p><strong>bold</strong></p><p><em>kursiv</em></p><p><u>unterstrichen</u></p><p><del>durchgestrichen</del></p><p><mark title="markierter Text">markiert</mark></p><p><dp-obscure>geschwärzt</dp-obscure></p>';
+
+        self::assertStringNotContainsString('<s>', $text);
+        self::assertStringNotContainsString('</s>', $text);
+        self::assertStringContainsString('<del>', $text);
+        self::assertStringContainsString('</del>', $text);
+
+        $handledText = $this->sut->latexFilter($text);
+
+        self::assertStringContainsString('\sout{', $handledText);
     }
 }


### PR DESCRIPTION
**Ticket:** [T35998](https://yaits.demos-deutschland.de/T35998)

Add strike-through to handling html tags, using keyed array  to map html to latex to improve readability and adjust test.

- [x] Implement strike-through on export a statement as PDF.
Implementation of marked text on export a statement as PDF will be another PR.

### How to review/test
Export a statement wich includes strike-through as format as PDF.

- [x] Tests updated/created
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
