### PR TITLE
fix (refs T30474): reduce inconsistent code duplication

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -801,9 +801,9 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles($plannerRoles);
     }
 
-    public function isHearingAuthority(): bool
+    public function isHearingAuthority(Customer $customer = null): bool
     {
-        return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::HEARING_AUTHORITY_WORKER]);
+        return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::HEARING_AUTHORITY_WORKER], $customer);
     }
 
     /**
@@ -814,9 +814,9 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::PLANNING_AGENCY_ADMIN]);
     }
 
-    public function isPlanningAgency(): bool
+    public function isPlanningAgency(Customer $customer = null): bool
     {
-        return $this->hasAnyOfRoles([RoleInterface::PLANNING_AGENCY_ADMIN, RoleInterface::PLANNING_AGENCY_WORKER]);
+        return $this->hasAnyOfRoles([RoleInterface::PLANNING_AGENCY_ADMIN, RoleInterface::PLANNING_AGENCY_WORKER], $customer);
     }
 
     public function isPublicAgency(): bool
@@ -1467,10 +1467,10 @@ class User implements SamlUserInterface, AddonUserInterface
         return in_array($role, $this->getDplanRolesArray($customer));
     }
 
-    public function hasAnyOfRoles(array $roles): bool
+    public function hasAnyOfRoles(array $roles, Customer $customer = null): bool
     {
         foreach ($roles as $role) {
-            if ($this->hasRole($role)) {
+            if ($this->hasRole($role, $customer)) {
                 return true;
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -51,6 +51,9 @@ use function in_array;
  */
 class User implements SamlUserInterface, AddonUserInterface
 {
+    public const HEARING_AUTHORITY_ROLES = [RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::HEARING_AUTHORITY_WORKER];
+    public const PLANNING_AGENCY_ROLES = [RoleInterface::PLANNING_AGENCY_ADMIN, RoleInterface::PLANNING_AGENCY_WORKER];
+    public const PUBLIC_AGENCY_ROLES = [RoleInterface::PUBLIC_AGENCY_COORDINATION, RoleInterface::PUBLIC_AGENCY_WORKER];
     /**
      * @var string|null
      *
@@ -803,7 +806,7 @@ class User implements SamlUserInterface, AddonUserInterface
 
     public function isHearingAuthority(Customer $customer = null): bool
     {
-        return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::HEARING_AUTHORITY_WORKER], $customer);
+        return $this->hasAnyOfRoles(self::HEARING_AUTHORITY_ROLES, $customer);
     }
 
     /**
@@ -816,17 +819,12 @@ class User implements SamlUserInterface, AddonUserInterface
 
     public function isPlanningAgency(Customer $customer = null): bool
     {
-        return $this->hasAnyOfRoles([RoleInterface::PLANNING_AGENCY_ADMIN, RoleInterface::PLANNING_AGENCY_WORKER], $customer);
+        return $this->hasAnyOfRoles(self::PLANNING_AGENCY_ROLES, $customer);
     }
 
     public function isPublicAgency(): bool
     {
-        $publicAgencyRoles = [
-            RoleInterface::PUBLIC_AGENCY_COORDINATION,
-            RoleInterface::PUBLIC_AGENCY_WORKER,
-        ];
-
-        return $this->hasAnyOfRoles($publicAgencyRoles);
+        return $this->hasAnyOfRoles(self::PUBLIC_AGENCY_ROLES);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1551,6 +1551,13 @@ class User implements SamlUserInterface, AddonUserInterface
             ->map(static fn (UserRoleInCustomerInterface $roleInCustomer) => $roleInCustomer->getCustomer())->toArray();
     }
 
+    public function isConnectedToCustomerId(string $customerId): bool
+    {
+        return $this->roleInCustomers
+            ->map(static fn (UserRoleInCustomerInterface $roleInCustomer): ?string => $roleInCustomer->getCustomer()?->getId())
+            ->contains($customerId);
+    }
+
     /**
      * Retrieve all customers that the user is associated with directly. This is only the case for customer users.
      *

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -49,7 +49,8 @@ class OwnsProcedureConditionFactory
         private readonly GlobalConfigInterface $globalConfig,
         private readonly LoggerInterface $logger,
         private readonly User|Procedure $userOrProcedure
-    ) {}
+    ) {
+    }
 
     /**
      * The organisation of the user must be set as planning office in the procedure.
@@ -66,6 +67,7 @@ class OwnsProcedureConditionFactory
         if ($this->userOrProcedure instanceof User) {
             $user = $this->userOrProcedure;
             $organisationId = $user->getOrganisationId();
+
             return $this->conditionFactory->propertyHasStringAsMember($organisationId, ['planningOffices']);
         }
 
@@ -143,7 +145,7 @@ class OwnsProcedureConditionFactory
                     ],
                     ['roleInCustomers', 'role', 'code']
                 ),
-                $this->isUserInCustomer($customer)
+                $this->isUserInCustomer($customer),
             ];
         } else {
             $ownsOrgaRoleCondition = [$this->conditionFactory->false()];
@@ -176,7 +178,7 @@ class OwnsProcedureConditionFactory
                     RoleInterface::PRIVATE_PLANNING_AGENCY,
                     ['roleInCustomers', 'role', 'code']
                 ),
-                $this->isUserInCustomer($customer)
+                $this->isUserInCustomer($customer),
             ];
         } else {
             $planningAgencyOwnsProcedure = [$this->conditionFactory->false()];

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -244,7 +244,7 @@ class OwnsProcedureConditionFactory
      *
      * @throws PathException
      */
-    public function isUndeletedProcedure(): ClauseFunctionInterface
+    public function isNotDeletedProcedure(): ClauseFunctionInterface
     {
         if ($this->userOrProcedure instanceof User) {
             return $this->conditionFactory->propertyHasValue(false, ['deleted']);

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -108,7 +108,7 @@ class OwnsProcedureConditionFactory
         $relevantRoles = [
             RoleInterface::CUSTOMER_MASTER_USER,
             ...User::PLANNING_AGENCY_ROLES,
-            ...User::HEARING_AUTHORITY_ROLES
+            ...User::HEARING_AUTHORITY_ROLES,
         ];
 
         if ($this->userOrProcedure instanceof User) {
@@ -125,7 +125,7 @@ class OwnsProcedureConditionFactory
             $this->logger->debug('Permissions: Check whether orga owns procedure');
             $ownsOrgaRoleCondition = [
                 $this->conditionFactory->propertyHasAnyOfValues($relevantRoles, ['roleInCustomers', 'role', 'code']),
-                $this->isUserInCustomer($customer)
+                $this->isUserInCustomer($customer),
             ];
         } else {
             $ownsOrgaRoleCondition = [$this->conditionFactory->false()];
@@ -157,7 +157,7 @@ class OwnsProcedureConditionFactory
             // ist es ein PLanungsbüro?
             $planningAgencyOwnsProcedure = [
                 $this->conditionFactory->propertyHasValue($relevantRole, ['roleInCustomers', 'role', 'code']),
-                $this->isUserInCustomer($customer)
+                $this->isUserInCustomer($customer),
             ];
         } else {
             $planningAgencyOwnsProcedure = [$this->conditionFactory->false()];

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2084,7 +2084,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      * Will copy Boilerplates including related Boilerplatecategories and also copy emtpy Categories.
      *
      * @param string    $blueprintId  - The ID of the blueprint procedure
-     * @param procedure $newProcedure - The new created procedure object
+     * @param Procedure $newProcedure - The new created procedure object
      *
      * @throws Exception
      */
@@ -2362,7 +2362,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      * @param string $title       - Title of BoilerplateGroup to create
      * @param string $procedureId - Procedure which BoilerplateGroup to create belongs to
      *
-     * @return boilerplateGroup - Created BoilerplateGroup
+     * @return BoilerplateGroup - Created BoilerplateGroup
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
@@ -66,20 +66,19 @@ class ProcedureAccessEvaluator
 
         // user must be in current customer
         $currentCustomer = $this->currentCustomerProvider->getCurrentCustomer();
-        $inCurrentCustomer = $ownsProcedureConditionFactory->isUserInCustomer($currentCustomer);
 
         // user owns via their organisation or was manually set
         $orgaOwnsProcedure = $this->conditionFactory->false();
-        $procedureAccessingRole = $ownsProcedureConditionFactory->hasProcedureAccessingRole();
-        if ($this->entityFetcher->objectMatchesAll($user, [$procedureAccessingRole, $inCurrentCustomer])) {
+        $procedureAccessingRole = $ownsProcedureConditionFactory->hasProcedureAccessingRole($currentCustomer);
+        if ($this->entityFetcher->objectMatchesAll($user, $procedureAccessingRole)) {
             $this->logger->debug('User is FP*');
             $orgaOwnsProcedure = $ownsProcedureConditionFactory->isAuthorizedViaOrgaOrManually();
         }
 
         // user has planning agency role in current customer and owns via owning planning agency organisation
         $planningAgencyOwnsProcedure = $this->conditionFactory->false();
-        $privatePlanningAgency = $ownsProcedureConditionFactory->hasPlanningAgencyRole();
-        if ($this->entityFetcher->objectMatchesAll($user, [$privatePlanningAgency, $inCurrentCustomer])) {
+        $privatePlanningAgency = $ownsProcedureConditionFactory->hasPlanningAgencyRole($currentCustomer);
+        if ($this->entityFetcher->objectMatchesAll($user, $privatePlanningAgency)) {
             $this->logger->debug('Permissions → User has role RMOPPO');
             $planningAgencyOwnsProcedure = $ownsProcedureConditionFactory->isAuthorizedViaPlanningAgency();
         }
@@ -133,20 +132,17 @@ class ProcedureAccessEvaluator
         );
 
         $currentCustomer = $this->currentCustomerProvider->getCurrentCustomer();
-        $inCurrentCustomer = $ownsProcedureConditionFactory->isUserInCustomer($currentCustomer);
 
         // user owns via their organisation or was manually set
         $orgaOwnsProcedure = $this->conditionFactory->allConditionsApply(
-            $inCurrentCustomer,
-            $ownsProcedureConditionFactory->hasProcedureAccessingRole(),
-            $ownsProcedureConditionFactory->isAuthorizedViaOrgaOrManually()
+            $ownsProcedureConditionFactory->isAuthorizedViaOrgaOrManually(),
+            ...$ownsProcedureConditionFactory->hasProcedureAccessingRole($currentCustomer),
         );
 
         // user has planning agency role in current customer and owns via owning planning agency organisation
         $planningAgencyOwnsProcedure = $this->conditionFactory->allConditionsApply(
-            $inCurrentCustomer,
-            $ownsProcedureConditionFactory->hasPlanningAgencyRole(),
-            $ownsProcedureConditionFactory->isAuthorizedViaPlanningAgency()
+            $ownsProcedureConditionFactory->isAuthorizedViaPlanningAgency(),
+            ...$ownsProcedureConditionFactory->hasPlanningAgencyRole($currentCustomer),
         );
 
         return [

--- a/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
@@ -60,7 +60,7 @@ class ProcedureAccessEvaluator
         );
 
         // procedure must not be deleted
-        $undeletedProcedureCondition = $ownsProcedureConditionFactory->isUndeletedProcedure();
+        $undeletedProcedureCondition = $ownsProcedureConditionFactory->isNotDeletedProcedure();
         if (!$this->entityFetcher->objectMatches($user, $undeletedProcedureCondition)) {
             return false;
         }
@@ -148,7 +148,7 @@ class ProcedureAccessEvaluator
 
         return [
             $ownsProcedureConditionFactory->isEitherTemplateOrProcedure($template),
-            $ownsProcedureConditionFactory->isUndeletedProcedure(),
+            $ownsProcedureConditionFactory->isNotDeletedProcedure(),
             // user owns via owning organisation or planning agency
             $this->conditionFactory->anyConditionApplies(
                 $orgaOwnsProcedure,

--- a/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
@@ -102,7 +102,7 @@ class ProcedureAccessEvaluator
     /**
      * Compiles a list of conditions to check if a procedure or procedure template is owned by the given user.
      *
-     * A procedure is owned a user if all conditions in the returned list match the procedure/user respectively.
+     * A procedure is owned by a user if all conditions in the returned list match the procedure/user respectively.
      *
      * If {@link GlobalConfigInterface::hasProcedureUserRestrictedAccess} is set to `false`
      * then the user must be in the organisation that created the procedure.

--- a/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
@@ -22,6 +22,7 @@ use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PathException;
 use Psr\Log\LoggerInterface;
+
 use function in_array;
 
 class ProcedureAccessEvaluator

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/NonAuthorizedAssignRemover.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/NonAuthorizedAssignRemover.php
@@ -99,9 +99,9 @@ class NonAuthorizedAssignRemover
      */
     private function getAssignableUserIds(Procedure $procedure): array
     {
-        $ownsProcedureCondition = $this->procedureAccessEvaluator->getOwnsProcedureCondition($procedure);
+        $ownsProcedureConditions = $this->procedureAccessEvaluator->getOwnsProcedureConditions($procedure, false);
         $authorizedUsers = $this->procedureService->getAuthorizedUsers($procedure->getId());
-        $owningUsers = $this->userRepository->getEntities([$ownsProcedureCondition], []);
+        $owningUsers = $this->userRepository->getEntities($ownsProcedureConditions, []);
 
         return $authorizedUsers
             ->merge($owningUsers)


### PR DESCRIPTION
Enhance the `OwnsProcedureConditionFactory` implementation, so that it can not only create conditions to match unknown users against a known procedure, but also to match unknown procedures against a known user. Logically the comparison is the same in both cases, but their implementation differs significantly.

Keeping the implementations as close together as possible avoids divergences, like were already present in
`ProcedureService::getAdminProcedureConditions`. The matching logic in this method behaved very similar to the one executed via `ProcedureAccessEvaluator::isOwningProcedure` (which uses `OwnsProcedureConditionFactory`), but was not exactly the same, causing a bug. Hence, `isOwningProcedure` was selected as "truth" and the logic in `getAdminProcedureConditions` was dropped.

**Ticket:** https://yaits.demos-deutschland.de/T30474

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
