### PR TITLE
Allow for opting out of default filter of procedures on public_index 

### DIFF
--- a/client/js/bundles/procedure/publicIndexNoMap.js
+++ b/client/js/bundles/procedure/publicIndexNoMap.js
@@ -41,6 +41,12 @@ const setSelectedOption = function () {
   const combinedParticipationPreparation = document.getElementById('combinedParticipationPreparation')
   const combinedFilterOption = document.getElementById('combinedFilter')
   const allOption = document.getElementById('all-option')
+  const filterPhasesSelectEl = document.getElementById('filterPhases')
+
+  // Allow projects to opt out of default filtering
+  if (filterPhasesSelectEl?.dataset?.defaultSelected === 'all') {
+    return
+  }
 
   //  If there are results for any of the filters in the 'all in participation and preparation' option
   if ((combinedParticipationPreparation.value === allInParticipationPreparationInternal &&
@@ -181,7 +187,6 @@ const filterProceduresByPhase = function () {
 }
 
 initialize().then(() => {
-  filterProceduresByPhase()
   setSelectedOption()
   document.getElementById('filterPhases').addEventListener('change', filterProceduresByPhase)
 })


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36464

Some projects may prefer not to filter procedures
when loading the public index page. This is now supported via dropping a `data-default-selected="all"` on the select element. In future iterations, other keys may be used to set another default filters.

### How to review/test
When loading the public index page in a project that uses `publicIndexNoMap.js` for its view, applying `data-default-selected="all"` to the select element with the id `filterPhases` should lead to no option being selected automagically.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
