### PR TITLE
feature (ref 36557): fix the address of include twig

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
@@ -106,7 +106,7 @@
                         linkButton: true
                     }"
                     value="{{ templateVars.emailText|default }}">
-                    {% include '@DemosPlanCore/DemosPlanProcedure/includes/email_editor_boilerplates_modal.html.twig' %}
+                    {% include '@DemosPlanCore/DemosPlanProcedure/includes/email_editor_boilerplate_modal.html.twig' %}
                 </dp-editor>
             </div>
 


### PR DESCRIPTION
 **Ticket:** https://yaits.demos-deutschland.de/T36557

Description: Adjustment the name of twig.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
