### PR TITLE
feat (T29878): map addon interfaces to core entities

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
@@ -52,7 +52,7 @@ class AddonResolveTargetEntity implements CompilerPassInterface
                         $this->addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName);
                     }
                 }
-                $definition->addTag('doctrine.event_subscriber', array('connection' => 'dplan'));
+                $definition->addTag('doctrine.event_subscriber', ['connection' => 'dplan']);
             }
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
@@ -15,16 +15,16 @@ namespace demosplan\DemosPlanCoreBundle\Addon;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * Handles connecting AddOn interfaces with their corresponding CoreEntities
+ * Handles connecting AddOn interfaces with their corresponding CoreEntities.
  */
 class AddonResolveTargetEntity implements CompilerPassInterface
 {
-
     private const CORE_ENTITY_DIRECTORY = 'demosplan/DemosPlanCoreBundle/Entity';
     private const ADDON_INTERFACE_DIRECTORY = 'DemosEurope\DemosplanAddon\Contracts\Entities';
 
@@ -33,26 +33,23 @@ class AddonResolveTargetEntity implements CompilerPassInterface
         $definition = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
         $corePath = DemosPlanPath::getRootPath(self::CORE_ENTITY_DIRECTORY);
 
-
         $iterator = new RecursiveDirectoryIterator($corePath);
 
-        //Go through the files on the Core Entity folder. In case it is a class, detect if any of its interfaces belongs to AddOn middle layer
-        //If so, then add it to resolveTargetEntity method call
-        foreach (new RecursiveIteratorIterator($iterator) as  $filename) {
+        // Go through the files on the Core Entity folder. In case it is a class, detect if any of its interfaces belongs to AddOn middle layer
+        // If so, then add it to resolveTargetEntity method call
+        foreach (new RecursiveIteratorIterator($iterator) as $filename) {
             $classNameWithoutExtension = pathinfo($filename->getFilename(), \PATHINFO_FILENAME);
-            $classNameRaw = $filename->getPath() . '/' . $classNameWithoutExtension;
+            $classNameRaw = $filename->getPath().'/'.$classNameWithoutExtension;
 
             if (!is_dir($classNameRaw)) {
-                $className = str_replace(array(DemosPlanPath::getRootPath(), '/'), array('', '\\'), $classNameRaw);
-                $reflectionClass = new \ReflectionClass($className);
+                $className = str_replace([DemosPlanPath::getRootPath(), '/'], ['', '\\'], $classNameRaw);
+                $reflectionClass = new ReflectionClass($className);
                 $interfaces = $reflectionClass->getInterfaces();
                 foreach ($interfaces as $interface) {
-
-                    if ($interface->getNamespaceName() === self::ADDON_INTERFACE_DIRECTORY && str_contains($interface->getShortName(), $reflectionClass->getShortName())) {
-                        $interfaceName = $interface->getNamespaceName() . '\\' . $interface->getShortName();
-                        $entityName = $reflectionClass->getNamespaceName() . '\\' . $reflectionClass->getShortName();
+                    if (self::ADDON_INTERFACE_DIRECTORY === $interface->getNamespaceName() && str_contains($interface->getShortName(), $reflectionClass->getShortName())) {
+                        $interfaceName = $interface->getNamespaceName().'\\'.$interface->getShortName();
+                        $entityName = $reflectionClass->getNamespaceName().'\\'.$reflectionClass->getShortName();
                         $this->addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName);
-
                     }
                 }
             }
@@ -62,19 +59,18 @@ class AddonResolveTargetEntity implements CompilerPassInterface
     /**
      * ResolveTargetEntity is a Doctrine utility that enables to map the targetEntity defined in each Addon Entity to an entity defined in Core.
      * ResolveTargetEntity intercepts the Doctrine calls that define the targetEntity, and rewrites that targetEntity (which is an Interface)
-     * at runtime with the concrete specified class (which is an entity in Core)
+     * at runtime with the concrete specified class (which is an entity in Core).
      *
      * @param Definition $definition
-     * @param string $interfaceName
-     * @param string $entityName
-     * @return void
+     * @param string     $interfaceName
+     * @param string     $entityName
      */
     private function addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName): void
     {
-        $definition->addMethodCall('addResolveTargetEntity', array(
-            $interfaceName, //Resolve from: Interface in AddOn
-            $entityName, //Resolve to: Entity in Core
-            array(),
-        ));
+        $definition->addMethodCall('addResolveTargetEntity', [
+            $interfaceName, // Resolve from: Interface in AddOn
+            $entityName, // Resolve to: Entity in Core
+            [],
+        ]);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
@@ -52,9 +52,9 @@ class AddonResolveTargetEntity implements CompilerPassInterface
                         $this->addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName);
                     }
                 }
-                $definition->addTag('doctrine.event_subscriber', ['connection' => 'dplan']);
             }
         }
+        $definition->addTag('doctrine.event_subscriber', ['connection' => 'dplan']);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Addon;
+
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Handles connecting AddOn interfaces with their corresponding CoreEntities
+ */
+class AddonResolveTargetEntity implements CompilerPassInterface
+{
+
+    private const CORE_ENTITY_DIRECTORY = 'demosplan/DemosPlanCoreBundle/Entity';
+    private const ADDON_INTERFACE_DIRECTORY = 'DemosEurope\DemosplanAddon\Contracts\Entities';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $definition = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
+        $corePath = DemosPlanPath::getRootPath(self::CORE_ENTITY_DIRECTORY);
+
+
+        $iterator = new RecursiveDirectoryIterator($corePath);
+
+        //Go through the files on the Core Entity folder. In case it is a class, detect if any of its interfaces belongs to AddOn middle layer
+        //If so, then add it to resolveTargetEntity method call
+        foreach (new RecursiveIteratorIterator($iterator) as  $filename) {
+            $classNameWithoutExtension = pathinfo($filename->getFilename(), \PATHINFO_FILENAME);
+            $classNameRaw = $filename->getPath() . '/' . $classNameWithoutExtension;
+
+            if (!is_dir($classNameRaw)) {
+                $className = str_replace(array(DemosPlanPath::getRootPath(), '/'), array('', '\\'), $classNameRaw);
+                $reflectionClass = new \ReflectionClass($className);
+                $interfaces = $reflectionClass->getInterfaces();
+                foreach ($interfaces as $interface) {
+
+                    if ($interface->getNamespaceName() === self::ADDON_INTERFACE_DIRECTORY && str_contains($interface->getShortName(), $reflectionClass->getShortName())) {
+                        $interfaceName = $interface->getNamespaceName() . '\\' . $interface->getShortName();
+                        $entityName = $reflectionClass->getNamespaceName() . '\\' . $reflectionClass->getShortName();
+                        $this->addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName);
+
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * ResolveTargetEntity is a Doctrine utility that enables to map the targetEntity defined in each Addon Entity to an entity defined in Core.
+     * ResolveTargetEntity intercepts the Doctrine calls that define the targetEntity, and rewrites that targetEntity (which is an Interface)
+     * at runtime with the concrete specified class (which is an entity in Core)
+     *
+     * @param Definition $definition
+     * @param string $interfaceName
+     * @param string $entityName
+     * @return void
+     */
+    private function addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName): void
+    {
+        $definition->addMethodCall('addResolveTargetEntity', array(
+            $interfaceName, //Resolve from: Interface in AddOn
+            $entityName, //Resolve to: Entity in Core
+            array(),
+        ));
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonResolveTargetEntity.php
@@ -52,6 +52,7 @@ class AddonResolveTargetEntity implements CompilerPassInterface
                         $this->addResolveTargetEntityMethodCalls($definition, $interfaceName, $entityName);
                     }
                 }
+                $definition->addTag('doctrine.event_subscriber', array('connection' => 'dplan'));
             }
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Application;
 
 use demosplan\DemosPlanCoreBundle\Addon\AddonBundleGenerator;
 use demosplan\DemosPlanCoreBundle\Addon\AddonDoctrineMigrationsPass;
+use demosplan\DemosPlanCoreBundle\Addon\AddonResolveTargetEntity;
 use demosplan\DemosPlanCoreBundle\Addon\LoadAddonInfoCompilerPass;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler\DeploymentStrategyLoaderPass;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler\DumpGraphContainerPass;
@@ -282,6 +283,7 @@ class DemosPlanKernel extends Kernel
         $container->addCompilerPass(new RpcMethodSolverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
         $container->addCompilerPass(new MenusLoaderPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
         $container->addCompilerPass(new OptionsLoaderPass(), PassConfig::TYPE_AFTER_REMOVING, 0);
+        $container->addCompilerPass(new AddonResolveTargetEntity(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         if ('test' !== $this->getEnvironment()) {
             $container->addCompilerPass(new LoadAddonInfoCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
             $container->addCompilerPass(new AddonDoctrineMigrationsPass());


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T29878

Description:
- Link CoreEntities to AddOn Interfaces on core
- Instead of linking every entity manually to its corresponding Interface in doctrine.yaml, the DemosPlanKernel does it using using AddonResolveTargetEntity (which is a CompilerPass)
- AddonResolveTargetEntity goes through the folder "Entity" in core and detects which Entities implement AddOn interfaces. If they do, then link them using addResolveTargetEntity.

### How to review/test
- Everytime that we create a new class in core (which implements an Addon Interfaces) we should clear cache e.g. bin/ewm dp:c:c , so that the DemosPlanKernel and consequently the new entities are linked with its interfaces.
- You can install demospipe:
-- in DemosEurope\DemosplanAddon\DemosPipes\Entity\PdfImport\AnnotatedStatementPdf update demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure for DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface
- Test DemosPipes

Delete the checkbox if it doesn't apply/isn't necessary.

- [x ] Move the tickets on the board accordingly
