### PR TITLE
bug (ref T36592) Adjust "element" in include for API request so EDT can understand and match the entity

### DIFF
--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -473,7 +473,7 @@ export default {
      */
     getStatementAction ({ commit, state, rootState }, data) {
       const includes = [
-        'elements',
+        'element',
         'paragraph',
         'document',
         'assignee',

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -473,7 +473,7 @@ export default {
      */
     getStatementAction ({ commit, state, rootState }, data) {
       const includes = [
-        'element',
+        'elements',
         'paragraph',
         'document',
         'assignee',

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
@@ -22,6 +22,7 @@ use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterEmailAddress @deprecated Move into StatementSubmitData resource type or something similar
@@ -61,7 +62,7 @@ use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isManual
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, File> $files @deprecated Use {@link StatementResourceType::$attachments} instead (needs implementation changes)
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Segment> $segments
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $paragraphOriginal
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, StatementFragment> $fragmentsElements @deprecated Create a {@link StatementFragment} relationship instead
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterPostalCode


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36582z

Description:
- Set ToOneRelationshipConfigBuilderInterface in the $element. It was configured to ToManyRelationshipConfigBuilderInterface. When the $element is null, it breaks. Now it does not.


Context:
- Abwägungstabelle does not load because the Procedure has Statements with no PlanungsDokumenten
- The PlanungDokumenten are this _st_element_id FK in the statement table. When _st_element_id is null, the Abwägungstabelle does not load
- This happens because element is defined as ToManyRelationshipConfigBuilderInterface but in reality it should be  ToOneRelationshipConfigBuilderInterface.

### How to review/test
- Go to Bebauungsplan Nr. 3 Supermarkt Kleinstadt-West Verfahren
- Click on "new"
- The Abwägungstabelle should load now


Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ x] Move the tickets on the board accordingly
