### PR TITLE
feature: change method from private to protected

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -78,7 +78,7 @@ class SegmentsExporter
         return IOFactory::createWriter($phpWord);
     }
 
-    private function addSimilarStatementSubmitters(Section $section, Statement $statement): void
+    protected function addSimilarStatementSubmitters(Section $section, Statement $statement): void
     {
         $similarStatementSubmitters = $this->getSimilarStatementSubmitters($statement);
         if ('' !== $similarStatementSubmitters) {


### PR DESCRIPTION
Description: Phpstan level 1 :

```
Line   DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php  
 ------ -------------------------------------------------------------------- 
  143    Call to private method addSimilarStatementSubmitters() of class     
         demosplan\DemosPlanCoreBundle\Logic\Segment\SegmentsExporter.       
 ------ --------------------------------------------------------------------                                                                                
 [ERROR] Found 1 error
```


### How to review/test
bin/projectname dp:phpstan -l 1

