### PR TITLE
fix (refs T36617): prevent a permission check via onKernelEvent before permissions are initialized.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -134,7 +134,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Initialisiere die Permissions.
      */
-    public function initPermissions(UserInterface $user, array $context = null): PermissionsInterface
+    public function initPermissions(UserInterface $user, ?array $context = null): PermissionsInterface
     {
         $this->user = $user;
 
@@ -882,7 +882,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Setzt das initiale Set von kontxtbezogenen Menue-Highlights.
      */
-    protected function initMenuhightlighting(array $context = null): void
+    protected function initMenuhightlighting(?array $context = null): void
     {
         if (null !== $context) {
             foreach ($context as $permission) {

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -156,11 +156,9 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
      */
     public function evaluateUserInvitedInProcedure(Procedure $procedure, Session $session): void
     {
-        if ($this->hasPermission('feature_public_consultation')) {
-            $invitedProcedures = $session->get('invitedProcedures', []);
-            if (\in_array($procedure->getId(), $invitedProcedures, true)) {
-                $this->userInvitedInProcedure = true;
-            }
+        $invitedProcedures = $session->get('invitedProcedures', []);
+        if (\in_array($procedure->getId(), $invitedProcedures, true)) {
+            $this->userInvitedInProcedure = true;
         }
     }
 


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36617

Description:
prevent a permission check via onKernelEvent before permissions are initialized.
https://demosdeutschland.slack.com/archives/CDYHJ0P41/p1709540989391119?thread_ts=1709298531.199759&cid=CDYHJ0P41

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
