### PR TITLE
fix(refs T36849): display procedure title below link(s)

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
@@ -21,7 +21,7 @@
         {% if full_width|default(false) != true %}
 
             {# link in left corner of pageheader #}
-                <div class="{{ (width_css.col1|default('u-1-of-4'|prefixClass) ~ (link_classes|default|prefixClass) ~ ' layout__item u-1-of-1-lap-down show-desk-up-ib-empty u-mv-0_5 u-pl-0_5-palm u-pr-0_5-palm')|prefixClass }}">
+                <div class="{{ (width_css.col1|default('u-1-of-4'|prefixClass) ~ ' block layout__item u-1-of-1-lap-down show-desk-up-ib-empty u-mv-0_25 u-pl-0_5-palm u-pr-0_5-palm')|prefixClass }}">
 
                 {# additional link to be inserted via link_caption / link #}
                     {% if link_caption|default != '' %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -84,7 +84,6 @@
         {% include '@DemosPlanCore/DemosPlanCore/includes/pageheader.html.twig' with {
             link: path('core_home'),
             link_caption: 'back.to.procedure.list'|trans,
-            link_classes: 'block',
             cssClasses: '',
             prefixCssClasses: true,
             width_css: {


### PR DESCRIPTION
**Ticket:** https://yaits.demos-deutschland.de/T36849

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- as there can be several links next to each other when a user is logged in, the procedure title cannot be displayed inline because the links take up more space than the actionbox (width-map-toolbar), breaking the layout
- we decided to keep the layout consistent among all projects and always display the procedure title below the link(s)

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
