### PR TITLE
bug(refs T36258): fix slicing tagging

### DIFF
--- a/client/js/store/procedure/SplitStatementStore.js
+++ b/client/js/store/procedure/SplitStatementStore.js
@@ -230,8 +230,8 @@ const SplitStatementStore = {
               for (let j = i + 1; j < segments.length; j++) {
                 // Check for overlap
                 if (
-                  (segments[i].charStart >= segments[j].charStart && segments[i].charStart <= segments[j].charEnd) ||
-                  (segments[j].charStart >= segments[i].charStart && segments[j].charStart <= segments[i].charEnd)
+                  (segments[i].charStart > segments[j].charStart && segments[i].charStart < segments[j].charEnd) ||
+                  (segments[j].charStart > segments[i].charStart && segments[j].charStart < segments[i].charEnd)
                 ) {
                   // Overlapping segments found
                   segments = []

--- a/client/js/store/procedure/storeHelpers/SplitStatementStore/HTMLIdxToProsemirrorIdx.js
+++ b/client/js/store/procedure/storeHelpers/SplitStatementStore/HTMLIdxToProsemirrorIdx.js
@@ -51,12 +51,12 @@ function transformHTMLPositionsToProsemirrorPositions (segments, initialText, al
   const PROSEMIRROR_NODE_SIZE = 1
   const PROSEMIRROR_MARK_SIZE = 0
 
-  const allowedNodeTags = allowedNodes || ['p', 'div', 'img', 'ol', 'ul', 'li']
+  const allowedNodeTags = allowedNodes || ['p', 'div', 'img', 'ol', 'ul', 'li', 'br']
   const nodeGroup = allowedNodeTags.join('|')
   const nodeRegex = new RegExp(`</?(${nodeGroup}).*?>`, 'ig')
   const allowedMarkTags = allowedMarks || ['strong', 'span', 'a', 'b', 'em', 'i', 'del', 'ins']
   const markGroup = allowedMarkTags.join('|')
-  const markRegex = new RegExp(`</?(${markGroup}).*?>`, 'ig')
+  const markRegex = new RegExp(`</?(?!br)(${markGroup}).*?>`, 'ig')
   const entitiesRegex = /&(#[0-9]+|[a-z]+);/g
 
   // We construct a flat array of positions to easily run calculations later.


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36258 
**Ticket:** https://yaits.demos-deutschland.de/T36246

- While checking for overlapping segments we need to exclude the start and end char, because they can be the same for different segments.
- Add 'br' tag to allowed nodes for prosemirror. We also need to transform 'br' tags to prosemirror positions. 
- Additionally exclude 'br' from markRegex, because otherwise it will be included due to 'b' tag and it will be transformed double (once as node and once as mark).

### How to review/test
Cannot be tested locally