### PR TITLE
fix(refs T36457): prevent corrupt layers from breaking draw fn

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -1110,6 +1110,12 @@ export default {
             }
             const printLayerName = printLayer.getProperties().name
             const source = printLayer.getSource()
+
+            // This covers the edge case that a layer which is set as print layer is no longer valid.
+            if (source === null) {
+              return
+            }
+
             const tileUrlFunction = source.getTileUrlFunction()
             const tileGrid = source.getTileGrid()
             const tileSize = tileGrid.getTileSize()


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36457

Although this is an edge case we have to handle it: if a layer that is set as print layer becomes disfunctional (maybe because the service is discontinued), it must not break the frontend.

### How to review/test
Set a non-working layer as print layer, try to draw in the public detail map -> it should work.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
