### PR TITLE
fix(refs T36689): document attribute name has to be without s

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -827,7 +827,21 @@ export default {
   computed: {
     // Get the Statement from the Store (if not Present there use initial data)
     ...mapState('statement', { statement (state) { return state.statements[this.statementId] } }),
-    ...mapGetters('assessmentTable', ['adviceValues', 'assessmentBase', 'assessmentBaseLoaded', 'elements', 'paragraph', 'priorities', 'procedureId', 'status', 'counties', 'municipalities', 'priorityAreas', 'tags', 'documents']),
+    ...mapGetters('assessmentTable', [
+      'adviceValues',
+      'assessmentBase',
+      'assessmentBaseLoaded',
+      'counties',
+      'documents',
+      'elements',
+      'municipalities',
+      'paragraph',
+      'priorities',
+      'priorityAreas',
+      'procedureId',
+      'status',
+      'tags'
+    ]),
     ...mapGetters('fragment', ['selectedFragments', 'fragmentsByStatement']),
     ...mapState('statement', ['selectedElements', 'statements', 'isFiltered']),
 
@@ -1179,6 +1193,7 @@ export default {
             })
           }
 
+          console.log(field)
           if (this.$refs[field]) {
             updatedField = field
             //  Handle components that use <dp-edit-field>

--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -1193,7 +1193,6 @@ export default {
             })
           }
 
-          console.log(field)
           if (this.$refs[field]) {
             updatedField = field
             //  Handle components that use <dp-edit-field>

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -857,18 +857,18 @@ export default {
           statementId: data.data.id,
           procedureId: state.procedureId,
           include: [
-            'elements',
-            'paragraph',
-            'documents',
-            'counties',
-            'municipalities',
-            'priorityAreas',
-            'tags',
             'assignee',
             'attachments',
             'attachments.file',
+            'counties',
+            'document',
+            'elements',
             'files',
-            'fragmentsElements'
+            'fragmentsElements',
+            'municipalities',
+            'paragraph',
+            'priorityAreas',
+            'tags'
           ].join(',')
         }),
         headers: {


### PR DESCRIPTION
getting the proper include fixes finishing the loading process because now the field-name matches the include name. With that the code enters the relevant condition.

**Ticket:** https://yaits.demos-deutschland.de/T36689

See Ticket to reproduce the bug(fix)


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
