### PR TITLE
fix(refs DPLAN-11392): Add Pattern to iterator input

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -422,6 +422,7 @@
                                                         },
                                                         control: {
                                                             name: 'r_phase_iteration',
+                                                            pattern: '^[1-9][0-9]*$',
                                                             value: proceduresettings.phaseObject.iteration
                                                         },
                                                         id: 'r_phase_iteration',
@@ -611,6 +612,7 @@
                                                         },
                                                         control: {
                                                             name: 'r_public_participation_phase_iteration',
+                                                            pattern: '^[1-9][0-9]*$',
                                                             value: proceduresettings.publicParticipationPhaseObject.iteration
                                                         },
                                                         id: 'r_public_participation_phase_iteration',


### PR DESCRIPTION
allow only numbers and not `0`

https://demoseurope.youtrack.cloud/issue/DPLAN-11392/Falsche-Reaktion-beim-Eintragen-ungultiger-Daten-im-Feld-fur-Durchgangsnummer

In "Grundeinstellungen" try to change the iterator (Durchgangsnummer). For internal and external only numbers should be valid and `0` should be unvalid