### PR TITLE
f DPLAN-1885 internId has to be sortable

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -262,6 +262,10 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
             $configBuilder->submitName->readable(true)->filterable()->sortable();
         }
 
+        if ($this->currentUser->hasPermission('area_admin_statement_list')) {
+            $configBuilder->internId->readable(true)->sortable();
+        }
+
         if ($this->currentUser->hasPermission('area_statement_segmentation')) {
             $configBuilder->segmentDraftList
                 ->updatable([$simpleStatementCondition], function (Statement $statement, array $rawJson): array {


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-1885/EWM-Prod-Sortierung-nach-Eingangsnummern-erzeugt-Fehlermeldung

Description: internId has to be sortable

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
