### PR TITLE
f T36454 convert paramater to string

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -439,7 +439,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
                 }
 
                 $formattedStatement[$attributeKey] =
-                    $this->editorService->handleObscureTags((string)$formattedStatement[$attributeKey], $anonymous);
+                    $this->editorService->handleObscureTags((string) $formattedStatement[$attributeKey], $anonymous);
             }
 
             if (!$pushed) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -439,7 +439,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
                 }
 
                 $formattedStatement[$attributeKey] =
-                    $this->editorService->handleObscureTags($formattedStatement[$attributeKey], $anonymous);
+                    $this->editorService->handleObscureTags((string)$formattedStatement[$attributeKey], $anonymous);
             }
 
             if (!$pushed) {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36454

Description:  convert paramater to string: the value of $formattedStatement[$attributeKey] can be type int that's why it have to be converted


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
