### PR TITLE
fix (refs T36342): disable element.assign when negative report is selected

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -173,6 +173,7 @@
 
         <template v-if="hasPermission('field_statement_add_assignment') && hasPlanningDocuments">
           <p
+            v-if="formData.r_isNegativeReport === '0'"
             aria-hidden="true"
             :class="prefixClass('c-statement__formblock-title u-mb-0_25 weight--bold inline-block')">
             {{ Translator.trans('element.assigned') }}
@@ -201,7 +202,7 @@
               </button>
             </template>
             <button
-              v-else
+              v-else-if="formData.r_isNegativeReport === '0'"
               data-cy="statementModal:elementAssign"
               @click="gotoTab('procedureDetailsDocumentlist')"
               :class="prefixClass('btn--blank o-link--default text-left')">


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36342

Description:
disable the option to add planningDocuments when negative report is selected

The file documentation/benutzerhandbuch/verfahrenstraeger/verfahren-einrichten/planungsdokumente.md points out that
`warning Hinweis Die Kategorien Gesamtstellungnahme, Fehlanzeige und Planzeichnung können nicht mit Dokumenten versehen werden.`

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
