### PR TITLE
feature (ref 36588): create a permission for profile edit

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1622,6 +1622,10 @@ feature_project_switcher:
     label: 'Display a dropdown menu in global header to allow users to quickly move to other instances of the SH platform.'
     loginRequired: false
     parent: area_admin
+feature_profile_editable:
+    description: 'If enabled the user can edit his/her data'
+    label: 'Speichern/Abrechnen Formular anzeigen'
+    loginRequired: true
 feature_public_consultation:
     description: 'When a procedure is in the consultation phase, participants must have a way to access it.'
     expose: true

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_profile.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_profile.html.twig
@@ -139,10 +139,12 @@ Therefor we want to hide it from the User #}
         </div>
     {% endif %}
 
-    <div class="{{ 'text-right space-inline-s'|prefixClass }}">
-        <input class="{{ 'btn btn--primary'|prefixClass }}" type="submit" value="{{ "save"|trans }}">
-        <input class="{{ 'btn btn--secondary'|prefixClass }}" type="reset" value="{{ "abort"|trans }}">
-    </div>
+    {% if hasPermission('feature_profile_editable') %}
+        <div class="{{ 'text-right space-inline-s'|prefixClass }}">
+            <input class="{{ 'btn btn--primary'|prefixClass }}" type="submit" value="{{ "save"|trans }}">
+            <input class="{{ 'btn btn--secondary'|prefixClass }}" type="reset" value="{{ "abort"|trans }}">
+        </div>
+    {% endif %}
 
 
 </form>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36588

Description: Institution_Sachbearbeitung and Fachplaner-Sachbearbeiter (PLANNING_AGENCY_WORKER and PUBLIC_AGENCY_WORKER) should not have a save/cancel option in my data form, because of that I created a new permission and use that in every project

### How to review/test
go to mein Daten and check these roles have those options or not

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly