### PR TITLE
feature (ref 34724): create new permission to can manage note, that b…

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1162,7 +1162,7 @@ feature_new_statement_form:
     loginRequired: true
     parent: feature_statement
 feature_show_notice_draft_statement:
-    description: 'some project with Gateway as a project type (diplanbeteiligung) should not be show not for submitter in statement public'
+    description: 'some project with Gateway as a project type (diplanbeteiligung) should not be shown for the submitter in the public statement'
     expose: false
     label: 'note show'
     loginRequired: true

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1161,7 +1161,7 @@ feature_new_statement_form:
     label: 'Stell. verf. Formular anzeigen'
     loginRequired: true
     parent: feature_statement
-feature_not_show_notice_comment_release_draft_statement:
+feature_show_notice_draft_statement:
     description: 'some project with Gateway as a project type (diplanbeteiligung) should not be show not for submitter in statement public'
     expose: false
     label: 'note show'

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1161,6 +1161,11 @@ feature_new_statement_form:
     label: 'Stell. verf. Formular anzeigen'
     loginRequired: true
     parent: feature_statement
+feature_not_show_notice_comment_release_draft_statement:
+    description: 'some project with Gateway as a project type (diplanbeteiligung) should not be show not for submitter in statement public'
+    expose: false
+    label: 'note show'
+    loginRequired: true
 feature_notification_citizen_statement_submitted:
     label: 'Benachrichtigung an den Bürger bei eingereichten Stellungnahmen'
     loginRequired: true

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/new_public_participation_statement_confirm_content.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/new_public_participation_statement_confirm_content.html.twig
@@ -37,10 +37,8 @@
     {% block user_data_hint %}
         <p>
             {% if projectType == 'gateway' %}
-                {% if not hasPermission('feature_not_show_notice_comment_release_draft_statement') %}
+                {% if not hasPermission('feature_show_notice_draft_statement') %}
                     {{ "explanation.data.user.change"|trans({ href: gatewayURL, label: 'gateway'|trans })|wysiwyg }}
-                {% else %}
-                    {{ "" }}
                 {% endif %}
             {% else %}
                 {{ "explanation.data.user.change.portal"|trans({ url: path('DemosPlan_user_portal'), label: 'profile'|trans })|wysiwyg }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/new_public_participation_statement_confirm_content.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/new_public_participation_statement_confirm_content.html.twig
@@ -37,7 +37,11 @@
     {% block user_data_hint %}
         <p>
             {% if projectType == 'gateway' %}
-                {{ "explanation.data.user.change"|trans({ href: gatewayURL, label: 'gateway'|trans })|wysiwyg }}
+                {% if not hasPermission('feature_not_show_notice_comment_release_draft_statement') %}
+                    {{ "explanation.data.user.change"|trans({ href: gatewayURL, label: 'gateway'|trans })|wysiwyg }}
+                {% else %}
+                    {{ "" }}
+                {% endif %}
             {% else %}
                 {{ "explanation.data.user.change.portal"|trans({ url: path('DemosPlan_user_portal'), label: 'profile'|trans })|wysiwyg }}
             {% endif %}


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T34724

Description: The Note appears after release a draft statement for submitter should not be show in some project with gateway project type, because of that we use a new permission in this kind of projects 

### How to review/test
Logging as a private person and save a statement as a draft. Then release draft statement.

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-project-diplanfest/pull/62
- https://github.com/demos-europe/demosplan-project-diplanrog/pull/92
- https://github.com/demos-europe/demosplan-project-diplanbau/pull/191

### PR Checklist

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
