### PR TITLE
bug(refs T36246): Allow char start and char end to be the same

### DIFF
--- a/client/js/store/procedure/SplitStatementStore.js
+++ b/client/js/store/procedure/SplitStatementStore.js
@@ -230,8 +230,8 @@ const SplitStatementStore = {
               for (let j = i + 1; j < segments.length; j++) {
                 // Check for overlap
                 if (
-                  (segments[i].charStart >= segments[j].charStart && segments[i].charStart <= segments[j].charEnd) ||
-                  (segments[j].charStart >= segments[i].charStart && segments[j].charStart <= segments[i].charEnd)
+                  (segments[i].charStart > segments[j].charStart && segments[i].charStart < segments[j].charEnd) ||
+                  (segments[j].charStart > segments[i].charStart && segments[j].charStart < segments[i].charEnd)
                 ) {
                   // Overlapping segments found
                   segments = []


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36246

While checking for overlapping segments we need to exclude the start and end char, because they can be the same for different segments.


