### PR TITLE
bug(refs T23768): Disable opacity for base map

### DIFF
--- a/client/js/lib/map/GisLayerEdit.js
+++ b/client/js/lib/map/GisLayerEdit.js
@@ -44,7 +44,7 @@ export default () => {
     }
   })
 
-  const elementsHiddenForBase = [
+  const elementsHiddenForBaseMap = [
     {
       node: document.querySelector('input[name="r_user_toggle_visibility"]'),
       defaultValue: true
@@ -57,7 +57,7 @@ export default () => {
 
   // Check if base layer and disable user toggling on load
   if (document.querySelector('input[name="r_type"][value="base"]').checked) {
-    elementsHiddenForBase.forEach((element) => {
+    elementsHiddenForBaseMap.forEach((element) => {
       disableNode(element.node, element.defaultValue)
     })
   }
@@ -94,11 +94,11 @@ export default () => {
   function handleUserToggle (e) {
     const radioVal = e.target.value
     if (radioVal === 'base') {
-      elementsHiddenForBase.forEach((element) => {
+      elementsHiddenForBaseMap.forEach((element) => {
         disableNode(element.node, element.defaultValue)
       })
     } else {
-      elementsHiddenForBase.forEach((element) => {
+      elementsHiddenForBaseMap.forEach((element) => {
         enableNode(element.node)
       })
     }

--- a/client/js/lib/map/GisLayerEdit.js
+++ b/client/js/lib/map/GisLayerEdit.js
@@ -44,43 +44,64 @@ export default () => {
     }
   })
 
+  const elementsHiddenForBase = [
+    {
+      node: document.querySelector('input[name="r_user_toggle_visibility"]'),
+      defaultValue: true
+    },
+    {
+      node: document.querySelector('input[name="r_opacity"]'),
+      defaultValue: '100'
+    }
+  ]
+
   // Check if base layer and disable user toggling on load
   if (document.querySelector('input[name="r_type"][value="base"]').checked) {
-    const checkbox = document.querySelector('input[name="r_user_toggle_visibility"]')
-    checkbox.checked = true
-    checkbox.setAttribute('disabled', true)
-    // Create hidden input with all necessary attributes
-    document.getElementById('form').appendChild(createHidden())
+    elementsHiddenForBase.forEach((element) => {
+      disableNode(element.node, element.defaultValue)
+    })
   }
 
   // Add event listener to handle checkbox change
   Array.from(document.querySelectorAll('input[name="r_type"]')).forEach(el => el.addEventListener('change', handleUserToggle))
 
-  function handleUserToggle (e) {
-    const radioVal = e.target.value
-    const checkbox = document.querySelector('input[name="r_user_toggle_visibility"]')
-    if (radioVal === 'base') {
-      checkbox.checked = true
-      checkbox.setAttribute('disabled', true)
-      document.getElementById('form').appendChild(createHidden())
+  function createHiddenNode (node) {
+    const hiddenElement = node.cloneNode()
+    hiddenElement.setAttribute('hidden', true)
+    hiddenElement.setAttribute('id', `hidden_${node.getAttribute('id')}`)
+
+    return hiddenElement
+  }
+
+  function disableNode (node, defaultValue) {
+    if (node.type === 'checkbox') {
+      node.checked = defaultValue
     } else {
-      checkbox.removeAttribute('disabled')
-      const hidden = document.getElementById('hiddenUserToggle')
-      if (hidden) {
-        document.getElementById('form').removeChild(hidden)
-      }
+      node.value = defaultValue
+    }
+    document.getElementById('form').appendChild(createHiddenNode(node))
+    node.setAttribute('disabled', 'true')
+  }
+
+  function enableNode (node) {
+    node.removeAttribute('disabled')
+    const hidden = document.getElementById(`hidden_${node.getAttribute('id')}`)
+    if (hidden) {
+      document.getElementById('form').removeChild(hidden)
     }
   }
 
-  function createHidden () {
-    const hiddenCheckbox = document.createElement('input')
-    hiddenCheckbox.setAttribute('type', 'checkbox')
-    hiddenCheckbox.setAttribute('hidden', true)
-    hiddenCheckbox.checked = true
-    hiddenCheckbox.setAttribute('value', 1)
-    hiddenCheckbox.setAttribute('name', 'r_user_toggle_visibility')
-    hiddenCheckbox.setAttribute('id', 'hiddenUserToggle')
-    return hiddenCheckbox
+  function handleUserToggle (e) {
+    const radioVal = e.target.value
+    if (radioVal === 'base') {
+      elementsHiddenForBase.forEach((element) => {
+        disableNode(element.node, element.defaultValue)
+      })
+    } else {
+      elementsHiddenForBase.forEach((element) => {
+        enableNode(element.node)
+      })
+    }
   }
 
   // Xplan default layer checkbox handling

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -197,7 +197,7 @@
                 elements: [
                     {
                         label: { text: 'opacity.percent'|trans },
-                        control: { name: 'r_opacity', value: gislayer.opacity|default(100), pattern: "^\\d{1,2}?([.|,]\\d{1,2})?$|^100$", size: 'tiny' },
+                        control: { name: 'r_opacity', value: gislayer.opacity|default(100), pattern: "^\\d{1,2}?([\\.,]\\d{1,2})?$|^100$", size: 'tiny' },
                         id: 'r_opacity',
                         type: 'text',
                         required: true

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -251,6 +251,7 @@
 
             <label class="u-mb-0_5">
                 <input
+                    id="user_toggle_visibility"
                     type="checkbox"
                     name="r_user_toggle_visibility"
                     value="1"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -112,7 +112,7 @@
             elements: [
                 {
                     label: { text: 'opacity.percent'|trans },
-                    control: { name: 'r_opacity', value: templateVars.inData.r_opacity|default(100), pattern: "^\\d{1,2}?([.|,]\\d{1,2})?$|^100$", size: 'tiny' },
+                    control: { name: 'r_opacity', value: templateVars.inData.r_opacity|default(100), pattern: "^\\d{1,2}?([\\.,]\\d{1,2})?$|^100$", size: 'tiny' },
                     id: 'r_opacity',
                     type: 'text',
                     required: true
@@ -167,6 +167,7 @@
 
         <label class="u-mb-0_5">
             <input
+                id="user_toggle_visibility"
                 type="checkbox"
                 name="r_user_toggle_visibility"
                 data-cy="newMapLayerUserToggleVisibility"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T23768

- Fix regex pattern for opacity. Period is a special character in regex and needs to be escaped (double escape because backslash is a special character in twig and needs to be escaped). Remove redundant pipe that causes error
- Disable opacity settings for base maps, because the opacity should always be 100%. 

### How to review/test
Verfahren -> Antragsunterlagen -> Kartenebenen definieren -> Neue Kartenebene oder Kartenebene bearbeiten -> If Grundkarte is selected opacity should be disabled and 100%. Also check if regex for opacity is applied correctly when selecting Overlay (you should be able to put 0-100 in with two decimals (`.` or `,`). 
