### PR TITLE
Fix(T35058): long emails break the layout

### DIFF
--- a/client/js/components/support/DpSupportCard.vue
+++ b/client/js/components/support/DpSupportCard.vue
@@ -23,6 +23,7 @@ All rights reserved
       {{ phoneNumber }}
     </a>
     <p
+      class="break-words"
       v-if="email"
       v-text="email" />
     <template v-if="reachability.officeHours">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35058

**Description:** To avoid breaking the layout, add the `break-words` class to handle/display too long email addresses.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
