### PR TITLE
chore: Update demosplan-ui to v0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0.3.5",
+    "@demos-europe/demosplan-ui": "^0.3.6",
     "@demos-europe/dp-consent": "^1.1.2",
     "@efrane/vuex-json-api": "0.0.38",
     "@masterportal/masterportalapi": "^2.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,10 +1372,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@demos-europe/demosplan-ui@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.3.5.tgz#fa4bb0af3a0e0db2accc13ad8246d844df8e3f63"
-  integrity sha512-sf1daP3XxR4NWKMYmZ8GO9mKVDGRLoMOBp1wy7FdvcJUaNgeno/nW1RP0sjfbcb2tAIVIADsxWN8S64jhCKSpg==
+"@demos-europe/demosplan-ui@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@demos-europe/demosplan-ui/-/demosplan-ui-0.3.6.tgz#a83b630a7b5574ecf0bff34784a60c38e641dadf"
+  integrity sha512-mu0sZLYzmw/b+NG4u/ocQM1nKTQSjHg9kV0ReCtUAKxI51/jh+FEu2jYsuZKtHyPX+t9/jI6iQnUxpzAhHUX4A==
   dependencies:
     "@braintree/sanitize-url" "^7.0.0"
     "@floating-ui/dom" "^1.4.5"


### PR DESCRIPTION
Update demosplan-ui to v0.3.6
