### PR TITLE
F (refs dplan 1924) change default ul latex pdf line width (#2929)

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTablePdfExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTablePdfExporter.php
@@ -258,6 +258,26 @@ class AssessmentTablePdfExporter extends AssessmentTableFileExporterAbstract
             // * Querformat: DemosPlanAssessmentTableBundle:DemosPlan:export_original.tex.twig
             // * Hochformat: DemosPlanAssessmentTableBundle:DemosPlan:export_original.tex.twig
             $fullTemplateName = '@DemosPlanCore/DemosPlanAssessmentTable/DemosPlan/'.$templateName.'.tex.twig';
+
+            // the line width of lists inside the generated pdf differs in following circumstances:
+            // vertical format (portrait) split view - Text | Response
+            $listLineWidth = 7;
+            if ('portrait' === $template && 'export_original' === $templateName) {
+                // vertical format (portrait) view not split - Text only
+                $listLineWidth = 17;
+            }
+            if (('landscape' === $template && 'export' === $templateName)
+                || ('condensed' === $template && 'export_condensed' === $templateName && !$original)) {
+                // horizontal format (landscape) split view - Text | Response
+                $listLineWidth = 12;
+            }
+            if (('landscape' === $template && 'export_original' === $templateName)
+                || ('condensed' === $template && 'export_condensed' === $templateName && $original)) {
+                // horizontal format (landscape) view not split - Text only
+                $listLineWidth = 24;
+            }
+            $templateVars['listwidth'] = $listLineWidth;
+
             $content = $this->twig->render(
                 $fullTemplateName,
                 [
@@ -270,6 +290,7 @@ class AssessmentTablePdfExporter extends AssessmentTableFileExporterAbstract
                     'anonymous'    => $anonymous,
                 ]
             );
+
             $procedureName = $this
                 ->assessmentTableOutput
                 ->selectProcedureName(

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -493,7 +493,7 @@ class DraftStatementService extends CoreService
     /**
      * Set all draftStatements of the given organisation, which are released and not submitted, to unreleased.
      *
-     * @param orga $organisation - organisation, whose draftStatements will be set to unreleased
+     * @param Orga $organisation - organisation, whose draftStatements will be set to unreleased
      *
      * @return bool - true, if all found draftStatements are successfully reset
      */
@@ -597,7 +597,7 @@ class DraftStatementService extends CoreService
     public function submitDraftStatement(
         $draftStatementIds,
         $user,
-        NotificationReceiver $notificationReceiver = null,
+        ?NotificationReceiver $notificationReceiver = null,
         bool $gdprConsentReceived = false,
         bool $convertToLegacy = true
     ): array {
@@ -626,7 +626,7 @@ class DraftStatementService extends CoreService
     protected function submitDraftStatements(
         array $draftStatementIds,
         $user,
-        NotificationReceiver $notificationReceiver = null,
+        ?NotificationReceiver $notificationReceiver = null,
         bool $gdprConsentReceived = false,
         bool $convertToLegacy = true
     ): array {
@@ -904,6 +904,8 @@ class DraftStatementService extends CoreService
         $outputResult['statementlist'] = $filteredStatementList;
         $templateVars['list'] = $outputResult;
         $templateVars['procedure'] = $procedureId;
+        // set listLineWidth for pdf vertical format (portrait) view not split - Text only
+        $templateVars['listwidth'] = 17;
         $procedure = $this->procedureService->getProcedure($procedureId);
 
         $content = $this->twig->render('@DemosPlanCore/DemosPlanStatement/'.$template.'.tex.twig', [

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -31,55 +31,53 @@ class LatexExtension extends ExtensionBase
     protected $fileService;
 
     final public const HTML_TO_LATEX = [
-        '\\'        => '\textbackslash~',
-        '{'         => '\{',
-        '}'         => '\}',
-        '['         => '\lbrack~',
-        ']'         => '\rbrack~',
-        '<u>'       => '\uline{',
-        '</u>'      => '}',
-        '<del>'     => '\sout{',
-        '</del>'    => '}',
-        '<s>'       => '\sout{',
-        '</s>'      => '}',
+        '\\'                                   => '\textbackslash~',
+        '{'                                    => '\{',
+        '}'                                    => '\}',
+        '['                                    => '\lbrack~',
+        ']'                                    => '\rbrack~',
+        '<u>'                                  => '\uline{',
+        '</u>'                                 => '}',
+        '<del>'                                => '\sout{',
+        '</del>'                               => '}',
+        '<s>'                                  => '\sout{',
+        '</s>'                                 => '}',
         '<mark title="markierter Text">'       => '\colorbox{yellow}{',
-        '</mark>'      => '}',
-        '<i>'       => '{\itshape ',
-        '</i>'      => '}',
-        '<em>'      => '{\itshape ',
-        '</em>'     => '}',
-        '<strong>'  => '{\bfseries ',
-        '</strong>' => '}',
-        '<b>'       => '{\bfseries ',
-        '</b>'      => '}',
-        '<ins>'     => '',
-        '<ul>'      => '\begin{itemize}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
-        '</ul>'     => '\end{itemize}',
-        '<ol>'      => '\begin{enumerate}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-7cm-\leftmargin\relax]',
-        '</ol>'     => '\end{enumerate}',
-        '<li>'      => '\item ',
-        '</li>'     => '',
-        '´'         => '\textquoteright ',
-        '`'         => '\textquoteleft ',
-        '&'         => '\&',
-        '$'         => '\$',
-        '<span>'    => '',
-        '</span>'   => '',
-        "' "        => '\textquoteright~',
-        "'"         => '\textquoteright ',
-        '&#039; '   => '\textquoteright~',
-        '&#039;'    => '\textquoteright ',
-        '§'         => '\S~',
-        '" '        => '\dq~',
-        '"'         => '\dq ',
-        '#'         => '\#',
-        '_'         => '\_',
-        '€'         => '\texteuro~',
-        '%'         => '\%',
-        '^'         => '\textasciicircum~',
-        '█'         => '\ding{122}',
-        '­'         => '\-',
-        '</ins>'    => '',
+        '</mark>'                              => '}',
+        '<i>'                                  => '{\itshape ',
+        '</i>'                                 => '}',
+        '<em>'                                 => '{\itshape ',
+        '</em>'                                => '}',
+        '<strong>'                             => '{\bfseries ',
+        '</strong>'                            => '}',
+        '<b>'                                  => '{\bfseries ',
+        '</b>'                                 => '}',
+        '<ins>'                                => '',
+        '</ul>'                                => '\end{itemize}',
+        '</ol>'                                => '\end{enumerate}',
+        '<li>'                                 => '\item ',
+        '</li>'                                => '',
+        '´'                                    => '\textquoteright ',
+        '`'                                    => '\textquoteleft ',
+        '&'                                    => '\&',
+        '$'                                    => '\$',
+        '<span>'                               => '',
+        '</span>'                              => '',
+        "' "                                   => '\textquoteright~',
+        "'"                                    => '\textquoteright ',
+        '&#039; '                              => '\textquoteright~',
+        '&#039;'                               => '\textquoteright ',
+        '§'                                    => '\S~',
+        '" '                                   => '\dq~',
+        '"'                                    => '\dq ',
+        '#'                                    => '\#',
+        '_'                                    => '\_',
+        '€'                                    => '\texteuro~',
+        '%'                                    => '\%',
+        '^'                                    => '\textasciicircum~',
+        '█'                                    => '\ding{122}',
+        '­'                                    => '\-',
+        '</ins>'                               => '',
     ];
 
     public function __construct(ContainerInterface $container, FileService $serviceFile, private readonly LoggerInterface $logger)
@@ -96,7 +94,14 @@ class LatexExtension extends ExtensionBase
     public function getFilters(): array
     {
         return [
-            new TwigFilter('latex', $this->latexFilter(...)),
+            new TwigFilter(
+                'latex', function (
+                    $string,
+                    $listwidth = 7
+                ) {
+                    return $this->latexFilter($string, $listwidth);
+                }
+            ),
             new TwigFilter('nl2texnl', $this->latexNewlineFilter(...)),
             new TwigFilter('latexPrepareImage', $this->prepareImage(...)),
             new TwigFilter('htmlPrepareImage', $this->prepareHtmlImage(...)),
@@ -122,7 +127,7 @@ class LatexExtension extends ExtensionBase
      *
      * @throws Exception
      */
-    public function latexFilter($text)
+    public function latexFilter($text, int $listwidth = 7)
     {
         try {
             // return numeric values without conversion
@@ -212,6 +217,11 @@ class LatexExtension extends ExtensionBase
             if (false !== stripos($text, '<table')) {
                 $text = $this->processTable($text);
             }
+            $htmlToLatexList = [
+                '<ul>'      => sprintf('\begin{itemize}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-%scm-\leftmargin\relax]', $listwidth),
+                '<ol>'      => sprintf('\begin{enumerate}[leftmargin=0.5cm,rightmargin=\dimexpr\linewidth-%scm-\leftmargin\relax]', $listwidth),
+            ];
+            $text = str_replace(array_keys($htmlToLatexList), $htmlToLatexList, $text);
 
             // Replace found URLs with latex-style URLs
             $hitcount = 0;
@@ -264,8 +274,6 @@ class LatexExtension extends ExtensionBase
      * Process Table.
      *
      * @param string $text
-     *
-     * @return mixed
      */
     public function processTable($text)
     {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
@@ -71,7 +71,7 @@
         \ParallelRText{{ '{' }}\textbf{{ '{' }}{{ "considerationadvice"|trans|latex|raw }}{{ '}' }}{{ '}' }}
         \end{Parallel}
     \begin{Parallel}{\columnsep}{\columnsep}
-    \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex|raw }}{{ '}' }}
+    \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
     \ParallelRText{{ '{' }}{{ statement.recommendation|default("notspecified"|trans)|latex|raw }}{{ '}' }}
     \end{Parallel}
     {% if statement.mapFile is defined and statement.mapFile != "" %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_condensed.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_condensed.tex.twig
@@ -88,7 +88,7 @@
         \ParallelRText{{ '{' }}{{ '}' }}
         \end{Parallel}
         \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}24.5cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
-        \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex|raw }}{{ '}' }}
+        \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
         \ParallelRText{{ '{' }}{{ '}' }}
         \end{Parallel}
 
@@ -99,7 +99,7 @@
         \ParallelRText{{ '{' }}\textbf{{ '{' }}{{ "considerationadvice"|trans|latex|raw }}{{ '}' }}{{ '}' }}
         \end{Parallel}
         \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}12.25cm{{ '}' }}{{ '{' }}12.25cm{{ '}' }}
-        \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex|raw }}{{ '}' }}
+        \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
         \ParallelRText{{ '{' }}{{ statement.recommendation|default("notspecified"|trans)|latex|raw }}{{ '}' }}
         \end{Parallel}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
@@ -60,7 +60,7 @@
     \begin{{ '{' }}longtable{{ '}' }}{{ '{' }}p{{ '{' }}17cm{{ '}' }}p{{ '{' }}0cm{{ '}' }}{{ '}' }}\centering \textbf{{ '{' }}{{ "statement"|trans|latex|raw }}{{ '}' }} & \\
     \end{{ '{' }}longtable{{ '}' }}
     \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}17cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
-    \ParallelLText{{ '{' }}{{ statement.text|default('')|latex|raw }}{{ '}' }}
+    \ParallelLText{{ '{' }}{{ statement.text|default('')|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
     \ParallelRText{{ '{' }}{{ '}' }}
     \end{Parallel}
     {% if hasPermission('feature_statement_gdpr_consent') %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
@@ -30,7 +30,7 @@
 \ParallelLText{{ '{' }}
 {% if statement.text is defined %}
     \textbf{{ '{' }}{{ "statementtext"|trans|latex|raw }}{{ '}' }}\\
-    {{ statement.text|latex|raw }}
+    {{ statement.text|latex(listwidth=templateVars.listwidth)|raw }}
     \\
 {% endif %}
 {% if statement.mapFile is defined and statement.mapFile != "" %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
@@ -87,7 +87,7 @@
         \hline
     \end{longtable}
 \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}17cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
-\ParallelLText{{ '{' }}{% if statement.text is defined %}{{ statement.text|latex|raw }}{% endif %}{{ '}' }}
+\ParallelLText{{ '{' }}{% if statement.text is defined %}{{ statement.text|latex(listwidth=templateVars.listwidth)|raw }}{% endif %}{{ '}' }}
 {% if statement.mapFile is defined and statement.mapFile != "" %}
     {% if statement.mapFile != "---" %}
         \centering

--- a/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
+++ b/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
@@ -452,6 +452,23 @@ class LatexExtensionTest extends UnitTestCase
         self::assertSame($partsExpectedToBeEqual[0], $partsExpectedToBeEqual[1]);
     }
 
+    public function testListWidthUlOl(): void
+    {
+        // Test the default list width value
+        $ul = $this->sut->latexFilter('<ul>');
+        $ol = $this->sut->latexFilter('<ol>');
+        self::assertStringContainsString('linewidth-7cm-', $ul);
+        self::assertStringContainsString('linewidth-7cm-', $ol);
+
+        // Test with custome list width
+        $ul = $this->sut->latexFilter('<ul>', 12);
+        $ol = $this->sut->latexFilter('<ol>', 12);
+        self::assertStringContainsString('linewidth-12cm-', $ul);
+        self::assertStringContainsString('linewidth-12cm-', $ol);
+        self::assertStringNotContainsString('linewidth-7cm-', $ul);
+        self::assertStringNotContainsString('linewidth-7cm-', $ol);
+    }
+
     public function testStrikeTagReplacement(): void
     {
         $text = '<p>test</p><p></p><p><strong>bold</strong></p><p><em>kursiv</em></p><p><u>unterstrichen</u></p><p><s>durchgestrichen</s></p><p><mark title="markierter Text">markiert</mark></p><p><dp-obscure>geschwärzt</dp-obscure></p>';


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-1924/Munchen-Prod-PDF-Export-eingereichter-STN-in-Bestatigungsmail-wird-falsch-dargestellt

Description:
See https://github.com/demos-europe/demosplan-core/pull/2905

### How to review/test
Create draft statements icluding lists with text longer than 7cm.
download your drafts as pdf....
hand them in to get a proper stn and download that as pdf...

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly