### PR TITLE
Remove wrapping div from addonWrapper

### DIFF
--- a/client/js/components/addon/AddonWrapper.vue
+++ b/client/js/components/addon/AddonWrapper.vue
@@ -1,11 +1,9 @@
 <template>
-  <div>
-    <component
-      :is="component"
-      :ref="refComponent"
-      v-bind="addonProps"
-      @addonEvent:emit="(event) => $emit(event.name, event.payload)" />
-  </div>
+  <component
+    :is="component"
+    :ref="refComponent"
+    v-bind="addonProps"
+    @addonEvent:emit="(event) => $emit(event.name, event.payload)" />
 </template>
 
 <script>
@@ -72,6 +70,7 @@ export default {
              * While eval is generally a BAD IDEA, we really need to evaluate the code
              * we're adding dynamically to use the provided addon's script from now on.
              */
+            // eslint-disable-next-line no-eval
             eval(content)
             this.$options.components[addon.entry] = window[addon.entry].default
 


### PR DESCRIPTION
As the addonWrapper should not occupy any space within the rendered layout by itself (maybe if no addons are registered with it), the wrapping div can eventually be removed.

### How to review/test
Things should work as before, with and without installed addons.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
