### PR TITLE
f T36440 Additional submitters should only be displayed if they have been specified

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -78,14 +78,17 @@ class SegmentsExporter
 
     public function addSimilarStatementSubmitters(Section $section, Statement $statement): void
     {
-        $similarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $this->getSimilarStatementSubmitters($statement)]);
-        $section->addText(
-            $similarStatementSubmittersText,
-            $this->styles['globalFont'],
-            $this->styles['globalSection']
-        );
+        $similarStatementSubmitters = $this->getSimilarStatementSubmitters($statement);
+        if ($similarStatementSubmitters !== '') {
+            $similarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $similarStatementSubmitters]);
+            $section->addText(
+                $similarStatementSubmittersText,
+                $this->styles['globalFont'],
+                $this->styles['globalSection']
+            );
 
-        $section->addTextBreak(2);
+            $section->addTextBreak(2);
+        }
     }
 
     protected function addHeader(Section $section, Procedure $procedure): void

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -79,7 +79,7 @@ class SegmentsExporter
     public function addSimilarStatementSubmitters(Section $section, Statement $statement): void
     {
         $similarStatementSubmitters = $this->getSimilarStatementSubmitters($statement);
-        if ($similarStatementSubmitters !== '') {
+        if ('' !== $similarStatementSubmitters) {
             $similarStatementSubmittersText = $this->translator->trans('segments.export.statement.similar.submitters', ['similarSubmitters' => $similarStatementSubmitters]);
             $section->addText(
                 $similarStatementSubmittersText,


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36440

Description: check whether similar statement submitters even exist before adding text


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
