### PR TITLE
fix(refs T35941): rollback partial fix, serialize params (2847)

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -563,11 +563,7 @@
                     With tiptap we can set obscure as prop always when the obscure button should be visible in the field,
                     because the permission check (featureObscureText) takes place in tiptap
                     -->
-                <dp-loading
-                  v-if="reloadStatementEditor"
-                  class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2 border--right" />
                 <editable-text
-                  v-else
                   class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2 border--right"
                   title="statement"
                   :procedure-id="procedureId"
@@ -588,11 +584,7 @@
                 <!--
                   Recommendation text
                -->
-                <dp-loading
-                  v-if="reloadRecommendationEditor"
-                  class="u-pb-0_5 u-pr-0_5 u-pt-0_25 u-1-of-2" />
                 <editable-text
-                  v-else
                   class="u-pb-0_25 u-pl-0_5 u-pt-0_25 u-1-of-2"
                   title="recommendation"
                   :procedure-id="procedureId"
@@ -759,7 +751,7 @@
 </template>
 
 <script>
-import { dpApi, DpLoading, formatDate, hasOwnProp, VPopover } from '@demos-europe/demosplan-ui'
+import { dpApi, formatDate, hasOwnProp, VPopover } from '@demos-europe/demosplan-ui'
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
 import { Base64 } from 'js-base64'
 import DpClaim from '../DpClaim'
@@ -779,7 +771,6 @@ export default {
     DpFragmentList: () => import(/* webpackChunkName: "dp-fragment-list" */ './DpFragmentList'),
     DpFragmentsSwitcher: () => import(/* webpackChunkName: "dp-fragments-switcher" */ './DpFragmentsSwitcher'),
     DpItemRow,
-    DpLoading,
     EditableText,
     TableCardFlyoutMenu,
     VPopover
@@ -818,9 +809,7 @@ export default {
       tab: this.$store.state.assessmentTable.currentTableView === 'fragments' ? 'fragments' : 'statement',
       updatingClaimState: false,
       fragmentsLoading: false,
-      placeholderStatementId: null,
-      reloadRecommendationEditor: false,
-      reloadStatementEditor: false
+      placeholderStatementId: null
     }
   },
 
@@ -1097,14 +1086,6 @@ export default {
       return payload
     },
 
-    reloadEditorOnSave (fieldName, value) {
-      if (fieldName === 'text') {
-        this.reloadStatementEditor = value
-      } else if (fieldName === 'recommendation') {
-        this.reloadRecommendationEditor = value
-      }
-    },
-
     resetRelatedFields () {
       if (this.elementHasParagraphs && this.$refs.paragraph) {
         this.resetSelectedParagraph()
@@ -1132,7 +1113,6 @@ export default {
      * @param fieldName {String} - the name of the property as sent to BE
      */
     saveStatement (data, propType, fieldName) {
-      this.reloadEditorOnSave(fieldName, true)
       const payload = this.preparePayload(data, propType, fieldName)
       this.$emit('statement:updated')
       //  ##### Fire store action #####
@@ -1199,7 +1179,6 @@ export default {
 
         // Used in DpVersionHistory to update items in version history sidebar
         this.$root.$emit('entity:updated', this.statementId, 'statement')
-        this.reloadEditorOnSave(fieldName, false)
 
         return updatedField
       }).then(updatedField => {

--- a/client/js/components/statement/assessmentTable/EditableText.vue
+++ b/client/js/components/statement/assessmentTable/EditableText.vue
@@ -332,7 +332,9 @@ export default {
        *
        */
       dpApi.get(
-        Routing.generate(this.fullTextFetchRoute, { statementId: this.entityId }), params
+        Routing.generate(this.fullTextFetchRoute, { statementId: this.entityId }),
+        params,
+        { serialize: true }
       ).then(response => {
         this.fullTextLoaded = true
 


### PR DESCRIPTION
**cherry picked from commit 40a4f0eb6d9599fc0a7078f293ca04a581d8c820**

The fix applied in 2521 introduced the side effect that the ref="recommendation" was undefined while the loading state was applied to the EditableText instance, and so, the `field` property was not correctly filled within the payload of the entityTextSaved event. As the bug originates in a change in dpApi, 2521 is partially rolled back. Instead, the params in dpApi.get() are now serialized, with the result that the code in
client/js/components/statement/assessmentTable/EditableText.vue:355 runs and everything is updated as intended.

 **Ticket:** https://yaits.demos-deutschland.de/T35941