### PR TITLE
Fix(refs:T36718): wrong message after click delete and reload

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
@@ -40,7 +40,8 @@ class DemosPlanHelpController extends BaseController
     ): Response {
         $templateVars = [];
         $requestPost = $request->request->all();
-        if (array_key_exists('delete', $requestPost)) {
+
+        if ($request->isMethod('POST') && array_key_exists('delete', $requestPost)) {
             if (empty($request->get('r_delete'))) {
                 $this->getMessageBag()->add('error', 'warning.select.entries');
             } else {
@@ -51,6 +52,9 @@ class DemosPlanHelpController extends BaseController
                     ['count' => $amount]
                 );
             }
+
+            // Redirect to the same route after form processing
+            return $this->redirectToRoute('dplan_contextual_help_list');
         }
 
         $templateVars['contextualHelpList'] = $helpHandler->getHelpNonGisLayer();

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanHelp/help_admin_contextual_help_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanHelp/help_admin_contextual_help_list.html.twig
@@ -72,7 +72,7 @@
                                 <input
                                     type="checkbox"
                                     name="r_delete[]"
-                                    ata-cy="contextualHelpSelect"
+                                    data-cy="contextualHelpSelect"
                                     value="{{ contextualHelp.ident }}"
                                     data-checkable-item>
                             </td>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36718

### Description: 

- when no checkbox selected and delete button clicked, there is an error message
- after reload the page the same error message shouldnt appear again

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
