### PR TITLE
feature (ref 36690): Data collector has a right link after create a s…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -195,7 +195,7 @@ class DemosPlanAssessmentController extends BaseController
                 $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId);
                 $routeName = $currentUser->getUser()->hasRole(Role::PROCEDURE_DATA_INPUT) ?
                     'DemosPlan_statement_orga_list' : 'dplan_assessmenttable_view_table';
-                $routeParameters = 'DemosPlan_statement_single_view' === $routeName ?
+                $routeParameters = 'DemosPlan_statement_orga_list' === $routeName ?
                     [
                         'procedureId' => $procedureId,
                     ] :


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36690

Description: The link appears after create a manual statement for data collector go to access denied page, because of that I used some condition for different roles

### How to review/test
loggin as a data collector, create a new statement and click on the link in success message

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
