### PR TITLE
feature (ref 36154): redirect new created Statement to AW table

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -22,8 +22,10 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\FileUploadService;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ServiceOutput;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\CountyService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\MunicipalityService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\PriorityAreaService;
@@ -155,6 +157,7 @@ class DemosPlanAssessmentController extends BaseController
         ServiceOutput $serviceOutput,
         StatementHandler $statementHandler,
         StatementService $statementService,
+        AssessmentHandler $assessmentHandler,
         string $procedureId
     ): ?Response {
         $rParams = $request->request->all();
@@ -189,11 +192,21 @@ class DemosPlanAssessmentController extends BaseController
                 if (null !== $headStatement) {
                     $statementHandler->addStatementToCluster($headStatement, $newStatement->getChildren()[0], true, true);
                 }
+                $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId);
 
                 if ($newStatement instanceof Statement) {
-                    $this->getMessageBag()->add(
-                        'confirm', 'confirm.statement.new', ['externId' => $newStatement->getExternId()]
-                    );
+                    $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
+                        'confirm',
+                        'confirm.statement.new',
+                        ['externId' => $newStatement->getExternId()],
+                        'dplan_assessmenttable_view_table',
+                        [
+                            'procedureId' => $procedureId,
+                            'filterHash'  => $filterSet->getHash(),
+                            '_fragment'   => $request->query->get('fragment', ''),
+                        ],
+                        $newStatement->getExternId()
+                    ));
 
                     return $this->redirectToRoute(
                         'DemosPlan_statement_new_submitted',


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36154

Description: The Message to be appeared after create a manual statement should have a link to statement table 

### How to review/test
create a new statement and click on external ID in message bag

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
