### PR TITLE
feature (ref 34305): use method to export umlaut alphabet

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ExportReportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ExportReportService.php
@@ -21,6 +21,7 @@ use PhpOffice\PhpWord\Exception\Exception;
 use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\Writer\WriterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\String\u;
 
 class ExportReportService extends CoreService
 {
@@ -177,7 +178,7 @@ class ExportReportService extends CoreService
 
         $userName = $reportEntry->getUserName();
         $userCell = $table->addCell($this->styles['userCellWidth']);
-        $userCell->addText($userName, $this->styles['baseFont']);
+        $userCell->addText(u($userName)->normalize()->toString(), $this->styles['baseFont']);
     }
 
     /**


### PR DESCRIPTION
 **Ticket:** https://yaits.demos-deutschland.de/T31585

Description: use method `u()` to support umlaut alphabet in export

### How to review/test
export protocol of procedures as a PDF, there should be user in correct format

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
