### PR TITLE
fix(refs T36753): use full width to display the stn text

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
@@ -218,7 +218,7 @@
       </span>
 
       <div
-        :class="prefixClass('sm:h-9 overflow-auto w-2')"
+        :class="prefixClass('sm:h-9 overflow-auto w-full')"
         v-cleanhtml="statement.r_text" />
     </div>
   </fieldset>

--- a/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
@@ -218,7 +218,7 @@
       </span>
 
       <div
-        :class="prefixClass('sm:h-9 overflow-auto w-full')"
+        :class="prefixClass('sm:h-9 overflow-auto')"
         v-cleanhtml="statement.r_text" />
     </div>
   </fieldset>


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36753

As not logged in user, write a statement a proceed to the "recheck"-view in the statement modal. There, the statement text should be displayed and readable.



### PR Checklist
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
