### PR TITLE
fix: elevate slidebar above z-fixed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_slidebar.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_slidebar.scss
@@ -18,7 +18,7 @@ $at-slidebar-animation:     cubic-bezier(0, 0, .3, 1);
 //  component
 .c-slidebar {
     position: fixed;
-    z-index: $dp-z-fixed;
+    z-index: $dp-z-fixed + 1;
     left: 0;
     top: 0;
     width: 100%;


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11431

As the slidebar is taking the whole available page height, it should be elevated above z-fixed which is applied to fixed headers and other fixed iu elements.

### How to review/test
In the page view mentioned in the bug report, the sidebar should display above the sticky header (for the bug to be reproducable, the browser window should be not too wide).

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
