### PR TITLE
F dplan 1924 adjust anonymous export templates

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTablePdfExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTablePdfExporter.php
@@ -267,7 +267,11 @@ class AssessmentTablePdfExporter extends AssessmentTableFileExporterAbstract
                 $listLineWidth = 17;
             }
             if (('landscape' === $template && 'export' === $templateName)
-                || ('condensed' === $template && 'export_condensed' === $templateName && !$original)) {
+                || ('condensed' === $template && 'export_condensed' === $templateName && !$original)
+                || ('condensed' === $template && 'export_condensed_anonymous' === $templateName && !$original)
+                || ('landscape' === $template && 'export_anonymous' === $templateName && !$original)
+                || ('landscapeWithFrags' === $template && 'export_fragments_anonymous' === $templateName && !$original)
+            ) {
                 // horizontal format (landscape) split view - Text | Response
                 $listLineWidth = 12;
             }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_anonymous.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_anonymous.tex.twig
@@ -7,7 +7,7 @@
         {{ statement_macros.statement_content_anonymous(
             "statement"|trans|latex|raw,
             "considerationadvice"|trans|latex|raw,
-            statement.text|default("notspecified"|trans)|dpObscure|latex|raw,
+            statement.text|default("notspecified"|trans)|dpObscure|latex(listwidth=templateVars.listwidth)|raw,
             statement.recommendation|default("notspecified"|trans)|dpObscure|latex|raw,
             statement,
             procedure) }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_anonymous_condensed.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_anonymous_condensed.tex.twig
@@ -55,7 +55,7 @@
         {{ statement_macros.statement_content_anonymous_condensed(
             "statement"|trans|latex|raw,
             "considerationadvice"|trans|latex|raw,
-            statement.text|default("notspecified"|trans)|dpObscure|latex|raw,
+            statement.text|default("notspecified"|trans)|dpObscure|latex(listwidth=templateVars.listwidth)|raw,
             statement.recommendation|default("notspecified"|trans)|dpObscure|latex|raw,
             procedure) }}
         %Download für Export

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_fragments_anonymous.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_fragments_anonymous.tex.twig
@@ -24,7 +24,7 @@
                     {{ statement_macros.statement_content_anonymous(
                         "statement"|trans|latex|raw,
                         "considerationadvice"|trans|latex|raw,
-                        statement.text|default("notspecified"|trans)|dpObscure|latex|raw,
+                        statement.text|default("notspecified"|trans)|dpObscure|latex(listwidth=templateVars.listwidth)|raw,
                         statement.recommendation|default("notspecified"|trans)|dpObscure|latex|raw,
                         statement,
                         procedure) }}
@@ -67,7 +67,7 @@
                                 {{ statement_macros.statement_content_anonymous(
                                     "statement"|trans|latex|raw,
                                     "considerationadvice"|trans|latex|raw,
-                                    statement.text|default("notspecified"|trans)|dpObscure|latex|raw,
+                                    statement.text|default("notspecified"|trans)|dpObscure|latex(listwidth=templateVars.listwidth)|raw,
                                     statement.recommendation|default("notspecified"|trans)|dpObscure|latex|raw,
                                     statement,
                                     procedure) }}


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-1924/Munchen-Prod-PDF-Export-eingereichter-STN-in-Bestatigungsmail-wird-falsch-dargestellt

