### PR TITLE
fix(T36196): procedure phase with write permission should have auto-switch activated by default

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -196,7 +196,16 @@ export default {
      * @return {boolean}
      */
     isParticipationPhaseSelected () {
-      const participationPhases = ['participation', 'earlyparticipation', 'anotherparticipation']
+      const participationPhases = [
+        'earlyparticipation',
+        'anotherearlyparticipation',
+        'participation',
+        'anotherparticipation',
+        'externalearlyparticipation',
+        'anotherexternalearlyparticipation',
+        'externalparticipation'
+      ]
+
       return participationPhases.includes(this.selectedCurrentPhase)
     },
 
@@ -230,6 +239,7 @@ export default {
       this.setSelectedPhase()
 
       if (hasPermission('feature_auto_switch_to_procedure_end_phase')) {
+        console.log('permission is true')
         this.autoSwitchPhase = this.isParticipationPhaseSelected
       }
     },

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -239,7 +239,6 @@ export default {
       this.setSelectedPhase()
 
       if (hasPermission('feature_auto_switch_to_procedure_end_phase')) {
-        console.log('permission is true')
         this.autoSwitchPhase = this.isParticipationPhaseSelected
       }
     },


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36196

**Description:** Procedure phases with the write permission should have auto-switch activated by default. Here is a list of the [procedure phases](https://github.com/demos-europe/demosplan-project-blp/blob/main/app/Resources/DemosPlanCoreBundle/config/procedure/procedurephases.yml) in blp project.

[Thread](https://demosdeutschland.slack.com/archives/C8M7GFXTP/p1706551936339009) in Slack

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
