### PR TITLE
fix(refs T36055): correctly fallback to defaultMapExtent

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -278,12 +278,14 @@ export default {
      * @return void
      */
     defineExtent (mapOptions) {
-      if (this._options.procedureExtent && mapOptions.procedureMaxExtent && mapOptions.procedureMaxExtent.length > 0) {
-        this.maxExtent = mapOptions.procedureMaxExtent
-      } else if (mapOptions.procedureDefaultMaxExtent && mapOptions.procedureDefaultMaxExtent.length > 0) {
-        this.maxExtent = mapOptions.procedureDefaultMaxExtent
-      } else {
-        this.maxExtent = mapOptions.defaultMapExtent
+      this.maxExtent = mapOptions.defaultMapExtent
+
+      if (this._options.procedureExtent !== false) {
+        if (mapOptions.procedureMaxExtent && mapOptions.procedureMaxExtent.length > 0) {
+          this.maxExtent = mapOptions.procedureMaxExtent
+        } else if (mapOptions.procedureDefaultMaxExtent && mapOptions.procedureDefaultMaxExtent.length > 0) {
+          this.maxExtent = mapOptions.procedureDefaultMaxExtent
+        }
       }
     },
 

--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -280,7 +280,7 @@ export default {
     defineExtent (mapOptions) {
       this.maxExtent = mapOptions.defaultMapExtent
 
-      if (this._options.procedureExtent !== false) {
+      if (this._options.procedureExtent) {
         if (mapOptions.procedureMaxExtent && mapOptions.procedureMaxExtent.length > 0) {
           this.maxExtent = mapOptions.procedureMaxExtent
         } else if (mapOptions.procedureDefaultMaxExtent && mapOptions.procedureDefaultMaxExtent.length > 0) {

--- a/client/js/components/statement/assessmentTable/DpMapModal.vue
+++ b/client/js/components/statement/assessmentTable/DpMapModal.vue
@@ -23,7 +23,7 @@
           :options="{
             autoSuggest: false,
             scaleSelect: false,
-            procedureExtent: false,
+            procedureExtent: true
           }">
           <template>
             <dp-ol-map-layer-vector


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36055

When using DpOlMap without this._options.procedureExtent being set to true, the default extent set in map_max_boundingbox should be used. This extent has to be set via props.

### How to review/test
See ticket for reproduction steps.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
