### PR TITLE
abort "yarn install" if demosplan-ui is mounted in container

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:robobsh": "cross-env ./fe build robobsh",
     "dev:teilhabe": "cross-env ./fe build teilhabe",
     "dev:wmmsh": "cross-env ./fe build wmmsh",
+    "preinstall": "if cat /proc/mounts | grep -q '/srv/www/node_modules/@demos-europe/demosplan-ui'; then echo 'Aborting install. Please restart container with disabled demosplan-ui.'; exit 1; fi",
     "prod:blp": "cross-env ./fe build --prod blp",
     "prod:bimschgsh": "cross-env ./fe build --prod bimschgsh",
     "prod:bobhh": "cross-env ./fe build --prod bobhh",


### PR DESCRIPTION
As this would delete the local git repo when running "yarn install", the "preinstall" hook cancels the installation. This is implemented as a oneliner to not have to think about a good place for the bash script. As we do not have the "docker" cli in the container, "cat proc/mounts" is used to determine if the specific volume is mounted.

### How to review/test
When running "yarn install" from within the container with demosplan-ui mounted as volume, the installation process should fail with this error:
![image](https://github.com/demos-europe/demosplan-core/assets/40452344/d8c8201b-ae3b-448d-b2a1-6ebd32e9b737)

When the volume is not mounted, "yarn install" should run as usual.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
