### PR TITLE
fix (DPLAN-11391): Remove duplicate label for "Durchgangsnummer".

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -447,20 +447,6 @@
                                     </div>
                                 {% endif %}
 
-                                {# Iteration for Institutions #}
-                                {% if hasPermission('field_phase_iterator') %}
-                                    <div class="u-mb">
-                                        <label class="inline-block u-mb-0" for="r_institutionPhasecounter">
-                                            {{ "procedure.phase.phasecounter"|trans }}*
-                                        </label>
-                                        {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                            helpText: 'text.procedure.phasecounter'|trans,
-                                            cssClasses:'u-mt-0_125',
-                                            showPlainHint: true
-                                        } %}
-                                    </div>
-                                {% endif %}
-
                                 {% if hasPermission('feature_procedure_legal_notice_read') %}
                                     <div class="u-mb">
                                         <label class="inline-block u-mb-0" for="r_legalNotice">


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11391/Doppelte-Anzeige-des-Feldes-Durchgangsnummer-im-Menu-Verfahrensschritt-fur-Institutionen

Remove duplicate ui label for "Durchgangsnummer".

### How to review/test
Code Review, check interface (see ticket) 


### PR Checklist

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
