### PR TITLE
feat (DPLAN-11392): fix key on report entry

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ReportMessageConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ReportMessageConverter.php
@@ -553,8 +553,8 @@ class ReportMessageConverter
                 $returnMessage[] = $translator->trans('text.protocol.publicphase', [
                     'oldPublicPhase'     => $message['oldPublicPhase'],
                     'newPublicPhase'     => $message['newPublicPhase'],
-                    'oldPublicIteration' => $message['oldPublicPhaseIteration'] ?? 0,
-                    'newPublicIteration' => $message['newPublicPhaseIteration'] ?? 0,
+                    'oldPublicPhaseIteration' => $message['oldPublicPhaseIteration'] ?? 0,
+                    'newPublicPhaseIteration' => $message['newPublicPhaseIteration'] ?? 0,
                 ]);
             }
         }


### PR DESCRIPTION
**Ticket:** [DPLAN-11393](https://demoseurope.youtrack.cloud/issue/DPLAN-11393/Durchgangsnummer-und-Anderungen-werden-nicht-im-Protokoll-berucksichtigt)

Wrong array-key leads to key in message.
With this PR the correct key will be used.

### How to review/test
Change the "durchgangsnummer" for public participation phase and check the related protocol entries.


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
