### PR TITLE
chore: trim Proxy params

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/HttpCall.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/HttpCall.php
@@ -83,7 +83,7 @@ class HttpCall
 
         // set proxy
         if (true === $this->isProxyEnabled()) {
-            $proxy = $this->proxyHost.':'.$this->proxyPort;
+            $proxy = trim($this->proxyHost).':'.trim($this->proxyPort);
             $options['proxy'] = $proxy;
             $this->logger->info('Use Proxy', [$proxy]);
         }

--- a/tests/backend/core/Core/Functional/HttpCallTest.php
+++ b/tests/backend/core/Core/Functional/HttpCallTest.php
@@ -1,10 +1,20 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Logic\HttpCall;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -12,10 +22,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class HttpCallTest extends TestCase
 {
-
     public function testRequestThrowsExceptionIfPathNotSet(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
@@ -59,9 +68,9 @@ class HttpCallTest extends TestCase
                 $method,
                 $path,
                 [
-                    'body' => $data,
+                    'body'    => $data,
                     'headers' => ['Content-Type' => 'application/json'], // Assuming content type is set
-                    'proxy' => $expected,
+                    'proxy'   => $expected,
                 ]
             )
             ->willReturn(new MockResponse('Response content'));

--- a/tests/backend/core/Core/Functional/HttpCallTest.php
+++ b/tests/backend/core/Core/Functional/HttpCallTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Logic\HttpCall;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class HttpCallTest extends TestCase
+{
+
+    public function testRequestThrowsExceptionIfPathNotSet(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $globalConfig = $this->createMock(GlobalConfigInterface::class);
+
+        $httpCall = new HttpCall($globalConfig, $httpClient, $logger);
+        $httpCall->request('GET', null, []);
+    }
+
+    public function testRequestUsesGetParametersWhenRequestMethodIsGet(): void
+    {
+        $path = '/example';
+        $data = ['key' => 'value'];
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', $path, ['query' => $data])
+            ->willReturn(new MockResponse('Response content'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $globalConfig = $this->createMock(GlobalConfigInterface::class);
+
+        $httpCall = new HttpCall($globalConfig, $httpClient, $logger);
+        $httpCall->request('GET', $path, $data);
+    }
+
+    /**
+     * @dataProvider provideRequestMethods
+     */
+    public function testRequestUsesOptionsCorrectly($proxyHost, $proxyPort, $expected): void
+    {
+        $method = 'POST';
+        $path = '/example';
+        $data = ['key' => 'value'];
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                $method,
+                $path,
+                [
+                    'body' => $data,
+                    'headers' => ['Content-Type' => 'application/json'], // Assuming content type is set
+                    'proxy' => $expected,
+                ]
+            )
+            ->willReturn(new MockResponse('Response content'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $globalConfig = $this->createMock(GlobalConfigInterface::class);
+        $globalConfig->method('isProxyEnabled')->willReturn(true);
+        $globalConfig->method('getProxyHost')->willReturn($proxyHost);
+        $globalConfig->method('getProxyPort')->willReturn($proxyPort);
+
+        $httpCall = new HttpCall($globalConfig, $httpClient, $logger);
+        $httpCall->setContentType('application/json'); // Set content type
+
+        $httpCall->request($method, $path, $data);
+    }
+
+    public function provideRequestMethods(): array
+    {
+        return [
+            ['proxy.example.com', '8080', 'proxy.example.com:8080'],
+            [' proxy.example.com ', ' 8080 ', 'proxy.example.com:8080'],
+        ];
+    }
+}


### PR DESCRIPTION
HttpClient needs to be a bit more robust regarding the configuration params, spaces should be trimmed

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
