### PR TITLE
fix(T36253): performance issue - ElementsList

### DIFF
--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -29,7 +29,8 @@
         @node-selection-change="nodeSelectionChange"
         :tree-data="recursiveElements"
         :branch-identifier="isBranch()"
-        :options="treeListOptions">
+        :options="treeListOptions"
+        leaf-only>
         <template v-slot:header="">
           <span class="color--grey">Dokumente des Verfahrens</span>
         </template>
@@ -104,13 +105,16 @@ export default {
     }),
 
     buttonLabel () {
-      let buttonLabel
-      if (this.selectedFiles.length > 0 && this.selectedFiles.length !== this.allFiles.length) {
-        buttonLabel = `Ausgewählte Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize(this.selectedFiles)})`
-      } else {
-        buttonLabel = `Alle Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize(this.allFiles)})`
-      }
-      return buttonLabel
+      return 'Hier sollte man über die Optimierung nachdenken, weil es viel kostet'
+      /*
+       *Let buttonLabel
+       *if (this.selectedFiles.length > 0 && this.selectedFiles.length !== this.allFiles.length) {
+       *buttonLabel = `Ausgewählte Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize2(this.selectedFiles)})`
+       *} else {
+       *buttonLabel = `Alle Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize(this.allFiles)})`
+       *}
+       *return buttonLabel
+       */
     },
 
     formAction () {
@@ -154,8 +158,7 @@ export default {
     },
 
     nodeSelectionChange (selected) {
-      const selectedFilesIds = selected.filter(node => node.nodeType === 'leaf').map(el => el.nodeId)
-      this.selectedFiles = this.allFiles.filter(file => selectedFilesIds.includes(file.id))
+      this.selectedFiles = selected
     },
 
     /*

--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -109,7 +109,7 @@ export default {
       /*
        *Let buttonLabel
        *if (this.selectedFiles.length > 0 && this.selectedFiles.length !== this.allFiles.length) {
-       *buttonLabel = `Ausgewählte Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize2(this.selectedFiles)})`
+       *buttonLabel = `Ausgewählte Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize(this.selectedFiles)})`
        *} else {
        *buttonLabel = `Alle Dokumente herunterladen (Zip, ca. ${this.accumulatedFileSize(this.allFiles)})`
        *}
@@ -159,6 +159,7 @@ export default {
 
     nodeSelectionChange (selected) {
       this.selectedFiles = selected
+      console.log('LENGTH', Object.values(this.selectedFiles).length)
     },
 
     /*


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36253

**Description:** `nodeSelectionChange` is an expensive function where a lot of interaction happens:

The parent component `ElementsList` receives a list/array of Objects with `nodeIds`:
1. it is filtered by _leaf_
2. a new array with Node-IDs is created
3. afterward `allFiles` are filtered accordingly to these nodeIds

There are a lot of interactions. Wouldn't it make more sense to not only pass nodeIds from child to parent, but also the node (with the file information, etc.)?

Changes here and in the [demosplan-ui](https://github.com/demos-europe/demosplan-ui/pull/761
) (DpTreeList components) helped optimize the loading time from 5-6 seconds to 2 (for a list of 800 elements).

But the main reason it freezes up is a reactive button that displays the size of the list.
