### PR TITLE
feature (ref 34305): use break class to handle big insert data

### DIFF
--- a/client/js/components/support/DpSupportCard.vue
+++ b/client/js/components/support/DpSupportCard.vue
@@ -11,11 +11,11 @@ All rights reserved
   <section class="c-support__wrapper">
     <h4
       v-if="title"
-      class="u-mb-0_75 font-semibold font-size-large"
+      class="u-mb-0_75 font-semibold font-size-large break-words"
       v-text="title" />
     <a
       v-if="phoneNumber"
-      class="u-mt-0_25 inline-block font-semibold font-size-large color--black"
+      class="u-mt-0_25 inline-block font-semibold font-size-large color--black break-words"
       :href="`tel:${phoneNumber}`">
       <dp-icon
         class="inline-block"
@@ -30,17 +30,17 @@ All rights reserved
       <div
         v-if="reachability.service">
         <h4
-          class="u-mt-0_75 font-semibold"
+          class="u-mt-0_75 font-semibold break-words"
           v-text="reachability.service" />
         <p v-cleanhtml="reachability.officeHours" />
         <span
-          class="color--grey-light font-size-smaller"
+          class="color--grey-light font-size-smaller break-words"
           v-text="reachability.exception" />
       </div>
       <div
         v-else
         v-cleanhtml="reachability.officeHours"
-        class="u-mt-0_75 lg:mt-2" />
+        class="u-mt-0_75 lg:mt-2 break-words" />
     </template>
   </section>
 </template>

--- a/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
@@ -7,9 +7,9 @@
       @reset="resetForm"
       @saveEntry="id => dpValidateAction('contactData', () => createOrUpdateContact(id), false)">
       <template v-slot:list="contact">
-        <h3 v-text="contact.attributes.title" />
-        <p v-text="contact.attributes.phoneNumber" />
-        <p v-text="contact.attributes.eMailAddress" />
+        <h3 class="break-words" v-text="contact.attributes.title" />
+        <p class="break-words" v-text="contact.attributes.phoneNumber" />
+        <p class="break-words" v-text="contact.attributes.eMailAddress" />
         <template v-html="contact.attributes.text" />
         <dp-badge
           class="color--white rounded-full whitespace--nowrap bg-color--grey u-mt-0_125"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T35058

Description: use class break-words to handle big inserted data in support fields

### How to review/test
as client administrator, the large inserted data in Content Support should remain in the frame
in the information page, the large inserted data should no longer be the size of the frame

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
