### PR TITLE
bug(refs T36509): Remove empty comment which is breaking the site

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -835,9 +835,9 @@
                                     <div class="u-mb">
                                         <label class="inline-block u-mb-0" for="r_publicParticipationContact">
                                             {{ 'public.participation.contact'|trans }}
-                                            {% if hasPermission('feature_require_procedure_contact_person') %}
+                                            {%- if hasPermission('feature_require_procedure_contact_person') -%}
                                                 <span aria-hidden="true">*</span>
-                                            {% endif %}
+                                            {%- endif -%}
                                         </label>
                                         {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
                                             helpText: 'text.procedure.edit.external.contact_person'|trans,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -834,9 +834,9 @@
                                 {% if hasPermission('field_procedure_contact_person') %}
                                     <div class="u-mb">
                                         <label class="inline-block u-mb-0" for="r_publicParticipationContact">
-                                            {{ 'public.participation.contact'|trans }}<!--
+                                            {{ 'public.participation.contact'|trans }}
                                             {% if hasPermission('feature_require_procedure_contact_person') %}
-                                                --><span aria-hidden="true">*</span>
+                                                <span aria-hidden="true">*</span>
                                             {% endif %}
                                         </label>
                                         {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36509

- Remove empty html comment which is breaking the site if the permission is not enabled
- Add twig whitespace control to trim any whitespace before or after the tag (`{%- ... -%}`)

### How to review/test
Verfahren -> Grundeinstellungen -> Informationen zum Verfahren -> Menu should be on the right side and more topics and save button should appear beneath "Informationen zum Verfahren"