### PR TITLE
fix(refs T36221): throw error if statements present

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
@@ -88,6 +88,7 @@ class DemosPlanMasterToebController extends BaseController
         $response = [
             'code'    => 100,
             'success' => true, ];
+
         // return result as JSON
         return new Response(Json::encode($response));
     }
@@ -150,6 +151,7 @@ class DemosPlanMasterToebController extends BaseController
             'code'              => 100,
             'success'           => true,
             'hasNewReportEntry' => $hasNewReportEntry, ];
+
         // return result as JSON
         return new JsonResponse($response);
     }
@@ -199,6 +201,7 @@ class DemosPlanMasterToebController extends BaseController
                     'code'    => 101,
                     'success' => true, ];
             }
+
             // return result as JSON
             return new Response(Json::encode($response));
         } catch (HttpException $e) {
@@ -213,6 +216,7 @@ class DemosPlanMasterToebController extends BaseController
                     // return default result as JSON
                     return $this->handleAjaxError($e);
             }
+
             // return result as JSON
             return new Response(Json::encode($response));
         }
@@ -235,6 +239,7 @@ class DemosPlanMasterToebController extends BaseController
         $response = [
             'code'    => 100,
             'success' => true, ];
+
         // return result as JSON
         return new Response(Json::encode($response));
     }

--- a/demosplan/DemosPlanCoreBundle/Exception/SubmittedStatementsOnMergeOrganisationsException.php
+++ b/demosplan/DemosPlanCoreBundle/Exception/SubmittedStatementsOnMergeOrganisationsException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Exception;
+
+use RuntimeException;
+
+class SubmittedStatementsOnMergeOrganisationsException extends RuntimeException
+{
+}

--- a/demosplan/DemosPlanCoreBundle/Exception/SubmittedStatementsOnMergeOrganisationsException.php
+++ b/demosplan/DemosPlanCoreBundle/Exception/SubmittedStatementsOnMergeOrganisationsException.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace demosplan\DemosPlanCoreBundle\Exception;
 
 use RuntimeException;

--- a/demosplan/DemosPlanCoreBundle/Repository/MasterToebRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/MasterToebRepository.php
@@ -673,6 +673,7 @@ class MasterToebRepository extends FluentRepository implements ArrayInterface
 
     /**
      * Checks if an organisation has already submitted draftStatements or statements.
+     *
      * @throws SubmittedStatementsOnMergeOrganisationsException
      */
     protected function checkIfOrgaHasSubmittedStatements(string $organisationId): void

--- a/demosplan/DemosPlanCoreBundle/Repository/MasterToebRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/MasterToebRepository.php
@@ -13,6 +13,9 @@ namespace demosplan\DemosPlanCoreBundle\Repository;
 use DateTime;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatement;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatementVersion;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\MasterToeb;
 use demosplan\DemosPlanCoreBundle\Entity\User\MasterToebVersion;
@@ -22,6 +25,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\MissingDataException;
+use demosplan\DemosPlanCoreBundle\Exception\SubmittedStatementsOnMergeOrganisationsException;
 use demosplan\DemosPlanCoreBundle\Repository\IRepository\ArrayInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\ORMException;
@@ -246,6 +250,8 @@ class MasterToebRepository extends FluentRepository implements ArrayInterface
                 $masterToebOrga->addUser($singleOrgaUser);
                 $masterToebDepartment->addUser($singleOrgaUser);
             }
+
+            $this->checkIfOrgaHasSubmittedStatements($organisationId);
 
             $entityManager->persist($masterToebOrga);
             $entityManager->persist($masterToebDepartment);
@@ -663,5 +669,32 @@ class MasterToebRepository extends FluentRepository implements ArrayInterface
         }
 
         return $entity;
+    }
+
+    /**
+     * Checks if an organisation has already submitted draftStatements or statements.
+     * @throws SubmittedStatementsOnMergeOrganisationsException
+     */
+    protected function checkIfOrgaHasSubmittedStatements(string $organisationId): void
+    {
+        $entityManager = $this->getEntityManager();
+
+        $draftStatementVersions = $entityManager
+            ->getRepository(DraftStatementVersion::class)
+            ->findBy(['organisation' => $organisationId]);
+
+        $draftStatements = $entityManager
+            ->getRepository(DraftStatement::class)
+            ->findBy(['organisation' => $organisationId]);
+
+        $statements = $entityManager
+            ->getRepository(Statement::class)
+            ->findBy(['organisation' => $organisationId]);
+
+        $statementCount = count($draftStatementVersions) + count($draftStatements) + count($statements);
+
+        if ($statementCount > 0) {
+            throw new SubmittedStatementsOnMergeOrganisationsException("Tried to merge organisations, expected no statements, got $statementCount.");
+        }
     }
 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1205,6 +1205,7 @@ error.orga.register.request: "Beim Anlegen der Organisation ist ein Fehler aufge
 error.organisation.duplicated.slug: "Der Direktlink zu Verfahren mit der Endung {slug} ist bereits vergeben."
 error.organisation.invalid: "In den Daten der Organisation sind folgende Felder ungültig: {fields}. Bitte korrigieren Sie diese Werte, um Änderungen speichern zu können."
 error.organisation.cssvars.invalid: "Die eingetragenen CSS-Variablen sind ungültig. Es dürfen nur ausgewählte Variablen mit gültigen Farbwerten verwendet werden."
+error.organisation.merge.statements.existing: "Die neue Organisation hat bereits Stellungnahmen angelegt und/oder eingereicht und kann daher nicht mit einem bestehenden Eintrag zusammengeführt werden."
 error.organisation.not.created: "Die neue Organisation konnte nicht gespeichert werden"
 error.organisation.not.deleted: "Die ausgewählte Organisation konnte nicht gelöscht werden"
 error.organisation.not.existent: "Ausgewählte Organisation wurde nicht gefunden"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36221

Orgas should only be merged if no statement has been submitted from them. As this will anyway not happen in prod instances (only when testing), a simple error message is shown in that case, instead of the "Ein Fehler ist aufgetreten"-Page.

![image](https://github.com/demos-europe/demosplan-core/assets/40452344/180f271f-daa9-47c5-bdae-9056c9d8a8c7)

### How to review/test
- When trying to merge an organisation, which has already submitted statements (or has saved draftStatements), the above error message should show up. 
- When merging orgas, which do not have statements or draftStatements attached, everything should work as before.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
