### PR TITLE
chore: remove vue-multiselect as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "tippy.js": "^6.3.7",
     "uuid": "^9.0.1",
     "vue": "~2.7.16",
-    "vue-multiselect": "^2.1.8",
     "vue-scrollto": "^2.20.0",
     "vue-sliding-pagination": "^1.3.2",
     "vue-template-compiler": "^2.7.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9850,7 +9850,7 @@ vue-loader@^15.11.1:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-multiselect@^2.1.6, vue-multiselect@^2.1.8:
+vue-multiselect@^2.1.6:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-2.1.8.tgz#73839f8fde7f9d01a5771129f940353cd6d74cd8"
   integrity sha512-bgpvWZlT4EiUUCcwLAR655LdiifeqF62BDL2TLVddKfS/NcdIYVlvOr456N7GQIlBFNbb7vHfq+qOl8mpGAOJw==


### PR DESCRIPTION
When reworking TagSelect to use demosplan-ui instead of directly using vue-multiselect in https://github.com/demos-europe/demosplan-addon-demospipes/pull/88, removing the dependency was forgotten as it seems. This is done here.

### PR Checklist

- [X] Link all relevant tickets