### PR TITLE
build(refs T36496): Configure yarn cache dir for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
                 script{
                     containerName = "testContainer" + env.BRANCH_NAME + env.BUILD_NUMBER
                     commandDockerRun = 'docker run --cpus=1 -d --name ' + containerName + ' -v ${PWD}:/srv/www -v /var/cache/demosplanCI/:/srv/www/.cache/ --env CURRENT_HOST_USERNAME=$(whoami) --env CURRENT_HOST_USERID=$(id -u $(whoami)) demosdeutschland/demosplan-base:latest'
-                    commandExecYarn =  _dockerExecAsRoot('yarn install --prefer-offline --frozen-lockfile', containerName)
+                    commandExecYarn =  _dockerExecAsUser('yarn install --cache-folder=/srv/www/.cache/yarn --prefer-offline --frozen-lockfile', containerName)
                     commandExecComposer = _dockerExecAsRoot('composer install --no-interaction', containerName)
                     sh "mkdir -p .cache"
                     sh "echo ${PWD}"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36496

At some point, the default directory for yarn caches got moved from ~/.cache/yarn to /usr/local/share/yarn. This led to the shared cache directory no longer containing the yarn caches and subsequently to a massive increase in inode usage during CI builds of several distinct branches.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Check the Jenkins Builds for this branch
- Check that on the builder server, /var/cache/demosplanCI/yarn exists

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

