### PR TITLE
f T26867 remove chapter (kapitel) from statement filter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
@@ -161,7 +161,7 @@ class StatementFilterHandler extends CoreHandler
     {
         $translator = $this->translator;
         $statusLabels = collect($this->getFormParameter('statement_status'))
-            ->transform(fn($transkey) => $translator->trans($transkey))
+            ->transform(fn ($transkey) => $translator->trans($transkey))
             ->toArray();
 
         return $this->getTranslatedLabelMapOptions($options, $statusLabels);
@@ -445,7 +445,7 @@ class StatementFilterHandler extends CoreHandler
                 'hasPermission' => $this->permissions->hasPermissions(
                     [
                     'area_admin_assessmenttable',
-                        'feature_documents_category_use_paragraph'
+                        'feature_documents_category_use_paragraph',
                     ]),
                 'type'          => 'statement',
             ],

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
@@ -442,9 +442,11 @@ class StatementFilterHandler extends CoreHandler
             [
                 'key'           => 'reasonParagraph',
                 // FB or FPA
-                'hasPermission' => $this->permissions->hasPermission(
-                    'area_admin_assessmenttable'
-                ),
+                'hasPermission' => $this->permissions->hasPermissions(
+                    [
+                    'area_admin_assessmenttable',
+                        'feature_documents_category_use_paragraph'
+                    ]),
                 'type'          => 'statement',
             ],
             // Datei - documentParentId - documentParentId


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T26867

Description: the permission 'feature_documents_category_use_paragraph' is used while creating a new document category to check if it's chapter related which can not be the case in planfest (there are nor chapter in this project). The same permission can be used too while getting the available filters to make sure that's chapter are not included.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
