### PR TITLE
fix(T36253): TreeList performance issue

### DIFF
--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -29,7 +29,8 @@
         @node-selection-change="nodeSelectionChange"
         :tree-data="recursiveElements"
         :branch-identifier="isBranch()"
-        :options="treeListOptions">
+        :options="treeListOptions"
+        selection-by-prop>
         <template v-slot:header="">
           <span class="color--grey">Dokumente des Verfahrens</span>
         </template>
@@ -153,9 +154,23 @@ export default {
       return formatBytes(byteSize).replace(/\./g, ',')
     },
 
-    nodeSelectionChange (selected) {
-      const selectedFilesIds = selected.filter(node => node.nodeType === 'leaf').map(el => el.nodeId)
-      this.selectedFiles = this.allFiles.filter(file => selectedFilesIds.includes(file.id))
+    getAllSelectedSingleDocuments (recursiveElements) {
+      let singleDocuments = []
+
+      recursiveElements.forEach(element => {
+        if (element.type === 'singleDocument' && element.isSelected) {
+          singleDocuments.push(element)
+        } else if (element.children && element.children.length > 0) {
+          const childSingleDocuments = this.getAllSelectedSingleDocuments(element.children)
+          singleDocuments = singleDocuments.concat(childSingleDocuments)
+        }
+      })
+
+      return singleDocuments
+    },
+
+    nodeSelectionChange () {
+      this.selectedFiles = this.getAllSelectedSingleDocuments(this.recursiveElements)
     },
 
     /*


### PR DESCRIPTION
**Issue:** 

When selecting a folder with many subfolders and approximately 800 files, each element in the list starts the process (points 1, 2, 3, 4) one after the other, and the page freezes because it takes about 1 minute to perform the calculations:

1. `DpTreeListNode.vue`: **An object is created** with the `nodeId` and **sent to parent** via emit.
2. `DpTreeList.vue`: The object is added to the list `selectedNodesObject`. Then this list is **transformed into an array** and forwarded to the parent via emit.
3. `ElementsList.vue`: The **array is filtered** by _leaf_ and a **new array** with IDs is **created**. Then **allFiles are filtered** by these IDs, and **a new array** with selected files is **created**.
4. ` ElementsList.vue`: Reactive Button Label responds to changes in the list, and the size of the selected files is calculated and displayed.

**The main issues with the current logic:**

- the list elements are in the DOM even when they are not visually visible. This was implemented so that the parent component (Folder) could have access to the child component in the DOM and clicked `nodeIds` could be collected.
- the data transmission from the child to the parent component with various data transformations are also time consuming, especially when there are many elements.

**Changes in these PRs:**

My suggestion would be to change a logic a bit and to add an `isSelected` property to each node object: if a checkbox is selected, the value changes. If the node has children, the value will also be recursively changed for the children. Using this, we could remove points 1, 2, and 3, which **improves the performance from 1 minute to milliseconds** for the list of 800 elements.

[PR in demosplan-ui](https://github.com/demos-europe/demosplan-ui/pull/771)

**Advantages:**

- list elements can exist in the DOM only when they should be visible, as this depends on the value of `isSelected`.
- events (child to parent) can be reduced

**The TreeList component is used in multiple places, so I have currently added a prop called `selectionByProp` that can enable this functionality. Currently, I cannot change the` v-show` directive to `v-if` because either `v-if` or `v-show` should be used in the template. But maybe we can implement this functionality as a standard?**