### PR TITLE
fix (refs T36732): Alter logic to query files via file-hash. file hash is not a unique identifier.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -66,7 +66,7 @@ class FileController extends BaseController
     {
         $fs = new Filesystem();
         // @improve T14122
-        $file = $fileService->getFileInfo($hash);
+        $file = $fileService->getFileInfo($hash, $procedureId);
 
         // ensure that procedure access check matches file procedure
         if (!$this->isValidProcedure($procedureId, $file, $strictCheck)) {

--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -93,9 +93,9 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws Exception
      */
-    public function getFileInfo($hash): FileInfo
+    public function getFileInfo($hash, ?string $procedureId = null): FileInfo
     {
-        $file = $this->fileRepository->getFileInfo($hash);
+        $file = $this->fileRepository->getFileInfo($hash, $procedureId);
 
         if (null !== $file) {
             $path = $file->getPath();


### PR DESCRIPTION
Ticket:
https://yaits.demos-deutschland.de/T36732

Description:
In case the same physical file is used for multiple procedures
There will be a fileI entity for every reference to a physical file.
They share the same hash - but not necessarily the procedure
- so the findOneBy method for the kindly supported hash is insufficient here.

I think all routes should be addressed and the current procedrueId should be used to retrieve the file.
But made the logic compatible with the previous behavior.

### How to review/test

### Linked PRs (optional)

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
