### PR TITLE
chore (refs DPLAN-11439): Distinct route for ai api file access to allow jwt authentication

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -78,7 +78,7 @@ class FileController extends BaseController
     /**
      * @throws Exception
      */
-    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, string $procedureId = null): Response
+    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, ?string $procedureId = null): Response
     {
         $fs = new Filesystem();
         // @improve T14122

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -60,6 +60,22 @@ class FileController extends BaseController
     }
 
     /**
+     * Distinct route for ai api file access to allow for jwt authentication via query parameter.
+     * Check Procedure permissions when procedureId is given in route and serve file if allowed.
+     */
+    #[\demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions(permissions: ['area_main_file'])]
+    #[Route(path: '/api/ai/file/{procedureId}/{hash}', name: 'core_file_procedure_api_ai', options: ['expose' => true])]
+    public function fileProcedureApiAction(FileService $fileService, string $procedureId, string $hash): Response
+    {
+        try {
+            return $this->prepareResponseWithHash($fileService, $hash, true, $procedureId);
+        } catch (Exception $e) {
+            $this->getLogger()->info('Could not serve Procedure Api ai file: ', [$e]);
+            throw new NotFoundHttpException();
+        }
+    }
+
+    /**
      * @throws Exception
      */
     protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, string $procedureId = null): Response

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -516,6 +516,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
 
             // enable ai specific permissions
             $this->enablePermissions([
+                'area_main_file',
                 'feature_read_source_statement_via_api',
                 'field_statement_recommendation',
             ]);


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11439/Hangenbleiben-nach-PDF-Import 

Distinct route for ai api file access to allow for jwt authentication via query parameter. Otherwise file could not be fetched

### How to review/test
import file via pdf import

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
