### PR TITLE
chore: use existing password create function

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
@@ -66,8 +66,6 @@ use function array_key_exists;
 
 class UserService extends CoreService implements UserServiceInterface
 {
-    private const HEX_CHARS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
-
     /**
      * The hash function that is being used to generate password hashes.
      */
@@ -908,7 +906,7 @@ class UserService extends CoreService implements UserServiceInterface
             'lastname'     => '',
             'email'        => $userLogin,
             'login'        => $userLogin,
-            'password'     => $this->generateRandomString(128, self::HEX_CHARS),
+            'password'     => $this->generateNewRandomPassword(),
             'customer'     => $customer,
             'roles'        => [Role::CUSTOMER_MASTER_USER],
         ]);
@@ -1532,29 +1530,6 @@ class UserService extends CoreService implements UserServiceInterface
     protected function isNotDefaultDepartment(Department $department): bool
     {
         return 'Keine Abteilung' !== $department->getName();
-    }
-
-    /**
-     * Generates a cryptographically random string.
-     *
-     * The implementation is probably slower and more greedy for randomness than necessary, but as
-     * it is intended for the creation of customers on container-build it is seldom used and
-     * performance is not a concern.
-     *
-     * @param list<string> $allowedCharacters
-     *
-     * @throws Exception
-     */
-    private function generateRandomString(int $length, array $allowedCharacters): string
-    {
-        $allowedCharactersCount = count($allowedCharacters);
-        $string = '';
-        for ($i = 0; $i < $length; ++$i) {
-            $position = random_int(1, $allowedCharactersCount);
-            $string .= $allowedCharacters[$position - 1];
-        }
-
-        return $string;
     }
 
     /**


### PR DESCRIPTION
There is no need to implement a security feature when we can use an existing method that uses php core hash method. Logic is changed slightly, now a user is created with a 10 char password just like any other user that is created and not 128 chars, as before. This should be sufficient. 

### How to review/test
code review might be best

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
