### PR TITLE
F t36299 tracking number of procedures per customer/client

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -527,6 +527,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
             $procedureList = [];
             foreach ($procedures as $procedure) {
                 $procedureList[$procedure->getId()] = $this->procedureToLegacyConverter->convertToLegacy($procedure);
+                $procedureList[$procedure->getId()]['customer'] = $procedure->getCustomer()?->getId();
             }
 
             return $this->procedureToLegacyConverter->toLegacyResult($procedureList, $search)->toArray();

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CustomerService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CustomerService.php
@@ -97,4 +97,12 @@ class CustomerService
             $existingCustomers
         );
     }
+
+    /**
+     * @return array<int, Customer>
+     */
+    public function getAllCustomers(): array
+    {
+        return $this->customerRepository->findAll();
+    }
 }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36299

Description:
Discussion within slack: https://demosdeutschland.slack.com/archives/CAJHZ7FHV/p1707208605942979

in short as an mvp wen want something like this:
```
choose {Customer-HH, Customer-SH, Customer-BY...}
with SubMenü regarding the chosen customer aka:
Orga-A => 35 Procedures
Orga-B => 1 Procedure
Orga-C => 3 Procedures
```

### How to review/test
blp->support->plattformtools->statistik

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] prepare templateVars['orgaInCustomerProcedureCreatedCount']
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
