### PR TITLE
fix (refs T30474): Use interfaces instead of entities as method parameters in core-entities implementing demosplan-addon interfaces

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -22620,5 +22620,5 @@
     "platform-overrides": {
         "php": "8.1.12"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.26",
+            "version": "v0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "e4f5a2cba028ee7a49ba5f941fa0df92edd81570"
+                "reference": "c56998e2fe811eb6bc7c546614f25d78cc939f5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/e4f5a2cba028ee7a49ba5f941fa0df92edd81570",
-                "reference": "e4f5a2cba028ee7a49ba5f941fa0df92edd81570",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/c56998e2fe811eb6bc7c546614f25d78cc939f5a",
+                "reference": "c56998e2fe811eb6bc7c546614f25d78cc939f5a",
                 "shasum": ""
             },
             "require": {
@@ -1435,9 +1435,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.26"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.28"
             },
-            "time": "2024-02-16T19:08:21+00:00"
+            "time": "2024-02-27T14:57:51+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",
@@ -22620,5 +22620,5 @@
     "platform-overrides": {
         "php": "8.1.12"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -804,7 +804,7 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles($plannerRoles);
     }
 
-    public function isHearingAuthority(Customer $customer = null): bool
+    public function isHearingAuthority(CustomerInterface $customer = null): bool
     {
         return $this->hasAnyOfRoles(self::HEARING_AUTHORITY_ROLES, $customer);
     }
@@ -817,7 +817,7 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::PLANNING_AGENCY_ADMIN]);
     }
 
-    public function isPlanningAgency(Customer $customer = null): bool
+    public function isPlanningAgency(CustomerInterface $customer = null): bool
     {
         return $this->hasAnyOfRoles(self::PLANNING_AGENCY_ROLES, $customer);
     }
@@ -1465,7 +1465,7 @@ class User implements SamlUserInterface, AddonUserInterface
         return in_array($role, $this->getDplanRolesArray($customer));
     }
 
-    public function hasAnyOfRoles(array $roles, Customer $customer = null): bool
+    public function hasAnyOfRoles(array $roles, CustomerInterface $customer = null): bool
     {
         foreach ($roles as $role) {
             if ($this->hasRole($role, $customer)) {

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -804,7 +804,7 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles($plannerRoles);
     }
 
-    public function isHearingAuthority(CustomerInterface $customer = null): bool
+    public function isHearingAuthority(?CustomerInterface $customer = null): bool
     {
         return $this->hasAnyOfRoles(self::HEARING_AUTHORITY_ROLES, $customer);
     }
@@ -817,7 +817,7 @@ class User implements SamlUserInterface, AddonUserInterface
         return $this->hasAnyOfRoles([RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::PLANNING_AGENCY_ADMIN]);
     }
 
-    public function isPlanningAgency(CustomerInterface $customer = null): bool
+    public function isPlanningAgency(?CustomerInterface $customer = null): bool
     {
         return $this->hasAnyOfRoles(self::PLANNING_AGENCY_ROLES, $customer);
     }
@@ -1297,7 +1297,7 @@ class User implements SamlUserInterface, AddonUserInterface
      *
      * @return Collection<int, RoleInterface>
      */
-    public function getDplanroles(CustomerInterface $customer = null): Collection
+    public function getDplanroles(?CustomerInterface $customer = null): Collection
     {
         $roles = new ArrayCollection();
         $relations = $this->roleInCustomers->toArray();
@@ -1327,7 +1327,7 @@ class User implements SamlUserInterface, AddonUserInterface
      *
      * @return string[]
      */
-    public function getDplanRolesArray(CustomerInterface $customer = null): array
+    public function getDplanRolesArray(?CustomerInterface $customer = null): array
     {
         if ($this->hasInvalidRoleCache()) {
             $this->rolesArrayCache = [];
@@ -1458,14 +1458,14 @@ class User implements SamlUserInterface, AddonUserInterface
      *
      * @param string $role
      */
-    public function hasRole($role, CustomerInterface $customer = null): bool
+    public function hasRole($role, ?CustomerInterface $customer = null): bool
     {
         $customer ??= $this->getCurrentCustomer();
 
         return in_array($role, $this->getDplanRolesArray($customer));
     }
 
-    public function hasAnyOfRoles(array $roles, CustomerInterface $customer = null): bool
+    public function hasAnyOfRoles(array $roles, ?CustomerInterface $customer = null): bool
     {
         foreach ($roles as $role) {
             if ($this->hasRole($role, $customer)) {


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T30474

Description:
Use interfaces instead of entities as method parameters in core-entities implementing demosplan-addon interfaces.

update composer.lock due to changes in demosplan-addon

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-addon/pull/93

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
