### PR TITLE
feature (ref 15938): use right key to show variable in pdf export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -1052,10 +1052,12 @@ class StatementFragmentService extends CoreService
                     foreach ($tags as $tagTitle) {
                         $newTag->put('topicTitle', $topicTitle);
                         $newTag->put('title', $tagTitle);
+                        $result[$key]['tagNames'][] = $topicTitle;
                     }
                     $tagsOfVersion->push($newTag->toArray());
                 }
                 $result[$key]['tags'] = $tagsOfVersion->toArray();
+
 
                 // counties:
                 $result[$key]['counties'] = [];
@@ -1063,6 +1065,7 @@ class StatementFragmentService extends CoreService
                 $countyNames = is_array($decoded) ? $decoded : [];
                 foreach ($countyNames as $countyName) {
                     $result[$key]['counties'][]['name'] = $countyName;
+                    $result[$key]['countyNames'][] = $countyName;
                 }
 
                 // municipalities:
@@ -1071,6 +1074,7 @@ class StatementFragmentService extends CoreService
                 $municipalityNames = is_array($decoded) ? $decoded : [];
                 foreach ($municipalityNames as $municipalityName) {
                     $result[$key]['municipalities'][]['name'] = $municipalityName;
+                    $result[$key]['municipalityNames'][] = $municipalityName;
                 }
 
                 // priorityAreas:
@@ -1079,6 +1083,7 @@ class StatementFragmentService extends CoreService
                 $priorityAreaKeys = is_array($decoded) ? $decoded : [];
                 foreach ($priorityAreaKeys as $priorityAreaKey) {
                     $result[$key]['priorityAreas'][]['key'] = $priorityAreaKey;
+                    $result[$key]['priorityAreaKeys'][]= $priorityAreaKey;
                 }
             }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -1058,7 +1058,6 @@ class StatementFragmentService extends CoreService
                 }
                 $result[$key]['tags'] = $tagsOfVersion->toArray();
 
-
                 // counties:
                 $result[$key]['counties'] = [];
                 $decoded = Json::decodeToMatchingType($latestVersion['countyNamesAsJson']);
@@ -1083,7 +1082,7 @@ class StatementFragmentService extends CoreService
                 $priorityAreaKeys = is_array($decoded) ? $decoded : [];
                 foreach ($priorityAreaKeys as $priorityAreaKey) {
                     $result[$key]['priorityAreas'][]['key'] = $priorityAreaKey;
-                    $result[$key]['priorityAreaKeys'][]= $priorityAreaKey;
+                    $result[$key]['priorityAreaKeys'][] = $priorityAreaKey;
                 }
             }
 


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T15938

Description: Export PDF from data records archive (Datensätze-Archive) has some missed Variable like (Tag, County, …). I used just right key for right value.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
