### PR TITLE
f T36467 Error when deleting other submitters of the same statement

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -32,6 +32,7 @@ use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\StatementResourceConfigB
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryStatement;
 use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
+use Doctrine\Common\Collections\ArrayCollection;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
@@ -404,7 +405,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 [$simpleStatementCondition],
                 [],
                 static function (Statement $statement, array $newValue): array {
-                    $statement->setSimilarStatementSubmitters($newValue);
+                    $statement->setSimilarStatementSubmitters(new ArrayCollection($newValue));
 
                     return [];
                 }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36467 

Description: adjust parameters type: the method 'setSimilarStatementSubmitters' need an doctrine array collection parameter not an array


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
