### PR TITLE
ref(T36269): remove the insert and delete functions from the editor

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
@@ -523,7 +523,6 @@
                             data-cy="submitterForm:statementText"
                             required
                             :toolbar-items="{
-                                insertAndDelete: true,
                                 obscure: hasPermission('feature_obscure_text'),
                                 mark: true,
                                 strikethrough: true


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36269

**Description:** Remove the mark as insert and delete functions from the editor on the new statement page.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
