### PR TITLE
fix (DPLAN-11429): fix false mandatory field error

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -1088,7 +1088,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
 
         $publicPhaseIteration = 'public_participation_phase_iteration';
         if (isset($procedure[$publicPhaseIteration])) {
-            return $this->validatePhaseIterationValue($procedure[$phaseIteration]);
+            return $this->validatePhaseIterationValue($procedure[$publicPhaseIteration]);
         }
 
         return [];

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -346,7 +346,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
 
         $procedure = $this->arrayHelper->addToArrayIfKeyExists($procedure, $data, 'phase_iteration');
         $procedure = $this->arrayHelper->addToArrayIfKeyExists($procedure, $data, 'public_participation_phase_iteration');
-        $phaseIterationError = $this->validatePhaseIteration($procedure);
+        $phaseIterationError = $this->validatePhaseIterations($procedure);
         if (count($phaseIterationError) > 0) {
             $mandatoryErrors[] = $phaseIterationError;
         }
@@ -1079,24 +1079,30 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         return $token;
     }
 
-    /**
-     * @return array<non-empty-string, non-empty-string>
-     */
-    private function validatePhaseIteration(array $procedure): array
+    private function validatePhaseIterations(array $procedure): array
     {
-        $error = [];
-        $key = 'phase_iteration';
-        $isNumericAndPositive2 = isset($procedure[$key]) && is_numeric($procedure[$key]) && (int) $procedure[$key] > 0;
-        $publicKey = 'public_participation_phase_iteration';
-        $isNumericAndPositive1 = isset($procedure[$publicKey]) && is_numeric($procedure[$publicKey]) && (int) $procedure[$publicKey] > 0;
+        $phaseIteration = 'phase_iteration';
+        if (isset($procedure[$phaseIteration])) {
+            return $this->validatePhaseIterationValue($procedure[$phaseIteration]);
+        }
 
-        if (!$isNumericAndPositive1 || !$isNumericAndPositive2) {
-            $error = [
+        $publicPhaseIteration = 'public_participation_phase_iteration';
+        if (isset($procedure[$publicPhaseIteration])) {
+            return $this->validatePhaseIterationValue($procedure[$phaseIteration]);
+        }
+
+        return [];
+    }
+
+    private function validatePhaseIterationValue($value): array
+    {
+        if (!is_numeric($value) || (int)$value < 1) {
+            return [
                 'type'    => 'error',
                 'message' => $this->translator->trans('error.phaseIteration.invalid'),
             ];
         }
 
-        return $error;
+        return [];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -1096,7 +1096,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
 
     private function validatePhaseIterationValue($value): array
     {
-        if (!is_numeric($value) || (int)$value < 1) {
+        if (!is_numeric($value) || (int) $value < 1) {
             return [
                 'type'    => 'error',
                 'message' => $this->translator->trans('error.phaseIteration.invalid'),

--- a/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
+++ b/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
@@ -55,7 +55,6 @@ class ServiceStorageTest extends FunctionalTestCase
         $this->procedureType = $this->getReferenceProcedureType(LoadProcedureTypeData::BRK);
         $this->masterBlueprint = $this->getReferenceProcedure('masterBlaupause');
         $this->testProcedure = $this->fixtures->getReference('testProcedure');
-
     }
 
     public function testAdministrationNewHandler(): void
@@ -123,7 +122,6 @@ class ServiceStorageTest extends FunctionalTestCase
         $procedureObject = $this->find(Procedure::class, $this->testProcedure->getId());
 
         if ([] === $expectedMandatoryError) {
-
             if (array_key_exists('r_phase_iteration', $data)) {
                 static::assertEquals($data['r_phase_iteration'], $procedureObject->getPhaseObject()->getIteration());
             }
@@ -185,7 +183,7 @@ class ServiceStorageTest extends FunctionalTestCase
             [[
                 'action'                                    => 'edit',
                 'r_ident'                                   => $this->testProcedure->getId(),
-                'r_public_participation_phase_iteration'    => '3'
+                'r_public_participation_phase_iteration'    => '3',
             ], 'mandatoryError' => []],
             [[
                 'action'                                    => 'edit',
@@ -195,7 +193,7 @@ class ServiceStorageTest extends FunctionalTestCase
             [[
                 'action'                                    => 'edit',
                 'r_ident'                                   => $this->testProcedure->getId(),
-                'r_public_participation_phase_iteration'    => '-2'
+                'r_public_participation_phase_iteration'    => '-2',
             ], 'mandatoryError' => $this->translator->trans('error.phaseIteration.invalid')],
         ];
     }

--- a/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
+++ b/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
@@ -50,7 +50,6 @@ class ServiceStorageTest extends FunctionalTestCase
         $this->procedureType = $this->getReferenceProcedureType(LoadProcedureTypeData::BRK);
         $this->masterBlueprint = $this->getReferenceProcedure('masterBlaupause');
         $this->testProcedure = $this->fixtures->getReference('testProcedure');
-
     }
 
     public function testAdministrationNewHandler(): void
@@ -102,10 +101,9 @@ class ServiceStorageTest extends FunctionalTestCase
         /** @var Procedure $procedure */
         $procedure = $this->find(Procedure::class, $procedure['id']);
 
-
-        //use equals here, because values are incoming as string but are stored as integers.
-        static::assertEquals($iterationValue,  $procedure->getPhaseObject()->getIteration());
-        static::assertEquals($publicIterationValue,  $procedure->getPublicParticipationPhaseObject()->getIteration());
+        // use equals here, because values are incoming as string but are stored as integers.
+        static::assertEquals($iterationValue, $procedure->getPhaseObject()->getIteration());
+        static::assertEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
     }
 
     public function testUpdatePhaseIteration2(): void
@@ -128,14 +126,12 @@ class ServiceStorageTest extends FunctionalTestCase
             $procedure['mandatoryfieldwarning'][0]['message']
         );
 
-
         /** @var Procedure $procedure */
         $procedure = $this->find(Procedure::class, $this->testProcedure->getId());
 
-        //use equals here, because values are incoming as string but are stored as integers.
-        static::assertNotEquals($iterationValue,  $procedure->getPhaseObject()->getIteration());
-        static::assertNotEquals($publicIterationValue,  $procedure->getPublicParticipationPhaseObject()->getIteration());
-
+        // use equals here, because values are incoming as string but are stored as integers.
+        static::assertNotEquals($iterationValue, $procedure->getPhaseObject()->getIteration());
+        static::assertNotEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
 
         $data = [
             'action'                                    => 'edit',
@@ -155,9 +151,9 @@ class ServiceStorageTest extends FunctionalTestCase
         /** @var Procedure $procedure */
         $procedure = $this->find(Procedure::class, $this->testProcedure->getId());
 
-        //use equals here, because values are incoming as string but are stored as integers.
-        static::assertNotEquals($iterationValue,  $procedure->getPhaseObject()->getIteration());
-        static::assertNotEquals($publicIterationValue,  $procedure->getPublicParticipationPhaseObject()->getIteration());
+        // use equals here, because values are incoming as string but are stored as integers.
+        static::assertNotEquals($iterationValue, $procedure->getPhaseObject()->getIteration());
+        static::assertNotEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
     }
 
     /**

--- a/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
+++ b/tests/backend/core/Procedure/Functional/ServiceStorageTest.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ServiceStorage;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
 
 class ServiceStorageTest extends FunctionalTestCase
@@ -41,15 +42,20 @@ class ServiceStorageTest extends FunctionalTestCase
     /** @var Procedure */
     private $testProcedure;
 
+    /** @var TranslatorInterface */
+    protected $translator;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sut = $this->getContainer()->get(ServiceStorage::class);
+        $this->translator = $this->getContainer()->get(TranslatorInterface::class);
         $this->testUser = $this->loginTestUser();
         $this->procedureType = $this->getReferenceProcedureType(LoadProcedureTypeData::BRK);
         $this->masterBlueprint = $this->getReferenceProcedure('masterBlaupause');
         $this->testProcedure = $this->fixtures->getReference('testProcedure');
+
     }
 
     public function testAdministrationNewHandler(): void
@@ -106,54 +112,44 @@ class ServiceStorageTest extends FunctionalTestCase
         static::assertEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
     }
 
-    public function testUpdatePhaseIteration2(): void
+    /**
+     * @dataProvider phaseIterationDataProvider()
+     */
+    public function testMandatoryErrorOnUpdatePhaseIteration($data, $expectedMandatoryError): void
     {
-        $iterationValue = '-3';
-        $publicIterationValue = '-2';
-
-        $data = [
-            'action'                                    => 'edit',
-            'r_ident'                                   => $this->testProcedure->getId(),
-            'r_phase_iteration'                         => $iterationValue,
-        ];
-
         $procedure = $this->sut->administrationEditHandler($data);
         static::assertIsArray($procedure);
-        static::assertArrayHasKey('mandatoryfieldwarning', $procedure);
-        self::assertSame('error', $procedure['mandatoryfieldwarning'][0]['type']);
-        self::assertSame(
-            'Die Durchgangsnummer einer Phase muss eine positive Ganzzahl sein.',
-            $procedure['mandatoryfieldwarning'][0]['message']
-        );
+        /** @var Procedure $procedureObject */
+        $procedureObject = $this->find(Procedure::class, $this->testProcedure->getId());
 
-        /** @var Procedure $procedure */
-        $procedure = $this->find(Procedure::class, $this->testProcedure->getId());
+        if ([] === $expectedMandatoryError) {
 
-        // use equals here, because values are incoming as string but are stored as integers.
-        static::assertNotEquals($iterationValue, $procedure->getPhaseObject()->getIteration());
-        static::assertNotEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
+            if (array_key_exists('r_phase_iteration', $data)) {
+                static::assertEquals($data['r_phase_iteration'], $procedureObject->getPhaseObject()->getIteration());
+            }
 
-        $data = [
-            'action'                                    => 'edit',
-            'r_ident'                                   => $this->testProcedure->getId(),
-            'r_public_participation_phase_iteration'    => $publicIterationValue,
-        ];
+            if (array_key_exists('r_public_participation_phase_iteration', $data)) {
+                static::assertEquals(
+                    $data['r_public_participation_phase_iteration'],
+                    $procedureObject->getPublicParticipationPhaseObject()->getIteration()
+                );
+            }
+        } else {
+            // use equals here, because values are incoming as string but are stored as integers.
+            static::assertArrayHasKey('mandatoryfieldwarning', $procedure);
+            self::assertSame('error', $procedure['mandatoryfieldwarning'][0]['type']);
+            self::assertSame(
+                $this->translator->trans('error.phaseIteration.invalid'),
+                $procedure['mandatoryfieldwarning'][0]['message']
+            );
 
-        $procedure = $this->sut->administrationEditHandler($data);
-        static::assertIsArray($procedure);
-        static::assertArrayHasKey('mandatoryfieldwarning', $procedure);
-        self::assertSame('error', $procedure['mandatoryfieldwarning'][0]['type']);
-        self::assertSame(
-            'Die Durchgangsnummer einer Phase muss eine positive Ganzzahl sein.',
-            $procedure['mandatoryfieldwarning'][0]['message']
-        );
-
-        /** @var Procedure $procedure */
-        $procedure = $this->find(Procedure::class, $this->testProcedure->getId());
-
-        // use equals here, because values are incoming as string but are stored as integers.
-        static::assertNotEquals($iterationValue, $procedure->getPhaseObject()->getIteration());
-        static::assertNotEquals($publicIterationValue, $procedure->getPublicParticipationPhaseObject()->getIteration());
+            if (array_key_exists('r_phase_iteration', $data)) {
+                static::assertNotEquals($data['r_phase_iteration'], $procedureObject->getPhaseObject()->getIteration());
+            }
+            if (array_key_exists('r_public_participation_phase_iteration', $data)) {
+                static::assertNotEquals($data['r_public_participation_phase_iteration'], $procedureObject->getPublicParticipationPhaseObject()->getIteration());
+            }
+        }
     }
 
     /**
@@ -174,6 +170,34 @@ class ServiceStorageTest extends FunctionalTestCase
     private function getReferenceProcedure(string $name): Procedure
     {
         return $this->fixtures->getReference($name);
+    }
+
+    public function phaseIterationDataProvider(): array
+    {
+        $this->setUp();
+
+        return [
+            [[
+                'action'                                    => 'edit',
+                'r_ident'                                   => $this->testProcedure->getId(),
+                'r_phase_iteration'                         => '2',
+            ], 'mandatoryError' => []],
+            [[
+                'action'                                    => 'edit',
+                'r_ident'                                   => $this->testProcedure->getId(),
+                'r_public_participation_phase_iteration'    => '3'
+            ], 'mandatoryError' => []],
+            [[
+                'action'                                    => 'edit',
+                'r_ident'                                   => $this->testProcedure->getId(),
+                'r_phase_iteration'                         => '-3',
+            ], 'mandatoryError' => $this->translator->trans('error.phaseIteration.invalid')],
+            [[
+                'action'                                    => 'edit',
+                'r_ident'                                   => $this->testProcedure->getId(),
+                'r_public_participation_phase_iteration'    => '-2'
+            ], 'mandatoryError' => $this->translator->trans('error.phaseIteration.invalid')],
+        ];
     }
 
     public function exceptionDataProvider(): array


### PR DESCRIPTION
**Ticket:** [DPLAN-11429](https://demoseurope.youtrack.cloud/issue/DPLAN-11429/Die-Durchgangsnummer-einer-Phase-muss-eine-positive-Ganzzahl-sein)

Fix bug which leads to an mandatory field error in case of value is not existing.

### How to review/test
In a project without this feature it should be possible to save the settings of a procedure.
Change the settings of a procedure and save.

- [x] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

Please merge in case of approvement.
