### PR TITLE
fix (refs DPLAN-1140): add Orga.Address.HouseNumber to eMail-invitation templates in addition to the street property

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_invitation_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_send_invitation_email.html.twig
@@ -23,8 +23,8 @@ Diese Einladung zur Beteiligung wurde verschickt von:
 {% if templateVars.organisation.nameLegal is defined %}
 {{ templateVars.organisation.nameLegal }}
 {% endif %}
-{% if address.street is defined %}
-{{ address.street }}
+{% if address.street is defined %}{{ address.street }} {% if address.houseNumber is defined %}{{ address.houseNumber }}
+{% endif %}
 {% endif %}
 {% if address.postalcode is defined %}
 {{ address.postalcode }}


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-11404/BLP-Hausnr.-aus-Daten-der-Organisation-wird-nicht-in-Hinweistext-an-Email-ubernommen

Description:
 add Orga.Address.HouseNumber to eMail-invitation templates in addition to the street property

### How to review/test
login as 'Institutions-Koordination' and add a housenumber to the organisation details.
goto 'Institutionen verwalten' (add one if there is none yet) and send an invitation... check the preview text.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
