### PR TITLE
fix (refs T36493): prevent editing map copyright content for bobsh

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -80,6 +80,10 @@ area_admin_map_description:
     label: 'Verwalten Planzeichenerkl.'
     loginRequired: true
     parent: area_admin
+area_admin_map_copyright:
+    label: "administrate procedure map copyright content"
+    loginRequired: tue
+    parent: area_admin
 area_admin_news:
     label: 'Verwalten Aktuelles'
     loginRequired: true

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -678,7 +678,9 @@ class ServiceStorage implements ProcedureServiceStorageInterface
             $procedure['settings']['defaultLayer'] = $data['r_defaultLayer'];
         }
 
-        if (array_key_exists('r_copyright', $data)) {
+        if ($this->currentUser->hasPermission('area_admin_map_copyright') &&
+            array_key_exists('r_copyright', $data)
+        ) {
             $procedure['settings']['copyright'] = $data['r_copyright'];
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -678,8 +678,8 @@ class ServiceStorage implements ProcedureServiceStorageInterface
             $procedure['settings']['defaultLayer'] = $data['r_defaultLayer'];
         }
 
-        if ($this->currentUser->hasPermission('area_admin_map_copyright') &&
-            array_key_exists('r_copyright', $data)
+        if ($this->currentUser->hasPermission('area_admin_map_copyright')
+            && array_key_exists('r_copyright', $data)
         ) {
             $procedure['settings']['copyright'] = $data['r_copyright'];
         }

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -538,6 +538,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 'area_admin_assessmenttable',  // Verwalten Abwaegungstabelle
                 'area_admin_dashboard',  // Übersichtsseite
                 'area_admin_map',  // Verwalten Planzeichnung
+                'area_admin_map_copyright',
                 'area_admin_map_description',  // Verwalten Planzeichenerklärung
                 'area_admin_news',  // Verwalten Aktuelles (im Verfahren)
                 'area_admin_paragraphed_document',  // Verwalten Begruendung + Textliche Festsettung/Verordnung

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -134,7 +134,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Initialisiere die Permissions.
      */
-    public function initPermissions(UserInterface $user, array $context = null): PermissionsInterface
+    public function initPermissions(UserInterface $user, ?array $context = null): PermissionsInterface
     {
         $this->user = $user;
 
@@ -885,7 +885,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Setzt das initiale Set von kontxtbezogenen Menue-Highlights.
      */
-    protected function initMenuhightlighting(array $context = null): void
+    protected function initMenuhightlighting(?array $context = null): void
     {
         if (null !== $context) {
             foreach ($context as $permission) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -103,6 +103,7 @@
                 {{ 'map.attribution'|trans }}
             </label><!--
          --><div class="layout__item u-3-of-4">
+                {% if hasPermission('area_admin_map_copyright') %}
                 <input
                     name="r_copyright"
                     type="text"
@@ -112,6 +113,11 @@
                 <p class="lbl__hint">
                     {{ 'map.attribution.placeholder'|trans|wysiwyg('strong') }}
                 </p>
+                {% else %}
+                <p class="layout__item">
+                    {{ mapglobals.copyright }}
+                </p>
+                {% endif %}
             </div>
 
             {# Show only layers from one category simultaneously #}


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36493

Description:
As the same default should be used as the procedure map copyright content - without the option to change this text...
A new permission was introduced to edit this field and to save its content.
A migration is added to adjust all map copyright contents present so far.

For now I think it is okay to use the deprecated `disablePermission` to prevent necessary changes to every project.

I would like to get some front-end help - as i am not sure about this solution.

### How to review/test
goto procedure->planungsdokumente/planzeichnung->StartkartenAusschnitt/Kartenbegrenzung->Copyright-Vermerk 

In bobsh you can not edit / save this field anymore - in all other projects you can.

### Linked PRs (optional)
See mentioned PRs for permission in bobsh

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
