### PR TITLE
fix(refs CareKan-34): Use proper Event when using DpSelect for Departments

### DIFF
--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -92,7 +92,7 @@
         :options="departmentSelectOptions"
         required
         :selected="localUser.relationships.department.data.id"
-        @change="changeUserDepartment" />
+        @select="changeUserDepartment" />
     </div>
 
     <!-- Role -->
@@ -295,8 +295,7 @@ export default {
       this.emitUserUpdate('relationships.roles.data', role, 'roles', 'add')
     },
 
-    changeUserDepartment (e) {
-      const departmentId = e.target.value
+    changeUserDepartment (departmentId) {
       this.localUser.relationships.department.data = {
         id: departmentId,
         type: 'department'


### PR DESCRIPTION
**Ticket** https://demoseurope.youtrack.cloud/issue/CareKan-34/RVMO-Raumordnung-Prod-Anderung-der-Abteilung-wird-nach-speichern-nicht-ubernommen

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

It was just a wrong event 


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

As "Organisationsadministration" try to change a department of a User and Save it. That should work without errors.


### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
