### PR TITLE
feat (refs T36297): Keep formatting on export original-STN as already…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
@@ -39,7 +39,6 @@ use demosplan\DemosPlanCoreBundle\ValueObject\Statement\ValuedLabel;
 use demosplan\DemosPlanCoreBundle\ValueObject\ToBy;
 use Exception;
 use PhpOffice\PhpWord\Element\AbstractContainer;
-use PhpOffice\PhpWord\Element\Cell;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\PhpWord;

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
@@ -374,7 +374,7 @@ class AssessmentTableServiceOutput
             } else {
                 $section->addText($this->translator->trans('statement'), $boldFontSetting, ['align' => Jc::CENTER]);
                 $section->addTextBreak();
-                $this->addHtml($section, $presentableOriginalStatement->getStatementText(), []);
+                $this->docxExporter->addHtml($section, $presentableOriginalStatement->getStatementText(), []);
 
                 if ($this->permissions->hasPermission('feature_statement_gdpr_consent')) {
                     if ($presentableOriginalStatement->getGdprConsentRevoked()) {
@@ -746,32 +746,6 @@ class AssessmentTableServiceOutput
         }
 
         return '<img height="'.$height.'" width="'.$width.'" src="'.$imageFile.'"/>';
-    }
-
-    /**
-     * @param Cell    $cell
-     * @param string  $text
-     * @param array[] $styles
-     *
-     * @return string
-     */
-    protected function addHtml($cell, $text, $styles)
-    {
-        if ('' === $text) {
-            return '';
-        }
-        try {
-            // phpword breaks when self closing tags are not closed
-            // as only br as "void-elememt" is allowed use specific regex
-            $text = preg_replace('/<(\s)*br(\s)*>/i', '<br/>', $text);
-            Html::addHtml($cell, $text, false);
-        } catch (Exception $e) {
-            $this->logger->warning('Could not parse HTML in Export', [$e, $text, $e->getTraceAsString()]);
-            // fallback: print with html tags
-            $cell->addText($text, $styles['textStyleStatementDetails'], $styles['textStyleStatementDetailsParagraphStyles']);
-        }
-
-        return '';
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -928,30 +928,37 @@ class DocxExporter
     }
 
     /**
+     * Used for non original statement and more?!
+     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used
+     *
      * @param Cell    $cell
      * @param string  $text
      * @param array[] $styles
      *
      * @return string
      */
-    protected function addHtml($cell, $text, $styles)
+    public function addHtml($cell, $text, $styles)
     {
         if ('' === $text) {
             return '';
         }
         try {
-            $text = $this->replaceTags($text);
+            $text = self::replaceTags($text);
             Html::addHtml($cell, $text, false);
         } catch (Exception $e) {
             $this->getLogger()->warning('Could not parse HTML in Export', [$e, $text, $e->getTraceAsString()]);
             // fallback: print with html tags
-            $cell->addText($text, $styles['textStyleStatementDetails'], $styles['textStyleStatementDetailsParagraphStyles']);
+            $cell->addText(
+                $text,
+                $styles['textStyleStatementDetails'],
+                $styles['textStyleStatementDetailsParagraphStyles']
+            );
         }
 
         return '';
     }
 
-    private function replaceTags(string $text): string
+    private static function replaceTags(string $text): string
     {
         $replacements = [
             // phpword breaks when self closing tags are not closed

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -929,7 +929,7 @@ class DocxExporter
 
     /**
      * Used for non original statement and more?!
-     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used
+     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used.
      *
      * @param Cell    $cell
      * @param string  $text

--- a/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
@@ -205,8 +205,7 @@ abstract class EntityGrouper
         CoreEntity&EntityInterface $entity,
         array $entityFieldsToUse,
         array $stopGroupingForKeys = []
-    ): int
-    {
+    ): int {
         if (0 === count($entityFieldsToUse)) {
             // if we do not have any fields to use as keys from the entity
             // then we just add the entity to the given array

--- a/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
@@ -200,7 +200,12 @@ abstract class EntityGrouper
      *
      * @return int number of times the given entity was added to a group
      */
-    protected function fillEntityIntoGroupStructure(EntityGroupInterface $group, CoreEntity&EntityInterface $entity, array $entityFieldsToUse, array $stopGroupingForKeys = []): int
+    protected function fillEntityIntoGroupStructure(
+        EntityGroupInterface $group,
+        CoreEntity&EntityInterface $entity,
+        array $entityFieldsToUse,
+        array $stopGroupingForKeys = []
+    ): int
     {
         if (0 === count($entityFieldsToUse)) {
             // if we do not have any fields to use as keys from the entity

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -78,7 +78,7 @@ class ExportService
     protected $procedureOutput;
 
     /**
-     * @var \demosplan\DemosPlanCoreBundle\Logic\News\ServiceOutput NewsOutput
+     * @var NewsOutput NewsOutput
      */
     protected $newsOutput;
 
@@ -488,8 +488,7 @@ class ExportService
         string $procedureId,
         string $procedureName,
         ZipStream $zip
-    ): ZipStream
-    {
+    ): ZipStream {
         $rParams = [
             'filters' => ['original' => 'IS NULL'],
             'request' => ['limit' => 1_000_000],

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -484,7 +484,11 @@ class ExportService
         return $zip;
     }
 
-    public function addAssessmentTableOriginalToZip(string $procedureId, string $procedureName, ZipStream $zip): ZipStream
+    public function addAssessmentTableOriginalToZip(
+        string $procedureId,
+        string $procedureName,
+        ZipStream $zip
+    ): ZipStream
     {
         $rParams = [
             'filters' => ['original' => 'IS NULL'],

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2179,7 +2179,11 @@ class StatementService extends CoreService implements StatementServiceInterface
      *
      * @throws Exception
      */
-    public function createElementsGroupStructure(string $procedureId, array $statementsIds, array $fragmentIds): StatementEntityGroup
+    public function createElementsGroupStructure(
+        string $procedureId,
+        array $statementsIds,
+        array $fragmentIds
+    ): StatementEntityGroup
     {
         $statements = $this->getStatementsByIds($statementsIds);
         $fragments = $this->statementFragmentRepository->getFragmentsById($fragmentIds);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2183,8 +2183,7 @@ class StatementService extends CoreService implements StatementServiceInterface
         string $procedureId,
         array $statementsIds,
         array $fragmentIds
-    ): StatementEntityGroup
-    {
+    ): StatementEntityGroup {
         $statements = $this->getStatementsByIds($statementsIds);
         $fragments = $this->statementFragmentRepository->getFragmentsById($fragmentIds);
         $entities = \array_merge($statements, $fragments);


### PR DESCRIPTION
**Ticket:** [T36297](https://yaits.demos-deutschland.de/T36297)

Keep formatting on export original-STN as already implemented for normal statement.
Use existing method to reduce code duplication and remove unused method to keep it clean. Minor formatting.

### How to review/test
Export an complete procedure within a original statement with multiple formatting.
Check the docx of the orginial-STN in the resulting zip.

### PR Checklist
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
