### PR TITLE
feat(refs DPLAN-3217): Merge statement detail views

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -387,17 +387,21 @@ export default {
     },
 
     submitterHelpText () {
-      const attr = this.localStatement.attributes
+      const { gdprConsent, original } = this.localStatement.attributes
       let helpText = ''
 
-      if (attr.gdprConsent && attr.gdprConsent.consentRevoked) {
+      const isConsentRevoked = gdprConsent?.consentRevoked
+      const isAnonymized = hasPermission('area_statement_anonymize') && original.submitterAndAuthorMetaDataAnonymized
+
+      if (isConsentRevoked) {
         helpText = Translator.trans('personal.data.usage.revoked')
-        if (hasPermission('area_statement_anonymize') &&
-          attr.original.submitterAndAuthorMetaDataAnonymized) {
+
+        if (isAnonymized) {
           helpText = helpText + `<br><br>${Translator.trans('statement.anonymized.submitter.data')}`
         }
-      } else if (hasPermission('area_statement_anonymize') &&
-        attr.original.submitterAndAuthorMetaDataAnonymized) {
+      }
+
+      if (!isConsentRevoked && isAnonymized) {
         helpText = Translator.trans('statement.anonymized.submitter.data')
       }
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -41,7 +41,7 @@
           id="statementSubmitter"
           v-model="statementSubmitterValue"
           class="u-mb-0_5"
-          :disabled="!statement.attributes.isManual || !editable || isSubmitterAnonymous()"
+          :disabled="!isStatementManual || !editable || isSubmitterAnonymous()"
           :label="{
             text: Translator.trans('submitter')
           }"
@@ -51,7 +51,7 @@
           id="statementDepartmentName"
           v-model="localStatement.attributes.initialOrganisationDepartmentName"
           class="u-mb-0_5"
-          :disabled="statement.attributes.isManual ? false : !editable"
+          :disabled="isStatementManual ? false : !editable"
           :label="{
             text: Translator.trans('department')
           }"
@@ -68,17 +68,17 @@
           v-if="localStatement.attributes.represents"
           id="representationCheck"
           v-model="localStatement.attributes.representationChecked"
-          :disabled="statement.attributes.isManual ? false : !editable"
+          :disabled="isStatementManual ? false : !editable"
           :label="{
             text: Translator.trans('statement.representation.checked')
           }"
           type="checkbox" />
         <dp-input
-          v-if="hasPermission('field_statement_submitter_email_address') || statement.attributes.isManual"
+          v-if="hasPermission('field_statement_submitter_email_address') || isStatementManual"
           id="statementEmailAddress"
           v-model="localStatement.attributes.submitterEmailAddress"
           class="u-mb-0_5"
-          :disabled="statement.attributes.isManual ? false : !editable"
+          :disabled="isStatementManual ? false : !editable"
           :label="{
             text: Translator.trans('email')
           }"
@@ -90,7 +90,7 @@
           id="statementOrgaName"
           v-model="localStatement.attributes.initialOrganisationName"
           class="u-mb-0_5"
-          :disabled="statement.attributes.isManual ? false : !editable"
+          :disabled="isStatementManual ? false : !editable"
           :label="{
             text: Translator.trans('organisation')
           }"
@@ -100,7 +100,7 @@
             id="statementStreet"
             v-model="localStatement.attributes.initialOrganisationStreet"
             class="o-form__group-item"
-            :disabled="statement.attributes.isManual ? false : !editable"
+            :disabled="isStatementManual ? false : !editable"
             :label="{
               text: Translator.trans('street')
             }"
@@ -109,7 +109,7 @@
             id="statementHouseNumber"
             v-model="localStatement.attributes.initialOrganisationHouseNumber"
             class="o-form__group-item shrink"
-            :disabled="statement.attributes.isManual ? false : !editable"
+            :disabled="isStatementManual ? false : !editable"
             :label="{
               text: Translator.trans('street.number.short')
             }"
@@ -121,7 +121,7 @@
             id="statementPostalCode"
             v-model="localStatement.attributes.initialOrganisationPostalCode"
             class="o-form__group-item shrink"
-            :disabled="statement.attributes.isManual ? false : !editable"
+            :disabled="isStatementManual ? false : !editable"
             :label="{
               text: Translator.trans('postalcode')
             }"
@@ -132,7 +132,7 @@
             id="statementCity"
             v-model="localStatement.attributes.initialOrganisationCity"
             class="o-form__group-item"
-            :disabled="statement.attributes.isManual ? false : !editable"
+            :disabled="isStatementManual ? false : !editable"
             :label="{
               text: Translator.trans('city')
             }"
@@ -154,7 +154,7 @@
         <div class="o-form__group u-mb-0_5">
           <!-- authoredDate: if manual statement -->
           <dp-input
-            v-if="statement.attributes.isManual ? true : !editable"
+            v-if="isStatementManual ? true : !editable"
             id="statementAuthoredDate"
             class="o-form__group-item"
             :disabled="true"
@@ -181,7 +181,7 @@
 
           <!-- submitDate: if manual statement -->
           <dp-input
-            v-if="statement.attributes.isManual ? true : !editable"
+            v-if="isStatementManual ? true : !editable"
             id="statementSubmitDate"
             class="o-form__group-item"
             :disabled="true"
@@ -357,6 +357,10 @@ export default {
         return this.currentUserId === this.storageStatement[this.statement.id].relationships.assignee.data.id
       }
       return false
+    },
+
+    isStatementManual () {
+      return this.statement.attributes.isManual
     },
 
     similarStatementSubmitters () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -409,13 +409,10 @@ export default {
     },
 
     submitterRole () {
-      let submitterRole = Translator.trans('institution')
-      if (this.localStatement.attributes.isSubmittedByCitizen &&
-          this.localStatement.attributes.submitterRole !== 'publicagency') {
-        submitterRole = Translator.trans('role.citizen')
-      }
+      const isSubmittedByCitizen = this.localStatement.attributes.isSubmittedByCitizen &&
+        this.localStatement.attributes.submitterRole !== 'publicagency'
 
-      return submitterRole
+      return isSubmittedByCitizen ? Translator.trans('role.citizen') : Translator.trans('institution')
     },
 
     submitType () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -452,10 +452,9 @@ export default {
     },
 
     isSubmitterAnonymous () {
-      const attr = this.localStatement.attributes
+      const { gdprConsent, original } = this.localStatement.attributes
 
-      return (attr.gdprConsent && attr.gdprConsent.consentRevoked) ||
-              attr.original.submitterAndAuthorMetaDataAnonymized
+      return gdprConsent?.consentRevoked || original.submitterAndAuthorMetaDataAnonymized
     },
 
     reset () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -379,14 +379,7 @@ export default {
 
     statementSubmitterValue: {
       get () {
-        const attr = this.localStatement.attributes
-        let submitterValue = attr[this.statementSubmitterField]
-        // If submitter has revoked the gdpr consent for this statement or statement has been anonymized
-        if (this.isSubmitterAnonymous()) {
-          submitterValue = Translator.trans('anonymized')
-        }
-
-        return submitterValue
+        return this.isSubmitterAnonymous() ? Translator.trans('anonymized') : this.localStatement.attributes[this.statementSubmitterField]
       },
       set (value) {
         this.localStatement.attributes[this.statementSubmitterField] = value

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -55,7 +55,7 @@
           :label="{
             text: Translator.trans('department')
           }"
-          @input="(val) => emitInput('initialOrganisationDepartmentName', val)" />
+          @input="val => emitInput('initialOrganisationDepartmentName', val)" />
         <dp-input
           v-if="localStatement.attributes.represents"
           id="statementRepresentation"

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -51,7 +51,7 @@
           id="statementDepartmentName"
           v-model="localStatement.attributes.initialOrganisationDepartmentName"
           class="u-mb-0_5"
-          :disabled="statement.isManual ? false : !editable"
+          :disabled="statement.attributes.isManual ? false : !editable"
           :label="{
             text: Translator.trans('department')
           }"
@@ -68,17 +68,17 @@
           v-if="localStatement.attributes.represents"
           id="representationCheck"
           v-model="localStatement.attributes.representationChecked"
-          :disabled="statement.isManual ? false : !editable"
+          :disabled="statement.attributes.isManual ? false : !editable"
           :label="{
             text: Translator.trans('statement.representation.checked')
           }"
           type="checkbox" />
         <dp-input
-          v-if="hasPermission('field_statement_submitter_email_address') || statement.isManual"
+          v-if="hasPermission('field_statement_submitter_email_address') || statement.attributes.isManual"
           id="statementEmailAddress"
           v-model="localStatement.attributes.submitterEmailAddress"
           class="u-mb-0_5"
-          :disabled="statement.isManual ? false : !editable"
+          :disabled="statement.attributes.isManual ? false : !editable"
           :label="{
             text: Translator.trans('email')
           }"
@@ -90,7 +90,7 @@
           id="statementOrgaName"
           v-model="localStatement.attributes.initialOrganisationName"
           class="u-mb-0_5"
-          :disabled="statement.isManual ? false : !editable"
+          :disabled="statement.attributes.isManual ? false : !editable"
           :label="{
             text: Translator.trans('organisation')
           }"
@@ -100,7 +100,7 @@
             id="statementStreet"
             v-model="localStatement.attributes.initialOrganisationStreet"
             class="o-form__group-item"
-            :disabled="statement.isManual ? false : !editable"
+            :disabled="statement.attributes.isManual ? false : !editable"
             :label="{
               text: Translator.trans('street')
             }"
@@ -109,7 +109,7 @@
             id="statementHouseNumber"
             v-model="localStatement.attributes.initialOrganisationHouseNumber"
             class="o-form__group-item shrink"
-            :disabled="statement.isManual ? false : !editable"
+            :disabled="statement.attributes.isManual ? false : !editable"
             :label="{
               text: Translator.trans('street.number.short')
             }"
@@ -121,7 +121,7 @@
             id="statementPostalCode"
             v-model="localStatement.attributes.initialOrganisationPostalCode"
             class="o-form__group-item shrink"
-            :disabled="statement.isManual ? false : !editable"
+            :disabled="statement.attributes.isManual ? false : !editable"
             :label="{
               text: Translator.trans('postalcode')
             }"
@@ -132,7 +132,7 @@
             id="statementCity"
             v-model="localStatement.attributes.initialOrganisationCity"
             class="o-form__group-item"
-            :disabled="statement.isManual ? false : !editable"
+            :disabled="statement.attributes.isManual ? false : !editable"
             :label="{
               text: Translator.trans('city')
             }"
@@ -154,7 +154,7 @@
         <div class="o-form__group u-mb-0_5">
           <!-- authoredDate: if manual statement -->
           <dp-input
-            v-if="statement.isManual ? true : !editable"
+            v-if="statement.attributes.isManual ? true : !editable"
             id="statementAuthoredDate"
             class="o-form__group-item"
             :disabled="true"
@@ -181,7 +181,7 @@
 
           <!-- submitDate: if manual statement -->
           <dp-input
-            v-if="statement.isManual ? true : !editable"
+            v-if="statement.attributes.isManual ? true : !editable"
             id="statementSubmitDate"
             class="o-form__group-item"
             :disabled="true"

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -136,6 +136,7 @@
         :attachments="filteredAttachments"
         :current-user-id="currentUser.id"
         :editable="editable"
+        :statement-form-definitions="statementFormDefinitions"
         :statement="statement"
         :submit-type-options="submitTypeOptions"
         @close="showInfobox = false"
@@ -239,6 +240,11 @@ export default {
     statementExternId: {
       type: String,
       required: true
+    },
+
+    statementFormDefinitions: {
+      required: true,
+      type: Object
     },
 
     submitTypeOptions: {
@@ -359,7 +365,7 @@ export default {
         orgaName: ''
       }
     },
-
+    // TO DO: add check for original statement
     editable () {
       return this.isCurrentUserAssigned && !this.statement.attributes.synchronized
     },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
@@ -11,6 +11,7 @@
 {% endfor %}
 
 {% block component_part %}
+{#    TP DO: Fill statementFormDefinitions #}
     <statement-segments-list
         :current-user="JSON.parse('{{ user|json_encode|e('js', 'utf-8') }}')"
         :is-source-and-coupled-procedure="{{ templateVars.isSourceAndCoupledProcedure ? 'true' : 'false' }}"
@@ -18,6 +19,7 @@
         :recommendation-procedure-ids="JSON.parse('{{ recommendationProcedureIds|json_encode|e('js', 'utf-8') }}')"
         statement-id="{{ statementId }}"
         statement-extern-id="{{ statementExternId }}"
+        statement-form-definitions="{}"
         :submit-type-options="JSON.parse('{{ submitTypeOptions|json_encode|e('js', 'utf-8') }}')">
     </statement-segments-list>
 {% endblock %}


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-3217

We want to have only one statement detail view. Here following fields from the old twig template (`templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig`) are added to the combined vue component:

-  `submitterRole`: Shows if statement is submitted by citizen or institution. Slightly changed logic from old template: Now only shows translation for citizen or institution and not institution name, because we already have an extra field for institution name.
-  help text for submitter name if submitter is anonymous 
- add more logic for submitter/author name: Field is also disabled if submitter is anonymous. Make submitter value and event name dynamically with logic from twig (`submitterName` vs `authorName`)
- `represents` and `represantionChecked`
- `statementFormDefinitions` as required prop

Some fields still need to be implemented from backend and won't work yet, see here https://demoseurope.youtrack.cloud/issue/DPLAN-11359
