### PR TITLE
fix(refs DPLAN-11457): Remove "Dead" Code

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -943,38 +943,37 @@ export default {
                   url: this.getFeatureInfoUrlPlanningArea
                 })
                   .then(responsePr => {
-                    // If we can't check the procedure we want to get the featureInfos anyway
-                    if (responsePr.data.code === 100 && responsePr.data.success && responsePr.data.body !== null && responsePr.data.body !== '') {
-                      /* Check if coordinates are in the area of the current procedure, but only if planningarea is not set to 'all' */
-                      if (responsePr.data.body.id !== this.procedureId && this.procedureSettings.planningArea !== 'all' && hasPermission('feature_map_new_statement')) {
-                        /*
-                         * Roll back to this one when we can handle procedure versions
-                         * let popUpContent = Translator.trans('procedure.move.to.participate', {name: responsePr.body.name}) +
-                         *     '<a class="btn btn--primary float-right u-mt-0_5 u-mb-0" href="' + Routing.generate('DemosPlan_procedure_public_detail', {'procedure': responsePr.body.id}) + '">' +
-                         *     Translator.trans('procedure.goto') +
-                         *     '</a>';
-                         */
-                        const popUpContent = Translator.trans('procedure.move.to.list') +
-                        '<a class="' + this.prefixClass('btn btn--primary float-right u-mt-0_5') + '" href="' + Routing.generate('core_home') + '">' +
-                        Translator.trans('procedures.all.show') +
-                        '</a>'
-                        this.showPopup('contentPopup', {
-                          title: Translator.trans('procedure.not.in.scope'),
-                          text: popUpContent
-                        }, coordinate)
-                      } else {
-                        this.getFeatureInfoAndShowPriorityAreaPopup(remappedUrl, coordinate)
-                      }
+                    /*
+                     * If we can't check the procedure we want to get the featureInfos anyway and
+                     * if coordinates are in the area of the current procedure, but only if planningarea is not set to 'all'
+                     */
+                    if (responsePr.data.code === 100 &&
+                      responsePr.data.success &&
+                      responsePr.data.body?.id !== this.procedureId &&
+                      this.procedureSettings.planningArea !== 'all' &&
+                      hasPermission('feature_map_new_statement')) {
+                      const popUpContent = Translator.trans('procedure.move.to.list') +
+                      '<a class="' + this.prefixClass('btn btn--primary float-right u-mt-0_5') + '" href="' + Routing.generate('core_home') + '">' +
+                      Translator.trans('procedures.all.show') +
+                      '</a>'
+
+                      this.showPopup('contentPopup', {
+                        title: Translator.trans('procedure.not.in.scope'),
+                        text: popUpContent
+                      }, coordinate)
                     } else {
-                      this.getFeatureInfoAndShowPriorityAreaPopup(remappedUrl, coordinate)
+                      this.showPopup('contentPopup', {
+                        title: Translator.trans('error.generic'),
+                        text: popUpContent
+                      }, coordinate)
                     }
                   })
-                  .catch(() => this.getFeatureInfoAndShowPriorityAreaPopup(remappedUrl, coordinate))
+                  .catch(e => {
+                    console.error(e)
+                  })
                   .then(() => {
                     $('#queryAreaButton').removeClass(this.prefixClass('is-progress'))
                   })
-              } else {
-                this.getFeatureInfoAndShowPriorityAreaPopup(remappedUrl, coordinate)
               }
             }
           }
@@ -1502,34 +1501,6 @@ export default {
       return output
     },
 
-    getFeatureInfoAndShowPriorityAreaPopup (url, coordinate) {
-      return dpApi.get(Routing.generate('DemosPlan_map_get_feature_info', { procedure: this.procedureId }), {
-        params: url,
-        infotype: 'vorranggebietId'
-      }).then(response => {
-        if (response.data.code === 100 && response.data.success) {
-          if (response.data.body !== null) {
-            //  Store response data which is used to generate statement for submission
-            this.statementActionFields = {
-              r_location: 'point',
-              r_location_priority_area_key: response.data.body.key,
-              r_location_priority_area_type: response.data.body.type,
-              r_location_point: '',
-              r_location_geometry: '',
-              location_is_set: 'priority_area'
-            }
-            //  Assign state to global var which doStatementAction() has access to
-            window.statementActionState = 'locationPriorityAreaAdded'
-            this.showPopup('priorityAreaPopup', response.data.body, coordinate)
-          } else {
-            // Silently discard result/error as user does not even know that a getFeatureInfo request was fired
-          }
-        } else {
-          // Silently discard result/error as user does not even know that a getFeatureInfo request was fired
-        }
-      })
-    },
-
     getLayersOfType (type) {
       const allLayers = this.layers
       const l = allLayers.length
@@ -1935,15 +1906,7 @@ export default {
       $(this.prefixClass('.c-actionbox__title--button')).removeClass(this.prefixClass('is-progress'))
 
       if (typeof content === 'object' && typeof contentElement === 'object') {
-        if (templateId === 'priorityAreaPopup') {
-          const heading = window.dplan.statement.labels[templateId].headings[content.type]
-          contentElement.innerHTML = contentSource.innerHTML.replace(/___content___/g, heading)
-            .replace(/___id___/g, content.key)
-          // Specialcase priorityArea with key 'Sonderregel' should not have an html view
-          if (content.key === 'Sonderregel') {
-            $('#popupContent').find('a').first().removeClass(this.prefixClass('block')).hide()
-          }
-        } else if (templateId === 'miscPopup') {
+        if (templateId === 'miscPopup') {
           contentElement.innerHTML = contentSource.innerHTML.replace(/___title___/g, content.title)
         } else if (templateId === 'contentPopup') {
           contentElement.innerHTML = contentSource.innerHTML.replace(/___title___/g, content.title)
@@ -1961,7 +1924,7 @@ export default {
         $popup.addClass(this.prefixClass('c-map__popup--small'))
       }
 
-      if (templateId === 'priorityAreaPopup' || templateId === 'markLocationPopup') {
+      if (templateId === 'markLocationPopup') {
         $popup.find('#popupAction').html(window.dplan.statement.showMapButtonState(templateId)).show()
       }
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -405,30 +405,6 @@
                 {% endif %}
             </div>
 
-            {% if procedureStatementPriorityArea %}
-                <div id="priorityAreaPopup">
-                    <h3 class="{{ 'c-map__popup__title o-spinner'|prefixClass }}">___content___</h3>
-                    <span class="{{ 'inline-block u-mr-0_5'|prefixClass }}">___id___</span>
-                    {% if templateVars.htmlAvailable %}
-                        <a
-                            class="{{ 'c-map__popup__link block u-mt-0_5'|prefixClass }}"
-                            target="_blank"
-                            rel="noopener"
-                            href="{{ path('dplan_project_procedure_show_datasheet', { 'priorityArea': '___id___', 'procedureId': procedure|default()  }) }}">
-                            <i class="{{ 'fa fa-external-link'|prefixClass }}" aria-hidden="true"></i> {{ "priorityArea.datasheet.open"|trans }}
-                        </a>
-                    {% endif %}
-
-                    <a
-                        class="{{ 'c-map__popup__link block u-mv-0_25 '|prefixClass }}"
-                        target="_blank"
-                        rel="noopener"
-                        href="{{ path('dplan_project_procedure_procedure_show_datasheet_pdf', { 'priorityArea': '___id___', 'procedureId': procedure|default() }) }}">
-                        <i class="{{ 'fa fa-download'|prefixClass }}" aria-hidden="true"></i> {{ "priorityArea.datasheet.download.pdf"|trans }}
-                    </a>
-                </div>
-            {% endif %}
-
             <div id="markLocationPopup">
                 <h3 class="{{ 'c-map__popup__title'|prefixClass }}">{{ "location.selected"|trans }}</h3>
                 ___content___


### PR DESCRIPTION
The Backend Code was already moved to an addon.
This was supposed to happen with that logic too. But since its not in use anymore and would be really complicated to migrate to an addon, we decided to delete the FE Part.

Along I found some corresponding Templates without any usage.


**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11457/Verfahrensdetailseite-des-Verfahrenstyps-Teilaufstellung-Regionalplan-Windenergie-fuhrt-zu-Fehlerseite

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->



### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
