### PR TITLE
Check all write phases in AutoSwitchProcedurePhaseForm

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -196,17 +196,10 @@ export default {
      * @return {boolean}
      */
     isParticipationPhaseSelected () {
-      const participationPhases = [
-        'earlyparticipation',
-        'anotherearlyparticipation',
-        'participation',
-        'anotherparticipation',
-        'externalearlyparticipation',
-        'anotherexternalearlyparticipation',
-        'externalparticipation'
-      ]
-
-      return participationPhases.includes(this.selectedCurrentPhase)
+      return Object.values(this.availablePhases)
+        .filter(phase => phase.permission === 'write')
+        .map(phase => phase.value)
+        .includes(this.selectedCurrentPhase)
     },
 
     endDateId () {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -484,7 +484,9 @@
                                     <auto-switch-procedure-phase-form
                                         :available-phases="JSON.parse('{{ templateVars.internalPhases|map(internalPhase => {
                                             label: internalPhase.name,
-                                            value: internalPhase.key})|json_encode|e('js', 'utf-8') }}')"
+                                            permission: internalPhase.permissionset,
+                                            value: internalPhase.key
+                                        })|json_encode|e('js', 'utf-8') }}')"
                                         data-cy-end-date="administrationEditForm:designatedEndDate"
                                         data-cy-start-date="administrationEditForm:designatedStartDate"
                                         class="u-mb"
@@ -616,7 +618,9 @@
                                     <auto-switch-procedure-phase-form
                                         :available-phases="JSON.parse('{{ templateVars.externalPhases|map(externalPhase => {
                                             label: externalPhase.name,
-                                            value: externalPhase.key})|json_encode|e('js', 'utf-8') }}')"
+                                            permission: externalPhase.permissionset,
+                                            value: externalPhase.key
+                                        })|json_encode|e('js', 'utf-8') }}')"
                                         data-cy-end-date="administrationEditForm:designatedPublicEndDate"
                                         data-cy-start-date="administrationEditForm:designatedPublicStartDate"
                                         class="u-mb"


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36196

By passing the permission into AutoSwitchProcedurePhaseForm, we do not need to maintain a list of keys
within the component. this is less error-prone, in case phases are added or removed later.

### How to review/test
In the basic settings view (blp), select "Verfahrensschritt Institutionen" >  Verfahrensschritt "erneute öffentliche Auslegung". The checkbox "Verfahrensschritt automatisch umstellen" should be checked and disabled automatically, as it is for other write-procedurePhases.

### Linked PRs (optional)
- https://github.com/demos-europe/demosplan-core/pull/2652

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
