### PR TITLE
feature (ref 26150): Fix issue with cascade persist in FileContainer …

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/FileContainer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/FileContainer.php
@@ -91,7 +91,7 @@ class FileContainer extends CoreEntity implements UuidEntityInterface, FileConta
     protected $fileString;
 
     /**
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\File")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\File", cascade={"persist"})
      *
      * @ORM\JoinColumn(name="file_id", referencedColumnName="_f_ident", nullable=false, onDelete="CASCADE")
      */


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T26150

Description: Fix issue with cascade persist in FileContainer entity. The previous configuration didn't properly handle the cascade persist operation for the related File entity. This fix ensures that new File entities are persisted along with the FileContainer.

### How to review/test
Make sure migrate is run before testing

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
