### PR TITLE
F t36528 add similar stn submitters to statement list export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -138,6 +138,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     public function exportStatement(Section $section, Statement $statement): void
     {
         $this->addStatementInfo($section, $statement);
+        $this->addSimilarStatementSubmitters($section, $statement);
         $this->addSegments($section, $statement);
         $this->addFooter($section, $statement);
     }


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36528

Description:
Adds similar stn submitters to statement list docx export(s)

The FE allert still needs to be done:
logic present in: ```client/js/components/statement/listStatements/ListStatements.vue Zeile 50 showHintAndDoExport```
needs to be implemented to ```client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue Zeile 71 mit @click.prevent```

How To Test:
![image](https://github.com/demos-europe/demosplan-core/assets/89914798/617f3de8-642b-4570-acfd-62200e68088d)

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [  ] Move the tickets on the board accordingly
