### PR TITLE
fix (refs T34551): fix output warnig for organisations In Multiple Customers

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240108110342.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/01/Version20240108110342.php
@@ -126,7 +126,7 @@ class Version20240108110342 extends AbstractMigration
                     ['orgaId' => $kommune]
                 );
                 if (null !== $organisationName && '' !== $organisationName) {
-                    $kommune = $organisationName;
+                    $kommune = $kommune.' '.$organisationName;
                 }
                 if (array_key_exists($kommune, $resultingKommunes)) {
                     $resultingKommunes[$kommune][] = $customer['shortage'];


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T34551

Description:
When transforming the gathered data into a more human readable form - the OrgaId got replaced by the OrgaName if present.
Some organisations have the same name even-though their ids are different.
Do not treat those organisations as same when calculating the warning output.

The logic did not change - so altering this migration should be fine.

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/2514

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
