### PR TITLE
feat(refs T36528): add message to confirm export.

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -69,7 +69,7 @@
           <li>
             <dp-button
               class="u-ph-0_25"
-              @click="showHintAndDoExport('dplan_segments_export')"
+              @click="showHintAndDoExport()"
               :text="Translator.trans('export.verb')"
               variant="subtle" />
           </li>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -69,7 +69,7 @@
           <li>
             <dp-button
               class="u-ph-0_25"
-              :href="Routing.generate('dplan_segments_export', { procedureId: procedureId, statementId: statementId })"
+              @click="showHintAndDoExport('dplan_segments_export')"
               :text="Translator.trans('export.verb')"
               variant="subtle" />
           </li>
@@ -603,6 +603,15 @@ export default {
 
       const defaultAction = hasPermission('feature_segment_recommendation_edit') ? 'addRecommendation' : 'editText'
       this.currentAction = action || defaultAction
+    },
+
+    showHintAndDoExport () {
+      if (window.dpconfirm(Translator.trans('export.statements.hint'))) {
+        window.location.href = Routing.generate('dplan_segments_export', {
+          procedureId: this.procedureId,
+          statementId: this.statementId
+        })
+      }
     },
 
     /**


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36528

To be consistent, we want to have confirm messages for all stn-docx-exports. There was one missing on the stn-detail page.

this here is implemented like here https://yaits.demos-deutschland.de/T35722 // https://github.com/demos-europe/demosplan-core/pull/2433
