### PR TITLE
feature (ref 36190): remove extra link in header

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
@@ -14,13 +14,6 @@
         feature: 'area_manage_mastertoeblist'
     },
     {
-        current: 'mastertoeblist_report' == highlighted|default,
-        href: path('DemosPlan_user_mastertoeblist_report'),
-        label: 'invitable_institution.master.report',
-        feature: 'area_report_mastertoeblist',
-        icon: 'fa-bell'
-    },
-    {
         current: 'mastertoeblist_merge' == highlighted|default,
         href: path('DemosPlan_user_mastertoeblist_merge'),
         label: 'invitable_institution.master.merge'|trans,


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36190

Description: Removed extra link. The link redirects to the same page that it is appeared.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
