### PR TITLE
chore (refs T36726): strip invalid a tags without href in export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -283,6 +283,10 @@ class SegmentsExporter
     {
         $text = str_replace('<br>', '<br/>', $text);
 
+        // strip all a tags without href
+        $pattern = '/<a\s+(?!.*?\bhref\s*=\s*([\'"])\S*\1)(.*?)>(.*?)<\/a>/i';
+        $text = preg_replace($pattern, '$3', $text);
+
         // avoid problems in phpword parser
         return $this->HTMLSanitizer->purify($text);
     }


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36726

Docx creation failed for a tags without href defined like `<a rel="noopener noreferrer nofollow">nolink</a>`. We need to strip all those occurrences without loosing `<a rel="noopener noreferrer nofollow" href="foo">mylink</a>`

### How to review/test
code review or tamper with the recommendation data and perform an docx export

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
