### PR TITLE
fix (refs: T30474) understandable procedure owning

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -68,6 +68,7 @@ class OwnsProcedureConditionFactory
 
         return [
             $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure(),
+            $this->procedureOrgaIdNotNull(),
             ...$this->hasProcedureAccessingRole($customer),
         ];
     }
@@ -88,6 +89,7 @@ class OwnsProcedureConditionFactory
 
         return [
             $this->userIsExplicitlyAuthorized(),
+            $this->procedureOrgaIdNotNull(),
             ...$this->hasProcedureAccessingRole($customer),
         ];
     }
@@ -123,8 +125,25 @@ class OwnsProcedureConditionFactory
 
         return [
             $this->isAuthorizedViaPlanningAgency(),
+            $this->procedureOrgaIdNotNull(),
             ...$this->hasProcedureAccessingRole($customer),
         ];
+    }
+
+    /**
+     * @return ClauseFunctionInterface<bool>
+     */
+    protected function procedureOrgaIdNotNull(): ClauseFunctionInterface
+    {
+        if ($this->userOrProcedure instanceof User) {
+            return $this->conditionFactory->propertyIsNotNull(['orga', 'id']);
+        }
+
+        $procedure = $this->userOrProcedure;
+
+        return null === $procedure->getOrgaId()
+            ? $this->conditionFactory->false()
+            : $this->conditionFactory->true();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -17,10 +17,10 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\ConditionFactory\ConditionGroupFactoryInterface;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PathException;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
@@ -53,16 +53,91 @@ class OwnsProcedureConditionFactory
     }
 
     /**
+     * Requires that all the following evaluates to `true`:
+     * * call to {@link GlobalConfig::isProcedureAuthorizationViaCreatingOrgaEnabled}
+     * * the accessing user has at least one of the following roles in the given customer: {@link Role::CUSTOMER_MASTER_USER}, {@link User::PLANNING_AGENCY_ROLES}, {@link User::HEARING_AUTHORITY_ROLES}
+     * * the accessing user is in the same organisation as the user that created the procedure in question
+     *
+     * @return list<ClauseFunctionInterface<bool>> all conditions that must evaluate to `true`
+     */
+    public function isAuthorizedViaCreatingOrga(Customer $customer): array
+    {
+        if (!$this->globalConfig->isProcedureAuthorizationViaCreatingOrgaEnabled()) {
+            return $this->conditionFactory->false();
+        }
+
+        return [
+            $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure(),
+            ...$this->hasProcedureAccessingRole($customer),
+        ];
+    }
+
+    /**
+     * Requires that all the following evaluates to `true`:
+     * * call to {@link GlobalConfig::isProcedureAuthorizationViaExplicitUserListEnabled}
+     * * the accessing user has at least one of the following roles in the given customer: {@link Role::CUSTOMER_MASTER_USER}, {@link User::PLANNING_AGENCY_ROLES}, {@link User::HEARING_AUTHORITY_ROLES}
+     * * the accessing user is listed in {@link Procedure::$authorizedUsers} of the procedure in question
+     *
+     * @return list<ClauseFunctionInterface<bool>> all conditions that must evaluate to `true`
+     */
+    public function isAuthorizedViaExplicitUserList(Customer $customer): array
+    {
+        if (!$this->globalConfig->isProcedureAuthorizationViaExplicitUserListEnabled()) {
+            return $this->conditionFactory->false();
+        }
+
+        return [
+            $this->userIsExplicitlyAuthorized(),
+            ...$this->hasProcedureAccessingRole($customer),
+        ];
+    }
+
+    /**
+     * Requires that all the following evaluates to `true`:
+     * * the accessing user has the following role in the given customer: {@link RoleInterface::PRIVATE_PLANNING_AGENCY}
+     * * the accessing user is in one of the organisations listed in {@link Procedure::$planningOffices} of the procedure in question
+     *
+     * @return list<ClauseFunctionInterface<bool>> all conditions that must evaluate to `true`
+     */
+    public function isAuthorizedViaPlanningAgencyStandardRole(Customer $currentCustomer): array
+    {
+        return [
+            $this->isAuthorizedViaPlanningAgency(),
+            ...$this->hasPlanningAgencyRole($currentCustomer),
+        ];
+    }
+
+    /**
+     * Requires that all the following evaluates to `true`:
+     * * call to {@link GlobalConfig::isProcedureAuthorizationViaPlannerInExplicitPlanningAgencyListEnabled}
+     * * the accessing user has at least one of the following roles in the given customer: {@link Role::CUSTOMER_MASTER_USER}, {@link User::PLANNING_AGENCY_ROLES}, {@link User::HEARING_AUTHORITY_ROLES}
+     * * the accessing user is in one of the organisations listed in {@link Procedure::$planningOffices} of the procedure in question
+     *
+     * @return list<ClauseFunctionInterface<bool>> all conditions that must evaluate to `true`
+     */
+    public function isAuthorizedViaPlanningAgencyPlannerRole(Customer $customer): array
+    {
+        if (!$this->globalConfig->isProcedureAuthorizationViaPlannerInExplicitPlanningAgencyListEnabled()) {
+            return $this->conditionFactory->false();
+        }
+
+        return [
+            $this->isAuthorizedViaPlanningAgency(),
+            ...$this->hasProcedureAccessingRole($customer),
+        ];
+    }
+
+    /**
      * The organisation of the user must be set as planning office in the procedure.
      *
-     * Planning agencies ("Planungsbüro") get the list of procedures they are
+     * Private planning agencies ("Planungsbüro") get the list of procedures they are
      * authorized for (enabled via field_procedure_adjustments_planning_agency).
      *
      * Will *not* check for the role of the user. Use {@link self::hasPlanningAgencyRole()} in conjunction with this method.
      *
-     * @return FunctionInterface<bool>
+     * @return ClauseFunctionInterface<bool>
      */
-    public function isAuthorizedViaPlanningAgency(): FunctionInterface
+    protected function isAuthorizedViaPlanningAgency(): ClauseFunctionInterface
     {
         if ($this->userOrProcedure instanceof User) {
             $user = $this->userOrProcedure;
@@ -74,34 +149,16 @@ class OwnsProcedureConditionFactory
         $procedure = $this->userOrProcedure;
         $procedurePlanningOffices = $procedure->getPlanningOfficesIds();
 
-        return $this->conditionFactory->propertyHasAnyOfValues($procedurePlanningOffices, ['orga', 'id']);
+        return [] === $procedurePlanningOffices
+            ? $this->conditionFactory->false()
+            : $this->conditionFactory->propertyHasAnyOfValues($procedurePlanningOffices, ['orga', 'id']);
     }
 
     /**
-     * If {@link GlobalConfigInterface::hasProcedureUserRestrictedAccess} is set to `false`,
-     * then the user must be in the organisation that created the procedure.
+     * Returns a condition to match users having the roles in the given customer to theoretically own a procedure if
+     * not in a private planning agency.
      *
-     * If {@link GlobalConfigInterface::hasProcedureUserRestrictedAccess} is set to `true`,
-     * then the user must be authorized manually for the procedure.
-     *
-     * The returned condition will not apply role checks by itself. Use in conjunction with
-     * {@link self::hasProcedureAccessingRole}.
-     *
-     * @return FunctionInterface<bool>
-     */
-    public function isAuthorizedViaOrgaOrManually(): FunctionInterface
-    {
-        // T8427: allow access by manually configured users if the config is set to `true`,
-        // overwriting the organisation-based access
-        return $this->globalConfig->hasProcedureUserRestrictedAccess()
-            ? $this->userIsExplicitlyAuthorized()
-            : $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure();
-    }
-
-    /**
-     * Returns a condition to match users having the roles in the given customer to theoretically own a procedure.
-     *
-     * @return list<FunctionInterface<bool>>
+     * @return list<ClauseFunctionInterface<bool>>
      */
     public function hasProcedureAccessingRole(Customer $customer): array
     {
@@ -137,7 +194,7 @@ class OwnsProcedureConditionFactory
     /**
      * The user must have the {@link RoleInterface::PRIVATE_PLANNING_AGENCY} role.
      *
-     * @return list<FunctionInterface<bool>>
+     * @return list<ClauseFunctionInterface<bool>>
      */
     public function hasPlanningAgencyRole(Customer $customer): array
     {
@@ -167,9 +224,9 @@ class OwnsProcedureConditionFactory
     }
 
     /**
-     * @return FunctionInterface<bool>
+     * @return ClauseFunctionInterface<bool>
      */
-    protected function isUserInCustomer(Customer $customer): FunctionInterface
+    protected function isUserInCustomer(Customer $customer): ClauseFunctionInterface
     {
         $customerId = $customer->getId();
         Assert::notNull($customerId);
@@ -206,7 +263,7 @@ class OwnsProcedureConditionFactory
      *
      * @throws PathException
      */
-    public function userIsExplicitlyAuthorized(): ClauseFunctionInterface
+    protected function userIsExplicitlyAuthorized(): ClauseFunctionInterface
     {
         if ($this->userOrProcedure instanceof User) {
             $user = $this->userOrProcedure;
@@ -226,7 +283,7 @@ class OwnsProcedureConditionFactory
      *
      * @throws PathException
      */
-    public function userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure(): ClauseFunctionInterface
+    protected function userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure(): ClauseFunctionInterface
     {
         if ($this->userOrProcedure instanceof User) {
             $user = $this->userOrProcedure;

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -63,7 +63,7 @@ class OwnsProcedureConditionFactory
     public function isAuthorizedViaCreatingOrga(Customer $customer): array
     {
         if (!$this->globalConfig->isProcedureAuthorizationViaCreatingOrgaEnabled()) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         return [
@@ -83,7 +83,7 @@ class OwnsProcedureConditionFactory
     public function isAuthorizedViaExplicitUserList(Customer $customer): array
     {
         if (!$this->globalConfig->isProcedureAuthorizationViaExplicitUserListEnabled()) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         return [
@@ -118,7 +118,7 @@ class OwnsProcedureConditionFactory
     public function isAuthorizedViaPlanningAgencyPlannerRole(Customer $customer): array
     {
         if (!$this->globalConfig->isProcedureAuthorizationViaPlannerInExplicitPlanningAgencyListEnabled()) {
-            return $this->conditionFactory->false();
+            return [$this->conditionFactory->false()];
         }
 
         return [

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Resources\config;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableViewMode;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -480,6 +481,9 @@ class GlobalConfig implements GlobalConfigInterface
     protected $roleGroupsFaqVisibility;
 
     /**
+     * T8427: allow access by manually configured users if the config is set to `true`,
+     * overwriting the organisation-based access.
+     *
      * Defines whether access to procedure is granted by owning organisation (false)
      * or whether it is possible to define specific users withing the organisation
      * who are granted access (true).
@@ -487,6 +491,9 @@ class GlobalConfig implements GlobalConfigInterface
      * Note that in the latter case (true), a user who would have been granted access
      * via its owning organisation **may not** get access if the following is true:
      * * s/he is **not** set in {@link Procedure::$authorizedUsers}
+     *
+     * Will also allow additional roles in private planning agencies (that are already allowed via
+     * {@link Procedure::$planningOffices}) to access the procedure.
      *
      * @var bool
      */
@@ -1784,5 +1791,20 @@ class GlobalConfig implements GlobalConfigInterface
         }
 
         return $externalLinks;
+    }
+
+    public function isProcedureAuthorizationViaCreatingOrgaEnabled(): bool
+    {
+        return !$this->procedureUserRestrictedAccess;
+    }
+
+    public function isProcedureAuthorizationViaExplicitUserListEnabled(): bool
+    {
+        return $this->procedureUserRestrictedAccess;
+    }
+
+    public function isProcedureAuthorizationViaPlannerInExplicitPlanningAgencyListEnabled(): bool
+    {
+        return $this->procedureUserRestrictedAccess;
     }
 }


### PR DESCRIPTION
Regarding draft state: it es to be clarified if the behavior of `$ownsViaPlanningAgencyExplicitly` is desired or not.


# **Yes, you are supposed to read all of the following text and review the assumptions and execution of each step, not just the code differences.**

## Refactoring of the `ownsProcedure` method

### Background, history and naming

Originally , the `Permissions::ownsProcedure` method abstracted away multiple factors to evaluate if a set of permissions should be enabled for a specific user when executing actions within a specific procedure.

The verb "owns" tries to summarize a specific access scope to the procedure. I.e. to just visit the public detail view or to submit statements as guest, citizen or institution, it is not necessary to "own" the procedure (see `Permissions::isMember`).

On the other hand, "owning" does not always grant exclusive nor full control over the procedure as the term may imply. Instead, multiple users of different organizations may "own" the procedure at the same time. Additionally the exact control of a user over a procedure he "owns" depends on the specific project and the user's roles.

To summarize, a modern description in place of "a user owns the procedure" may be "a user has work access to the procedure". This tries to imply that this is not simply about adding data from the outside (i.e. submitting statements), but about changing data within the procedure, be it its configuration, adding statements manually or processing submitted statements in some way.

### The need to move forward

Originally , the evaluation within `Permissions::ownsProcedure` was done using PHP logic with the specific user and procedure entities being present.

This however, is no longer sufficient, e.g.:
1. When a procedure is edited, some users may lose their claim on contained statements, thus a list of authorized users based on a given procedure is needed from the database¹. 
2. On the page displaying the procedure list a user is allowed to administrate, the list of procedures for a given user is needed from the database¹.
3. At some point it will be necessary to edit permission settings within a configuration file or via the web-UI. This is especially true for addons, as those can only provide one default configuration, which may not be able to cover all projects in which that addon is required. Thus, a format is needed to store the evaluation logic as text.

¹Ideally, the database request can be combined with additional conditions, to further reduce the result returned from the database.

All requirements can be covered by using the Drupal filter format and parsing it into EDT conditions. Even though the Drupal filter format can only cover filtering logic, this has the advantage of far smaller security implications, e.g. when using `eval` instead.

Writing support for Drupal filters and parsing them into conditions is already supported. The remaining tasks are thus limited to moving and adapting the PHP logic into Drupal filters.

By transforming the PHP logic into Drupal filters and providing them via the `demosplan-addon` git repository instead of `demosplan-core`, addons can use the "owning" logic while avoiding duplication (and thus potential deviations) of this logically complex and security sensitive code.

### Step 1: Consolidation of the "original" logic

After the logic in the `Permissions::ownsProcedure` method was mostly untouched for years, its refactoring into a different technical base began with [83c3a5adf02b2a8513f386ee8d626d52f500856d](https://github.com/demos-europe/demosplan/commit/83c3a5adf02b2a8513f386ee8d626d52f500856d) (archive). The "original" state can thus be viewed in the previous commit [2aad5a442ee17ae3e1feec091bf7a482872adf51](https://github.com/demos-europe/demosplan/commit/2aad5a442ee17ae3e1feec091bf7a482872adf51) (archive).

Leaving debugging statements aside and adding the (at that time non-existent) hearing authority roles, it can be summarized by the following pseudocode:

```
$roleSetA = [
    Role::CUSTOMER_MASTER_USER,
    Role::PLANNING_AGENCY_ADMIN,
    Role::PLANNING_AGENCY_WORKER,
    Role::HEARING_AUTHORITY_ADMIN,
    Role::HEARING_AUTHORITY_WORKER,
];

$configBasedLogic =
if globalConfig->hasProcedureUserRestrictedAccess()
  atLeastOneApplies
    procedure->getAuthorizedUsers() contains user
    procedure->planningOffices contains user->getOrga
else
  procedure->orgaId === $user->getOrganisationId

$orgaOwnsProcedure =
allApply
  procedure->orgaId not null
  user has at least one role in $roleSetA
  $configBasedLogic

$planningAgencyOwnsProcedure =
allApply
  procedure->planningOffices not empty
  user->hasRole(Role::PRIVATE_PLANNING_AGENCY)
  procedure->planningOffices contains user->getOrga

$result =
allApply
  user not null
  procedure not deleted
  atLeastOneApplies
    $orgaOwnsProcedure
    $planningAgencyOwnsProcedure
```

Some original variable names were kept, but even those do not correctly represent the underlying logic. 

### Step 2: Logic restructuring

In the following pseudocode, `globalConfig->hasProcedureUserRestrictedAccess()` was split into three configurations:
* `ownsProcedureViaCreatingOrga`
* `ownsProcedureViaExplicitUserAuthorization`
* `ownsProcedureViaExplicitPlanningAgencyAuthorization`

If all three are still based on the same parameter, the following pseudocode will behave exactly as the code above, while allowing a better understanding of the underlying concepts.

```
$roleSetA = [
    Role::CUSTOMER_MASTER_USER,
    Role::PLANNING_AGENCY_ADMIN,
    Role::PLANNING_AGENCY_WORKER,
    Role::HEARING_AUTHORITY_ADMIN,
    Role::HEARING_AUTHORITY_WORKER,
];

$ownsViaCreatingOrga =
allApply
  procedure->orgaId not null
  user has at least one role in $roleSetA in the current customer
  globalConfig->ownsProcedureViaCreatingOrga is enabled
  procedure->orgaId === $user->getOrganisationId

$ownsViaUserExplicity =
allApply
  procedure->orgaId not null
  user has at least one role in $roleSetA in the current customer
  globalConfig->ownsProcedureViaExplicitUserAuthorization is enabled
  procedure->getAuthorizedUsers() contains user

$ownsViaPlanningAgencyAutomatically =
allApply
  procedure->planningOffices not empty
  user has role Role::PRIVATE_PLANNING_AGENCY in the current customer
  procedure->planningOffices contains user->getOrga

$ownsViaPlanningAgencyExplicitly =
allApply
  procedure->orgaId not null
  user has at least one role in $roleSetA in the current customer
  globalConfig->ownsProcedureViaExplicitPlanningAgencyAuthorization is enabled
  procedure->planningOffices contains user->getOrga


$result =
allApply
  user not null
  procedure not deleted
  atLeastOneApplies
    $ownsViaCreatingOrga
    $ownsViaUserExplicity
    $ownsViaPlanningAgencyAutomatically
    $ownsViaPlanningAgencyExplicitly
```

### Step 3 (this PR)

Implement logic above in `demosplan-core` via `OwnsProcedureConditionFactory`. `OwnsProcedureConditionFactory` outputs PHP/DQL conditions, meaning the conditions can be executed via PHP and Doctrine, but not be stored as text in the Drupal filter format. Also, as `OwnsProcedureConditionFactory` resides in the core, it can not be easily used by addons. Both drawbacks are acceptable for this intermediate step.

### Step 4 (follow up PR)

Re-implement logic in `OwnsProcedureConditionFactory` as Drupal filters in a class residing in `demosplan-addon` and make the core use that class. This makes the "owning" logic available to addons while avoiding logic and code duplication between `demosplan-core` and `demosplan-addon`. As the implementation is new there are no licensing issues and by using Drupal filters the implementation can be stored as text or transformed into PHP/DQL conditions.


________

### How to review/test

Make sure you have executed all migrations!

As mentioned above, read all the text above and review the assumptions and execution of each step. Test the changes locally. You will notice that at least in BLP a lot of "Cypress Test" procedures are shown in the procedure list. This is due to the `isAuthorizedViaPlanningAgencyPlannerRole` logic. As I could not find any mistake on my part, I currently assume they should be displayed according to the original logic. But it may imply that the original logic should not be used for "modern" projects like BLP? This needs to be 

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
