### PR TITLE
fix(refs T36638): remove obsolete negative margin

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_switcher.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_switcher.scss
@@ -16,7 +16,6 @@
 //  object container
 .o-switcher {
     display: inline-block;
-    margin-left: -22px;
     height: 35px;
     line-height: 35px;
     background-color: $dp-color-neutral-light-2;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36638

The surrounding container seems to not apply a margin anymore, so there is no need for the negative margin anymore.

### How to review/test
should look like this:
![image](https://github.com/demos-europe/demosplan-core/assets/40452344/8126612f-0d18-4422-a9e5-36a68e89405d)

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
