### PR TITLE
bug (refs t30978) license notice in mapview missing

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -440,6 +440,8 @@ export default {
     this.centerX = (this.maxExtent[0] + this.maxExtent[2]) / 2
     this.centerY = (this.maxExtent[1] + this.maxExtent[3]) / 2
 
+    this.options.defaultAttribution =  mapOptions.copyright
+
     // Initial view values that can be defined in options object
     if (this._options.initialExtent.length > 0) {
       this.initialExtent = this._options.initialExtent

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
@@ -772,6 +772,9 @@ class MapService extends CoreService
         $mapOptions->setPublicSearchAutoZoom($config->getMapPublicSearchAutozoom());
         $mapOptions->setAvailableProjections($config->getMapAvailableProjections());
         $mapOptions->setDefaultProjection($config->getMapDefaultProjection());
+
+        $mapOptions->setCopyright($procedureSettings->getCopyright());
+
         $mapOptions->setId($procedureId);
 
         $mapOptions->lock();

--- a/demosplan/DemosPlanCoreBundle/Transformers/Map/MapOptionsTransformer.php
+++ b/demosplan/DemosPlanCoreBundle/Transformers/Map/MapOptionsTransformer.php
@@ -39,6 +39,7 @@ class MapOptionsTransformer extends BaseTransformer
             'availableProjections'          => $mapOptions->getAvailableProjections(),
             'defaultProjection'             => $mapOptions->getDefaultProjection(),
             'baseLayerProjection'           => $mapOptions->getBaseLayerProjection(),
+            'copyright'                     => $mapOptions->getCopyright(),
         ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Map/MapOptions.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Map/MapOptions.php
@@ -43,6 +43,8 @@ use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
  * @method        setDefaultProjection(array $defaultProjection)
  * @method string getBaseLayerProjection()
  * @method        setBaseLayerProjection(string $baseLayerProjection)
+ * @method        getCopyright(string $copyright)
+ * @method        setCopyright(string $copyright)
  */
 class MapOptions extends ValueObject
 {
@@ -91,4 +93,9 @@ class MapOptions extends ValueObject
      * @var string
      */
     protected $baseLayerProjection;
+
+    /**
+     * @var string
+     */
+    protected $copyright;
 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T30978

Description:
- The copyright (or also called license) saved in procedure_settings table was not displayed in the map (on the right bottom corner) for the corresponding procedure
- Now it is displayed. To do so:
-- MapService was adjusted to get the copyright.
-- FE makes a call to DemosPlanMapApiController -> dplan_api_map_options_public where MapService was adjusted
-- FE was also modified so that the new field copyright is detected and displayed

### How to review/test
1. Make a copy of bobsh dev
2. Go to this particular http://bobsh.dplan.local/app_dev.php/verfahren/da1074e4-c2c1-4e56-971c-411484cde6af/stellungnahmen/entwuerfe
3. Click on "Ansehen"
4. You will see the copyright saved in procedure_settings table (and not the default one)

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
