### PR TITLE
bug(refs T36258): Add 'br' tag to allowed nodes for prosemirror

### DIFF
--- a/client/js/store/procedure/storeHelpers/SplitStatementStore/HTMLIdxToProsemirrorIdx.js
+++ b/client/js/store/procedure/storeHelpers/SplitStatementStore/HTMLIdxToProsemirrorIdx.js
@@ -51,12 +51,13 @@ function transformHTMLPositionsToProsemirrorPositions (segments, initialText, al
   const PROSEMIRROR_NODE_SIZE = 1
   const PROSEMIRROR_MARK_SIZE = 0
 
-  const allowedNodeTags = allowedNodes || ['p', 'div', 'img', 'ol', 'ul', 'li']
+  const allowedNodeTags = allowedNodes || ['p', 'div', 'img', 'ol', 'ul', 'li', 'br']
   const nodeGroup = allowedNodeTags.join('|')
   const nodeRegex = new RegExp(`</?(${nodeGroup}).*?>`, 'ig')
   const allowedMarkTags = allowedMarks || ['strong', 'span', 'a', 'b', 'em', 'i', 'del', 'ins']
   const markGroup = allowedMarkTags.join('|')
-  const markRegex = new RegExp(`</?(${markGroup}).*?>`, 'ig')
+  // Explicitly exclude 'br', because of 'b' tag
+  const markRegex = new RegExp(`</?(?!br)(${markGroup}).*?>`, 'ig')
   const entitiesRegex = /&(#[0-9]+|[a-z]+);/g
 
   // We construct a flat array of positions to easily run calculations later.


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36258

We also need to transform 'br' tags to prosemirror positions. Additionally exclude 'br' from markRegex, because otherwise it will be included due to 'b' tag and it will be transformed double (once as node and once as mark).

### How to review/test
Cannot be tested locally