### PR TITLE
feat (DPLAN-11355): get procedure by phase id

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.29",
+            "version": "v0.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "b4b057cb6e76ae4c413ba32b68b40753d91af1a9"
+                "reference": "f608676c60531daffbbb543aba55f9442cbf20c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/b4b057cb6e76ae4c413ba32b68b40753d91af1a9",
-                "reference": "b4b057cb6e76ae4c413ba32b68b40753d91af1a9",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/f608676c60531daffbbb543aba55f9442cbf20c5",
+                "reference": "f608676c60531daffbbb543aba55f9442cbf20c5",
                 "shasum": ""
             },
             "require": {
@@ -1435,9 +1435,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.29"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.30"
             },
-            "time": "2024-04-05T11:40:23+00:00"
+            "time": "2024-04-08T14:01:00+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\Repositories\ProcedurePhaseRepositoryInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 
-class ProcedurePhaseRepository extends FluentRepository
+class ProcedurePhaseRepository extends FluentRepository implements ProcedurePhaseRepositoryInterface
 {
     public function getProcedureByInstitutionPhaseId(string $phaseId): ProcedureInterface|null
     {

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
@@ -18,12 +18,12 @@ use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 
 class ProcedurePhaseRepository extends FluentRepository implements ProcedurePhaseRepositoryInterface
 {
-    public function getProcedureByInstitutionPhaseId(string $phaseId): ProcedureInterface|null
+    public function getProcedureByInstitutionPhaseId(string $phaseId): ?ProcedureInterface
     {
         return $this->getEntityManager()->getRepository(ProcedureInterface::class)->findOneBy(['phase' => $phaseId]);
     }
 
-    public function getProcedureByPublicParticipationPhaseId(string $phaseId): ProcedureInterface|null
+    public function getProcedureByPublicParticipationPhaseId(string $phaseId): ?ProcedureInterface
     {
         return $this->getEntityManager()->getRepository(ProcedureInterface::class)
             ->findOneBy(['publicParticipationPhase' => $phaseId]);

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedurePhaseRepository.php
@@ -12,8 +12,19 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 
 class ProcedurePhaseRepository extends FluentRepository
 {
+    public function getProcedureByInstitutionPhaseId(string $phaseId): ProcedureInterface|null
+    {
+        return $this->getEntityManager()->getRepository(ProcedureInterface::class)->findOneBy(['phase' => $phaseId]);
+    }
+
+    public function getProcedureByPublicParticipationPhaseId(string $phaseId): ProcedureInterface|null
+    {
+        return $this->getEntityManager()->getRepository(ProcedureInterface::class)
+            ->findOneBy(['publicParticipationPhase' => $phaseId]);
+    }
 }


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11355/DiPlanBeteiligung-generiert-korrekte-XBeteiligung-Nachrichteninhalte-fur-die-Raumordnung

This will add two new functions to the ProcedurePhaseRepository for getting a procedure by a given phase id.

### How to review/test
Code Review

### Linked PRs

- [demosplan-addon](https://github.com/demos-europe/demosplan-addon/pull/100)
- [demosplan-addon release v0.30](https://github.com/demos-europe/demosplan-addon/pull/101)


### Tasks 

- [x] Merge related demosplan-addon pr
- [x] release a new demosplan-addon version
- [x] update composer lock with new demosplan-addon
- [x] implement the new ProcedurePhaseRepositoryInterface


### PR Checklist

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
