### PR TITLE
feature (ref 32892): set permission to required contact person

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1649,6 +1649,11 @@ feature_require_locality_confirmation:
     expose: false
     label: 'Submission of draft statements as statements requires to confirm the locality'
     loginRequired: true
+feature_require_procedure_contact_person:
+    description: 'When a procedure be created, in diplanbeteiligung should contact person be required, therefore field should be empty otherwise be k.A'
+    expose: false
+    lable: 'Allows to set contact person without use default value'
+    loginRequired: true
 feature_screenshot_map_nonpublic_printlayers:
     description: 'Enables having a gislayer which is not published but is used only as print/export layer.'
     label: 'Include GisLayers that are not enabled, but marked as print in map screenshots'

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -850,7 +850,8 @@
                                             data-cy="publicParticipationContact"
                                             :toolbar-items="{ listButtons: false }"
                                             :maxlength="2000"
-                                            value="{{ proceduresettings.publicParticipationContact|default( "notspecified"|trans ) }}">
+                                            value="{{ proceduresettings.publicParticipationContact|default((hasPermission('feature_require_procedure_contact_person') ? '' : 'notspecified')|trans ) }}"
+                                            required>
                                         </dp-editor>
                                     </div>
                                 {% endif %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T32892

Description: created new procedure, should have required field of contact person, because of that we need a new permission to set default value of that

### How to review/test
set new procdure and if not set contact person under information of procedure in procedure setting, user can not save it.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
