### PR TITLE
feat (DPLAN-11355): trigger no update for procedure phases during procedure creation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2707,13 +2707,6 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
 
         $this->copyPlaces($blueprintId, $newProcedure);
 
-        /** @var Procedure $blueprint */
-        $blueprint = $this->procedureRepository->get($blueprintId);
-        $newProcedure->setPhaseObject(clone $blueprint->getPhaseObject());
-        $newProcedure->setPublicParticipationPhaseObject(
-            clone $blueprint->getPublicParticipationPhaseObject()
-        );
-
         /** @var NewProcedureAdditionalDataEvent $additionalDataEvent */
         $additionalDataEvent = $this->eventDispatcher->dispatch(new NewProcedureAdditionalDataEvent($newProcedure));
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2709,8 +2709,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
 
         /** @var Procedure $blueprint */
         $blueprint = $this->procedureRepository->get($blueprintId);
-        $newProcedure->getPhaseObject()->copyValuesFromPhase($blueprint->getPhaseObject());
-        $newProcedure->getPublicParticipationPhaseObject()->copyValuesFromPhase($blueprint->getPublicParticipationPhaseObject());
+        $newProcedure->setPhaseObject(clone $blueprint->getPhaseObject());
+        $newProcedure->setPublicParticipationPhaseObject(
+            clone $blueprint->getPublicParticipationPhaseObject()
+        );
 
         /** @var NewProcedureAdditionalDataEvent $additionalDataEvent */
         $additionalDataEvent = $this->eventDispatcher->dispatch(new NewProcedureAdditionalDataEvent($newProcedure));

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -245,10 +245,6 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             $procedure->setSettings($procedureSettings);
 
             $currentDate = new DateTime();
-            $procedure->setStartDate($currentDate);
-            $procedure->setEndDate($currentDate);
-            $procedure->setPublicParticipationStartDate($currentDate);
-            $procedure->setPublicParticipationEndDate($currentDate);
             $procedure->setDeletedDate($currentDate);
             $procedure->setClosedDate($currentDate);
             $procedure->setAuthorizedUsers([]);

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -269,7 +269,11 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             $procedure->setElements(new ArrayCollection());
 
             $procedure->setPhaseObject(new ProcedurePhase());
+            $procedure->getPhaseObject()->copyValuesFromPhase($procedureMaster->getPhaseObject());
             $procedure->setPublicParticipationPhaseObject(new ProcedurePhase());
+            $procedure->getPublicParticipationPhaseObject()->copyValuesFromPhase(
+                $procedureMaster->getPublicParticipationPhaseObject()
+            );
 
             // improve T20997:
             // this kind of denylisting should be avoided by do not using "clone"


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11355/DiPlanBeteiligung-generiert-korrekte-XBeteiligung-Nachrichteninhalte-fur-die-Raumordnung, https://demoseurope.youtrack.cloud/issue/DPLAN-11398/Es-wird-eine-XBeteiligung-Update-Nachricht-vor-Create-Nachricht-erstellt

These changes are needed to avoid that the ProcedurePhase Entity will be as updated in onFlush events.

### How to review/test
Code Review

### Linked PRs

- https://github.com/demos-europe/demosplan-addon-xbeteiligung-async/pull/20

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
