### PR TITLE
allow highlighted text in pdf export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -42,6 +42,8 @@ class LatexExtension extends ExtensionBase
         '</del>'    => '}',
         '<s>'       => '\sout{',
         '</s>'      => '}',
+        '<mark title="markierter Text">'       => '\colorbox{yellow}{',
+        '</mark>'      => '}',
         '<i>'       => '{\itshape ',
         '</i>'      => '}',
         '<em>'      => '{\itshape ',
@@ -190,7 +192,7 @@ class LatexExtension extends ExtensionBase
             // Alle anderen Tags beseitigen
             $text = strip_tags(
                 $text,
-                '<p><table><tr><td><tcs2><tcs><tcs3><tcs4><tcs5><tcs6><th><br><ol><strike><u><s><del><i><ol><ul><li><b><strong><em><span><ins>'
+                '<p><table><tr><td><tcs2><tcs><tcs3><tcs4><tcs5><tcs6><th><br><ol><strike><u><s><del><i><ol><ul><li><b><strong><em><span><ins><mark>'
             );
 
             // remove <ins> title attribute
@@ -262,6 +264,8 @@ class LatexExtension extends ExtensionBase
      * Process Table.
      *
      * @param string $text
+     *
+     * @return mixed
      */
     public function processTable($text)
     {

--- a/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
+++ b/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
@@ -479,4 +479,16 @@ class LatexExtensionTest extends UnitTestCase
 
         self::assertStringContainsString('\sout{', $handledText);
     }
+
+    public function testHighlightTagReplacement(): void
+    {
+        $text = '<p><strong>bold</strong></p> <p><em>kursiv</em></p> <p><em><u>kusrivunterstrichen</u></em></p> <p><u>unterstrichen</u></p> <p><s>durchgestrichen</s></p> <p><mark title="markierter Text">markiert</mark></p> <p><mark title="markierter Text"><strong>boldmarkiert</strong></mark></p> <p><dp-obscure>geschwärzt</dp-obscure></p> ';
+
+        self::assertStringContainsString('<mark title="markierter Text">', $text);
+        self::assertStringContainsString('</mark>', $text);
+
+        $handledText = $this->sut->latexFilter($text);
+
+        self::assertStringContainsString('\colorbox{yellow}{', $handledText);
+    }
 }


### PR DESCRIPTION
**Tickets:** (more or less)
[T36015](https://yaits.demos-deutschland.de/T36015)
[T35998](https://yaits.demos-deutschland.de/T35998)

PDF-Export an Statement wich includes highlighted text.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
Very close to #2650

- [x] Tests updated/created
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
