### PR TITLE
fix(refs T27465): display only documents that should be visible

### DIFF
--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -189,8 +189,8 @@ export default {
         const isTopLevel = node.attributes.parentId === null
 
         // Make documents direct children of node, if there are any
-        if (node.hasRelationship('documents')) {
-          node.children = [...node.children, ...Object.values(node.relationships.documents.list())]
+        if (node.hasRelationship('visibleDocuments')) {
+          node.children = [...node.children, ...Object.values(node.relationships.visibleDocuments.list())]
         }
 
         // Push item to correct position in map
@@ -235,7 +235,7 @@ export default {
   mounted () {
     // Initially get data from endpoint
     this.elementList({
-      include: ['children', 'documents'].join(),
+      include: ['children', 'visibleDocuments'].join(),
       filter: {
         enabledElements: {
           condition: {
@@ -254,11 +254,11 @@ export default {
          * Initially get the files attached to all elements to calculate the size for all files.
          * However, this does not have to be reactive since does not change.
          */
-        this.allFiles = Object.values(this.elements).reduce((documents, element) => {
-          if (element.hasRelationship('documents')) {
-            return [...documents, ...Object.values(element.relationships.documents.list())]
+        this.allFiles = Object.values(this.elements).reduce((visibleDocuments, element) => {
+          if (element.hasRelationship('visibleDocuments')) {
+            return [...visibleDocuments, ...Object.values(element.relationships.visibleDocuments.list())]
           } else {
-            return documents
+            return visibleDocuments
           }
         }, [])
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
@@ -506,7 +506,7 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
     }
 
     /**
-     * @return ArrayCollection|SingleDocument[]
+     * @return Collection<int, SingleDocument>
      */
     public function getDocuments(): Collection
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
@@ -199,9 +199,6 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
      */
     protected $organisations;
 
-    /**
-     * @var mixed
-     */
     protected $type;
 
     /**
@@ -567,17 +564,11 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
         }
     }
 
-    /**
-     * @return DateTime
-     */
     public function getDesignatedSwitchDate(): ?DateTime
     {
         return $this->designatedSwitchDate;
     }
 
-    /**
-     * @param DateTime $designatedSwitchDate
-     */
     public function setDesignatedSwitchDate(?DateTime $designatedSwitchDate): void
     {
         $this->designatedSwitchDate = $designatedSwitchDate;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T27465

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- only documents with the attribute `visible` set to `true` should be displayed in the list
- normally, this is filtered in the backend, but if the user `hasPermission('area_admin_single_document')`, documents are not
filtered, so all documents are displayed
- since we can't currently filter the relationships of a resourceType via json api request, we decided to add a new relationship
`visibleDocuments` that is now used instead of `documents`

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
