### PR TITLE
fix(refs dplan-11402, dplan-11403):  Refactor logic to display Permissions for selected Phase

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -64,7 +64,10 @@
             enforce-plausible-dates
             :min-date="startDate"
             required
-^
+            :data-cy="{
+                endDate: dataCyEndDate,
+                startDate: dataCyStartDate
+            }"
             start-disabled
             :start-id="startDateId"
             :start-name="startDateId"

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -64,10 +64,7 @@
             enforce-plausible-dates
             :min-date="startDate"
             required
-            :data-cy="{
-                endDate: dataCyEndDate,
-                startDate: dataCyStartDate
-            }"
+^
             start-disabled
             :start-id="startDateId"
             :start-name="startDateId"

--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -22,6 +22,7 @@ import {
 import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import DpEmailList from './DpEmailList'
 import ExportSettings from './ExportSettings'
+import ParticipationPhases from './ParticipationPhases'
 
 export default {
   name: 'DpBasicSettings',
@@ -42,7 +43,8 @@ export default {
       const { DpUploadFiles } = await import('@demos-europe/demosplan-ui')
       return DpUploadFiles
     },
-    ExportSettings
+    ExportSettings,
+    ParticipationPhases
   },
 
   props: {
@@ -126,8 +128,6 @@ export default {
       selectedDataInputOrgas: this.initDataInputOrgas,
       selectedAuthUsers: this.initAuthUsers,
       selectedProcedureCategories: this.initProcedureCategories,
-      selectedInternalPhase: this.initProcedurePhaseInternal,
-      selectedPublicPhase: this.initProcedurePhasePublic,
       selectedSimilarRecommendationProcedures: this.initSimilarRecommendationProcedures,
       procedureDescription: this.procedureExternalDesc,
       procedureName: this.initProcedureName
@@ -138,14 +138,6 @@ export default {
     authUsersOptions () {
       const users = JSON.parse(JSON.stringify(this.authorizedUsersOptions))
       return sortAlphabetically(users, 'name')
-    },
-
-    publicPhaseIsInParticipation () {
-      return this.participationPhases.includes(this.selectedPublicPhase)
-    },
-
-    internalPhaseIsInParticipation () {
-      return this.participationPhases.includes(this.selectedInternalPhase)
     }
   },
 

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -93,7 +93,7 @@ export default {
       type: Object,
       required: false,
       default: () => ({}),
-      validate: val => {
+      validator: val => {
         const requiredKeys = ['label', 'name', 'tooltip', 'value']
         let keyCounter = 0
 

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -1,31 +1,28 @@
 <template>
   <div>
     <div class="flex gap-2">
-      <div class="w-8-12">
-        <dp-select
-          :label="{
-            text: labelText,
-            tooltip: helpText
-          }"
-          :name="fieldName"
-          :options="phaseOptions"
-          required
-          v-model="selectedPhase" />
-      </div>
+      <dp-select
+        class="w-8/12"
+        :label="{
+          text: labelText,
+          tooltip: helpText
+        }"
+        :name="fieldName"
+        :options="phaseOptions"
+        required
+        v-model="selectedPhase" />
 
-      <div
-        v-if="true || hasPermission('field_phase_iterator')"
-        class="w-4/12 inline-block relative">
-        <dp-label
-          for="r_public_participation_phase_iteration"
-          :text="iterator.label"
-          :tooltip="iterator.tooltip"
-          required />
-        <dp-input
-          name="r_public_participation_phase_iteration"
-          :value="iterator.value"
-          pattern="^[1-9][0-9]*$" />
-      </div>
+      <dp-input
+        v-if="hasPermission('field_phase_iterator')"
+        width="w-4/12"
+        :label="{
+          text: iterator.label,
+          tooltip: iterator.tooltip
+        }"
+        :name="iterator.name"
+        :value="iterator.value"
+        pattern="^[1-9][0-9]*$"
+        required />
     </div>
 
     <dp-inline-notification
@@ -44,7 +41,6 @@
 import {
   DpInlineNotification,
   DpInput,
-  DpLabel,
   DpSelect
 } from '@demos-europe/demosplan-ui'
 
@@ -54,7 +50,6 @@ export default {
   components: {
     DpInlineNotification,
     DpInput,
-    DpLabel,
     DpSelect
   },
 

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -135,14 +135,14 @@ export default {
   computed: {
     permissionMessageText () {
       const currentPhase = this.phaseOptions.find(option => option.value === this.selectedPhase)
-       /*
-       * Generated Trans-Keyes:
+      /*
+       * Generated Trans-Keys:
        *
        * 'permissionset.hidden'
        * 'permissionset.read'
        * 'permissionset.write'
        */
-      const permissionsetMessage =  Translator.trans(`permissionset.${currentPhase.permissionset}`)
+      const permissionsetMessage = Translator.trans(`permissionset.${currentPhase.permissionset}`)
 
       return `${this.permissionMessage} ${permissionsetMessage}`
     },

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -118,14 +118,16 @@ export default {
   computed: {
     permissionMessageText () {
       const currentPhase = this.phaseOptions.find(option => option.value === this.selectedPhase)
-      /*
+       /*
        * Generated Trans-Keyes:
        *
        * 'permissionset.hidden'
        * 'permissionset.read'
        * 'permissionset.write'
        */
-      return this.permissionMessage + Translator.trans(`permissionset.${currentPhase.permissionset}`)
+      const permissionsetMessage =  Translator.trans(`permissionset.${currentPhase.permissionset}`)
+     
+      return `${this.permissionMessage} ${permissionsetMessage}`
     },
 
     isInParticipation () {

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -134,7 +134,7 @@ export default {
 
   computed: {
     permissionMessageText () {
-      const currentPhase = this.phaseOptions.find(option => option.value === this.selectedPhase)
+      const currentPhase = this.phaseOptions.find(option => option.value === this.selectedPhase) || this.phaseOptions[0]
       /*
        * Generated Trans-Keys:
        *

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -14,6 +14,7 @@
 
       <dp-input
         v-if="hasPermission('field_phase_iterator')"
+        :id="iterator.name"
         width="w-4/12"
         :label="{
           text: iterator.label,
@@ -142,7 +143,7 @@ export default {
        * 'permissionset.write'
        */
       const permissionsetMessage =  Translator.trans(`permissionset.${currentPhase.permissionset}`)
-     
+
       return `${this.permissionMessage} ${permissionsetMessage}`
     },
 

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -1,0 +1,141 @@
+<template>
+  <div>
+    <div class="flex gap-2">
+      <div class="w-8-12">
+        <dp-select
+          :label="{
+            text: labelText,
+            tooltip: helpText
+          }"
+          :name="fieldName"
+          :options="phaseOptions"
+          required
+          v-model="selectedPhase" />
+      </div>
+
+      <div
+        v-if="true || hasPermission('field_phase_iterator')"
+        class="w-4/12 inline-block relative">
+        <dp-label
+          for="r_public_participation_phase_iteration"
+          :text="iterator.label"
+          :tooltip="iterator.tooltip"
+          required />
+        <dp-input
+          name="r_public_participation_phase_iteration"
+          :value="iterator.value"
+          pattern="^[1-9][0-9]*$" />
+      </div>
+    </div>
+
+    <dp-inline-notification
+      :message="permissionMessageText"
+      type="warning" />
+
+    <div
+      v-if="hasPermission('feature_auto_switch_to_procedure_end_phase') && !hasPermission('feature_auto_switch_procedure_phase') && isInParticipation"
+      class="lbl__hint u-mt-0_25 u-mb-0">
+      {{ autoswitchHint }}
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  DpInlineNotification,
+  DpInput,
+  DpLabel,
+  DpSelect
+} from '@demos-europe/demosplan-ui'
+
+export default {
+  name: 'ParticipationPhases',
+
+  components: {
+    DpInlineNotification,
+    DpInput,
+    DpLabel,
+    DpSelect
+  },
+
+  props: {
+    autoswitchHint: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    labelText: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    fieldName: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    helpText: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    initSelectedPhase: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    iterator: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    },
+
+    participationPhases: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+
+    permissionMessage: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    phaseOptions: {
+      type: Array,
+      required: false,
+      default: () => []
+    }
+  },
+
+  data () {
+    return {
+      selectedPhase: this.initSelectedPhase
+    }
+  },
+
+  computed: {
+    permissionMessageText () {
+      const currentPhase = this.phaseOptions.find(option => option.value === this.selectedPhase)
+      /*
+       * Generated Trans-Keyes:
+       *
+       * 'permissionset.hidden'
+       * 'permissionset.read'
+       * 'permissionset.write'
+       */
+      return this.permissionMessage + Translator.trans(`permissionset.${currentPhase.permissionset}`)
+    },
+
+    isInParticipation () {
+      return this.participationPhases.includes(this.selectedPhase)
+    }
+  }
+}
+</script>

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -60,12 +60,6 @@ export default {
       default: ''
     },
 
-    labelText: {
-      type: String,
-      required: false,
-      default: ''
-    },
-
     fieldName: {
       type: String,
       required: false,
@@ -78,16 +72,38 @@ export default {
       default: ''
     },
 
+    labelText: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     initSelectedPhase: {
       type: String,
       required: false,
       default: ''
     },
 
+    /**
+     * Manually set iterator for the phase
+     * The Value can only be a number larger than 0 ( > 0 )
+     */
     iterator: {
       type: Object,
       required: false,
-      default: () => ({})
+      default: () => ({}),
+      validate: val => {
+        const requiredKeys = ['label', 'name', 'tooltip', 'value']
+        let keyCounter = 0
+
+        Object.keys(val).forEach(key => {
+          if (requiredKeys.includes(key)) {
+            keyCounter++
+          }
+        })
+
+        return keyCounter === requiredKeys.length
+      }
     },
 
     participationPhases: {

--- a/client/js/lib/procedure/AdministrationMaster.js
+++ b/client/js/lib/procedure/AdministrationMaster.js
@@ -37,49 +37,6 @@ export default function AdministrationMaster () {
 
   // *********FROM ADMINISTRATION_EDIT*********
 
-  function updatePermissionsetdescription (element) {
-    const $element = $(element)
-    const permissionset = $element.find(':selected').data('permissionset')
-    let permissionsetVerbose
-
-    switch (permissionset) {
-      case 'hidden':
-        permissionsetVerbose = Translator.trans('permissionset.hidden')
-        break
-      case 'read':
-        permissionsetVerbose = Translator.trans('permissionset.read')
-        break
-      case 'write':
-        permissionsetVerbose = Translator.trans('permissionset.write')
-        break
-      default:
-        break
-    }
-    // Update der Beschreibung der Phase
-    $element.next('div').find('[data-procedure-permission-set]').text(permissionsetVerbose)
-  }
-
-  // Ausgabe der Rechte der Institutionen in der Phase
-  const internalPermissionElement = $('select[name="r_phase"]')
-  // Ausgabe beim Laden der Seite
-  updatePermissionsetdescription(internalPermissionElement)
-  // Ausgabe beim Verändern
-  $(internalPermissionElement).on('change', function () {
-    updatePermissionsetdescription($(this))
-  })
-
-  //  Dito Phase der Öffentlichkeitsbeteiligung
-  if (hasPermission('area_public_participation')) {
-    // Ausgabe der Rechte der Öffentlichkeit in der Phase
-    const externalPermissionElement = $('select[name="r_publicParticipationPhase"]')
-    // Ausgabe beim Laden der Seite
-    updatePermissionsetdescription(externalPermissionElement)
-    // Ausgabe beim Verändern
-    $(externalPermissionElement).on('change', function () {
-      updatePermissionsetdescription($(this))
-    })
-  }
-
   // Atm broken (was not reimplemented after removing jQuery autocomplete)
   if (dplan.settings.useOpenGeoDb === true && document.querySelector('.js__locationName') !== null) {
     // Autocomplete Ort

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -109,7 +109,6 @@
         init-procedure-phase-internal="{{ proceduresettings.phase }}"
         init-procedure-phase-public="{{ proceduresettings.publicParticipationPhase }}"
         :init-similar-recommendation-procedures="JSON.parse('{{ selectedAllowedSegmentAccessProcedures|json_encode|e('js', 'utf-8') }}')"
-        :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
     >
         <form
             name="configForm"
@@ -386,66 +385,30 @@
                             <div class="o-wizard__main">
 
                                 {% if hasPermission('feature_procedure_change_phase') %}
-                                    <div class="u-mb">
-                                        <div class="flex gap-2">
-                                            <div class="w-8/12 inline-block">
-                                                <label class="inline-block mb-0.5" for="r_phase">
-                                                    {{ "procedure.phase.institutions"|trans }}*
-                                                </label>
-                                                {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                    helpText: 'text.procedure.edit.internal.change_phase'|trans,
-                                                    showPlainHint: true
-                                                } %}
-
-                                                <select
-                                                    class="o-form__control-select"
-                                                    id="r_phase"
-                                                    v-model="selectedInternalPhase"
-                                                    data-cy="r_phase"
-                                                    name="r_phase">
-                                                    {% for internalPhase in templateVars.internalPhases %}
-                                                        <option
-                                                            value="{{ internalPhase.key }}"{% if proceduresettings.phase == internalPhase.key %}
-                                                            selected="selected"{% endif %}
-                                                            data-permissionset="{{ internalPhase.permissionset }}">
-                                                            {{ internalPhase.name }}
-                                                        </option>
-                                                    {% endfor %}
-                                                </select>
-                                            </div>
-                                            {% if hasPermission('field_phase_iterator') %}
-                                                <div class="w-4/12 inline-block relative">
-                                                    {{ uiComponent('form.element', {
-                                                        label: {
-                                                            text: 'procedure.phase.phasecounter'|trans,
-                                                            tooltip: 'text.procedure.phasecounter'|trans
-                                                        },
-                                                        control: {
-                                                            name: 'r_phase_iteration',
-                                                            pattern: '^[1-9][0-9]*$',
-                                                            value: proceduresettings.phaseObject.iteration
-                                                        },
-                                                        id: 'r_phase_iteration',
-                                                        type: 'text',
-                                                        required: true,
-                                                    }) }}
-                                                </div>
-                                            {% endif %}
-                                        </div>
-
-                                        {{ uiComponent('inline-notification', {
-                                            message: 'explanation.procedure.internal.permissions'|trans ~ '<span data-procedure-permission-set></span>',
-                                            type: 'warning'
-                                        }) }}
-
-                                        {%  if hasPermission('feature_auto_switch_to_procedure_end_phase') and not hasPermission('feature_auto_switch_procedure_phase') %}
-                                            <div
-                                                v-if="internalPhaseIsInParticipation"
-                                                class="lbl__hint u-mt-0_25 u-mb-0">
-                                                {{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.internal.analysis'|trans }) }}
-                                            </div>
-                                        {% endif %}
-                                    </div>
+                                    {# phase for institution participation #}
+                                    {% set internalPhaseOptions = [] %}
+                                    {% for phase in templateVars.internalPhases %}
+                                        {% set internalPhaseOptions = internalPhaseOptions|merge([{
+                                            value: phase.key,
+                                            label: phase.name,
+                                            permissionset: phase.permissionset,
+                                        }]) %}
+                                    {% endfor %}
+                                    <participation-phases
+                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.internal.evaluating'|trans }) }}"
+                                        field-name="r_phase"
+                                        help-text="{{ 'text.procedure.edit.internal.change_phase'|trans }}"
+                                        label-text="{{ "procedure.phase.institutions"|trans }}"
+                                        :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
+                                        permission-message="{{ 'explanation.procedure.permissions'|trans }}"
+                                        :phase-options="JSON.parse('{{ internalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
+                                        init-selected-phase="{{ proceduresettings.phase }}"
+                                        :iterator="{
+                                            label: Translator.trans('procedure.phase.phasecounter'),
+                                            tooltip: Translator.trans('text.procedure.phasecounter'),
+                                            value: '{{ proceduresettings.phaseObject.iteration }}'
+                                        }">
+                                    </participation-phases>
                                 {% endif %}
 
                                 {% if hasPermission('feature_procedure_legal_notice_read') %}
@@ -488,7 +451,10 @@
 
                                     <dp-date-range-picker
                                         class="u-2-of-4"
-                                        data-cy="procedureSettingsDate"
+                                        :data-cy="{
+                                            endDate: 'dataCyEndDate',
+                                            startDate: 'dataCyStartDate'
+                                        }"
                                         data-dp-validate-error-fieldname="{{ "period.institutions"|trans }}"
                                         start-id="r_startdate"
                                         start-name="r_startdate"
@@ -564,64 +530,29 @@
 
                                 {# phase for public participation #}
                                 {% if hasPermission('feature_procedure_change_phase') %}
-                                    <div>
-                                        <div class="flex gap-2">
-                                            <div class="w-8-12">
-                                                <label class="inline-block mb-0.5" for="r_publicParticipationPhase">
-                                                    {{ "procedure.public.phase"|trans }}*
-                                                </label>
-                                                {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                    helpText: 'text.procedure.edit.external.change_phase'|trans,
-                                                    cssClasses:'u-mt-0_125',
-                                                    showPlainHint: true
-                                                } %}
-                                                <select
-                                                    id="r_publicParticipationPhase"
-                                                    class="o-form__control-select u-11-of-12"
-                                                    data-cy="r_publicParticipationPhase"
-                                                    v-model="selectedPublicPhase"
-                                                    name="r_publicParticipationPhase">
-                                                    {% for externalPhase in templateVars.externalPhases %}
-                                                        <option value="{{ externalPhase.key }}"{% if proceduresettings.publicParticipationPhase == externalPhase.key %} selected="selected"{% endif %} data-permissionset="{{ externalPhase.permissionset }}">
-                                                            {{ externalPhase.name }}
-                                                        </option>
-                                                    {% endfor %}
-                                                </select>
-                                            </div>
-
-                                            {% if hasPermission('field_phase_iterator') %}
-                                                <div class="w-4/12 inline-block relative">
-                                                    {{ uiComponent('form.element', {
-                                                        label: {
-                                                            text: 'procedure.phase.phasecounter'|trans,
-                                                            tooltip: 'text.procedure.phasecounter'|trans
-                                                        },
-                                                        control: {
-                                                            name: 'r_public_participation_phase_iteration',
-                                                            pattern: '^[1-9][0-9]*$',
-                                                            value: proceduresettings.publicParticipationPhaseObject.iteration
-                                                        },
-                                                        id: 'r_public_participation_phase_iteration',
-                                                        type: 'text',
-                                                        required: true,
-                                                    }) }}
-                                                </div>
-                                            {% endif %}
-                                        </div>
-
-                                        {{ uiComponent('inline-notification', {
-                                            message: 'explanation.procedure.external.permissions'|trans ~ '<span data-procedure-permission-set></span>',
-                                            type: 'warning'
-                                        }) }}
-
-                                        {% if hasPermission('feature_auto_switch_to_procedure_end_phase') and not hasPermission('feature_auto_switch_procedure_phase') %}
-                                            <div
-                                                v-if="publicPhaseIsInParticipation"
-                                                class="lbl__hint u-mt-0_25 u-mb-0">
-                                                {{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.external.evaluating'|trans }) }}
-                                            </div>
-                                        {% endif %}
-                                    </div>
+                                    {% set externalPhaseOptions = [] %}
+                                    {% for phase in templateVars.externalPhases %}
+                                        {% set externalPhaseOptions = externalPhaseOptions|merge([{
+                                            value: phase.key,
+                                            label: phase.name,
+                                            permissionset: phase.permissionset,
+                                        }]) %}
+                                    {% endfor %}
+                                    <participation-phases
+                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.external.evaluating'|trans }) }}"
+                                        field-name="r_publicParticipationPhase"
+                                        help-text="{{ 'text.procedure.edit.external.change_phase'|trans }}"
+                                        label-text="{{ "procedure.public.phase"|trans }}"
+                                        :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
+                                        permission-message="{{ 'explanation.procedure.external.permissions'|trans }}"
+                                        :phase-options="JSON.parse('{{ externalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
+                                        init-selected-phase="{{ proceduresettings.publicParticipationPhase }}"
+                                        :iterator="{
+                                          label: Translator.trans('procedure.phase.phasecounter'),
+                                          tooltip: Translator.trans('text.procedure.phasecounter'),
+                                          value: '{{ proceduresettings.publicParticipationPhaseObject.iteration }}'
+                                        }">
+                                    </participation-phases>
                                 {% endif %}
 
                                 {# start/end date for public participation #}
@@ -642,7 +573,10 @@
                                     } %}
                                     <dp-date-range-picker
                                         class="u-2-of-4"
-                                        data-cy="procedureSettingsParticipationDate"
+                                        :data-cy="{
+                                            endDate: 'administrationEditForm:publicParticipationEndDate',
+                                            startDate: 'administrationEditForm:publicParticipationStartDate'
+                                        }"
                                         data-dp-validate-error-fieldname="{{ "period.public"|trans }}"
                                         start-id="r_publicParticipationStartDate"
                                         start-name="r_publicParticipationStartDate"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -400,7 +400,7 @@
                                         help-text="{{ 'text.procedure.edit.internal.change_phase'|trans }}"
                                         label-text="{{ "procedure.phase.institutions"|trans }}"
                                         :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
-                                        permission-message="{{ 'explanation.procedure.permissions'|trans }}"
+                                        permission-message="{{ 'explanation.procedure.internal.permissions'|trans }}"
                                         :phase-options="JSON.parse('{{ internalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
                                         init-selected-phase="{{ proceduresettings.phase }}"
                                         :iterator="{

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -405,6 +405,7 @@
                                         init-selected-phase="{{ proceduresettings.phase }}"
                                         :iterator="{
                                             label: Translator.trans('procedure.phase.phasecounter'),
+                                            name: 'r_phase_iteration',
                                             tooltip: Translator.trans('text.procedure.phasecounter'),
                                             value: '{{ proceduresettings.phaseObject.iteration }}'
                                         }">
@@ -548,9 +549,10 @@
                                         :phase-options="JSON.parse('{{ externalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
                                         init-selected-phase="{{ proceduresettings.publicParticipationPhase }}"
                                         :iterator="{
-                                          label: Translator.trans('procedure.phase.phasecounter'),
-                                          tooltip: Translator.trans('text.procedure.phasecounter'),
-                                          value: '{{ proceduresettings.publicParticipationPhaseObject.iteration }}'
+                                            label: Translator.trans('procedure.phase.phasecounter'),
+                                            name: 'r_public_participation_phase_iteration',
+                                            tooltip: Translator.trans('text.procedure.phasecounter'),
+                                            value: '{{ proceduresettings.publicParticipationPhaseObject.iteration }}'
                                         }">
                                     </participation-phases>
                                 {% endif %}

--- a/tests/frontend/unit/ParticipationPhases.spec.js
+++ b/tests/frontend/unit/ParticipationPhases.spec.js
@@ -41,7 +41,7 @@ describe('ParticipationPhases', () => {
     expect(ParticipationPhases.name).toBe('ParticipationPhases')
   })
 
-  it('should set the "inParticipation"-State as expected', async () => {
+  it('should set the "inParticipation"-State to true if the selected Phase occures in the participationPhases Array', async () => {
     const localVue = createLocalVue()
 
     const wrapper = shallowMountWithGlobalMocks(ParticipationPhases, {
@@ -64,7 +64,7 @@ describe('ParticipationPhases', () => {
     expect(wrapper.vm.isInParticipation).toBe(false)
   })
 
-  it('should set the Permission-Message-Text as expected', async () => {
+  it('should set the Permission-Message-Text depending on the selected participation phase permissionset ', async () => {
     const localVue = createLocalVue()
 
     const wrapper = shallowMountWithGlobalMocks(ParticipationPhases, {

--- a/tests/frontend/unit/ParticipationPhases.spec.js
+++ b/tests/frontend/unit/ParticipationPhases.spec.js
@@ -41,7 +41,7 @@ describe('ParticipationPhases', () => {
     expect(ParticipationPhases.name).toBe('ParticipationPhases')
   })
 
-  it('should set the "inParticipation"-State to true if the selected Phase occures in the participationPhases Array', async () => {
+  it('sets the 'inParticipation' state correctly depending on whether the selected Phase is a participation phase', async () => {
     const localVue = createLocalVue()
 
     const wrapper = shallowMountWithGlobalMocks(ParticipationPhases, {

--- a/tests/frontend/unit/ParticipationPhases.spec.js
+++ b/tests/frontend/unit/ParticipationPhases.spec.js
@@ -1,0 +1,89 @@
+import { createLocalVue } from '@vue/test-utils'
+import ParticipationPhases from '@DpJs/components/procedure/basicSettings/ParticipationPhases'
+import shallowMountWithGlobalMocks from '@DpJs/VueConfigLocal'
+
+describe('ParticipationPhases', () => {
+  const componentsPropsData = {
+    autoswitchHint: 'Here comes a tooltip Hint',
+    fieldName: 'some_name',
+    helpText: 'Some Help Text',
+    labelText: 'I am a Label',
+    participationPhases: ['first', 'second', 'third'],
+    permissionMessage: 'Some Message',
+    phaseOptions: [{
+      label: 'My Label C',
+      permissionset: 'read',
+      value: 'first'
+    }, {
+      label: 'My Label A',
+      permissionset: 'write',
+      value: 'fourth'
+    }, {
+      label: 'My Label B',
+      permissionset: 'hidden',
+      value: 'fifth'
+    }],
+    initSelectedPhase: 'first',
+    iterator: {
+      label: 'Iterator Label',
+      name: 'iterator_input_name',
+      tooltip: 'Tooltip text for the itereator',
+      value: '1'
+    }
+  }
+
+
+  it('should be an object', () => {
+    expect(typeof ParticipationPhases).toBe('object')
+  })
+
+  it('should be named ParticipationPhases', () => {
+    expect(ParticipationPhases.name).toBe('ParticipationPhases')
+  })
+
+  it('should set the "inParticipation"-State as expected', async () => {
+    const localVue = createLocalVue()
+
+    const wrapper = shallowMountWithGlobalMocks(ParticipationPhases, {
+      propsData: componentsPropsData,
+      localVue
+    })
+
+    expect(wrapper.vm.isInParticipation).toBe(true)
+
+    await wrapper.setData({
+      selectedPhase: 'fourth',
+    })
+
+    expect(wrapper.vm.isInParticipation).toBe(false)
+
+    await wrapper.setData({
+      selectedPhase: 'noneAtall',
+    })
+
+    expect(wrapper.vm.isInParticipation).toBe(false)
+  })
+
+  it('should set the Permission-Message-Text as expected', async () => {
+    const localVue = createLocalVue()
+
+    const wrapper = shallowMountWithGlobalMocks(ParticipationPhases, {
+      propsData: componentsPropsData,
+      localVue
+    })
+
+    expect(wrapper.vm.permissionMessageText).toEqual('Some Message permissionset.read')
+
+    await wrapper.setData({
+      selectedPhase: 'fifth',
+    })
+
+    expect(wrapper.vm.permissionMessageText).toEqual('Some Message permissionset.hidden')
+
+    await wrapper.setData({
+      selectedPhase: 'fourth',
+    })
+
+    expect(wrapper.vm.permissionMessageText).toEqual('Some Message permissionset.write')
+  })
+})

--- a/tests/frontend/unit/ParticipationPhases.spec.js
+++ b/tests/frontend/unit/ParticipationPhases.spec.js
@@ -27,7 +27,7 @@ describe('ParticipationPhases', () => {
     iterator: {
       label: 'Iterator Label',
       name: 'iterator_input_name',
-      tooltip: 'Tooltip text for the itereator',
+      tooltip: 'Tooltip text for the iterator',
       value: '1'
     }
   }


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-11402/Hinweis-Grundeinstellungen-Angaben-der-Rechte-zu-Verfahrensschritten-fehlen

https://demoseurope.youtrack.cloud/issue/DPLAN-11403/Layout-in-Grundeinstellungen-nicht-einheitlich

To fix the Bug, I hat to move the logic from twig and wrapper to a dedicated Component.




<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Goto Grundeinstellungen and change the phases. See if the Permission text is displayed and makes sense.

