### PR TITLE
chore: simplify logger

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -2,17 +2,8 @@ monolog:
     use_microseconds: false
     channels:
         - 'dplan'
-        - 'dplan_cockpit'
-        - 'dplan_export'
-        - 'dplan_gateway'
-        - 'dplan_importer'
-        - 'dplan_mail'
         - 'dplan_maintenance'
-        - 'dplan_plugin'
-        - 'dplan_request'
         - 'dplan_404'
-        - 'dplan_csp'
-        - 'lgv'
     handlers:
         main:
             type: fingers_crossed
@@ -24,11 +15,6 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%demosplan_main_logfile%"
             channels: ["!console"] # log all channels in http request
-        deprecations:
-            type: stream
-            level: INFO
-            path: '%kernel.logs_dir%/php_info.log'
-            channels: [php]
         file:
             type: "%logging_strategy%"
             max_files: "%logging_max_files%"
@@ -41,60 +27,20 @@ monolog:
             type: "%logging_strategy%"
             max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/%demosplan_main_logfile%"
-            level: "%frontend_loglevel%"
+            level: "%symfony_loglevel%"
             channels: ["dplan"]
-        dplan.plugin:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            path: "%kernel.logs_dir%/%demosplan_main_logfile%"
-            level: "%frontend_loglevel%"
-            channels: ["dplan_plugin"]
-        dplan.gateway:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            path: "%kernel.logs_dir%/%demosplan_call_logfile%"
-            level: "%gatewayservice_loglevel%"
-            channels: ["dplan_gateway"]
-        dplan.request:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            path: "%kernel.logs_dir%/%demosplan_request_logfile%"
-            level: "%frontend_loglevel%"
-            channels: ["dplan_request"]
-        dplan.mail:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            path: "%kernel.logs_dir%/%demosplan_mail_logfile%"
-            level: "%mailservice_loglevel%"
-            channels: ["dplan_mail"]
         dplan.maintenance:
             type: "%logging_strategy%"
             max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/dplanmaintenance.log"
-            level: "%frontend_loglevel%"
+            level: "%symfony_loglevel%"
             channels: ["dplan_maintenance"]
-        dplan.importer:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            level: "%importer_loglevel%"
-            channels: ["dplan_importer"]
         dplan.404:
             type: "%logging_strategy%"
             max_files: "%logging_max_files%"
             path: "%kernel.logs_dir%/404.log"
-            level: "%frontend_loglevel%"
+            level: "%symfony_loglevel%"
             channels: ["dplan_404"]
-        dplan.csp:
-            type: "%logging_strategy%"
-            max_files: "%logging_max_files%"
-            path: "%kernel.logs_dir%/csp.log"
-            level: "notice"
-            channels: ["dplan_csp"]
-        lgv:
-            type: "%logging_strategy%"
-            path: "%kernel.logs_dir%/%lgv_logfile%"
-            level: "%lgv_local_debug%"
-            channels: ["lgv"]
 
 when@test:
     monolog:

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -33,10 +33,6 @@ nelmio_security:
             worker-src:
                 - 'none'
             upgrade-insecure-requests: '%https_only%' # upgrades HTTP requests to HTTPS transport
-        # log csp violations to a custom log channel
-        report_logger_service: monolog.logger.dplan_csp
-        report_endpoint:
-            log_channel: "dplan_csp"
 
         compat_headers: false #Disable compat_headers to avoid sending X-Content-Security-Policy (IE10, IE11, Firefox < 23). This will mean those browsers get no CSP instructions.
     clickjacking:

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -208,20 +208,8 @@ parameters:
     cache_doctrine: "filesystem"
 
     # Logging
-    # #refactor: Loglevels could be squeezed to symfony_loglevel only
-    symfony_loglevel: "INFO"
-    frontend_loglevel: "INFO"
-    mailservice_loglevel: "INFO"
-    importer_loglevel: "INFO"
-    gatewayservice_loglevel: "INFO"
+    symfony_loglevel: "info"
     demosplan_main_logfile: "dplan.log"
-    demosplan_frontend_logfile: "frontend.log"
-    demosplan_call_logfile: "servicecall.log"
-    demosplan_request_logfile: "request.log"
-    demosplan_mail_logfile: "mail.log"
-    demosplan_ids_logfile: "ids.log"
-    lgv_local_debug: "INFO"
-    lgv_logfile: "lgv.log"
 
     # Keep update logs instead of overwriting them
     keep_update_logfiles: false

--- a/config/services.yml
+++ b/config/services.yml
@@ -389,7 +389,6 @@ services:
 
     demosplan\DemosPlanCoreBundle\Logic\MailService:
         arguments:
-            $logger: '@monolog.logger.dplan_mail'
             $mailer: '@demosplan\DemosPlanCoreBundle\Logic\TestMailer'
         lazy: true
 
@@ -1206,10 +1205,7 @@ services:
 
     demosplan\DemosPlanCoreBundle\Logic\User\UserMapper: ~
 
-    demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGateway:
-        lazy: true
-        arguments:
-            $logger: '@monolog.logger.dplan_gateway'
+    demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGateway: ~
 
     demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGatewaySH:
         lazy: true


### PR DESCRIPTION
There is no need to have these huge amount of different channels. Finally we need to log everything to stderr in container context, this simplification is a step towards it.

ADO AB#14019

### How to review/test
do anything in dev and prod mode and follow logs or code review

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
