### PR TITLE
Cleanup calls of dpApi

### DIFF
--- a/client/js/bundles/procedure/publicIndexMapAndList.js
+++ b/client/js/bundles/procedure/publicIndexMapAndList.js
@@ -42,9 +42,8 @@ initialize(components, stores).then(() => {
 
       dpApi({
         method: 'POST',
-        data: { procedureId: procedureId },
-        responseType: 'json',
-        url: Routing.generate(route, { procedureId: procedureId })
+        url: Routing.generate(route, { procedureId: procedureId }),
+        data: { procedureId: procedureId }
       })
         .then(() => {
           checkbox.closest(prefixClass('.c-procedurelist__item')).classList.toggle(prefixClass('is-done'))

--- a/client/js/bundles/procedure/publicIndexSimpleList.js
+++ b/client/js/bundles/procedure/publicIndexSimpleList.js
@@ -19,10 +19,9 @@ initialize()
       const data = new FormData(form)
 
       return dpApi({
-        method: 'post',
+        method: 'POST',
         url: Routing.generate('DemosPlan_procedure_public_list_json'),
-        data: data,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        data: data
       }).then(({ data }) => {
         const parsedData = JSON.parse(data)
         if (parsedData.code === 100 && parsedData.success === true) {

--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -332,7 +332,7 @@ export default {
         return this.mapOptions
       }
       return dpApi({
-        method: 'get',
+        method: 'GET',
         url: Routing.generate(this.mapOptionsRoute, { procedureId: this.procedureId })
       })
         .then(checkResponse)

--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -834,7 +834,7 @@ export default {
           //  Add progress indicator (.o-spinner on same element required)
           $popup.find('#popupContent h3').addClass(this.prefixClass('is-progress'))
 
-          dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), getData, { serialize: true })
+          dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), getData)
             .then(response => {
               const parsedData = JSON.parse(response.data)
               if (parsedData.code === 100 && parsedData.success) {

--- a/client/js/components/procedure/DpDashboardTaskCard.vue
+++ b/client/js/components/procedure/DpDashboardTaskCard.vue
@@ -72,7 +72,7 @@ export default {
 
     // Get count of segments assigned to the current user
     const segmentUrl = Routing.generate('api_resource_list', { resourceType: 'StatementSegment' })
-    dpApi.get(segmentUrl, { filter: filterQuery }, { serialize: true }).then(response => {
+    dpApi.get(segmentUrl, { filter: filterQuery }).then(response => {
       this.assignedSegmentCount = response.data.data.length
     })
 

--- a/client/js/components/procedure/DpSearchProcedures.vue
+++ b/client/js/components/procedure/DpSearchProcedures.vue
@@ -170,7 +170,7 @@ export default {
             }
           }
         }
-        dpApi.get(url, params, { serialize: true })
+        dpApi.get(url, params)
           .then(response => {
             this.results = response.data.data
             if (this.results.length === 0) {

--- a/client/js/components/procedure/DpSubmitterList.vue
+++ b/client/js/components/procedure/DpSubmitterList.vue
@@ -162,8 +162,7 @@ export default {
               'submitterEmailAddress'
             ].join()
           }
-        },
-        { serialize: true }
+        }
       )
 
       this.items = [...response.data.data]

--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -304,7 +304,7 @@ export default {
         sort: sort
       }
 
-      dpApi.get(url, params, { serialize: true })
+      dpApi.get(url, params)
         .then(response => {
           response.data.data.forEach(el => this.items.push({
             creationDate: formatDate(el.attributes.creationDate),

--- a/client/js/components/procedure/admin/AuthorizedUsersList.vue
+++ b/client/js/components/procedure/admin/AuthorizedUsersList.vue
@@ -442,7 +442,7 @@ export default {
           ].join()
         }
       }
-      return dpApi.get(url, params, { serialize: true })
+      return dpApi.get(url, params)
         .then(response => {
           this.consultationTokens = [...response.data.data].map(token => {
             if (token.relationships && token.relationships.statement) {

--- a/client/js/components/procedure/admin/NewBlueprintForm.vue
+++ b/client/js/components/procedure/admin/NewBlueprintForm.vue
@@ -256,7 +256,7 @@ export default {
         },
         include: 'agencyExtraEmailAddresses'
       }
-      return dpApi.get(url, params, { serialize: true })
+      return dpApi.get(url, params)
         .then(({ data }) => {
           this.isLoading = false
           return {

--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -152,8 +152,7 @@ export default {
   methods: {
     getDataPlis (plisId, routeName) {
       return dpApi({
-        method: 'get',
-        responseType: 'json',
+        method: 'GET',
         url: Routing.generate(routeName, { uuid: plisId })
       })
         .then(data => {

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -199,7 +199,7 @@ export default {
         },
         include: 'annotatedStatementPdfPages'
       }
-      const documentResponse = await dpApi.get(url, params, { serialize: true })
+      const documentResponse = await dpApi.get(url, params)
       this.document = documentResponse.data.data.find(el => el.type === 'AnnotatedStatementPdf')
       this.formValues = { ...this.formValues, text: this.document.attributes.text }
       this.pages = documentResponse.data.included.filter(el => el.type === 'AnnotatedStatementPdfPage')

--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -505,7 +505,7 @@ export default {
         },
         include: ['annotatedStatementPdf'].join()
       }
-      const pageResponse = await dpApi.get(url, params, { serialize: true })
+      const pageResponse = await dpApi.get(url, params)
       if (hasOwnProp(pageResponse, 'data') && hasOwnProp(pageResponse.data, 'data') && pageResponse.data.data.length) {
         const pageAttrs = pageResponse.data.data[0].attributes
         this.geoJson = pageAttrs.geoJson

--- a/client/js/components/procedure/survey/DpSurveyCommentsList.vue
+++ b/client/js/components/procedure/survey/DpSurveyCommentsList.vue
@@ -164,10 +164,6 @@ export default {
       return dpApi({
         method: 'PATCH',
         url: Routing.generate('dplan_surveyvote_update', { surveyVoteId: id }),
-        headers: {
-          'Content-type': 'application/vnd.api+json',
-          Accept: 'application/vnd.api+json'
-        },
         data: {
           data: {
             type: 'SurveyVote',
@@ -176,6 +172,10 @@ export default {
               textReview: textReview
             }
           }
+        },
+        headers: {
+          'Content-type': 'application/vnd.api+json',
+          Accept: 'application/vnd.api+json'
         }
       })
         .then((response) => {

--- a/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
+++ b/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
@@ -147,8 +147,8 @@ export default {
 
     addTagBoilerplate (value) {
       if (hasPermission('area_admin_boilerplates')) {
-        const tagGetPath = Routing.generate('dm_plan_assessment_get_boilerplates_ajax', { tag: value.id, procedure: this.procedureId })
-        dpApi.get(tagGetPath).then(response => {
+        const url = Routing.generate('dm_plan_assessment_get_boilerplates_ajax', { tag: value.id, procedure: this.procedureId })
+        dpApi.get(url).then(response => {
           if (response.status === 200 && response.data.body !== '') {
             this.currentRecommendation = this.currentRecommendation + '<p>' + response.data.body + '</p>'
           }

--- a/client/js/components/statement/assessmentTable/EditableText.vue
+++ b/client/js/components/statement/assessmentTable/EditableText.vue
@@ -333,8 +333,7 @@ export default {
        */
       dpApi.get(
         Routing.generate(this.fullTextFetchRoute, { statementId: this.entityId }),
-        params,
-        { serialize: true }
+        params
       ).then(response => {
         this.fullTextLoaded = true
 

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -832,7 +832,7 @@ export default {
     },
 
     getStatementsFullText (statementId) {
-      return dpApi.get(Routing.generate('api_resource_get', { resourceType: 'Statement', resourceId: statementId }), { fields: { Statement: ['fullText'].join() } }, { serialize: true })
+      return dpApi.get(Routing.generate('api_resource_get', { resourceType: 'Statement', resourceId: statementId }), { fields: { Statement: ['fullText'].join() } })
         .then((response) => {
           const oldStatement = Object.values(this.statementsObject).find(el => el.id === statementId)
           const fullText = response.data.data.attributes.fullText

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -477,7 +477,7 @@ export default {
 
     fetchAssignableUsers () {
       const url = Routing.generate('api_resource_list', { resourceType: 'AssignableUser' })
-      return dpApi.get(url, { sort: 'lastname' }, { serialize: true })
+      return dpApi.get(url, { sort: 'lastname' })
         .then(response => {
           this.assignableUsers = response.data.data.map(assignableUser => {
             return {

--- a/client/js/components/statement/statement/DpVersionHistory.vue
+++ b/client/js/components/statement/statement/DpVersionHistory.vue
@@ -141,7 +141,7 @@ export default {
 
       this.entityId = id
       return dpApi({
-        method: 'get',
+        method: 'GET',
         url: Routing.generate(route, params)
       })
         .then(response => checkResponse(response))

--- a/client/js/components/statement/statement/DpVersionHistoryItem.vue
+++ b/client/js/components/statement/statement/DpVersionHistoryItem.vue
@@ -228,7 +228,7 @@ export default {
 
     loadHistory () {
       return dpApi({
-        method: 'get',
+        method: 'GET',
         url: Routing.generate('dplan_api_history_of_all_fields_of_specific_datetime', {
           entityContentChangeId: this.time.anyEntityContentChangeIdOfThisChangeInstance,
           procedureId: this.procedureId

--- a/client/js/components/user/CustomerSettings/CustomerSettings.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettings.vue
@@ -158,9 +158,9 @@
             linkButton: true,
             headings: [2, 3, 4]
           }" />
-          <h3
-            class="u-mt"
-            v-text="Translator.trans('video')" />
+        <h3
+          class="u-mt"
+          v-text="Translator.trans('video')" />
         <customer-settings-sign-language-video
           v-if="!isLoadingSignLanguageOverviewVideo"
           :current-customer-id="this.currentCustomerId"
@@ -337,7 +337,7 @@ export default {
         mimetype: '',
         title: ''
       },
-      isBusy:false
+      isBusy: false
     }
   },
 
@@ -390,7 +390,7 @@ export default {
       this.isLoadingSignLanguageOverviewVideo = true
       const payload = this.getRequestPayload()
 
-      this.fetchCustomer(payload, { serialize: true })
+      this.fetchCustomer(payload)
         .then(res => {
           // Update fields
           const response = res.data

--- a/client/js/components/user/DpUserListExtended.vue
+++ b/client/js/components/user/DpUserListExtended.vue
@@ -181,7 +181,7 @@ export default {
           Orga: ['departments', 'masterToeb', 'name'].join(),
           MasterToeb: ['id'].join()
         }
-      }, { serialize: true })
+      })
         .then((response) => {
           this.organisations = response?.data?.data ?? {}
         })

--- a/client/js/lib/procedure/CreateProcedure.js
+++ b/client/js/lib/procedure/CreateProcedure.js
@@ -45,9 +45,7 @@ const setConfirmForBounds = function (data) {
 
 function getXplanboxBounds (procedureName) {
   return dpApi({
-    method: 'get',
-    data: '',
-    responseType: 'json',
+    method: 'GET',
     url: Routing.generate('DemosPlan_xplanbox_get_bounds', { procedureName: procedureName })
   })
     .then(data => {
@@ -86,10 +84,8 @@ export default function CreateProcedure () {
     // Ask BE about the selection - but only if selectedOption is not empty
     if (selectedOption.value !== '') {
       dpApi({
-        method: 'get',
-        data: '',
-        responseType: 'json',
-        url: Routing.generate('DemosPlan_plis_get_procedure', { uuid: selectedOption.value })
+        url: Routing.generate('DemosPlan_plis_get_procedure', { uuid: selectedOption.value }),
+        method: 'GET'
       })
         .then(data => {
           const dataResponse = JSON.parse(data.data)

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -47,11 +47,8 @@ export default function AssessmentTable () {
 
     return dpApi({
       method: 'POST',
-      data: inputFields,
-      responseType: 'json',
-      url: Routing.generate(
-        'dplan_api_procedure_update_filter_hash',
-        { procedureId })
+      url: Routing.generate('dplan_api_procedure_update_filter_hash', { procedureId }),
+      data: inputFields
     }).then(checkResponse)
       .then((data) => {
         return data.data.attributes.hash

--- a/client/js/lib/statement/AssessmentTableOriginal.js
+++ b/client/js/lib/statement/AssessmentTableOriginal.js
@@ -34,9 +34,8 @@ export default function AssessmentTableOriginal () {
 
     return dpApi({
       method: 'POST',
-      data: inputFields,
-      responseType: 'json',
-      url: Routing.generate('dplan_api_procedure_update_original_filter_hash', { procedureId })
+      url: Routing.generate('dplan_api_procedure_update_original_filter_hash', { procedureId }),
+      data: inputFields
     }).then(checkResponse)
       .then(function (data) {
         return data.data.attributes.hash

--- a/client/js/lib/statement/DeleteFragmentButton.js
+++ b/client/js/lib/statement/DeleteFragmentButton.js
@@ -30,7 +30,7 @@ export default function DeleteFragmentButton () {
 
         //  Post to delete route
         dpApi({
-          method: 'post',
+          method: 'POST',
           url: elem.getAttribute('data-post-delete'),
           data: formData
         })

--- a/client/js/store/core/utils/storeUtils.js
+++ b/client/js/store/core/utils/storeUtils.js
@@ -14,7 +14,6 @@ import { set } from 'vue'
 const fetchResourcesByProcedureId = (mutationName, url, includes = []) => ({ commit }, procedureId) => {
   return dpApi({
     method: 'GET',
-    responseType: 'json',
     url: Routing.generate(url, {
       procedureId: procedureId,
       includes: includes

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -200,15 +200,13 @@ const LayersStore = {
       commit('setProcedureId', procedureId)
 
       return dpApi({
-        method: 'get',
-        url: Routing.generate(
-          'dplan_api_procedure_layer_list',
+        method: 'GET',
+        url: Routing.generate('dplan_api_procedure_layer_list',
           {
             procedureId: procedureId,
             include: ['categories', 'gisLayers'].join()
           }
-        ),
-        responseType: 'json'
+        )
       })
         .then(checkResponse)
         .then(data => {
@@ -255,14 +253,8 @@ const LayersStore = {
 
     save ({ state, commit, dispatch }) {
       return dpApi({
-        method: 'post',
-        url: Routing.generate(
-          'dplan_api_procedure_layer_update',
-          {
-            procedureId: state.procedureId
-          }
-        ),
-        responseType: 'json',
+        method: 'POST',
+        url: Routing.generate('dplan_api_procedure_layer_update', { procedureId: state.procedureId }),
         data: { data: state.apiData }
       })
         .then(checkResponse)

--- a/client/js/store/procedure/Boilerplates.js
+++ b/client/js/store/procedure/Boilerplates.js
@@ -32,7 +32,6 @@ const BoilerplatesStore = {
       commit('getBoilerplatesFired', true)
       return dpApi({
         method: 'GET',
-        responseType: 'json',
         url: Routing.generate('api_resource_list', {
           resourceType: 'Boilerplate',
           includes: ['groups']

--- a/client/js/store/procedure/Location.js
+++ b/client/js/store/procedure/Location.js
@@ -27,12 +27,11 @@ const LocationStore = {
   actions: {
     get ({ commit }, args = { query: '' }) {
       return dpApi({
-        method: 'get',
+        method: 'GET',
         url: Routing.generate('DemosPlan_procedure_public_suggest_procedure_location_json', {
           query: args.query,
           maxResults: 12
-        }),
-        responseType: 'json'
+        })
       })
         .then(response => {
           const locations = []

--- a/client/js/store/procedure/Procedure.js
+++ b/client/js/store/procedure/Procedure.js
@@ -57,9 +57,8 @@ const ProcedureStore = {
       }
 
       return dpApi({
-        method: 'get',
-        url: Routing.generate('DemosPlan_procedure_search_ajax', urlParams),
-        responseType: 'json'
+        method: 'GET',
+        url: Routing.generate('DemosPlan_procedure_search_ajax', urlParams)
       }).then(response => {
         commit('reset')
         nextTick(() => {

--- a/client/js/store/statement/AssessmentTable.js
+++ b/client/js/store/statement/AssessmentTable.js
@@ -161,8 +161,6 @@ const AssessmentTable = {
     async applyBaseData ({ commit, state }, procedureId) {
       const data = await dpApi({
         method: 'GET',
-        data: '',
-        responseType: 'json',
         url: Routing.generate('DemosPlan_assessment_base_ajax', { procedureId: procedureId })
       })
         .then(this.api.checkResponse)

--- a/client/js/store/statement/Filter.js
+++ b/client/js/store/statement/Filter.js
@@ -241,10 +241,7 @@ const Filter = {
 
       return dpApi({
         method: 'GET',
-        responseType: 'json',
-        url: Routing.generate(route, {
-          procedureId: state.procedureId
-        })
+        url: Routing.generate(route, { procedureId: state.procedureId })
       })
         .then(this.api.checkResponse)
         .then(data => {
@@ -273,11 +270,7 @@ const Filter = {
 
       return dpApi({
         method: 'GET',
-        responseType: 'json',
-        url: Routing.generate(route, {
-          procedureId: state.procedureId,
-          filterHash: data.filterHash
-        })
+        url: Routing.generate(route, { procedureId: state.procedureId, filterHash: data.filterHash })
       })
         .then(this.api.checkResponse)
         .then(response => {
@@ -308,10 +301,7 @@ const Filter = {
     getUserFilterSetsAction ({ commit, state }) {
       return dpApi({
         method: 'GET',
-        url: Routing.generate(
-          'api_resource_list',
-          { resourceType: 'UserFilterSet' }
-        )
+        url: Routing.generate('api_resource_list', { resourceType: 'UserFilterSet' })
       }).then(this.api.checkResponse)
         .then(data => {
           commit('updateUserFilterSets', data)
@@ -328,7 +318,6 @@ const Filter = {
     removeUserFilterSetAction ({ commit, state }, userFilterSetId) {
       return dpApi({
         method: 'DELETE',
-        responseType: 'json',
         url: Routing.generate('dplan_api_procedure_delete_statement_filter', {
           procedureId: state.procedureId,
           filterSetId: userFilterSetId

--- a/client/js/store/statement/Fragment.js
+++ b/client/js/store/statement/Fragment.js
@@ -296,13 +296,7 @@ export default {
     setAssigneeAction ({ commit }, { fragmentId, statementId, ignoreLastClaimed, assigneeId, lastClaimed }) {
       return dpApi({
         method: 'PATCH',
-        url: Routing.generate('dplan_claim_fragments_api', {
-          entityId: fragmentId
-        }),
-        headers: {
-          'Content-type': 'application/vnd.api+json',
-          Accept: 'application/vnd.api+json'
-        },
+        url: Routing.generate('dplan_claim_fragments_api', { entityId: fragmentId }),
         data: {
           data: {
             type: 'user',
@@ -310,6 +304,10 @@ export default {
             ignoreLastClaimed: ignoreLastClaimed,
             ...((ignoreLastClaimed === false && typeof lastClaimed !== 'undefined') && { relationships: { lastClaimed: { data: { id: lastClaimed, type: 'user' } } } })
           }
+        },
+        headers: {
+          'Content-type': 'application/vnd.api+json',
+          Accept: 'application/vnd.api+json'
         }
       })
         .then(this.api.checkResponse)
@@ -393,7 +391,23 @@ export default {
 
       return dpApi({
         method: 'PATCH',
-        params,
+        url: Routing.generate('dplan_api_statement_fragment_edit', {
+          statementFragmentId: data.id,
+          include: [
+            'statement',
+            'department',
+            'tags',
+            'counties',
+            'municipalities',
+            'priorityAreas',
+            'element',
+            'paragraph',
+            'document',
+            'assignee',
+            'lastClaimedUser'
+          ].join(),
+          ...params
+        }),
         data: {
           data: {
             type: 'StatementFragment',
@@ -401,26 +415,6 @@ export default {
             attributes: payload
           }
         },
-        responseType: 'json',
-        url: Routing.generate(
-          'dplan_api_statement_fragment_edit',
-          {
-            statementFragmentId: data.id,
-            include: [
-              'statement',
-              'department',
-              'tags',
-              'counties',
-              'municipalities',
-              'priorityAreas',
-              'element',
-              'paragraph',
-              'document',
-              'assignee',
-              'lastClaimedUser'
-            ].join()
-          }
-        ),
         headers: {
           'Content-type': 'application/vnd.api+json',
           Accept: 'application/vnd.api+json'

--- a/client/js/store/statement/SplitStatementStore.js
+++ b/client/js/store/statement/SplitStatementStore.js
@@ -219,9 +219,11 @@ const SplitStatementStore = {
           }
           const initialData = data.data.attributes.segmentDraftList.data
           let segments = initialData.attributes.segments
-            // Filter out segments with less than 10 characters as those may lead the frontend to crash
-            // (because often that are closing or opening tags)
-            // and should probably not be needed in a real world scenario.
+            /*
+             * Filter out segments with less than 10 characters as those may lead the frontend to crash
+             * (because often that are closing or opening tags)
+             * and should probably not be needed in a real world scenario.
+             */
             .filter(segment => (segment.charEnd - segment.charStart) > 10)
 
           // Check if we are getting overlapping segments from pipeline that would cause errors
@@ -368,7 +370,7 @@ const SplitStatementStore = {
 
     fetchTags ({ commit }) {
       const url = Routing.generate('api_resource_list', { resourceType: 'Tag' })
-      return dpApi.get(url, { include: 'topic' }, { serialize: true })
+      return dpApi.get(url, { include: 'topic' })
         .then(response => {
           const tags = response.data
           commit('setProperty', { prop: 'availableTags', val: tags.data })

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -415,7 +415,6 @@ export default {
     copyStatementAction ({ state }, data) {
       return dpApi({
         method: 'POST',
-        responseType: 'json',
         url: Routing.generate('dplan_api_statement_copy_to_procedure', {
           procedureId: state.procedureId,
           statementId: data.statementId,
@@ -436,11 +435,11 @@ export default {
         url: Routing.generate('dplan_api_create_group_statement', {
           procedureId: state.procedureId
         }),
+        data: { data },
         headers: {
           'Content-type': 'application/vnd.api+json',
           Accept: 'application/vnd.api+json'
-        },
-        data: { data }
+        }
       })
         .then(this.api.checkResponse)
         .then(response => {
@@ -519,7 +518,6 @@ export default {
 
       return dpApi({
         method: 'GET',
-        responseType: 'json',
         // @improve T12984
         url: Routing.generate('dplan_assessmentqueryhash_get_procedure_statement_list', {
           procedureId: data.procedureId,
@@ -658,7 +656,6 @@ export default {
     moveStatementAction ({ state }, data) {
       return dpApi({
         method: 'POST',
-        responseType: 'json',
         url: Routing.generate('dplan_api_statement_move', {
           procedureId: state.procedureId,
           statementId: data.statementId,
@@ -730,18 +727,16 @@ export default {
     setAssigneeAction ({ commit }, { statementId, assigneeId }) {
       return dpApi({
         method: 'PATCH',
-        url: Routing.generate('dplan_claim_statements_api', {
-          statementId: statementId
-        }),
-        headers: {
-          'Content-type': 'application/vnd.api+json',
-          Accept: 'application/vnd.api+json'
-        },
+        url: Routing.generate('dplan_claim_statements_api', { statementId: statementId }),
         data: {
           data: {
             type: 'user',
             id: assigneeId
           }
+        },
+        headers: {
+          'Content-type': 'application/vnd.api+json',
+          Accept: 'application/vnd.api+json'
         }
       })
         .then(this.api.checkResponse)
@@ -851,8 +846,6 @@ export default {
 
       return dpApi({
         method: 'POST',
-        data: payload,
-        responseType: 'json',
         url: Routing.generate('dplan_api_statement_edit', {
           statementId: data.data.id,
           procedureId: state.procedureId,
@@ -871,6 +864,7 @@ export default {
             'tags'
           ].join(',')
         }),
+        data: payload,
         headers: {
           'Content-type': 'application/json'
         }
@@ -916,11 +910,11 @@ export default {
         url: Routing.generate('dplan_api_update_group_statement', {
           procedureId: state.procedureId
         }),
+        data: { data },
         headers: {
           'Content-type': 'application/vnd.api+json',
           Accept: 'application/vnd.api+json'
-        },
-        data: { data }
+        }
       })
         .then(this.api.checkResponse)
         .then(response => {


### PR DESCRIPTION
Due to the removal of axios within dpApi there were some leftovers that are tackled.

- responseType: 'json' is not used anywhere, can be removed
- for clarity, properties within dpApi param are always sorted method, url, data, headers
- method always uppercase
- the "x-www-form-urlencoded" header was actually never applied to the request after dropping axios, and as it turns out, it is not needed anyway
- serialize: true is removed, as all GET calls have serialized params now
- "data" carrying an empty string was removed in the assumption that it is the same as omitting it
- within the call to dplan_api_statement_fragment_edit the params have been moved to Routing.generate (which, in fact, also takes care of url params), because atm dpApi only appends params to GET requests

### How to review/test
Api calls should work as before...

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-ui/pull/803

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
