### PR TITLE
feature (ref 15290): remove session between pages.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -466,11 +466,6 @@ class DemosPlanAssessmentController extends BaseController
                 'fragmentListKeepPost',
                 $requestKeepPost
             );
-        } else {
-            $requestPost = $request->getSession()->get(
-                'fragmentListKeepPost',
-                $requestPost
-            );
         }
 
         return $requestPost;


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T15290

Description: the method (`remmemberFilters`) used just in two methods  `getStatementFragmentListAction` and `getStatementFragmentListArchiveAction` in the `DemosPlanAssessmentStatementFragmentController`, this `else` in the method save session and used it in another page. For example, if we set filter in Datensätze and then go to Datensätze-Archive, the filter applies the wrong value in the new page.

### How to review/test
login as an FP-FB and set filter in Datensätze then go to Datensätze-Archive, filter should not run in new page.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
