### PR TITLE
fix (refs T15681): Only show legend of layer if the layer is enabled and contains a legend file

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -254,7 +254,6 @@
     {% set layers_with_legend_files = [] %}
     {% for layer in filtered_legends %}
         {% if layer.defaultVisibility == true %}
-            {{ dump(layer.defaultVisibility) }}
             Transform object to be consumable by vue component
             {% set layers_with_legend_files = layers_with_legend_files|merge([{
                 name: layer.name,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -248,20 +248,23 @@
         {% set planPdf = { pdf: procedureSettings.planPDF, hash: procedureSettings.planPDF|getFile('hash'), mimeType: procedureSettings.planPDF|getFile('mimeType'), size: procedureSettings.planPDF|getFile('size','MB') } %}
     {% endif %}
 
-    {# Check whether there are layers with attached legend pdf files (feature_map_layer_legend_file) #}
+     Check whether there are layers with attached legend pdf files (feature_map_layer_legend_file)
     {% set all_layers = templateVars.baselayers.gislayerlist|default([])|merge(templateVars.overlays.gislayerlist|default([])) %}
     {% set filtered_legends = all_layers|filter(layer => '//' in layer.url and (layer.legend|default|getFile('size')|length > 0 or layer.legend|default|getFile('mimeType')|length > 0)) %}
     {% set layers_with_legend_files = [] %}
     {% for layer in filtered_legends %}
-        {# Transform object to be consumable by vue component #}
-        {% set layers_with_legend_files = layers_with_legend_files|merge([{
-            name: layer.name,
-            legend: {
-                hash: layer.legend|getFile('hash'),
-                mimeType: layer.legend|getFile('mimeType'),
-                fileSize: layer.legend|getFile('size')
-            }
-        }]) %}
+        {% if layer.defaultVisibility == true %}
+            {{ dump(layer.defaultVisibility) }}
+            Transform object to be consumable by vue component
+            {% set layers_with_legend_files = layers_with_legend_files|merge([{
+                name: layer.name,
+                legend: {
+                    hash: layer.legend|getFile('hash'),
+                    mimeType: layer.legend|getFile('mimeType'),
+                    fileSize: layer.legend|getFile('size')
+                }
+            }]) %}
+        {%  endif %}
     {% endfor %}
     {% if false == display_legend_box %}
         {% set display_legend_box = layers_with_legend_files|length > 0 %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -248,13 +248,13 @@
         {% set planPdf = { pdf: procedureSettings.planPDF, hash: procedureSettings.planPDF|getFile('hash'), mimeType: procedureSettings.planPDF|getFile('mimeType'), size: procedureSettings.planPDF|getFile('size','MB') } %}
     {% endif %}
 
-     Check whether there are layers with attached legend pdf files (feature_map_layer_legend_file)
+    {# Check whether there are layers with attached legend pdf files (feature_map_layer_legend_file) #}
     {% set all_layers = templateVars.baselayers.gislayerlist|default([])|merge(templateVars.overlays.gislayerlist|default([])) %}
     {% set filtered_legends = all_layers|filter(layer => '//' in layer.url and (layer.legend|default|getFile('size')|length > 0 or layer.legend|default|getFile('mimeType')|length > 0)) %}
     {% set layers_with_legend_files = [] %}
     {% for layer in filtered_legends %}
         {% if layer.defaultVisibility == true %}
-            Transform object to be consumable by vue component
+            {# Transform object to be consumable by vue component #}
             {% set layers_with_legend_files = layers_with_legend_files|merge([{
                 name: layer.name,
                 legend: {


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T15681

Description:
Only show legend of layer if the layer is enabled and contains a legend file
previously only the layer contains file check was active.

### How to review/test
Verfahren->Planunterlagen und Planzeichnung->Planzeichenerklärung hochladen->
either:
you upload a legend and switch to the public-view and check if the legend box gets displayed... go back and delete the legend and check again...
or:
you edit a baselayer -> attach a legend file and then check the public view depending on the layer being set to enabled or disabled. The legend box should only show up - if the layer contains a legend and is enabled.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
