### PR TITLE
feature (ref 36461): fix wrong naming for function in resourcetype

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerLoginSupportContactResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerLoginSupportContactResourceType.php
@@ -145,7 +145,7 @@ class CustomerLoginSupportContactResourceType extends DplanResourceType
         }
     }
 
-    public function isCreatable(): bool
+    public function isCreateAllowed(): bool
     {
         return $this->hasManagementPermission();
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36461

Description: Fix wrong naming of function `isCreatable`. Base on parent should be `isCreateAllowed`

### How to review/test
login as mandanten Admn, in Platform setting, try to create, edit, delete the field: Kontakt für fehlende Berechtigungen

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
