### PR TITLE
feat(DPLAN-3306): move pagionation to the sticky element

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -61,7 +61,7 @@
           @click.prevent="handleBulkEdit"
           :text="Translator.trans('segments.bulk.edit')" />
       </dp-bulk-edit-header>
-      <div class="flex justify-between items-center mt-4 mb-3">
+      <div class="flex justify-between items-center mt-4">
         <dp-pager
           v-if="pagination.currentPage"
           :class="{ 'invisible': isLoading }"

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -61,7 +61,18 @@
           @click.prevent="handleBulkEdit"
           :text="Translator.trans('segments.bulk.edit')" />
       </dp-bulk-edit-header>
-      <div class="u-mt text-right">
+      <div class="flex justify-between items-center mt-4 mb-3">
+        <dp-pager
+          v-if="pagination.currentPage"
+          :class="{ 'invisible': isLoading }"
+          :current-page="pagination.currentPage"
+          :total-pages="pagination.totalPages"
+          :total-items="pagination.total"
+          :per-page="pagination.perPage"
+          :limits="pagination.limits"
+          @page-change="applyQuery"
+          @size-change="handleSizeChange"
+          :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
         <dp-column-selector
           data-cy="segmentsList:selectableColumns"
           :initial-selection="currentSelection"
@@ -223,19 +234,6 @@
           {{ Translator.trans('segments.none') }}
         </p>
       </div>
-
-      <dp-pager
-        v-if="pagination.currentPage"
-        :class="{ 'invisible': isLoading }"
-        class="u-pt-0_5 text-right u-1-of-1"
-        :current-page="pagination.currentPage"
-        :total-pages="pagination.totalPages"
-        :total-items="pagination.total"
-        :per-page="pagination.perPage"
-        :limits="pagination.limits"
-        @page-change="applyQuery"
-        @size-change="handleSizeChange"
-        :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
     </template>
   </div>
 </template>

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -12,8 +12,8 @@
     <!-- Header -->
     <dp-sticky-element
       border
-      class="u-pv-0_5 space-stack-s">
-      <div class="flex space-inline-xs">
+      class="py-2">
+      <div class="flex mb-2">
         <search-modal
           :search-in-fields="searchFields"
           @search="(term, selectedFields) => applySearch(term, selectedFields)"
@@ -36,37 +36,48 @@
           @click.prevent="handleBulkShare"
           :text="Translator.trans('procedure.share_statements.bulk.share')" />
       </dp-bulk-edit-header>
-      <div class="flex space-inline-xs">
-        <dp-flyout
-          ref="flyout"
-          data-cy="listStatements:export"
-          :align="'left'">
-          <template v-slot:trigger>
-            {{ Translator.trans('export.verb') }}
-            <i
-              class="fa fa-angle-down"
-              aria-hidden="true" />
-          </template>
-          <a
-            data-cy="listStatements:exportStatementsDocx"
-            href="#"
-            @click="showHintAndDoExport('dplan_statement_segments_export')">
-            {{ Translator.trans('export.statements.docx') }}
-          </a>
-          <a
-            data-cy="listStatements:exportStatementsZip"
-            href="#"
-            @click="showHintAndDoExport('dplan_statement_segments_export_packaged')">
-            {{ Translator.trans('export.statements.zip') }}
-          </a>
-          <a
-            v-if="hasPermission('feature_admin_assessmenttable_export_statement_generic_xlsx')"
-            :href="exportRoute('dplan_statement_xls_export')"
-            data-cy="listStatements:exportStatementsXlsx"
-            rel="noopener">
-            {{ Translator.trans('export.statements.xlsx') }}
-          </a>
-        </dp-flyout>
+      <dp-flyout
+        ref="flyout"
+        data-cy="listStatements:export"
+        :align="'left'">
+        <template v-slot:trigger>
+          {{ Translator.trans('export.verb') }}
+          <i
+            class="fa fa-angle-down"
+            aria-hidden="true" />
+        </template>
+        <a
+          data-cy="listStatements:exportStatementsDocx"
+          href="#"
+          @click="showHintAndDoExport('dplan_statement_segments_export')">
+          {{ Translator.trans('export.statements.docx') }}
+        </a>
+        <a
+          data-cy="listStatements:exportStatementsZip"
+          href="#"
+          @click="showHintAndDoExport('dplan_statement_segments_export_packaged')">
+          {{ Translator.trans('export.statements.zip') }}
+        </a>
+        <a
+          v-if="hasPermission('feature_admin_assessmenttable_export_statement_generic_xlsx')"
+          :href="exportRoute('dplan_statement_xls_export')"
+          data-cy="listStatements:exportStatementsXlsx"
+          rel="noopener">
+          {{ Translator.trans('export.statements.xlsx') }}
+        </a>
+      </dp-flyout>
+      <div class="flex mt-2">
+        <dp-pager
+          v-if="pagination.currentPage"
+          :class="{ 'invisible': isLoading }"
+          :current-page="pagination.currentPage"
+          :total-pages="pagination.totalPages"
+          :total-items="pagination.total"
+          :per-page="pagination.perPage"
+          :limits="pagination.limits"
+          @page-change="getItemsByPage"
+          @size-change="handleSizeChange"
+          :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
         <div class="ml-auto flex items-center space-inline-xs">
           <label class="u-mb-0">
             {{ Translator.trans('sorting') }}
@@ -77,17 +88,6 @@
             @select="applySort" />
         </div>
       </div>
-      <dp-pager
-        v-if="pagination.currentPage"
-        :class="{ 'invisible': isLoading }"
-        :current-page="pagination.currentPage"
-        :total-pages="pagination.totalPages"
-        :total-items="pagination.total"
-        :per-page="pagination.perPage"
-        :limits="pagination.limits"
-        @page-change="getItemsByPage"
-        @size-change="handleSizeChange"
-        :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
     </dp-sticky-element>
 
     <dp-loading v-if="isLoading" />

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -77,6 +77,17 @@
             @select="applySort" />
         </div>
       </div>
+      <dp-pager
+        v-if="pagination.currentPage"
+        :class="{ 'invisible': isLoading }"
+        :current-page="pagination.currentPage"
+        :total-pages="pagination.totalPages"
+        :total-items="pagination.total"
+        :per-page="pagination.perPage"
+        :limits="pagination.limits"
+        @page-change="getItemsByPage"
+        @size-change="handleSizeChange"
+        :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
     </dp-sticky-element>
 
     <dp-loading v-if="isLoading" />
@@ -266,19 +277,6 @@
           </div>
         </template>
       </dp-data-table>
-
-      <dp-pager
-        v-if="pagination.currentPage"
-        :class="{ 'invisible': isLoading }"
-        class="u-pt-0_5 text-right u-1-of-1"
-        :current-page="pagination.currentPage"
-        :total-pages="pagination.totalPages"
-        :total-items="pagination.total"
-        :per-page="pagination.perPage"
-        :limits="pagination.limits"
-        @page-change="getItemsByPage"
-        @size-change="handleSizeChange"
-        :key="`pager1_${pagination.currentPage}_${pagination.count}`" />
     </template>
 
     <dp-inline-notification


### PR DESCRIPTION
 **Ticket:** [DPLAN-3306](https://demoseurope.youtrack.cloud/issue/DPLAN-3306/FE-1-Als-Nutzerin-mochte-ich-sowohl-am-Seitenanfang-als-auch-am-Seitenende-eine-Seitennavigation-vorfinden-um-weniger-Scrollen)

**Description:** Improve usability by adding the pagination to the sticky element at the top of the page (STN-liste and Abschnitte)

![image](https://github.com/demos-europe/demosplan-core/assets/110987766/38dcf097-f544-4bdf-8153-931dfe3096f9)


After discussing with @hans, it was decided to place pagination on the same line as the sorting (STN page):
![image](https://github.com/demos-europe/demosplan-core/assets/110987766/61d0788b-d1a5-47a4-9b48-2f0f5241dd51)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
