### PR TITLE
Fix(T36635): improve error validation for DpMultiselect component

### DIFF
--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -112,6 +112,7 @@
           v-model="currentProcedureType"
           class="layout__item u-1-of-1 u-pl-0 u-mb inline-block"
           label="name"
+          :data-dp-validate-error-fieldname="Translator.trans('text.procedures.type')"
           :options="procedureTypes"
           required
           track-by="id">


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36635

**Description:** To improve the UX and provide information about invalid fields, add the prop called `dataDpValidateErrorFieldname`. This prop is needed for the `dpValidate` mixin to display the correct error message with the invalid fields.

[PR in demosplan-ui](https://github.com/demos-europe/demosplan-ui/pull/783)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
