### PR TITLE
Add global bottom padding to content area

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -81,7 +81,7 @@
             <main id="mainContent" class="o-page__main layout bg-color--white relative">
 
                 {% block maincontent_section %}
-                    <section id="jumpContent" class="o-page__content layout__item relative" role="main">
+                    <section id="jumpContent" class="o-page__content layout__item relative pb-4" role="main">
 
                         {% block breadcrumb %}
                             <div class="flex items-center justify-between u-pv-0_25">


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-1963/Speichern-Abbrechen-Button-liegt-auf-Footer-auf-in-Grundeinstellungen

`pb-4` is added globally to prevent this behavior once and for all. Views that add bottom margin or padding, should be adapted in another PR.

### How to review/test
All views should feature a decent padding between content and footer.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
