### PR TITLE
fix(refs T36849): display link inline

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
@@ -21,7 +21,7 @@
         {% if full_width|default(false) != true %}
 
             {# link in left corner of pageheader #}
-                <div class="{{ (width_css.col1|default('u-1-of-4'|prefixClass) ~ ' layout__item u-1-of-1-lap-down show-desk-up-ib-empty u-mv-0_25 flow-root u-pl-0_5-palm u-pr-0_5-palm')|prefixClass }}">
+                <div class="{{ (width_css.col1|default('u-1-of-4'|prefixClass) ~ (link_classes|default|prefixClass) ~ ' layout__item u-1-of-1-lap-down show-desk-up-ib-empty u-mv-0_5 u-pl-0_5-palm u-pr-0_5-palm')|prefixClass }}">
 
                 {# additional link to be inserted via link_caption / link #}
                     {% if link_caption|default != '' %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -84,6 +84,7 @@
         {% include '@DemosPlanCore/DemosPlanCore/includes/pageheader.html.twig' with {
             link: path('core_home'),
             link_caption: 'back.to.procedure.list'|trans,
+            link_classes: 'block',
             cssClasses: '',
             prefixCssClasses: true,
             width_css: {


### PR DESCRIPTION
**Ticket:**  https://yaits.demos-deutschland.de/T36849

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- `flow-root` unexpectedly overwrote the display property (to `block`) which is desired in most projects, but not in all of them
- it is replaced with 'block' and passed to the pageheader as a variable, so in projects that display the link inline, we can just use the pageheader template as is
- vertical margin of the link has been adjusted so it aligns properly with the procedure title in projects that display link and procedure title inline

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
