### PR TITLE
Feat(DPLAN-11460): adjust fullscreen mode for stn and segments list

### DIFF
--- a/client/js/components/procedure/SegmentsList/CustomSearch.vue
+++ b/client/js/components/procedure/SegmentsList/CustomSearch.vue
@@ -18,7 +18,7 @@
       <dp-flyout
         align="left"
         data-cy="customSearch:searchCustomLimitFields"
-        class="u-top-0 u-right-0 absolute"
+        class="u-top-0 u-right-0 absolute p-0.5"
         :has-menu="false"
         :padded="false">
         <template v-slot:trigger>

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -9,12 +9,13 @@
 
 <template>
   <div
-    :class="{'top-0 left-0 w-full h-full fixed z-[2200] px-4 bg-white overflow-y-scroll': isFullscreen}">
+    :class="{ 'top-0 left-0 w-full h-full fixed z-[2200] bg-white': isFullscreen }">
     <dp-sticky-element
       border
-      class="py-4">
+      class="py-4"
+      :class="{ 'fixed top-0 left-0 w-full h-[15%] px-4': isFullscreen }">
       <div
-        class="flex items-center justify-between space-inline-s">
+        class="flex items-center justify-between mb-2">
         <custom-search
           ref="customSearch"
           id="customSearch"
@@ -54,21 +55,14 @@
             :disabled="noQuery"
             :text="Translator.trans('reset')" />
         </div>
-        <div>
-          <button
-            class="btn--primary btn--outline"
-            data-cy="editorFullscreen"
-            :aria-label="Translator.trans('editor.fullscreen')"
-            v-tooltip="{
-              content: Translator.trans('editor.fullscreen')
-            }"
-            @click="isFullscreen = !isFullscreen">
-            <dp-icon
-              class="inline-block"
-              :icon="isFullscreen ? 'compress' : 'expand'"
-              aria-hidden="true" />
-          </button>
-        </div>
+        <dp-button
+          data-cy="editorFullscreen"
+          :icon="isFullscreen ? 'compress' : 'expand'"
+          icon-size="medium"
+          hide-text
+          variant="outline"
+          :text="isFullscreen ? Translator.trans('editor.fullscreen.close') : Translator.trans('editor.fullscreen')"
+          @click="isFullscreen = !isFullscreen" />
       </div>
       <dp-bulk-edit-header
         class="layout__item u-12-of-12 u-mt-0_5"
@@ -109,6 +103,7 @@
     <template v-else>
       <dp-data-table
         class="overflow-x-auto"
+        :class="{ 'px-4 overflow-y-scroll h-[85%]': isFullscreen }"
         v-if="items"
         :header-fields="headerFields"
         :items="items"
@@ -267,7 +262,6 @@ import {
   DpColumnSelector,
   DpDataTable,
   DpFlyout,
-  DpIcon,
   DpLoading,
   DpPager,
   dpRpc,
@@ -293,7 +287,6 @@ export default {
     DpColumnSelector,
     DpDataTable,
     DpFlyout,
-    DpIcon,
     DpLoading,
     DpPager,
     DpStickyElement,

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -8,11 +8,13 @@
 </license>
 
 <template>
-  <div>
+  <div
+    :class="{'top-0 left-0 w-full h-full fixed z-[2200] px-4 bg-white overflow-y-scroll': isFullscreen}">
     <dp-sticky-element
       border
-      class="u-pv-0_5">
-      <div class="flex items-start space-inline-s">
+      class="py-4">
+      <div
+        class="flex items-center justify-between space-inline-s">
         <custom-search
           ref="customSearch"
           id="customSearch"
@@ -25,31 +27,48 @@
           @change-fields="updateSearchFields"
           @search="updateSearchQuery"
           @reset="updateSearchQuery" />
-        <div class="flex bg-color--grey-light-2 rounded-md space-inline-xs">
-          <span class="color--grey u-ml-0_5 line-height--2">
-            {{ Translator.trans('filter') }}
-          </span>
-          <filter-flyout
-            v-for="filter in filters"
-            :data-cy="`segmentsListFilter:${filter.labelTranslationKey}`"
-            :initial-query="queryIds"
-            :key="`filter_${filter.labelTranslationKey}`"
-            :additional-query-params="{ searchPhrase: searchTerm }"
-            ref="filterFlyout"
-            :label="Translator.trans(filter.labelTranslationKey)"
-            :operator="filter.comparisonOperator"
-            :path="filter.rootPath"
-            :procedure-id="procedureId"
-            @filter-apply="sendFilterQuery" />
+        <div class="flex items-center">
+          <div class="bg-color--grey-light-2 rounded-md space-inline-xs">
+            <span class="color--grey ml-2 line-height--2">
+              {{ Translator.trans('filter') }}
+            </span>
+            <filter-flyout
+              v-for="filter in filters"
+              :data-cy="`segmentsListFilter:${filter.labelTranslationKey}`"
+              :initial-query="queryIds"
+              :key="`filter_${filter.labelTranslationKey}`"
+              :additional-query-params="{ searchPhrase: searchTerm }"
+              ref="filterFlyout"
+              :label="Translator.trans(filter.labelTranslationKey)"
+              :operator="filter.comparisonOperator"
+              :path="filter.rootPath"
+              :procedure-id="procedureId"
+              @filter-apply="sendFilterQuery" />
+          </div>
+          <dp-button
+            class="ml-2 h-fit"
+            data-cy="segmentsList:resetFilter"
+            variant="outline"
+            @click="resetQuery"
+            v-tooltip="Translator.trans('search.filter.reset')"
+            :disabled="noQuery"
+            :text="Translator.trans('reset')" />
         </div>
-        <dp-button
-          class="ml-auto"
-          data-cy="segmentsList:resetFilter"
-          variant="outline"
-          @click="resetQuery"
-          v-tooltip="Translator.trans('search.filter.reset')"
-          :disabled="noQuery"
-          :text="Translator.trans('reset')" />
+        <div>
+          <button
+            class="btn--primary btn--outline"
+            data-cy="editorFullscreen"
+            :aria-label="Translator.trans('editor.fullscreen')"
+            v-tooltip="{
+              content: Translator.trans('editor.fullscreen')
+            }"
+            @click="isFullscreen = !isFullscreen">
+            <dp-icon
+              class="inline-block"
+              :icon="isFullscreen ? 'compress' : 'expand'"
+              aria-hidden="true" />
+          </button>
+        </div>
       </div>
       <dp-bulk-edit-header
         class="layout__item u-12-of-12 u-mt-0_5"
@@ -250,6 +269,7 @@ import {
   DpColumnSelector,
   DpDataTable,
   DpFlyout,
+  DpIcon,
   DpLoading,
   DpPager,
   dpRpc,
@@ -275,6 +295,7 @@ export default {
     DpColumnSelector,
     DpDataTable,
     DpFlyout,
+    DpIcon,
     DpLoading,
     DpPager,
     DpStickyElement,
@@ -328,6 +349,7 @@ export default {
         limits: [10, 25, 50, 100],
         perPage: 10
       },
+      isFullscreen: false,
       headerFieldsAvailable: [
         { field: 'externId', label: Translator.trans('id') },
         { field: 'internId', label: Translator.trans('internId.shortened'), colClass: 'w-8' },

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -8,23 +8,35 @@
 </license>
 
 <template>
-  <div>
+  <div
+    :class="{ 'top-0 left-0 w-full h-full fixed z-[2200] bg-white': isFullscreen }">
     <!-- Header -->
     <dp-sticky-element
       border
-      class="py-2">
-      <div class="flex mb-2">
-        <search-modal
-          :search-in-fields="searchFields"
-          @search="(term, selectedFields) => applySearch(term, selectedFields)"
-          ref="searchModal" />
+      class="py-4"
+      :class="{ 'fixed top-0 left-0 w-full h-1/6 px-4' : isFullscreen }">
+      <div class="flex items-center justify-between mb-2">
+        <div class="flex">
+          <search-modal
+            :search-in-fields="searchFields"
+            @search="(term, selectedFields) => applySearch(term, selectedFields)"
+            ref="searchModal" />
+          <dp-button
+            class="ml-2"
+            variant="outline"
+            data-cy="listStatements:searchReset"
+            :href="Routing.generate('dplan_procedure_statement_list', { procedureId: procedureId })"
+            :disabled="searchValue === ''"
+            :text="Translator.trans('search.reset')" />
+        </div>
         <dp-button
-          class="ml-auto"
+          data-cy="editorFullscreen"
+          :icon="isFullscreen ? 'compress' : 'expand'"
+          icon-size="medium"
+          hide-text
           variant="outline"
-          data-cy="listStatements:searchReset"
-          :href="Routing.generate('dplan_procedure_statement_list', { procedureId: procedureId })"
-          :disabled="searchValue === ''"
-          :text="Translator.trans('search.reset')" />
+          :text="isFullscreen ? Translator.trans('editor.fullscreen.close') : Translator.trans('editor.fullscreen')"
+          @click="isFullscreen = !isFullscreen" />
       </div>
       <dp-bulk-edit-header
         class="layout__item u-12-of-12 u-mt-0_5"
@@ -96,6 +108,7 @@
     <template v-if="!isLoading && items.length > 0">
       <dp-data-table
         data-cy="listStatements"
+        :class="{'px-4 overflow-y-scroll h-5/6': isFullscreen }"
         has-flyout
         :is-selectable="isSourceAndCoupledProcedure"
         :header-fields="headerFields"
@@ -370,6 +383,7 @@ export default {
         limits: [10, 25, 50, 100],
         perPage: 10
       },
+      isFullscreen: false,
       headerFields: [
         { field: 'externId', label: Translator.trans('id') },
         { field: 'internId', label: Translator.trans('internId.shortened'), colClass: 'w-8' },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_segments_list.html.twig
@@ -22,7 +22,6 @@
     </dp-slidebar>
 
     <segments-list
-        class="u-mv-0_5"
         :filters="JSON.parse('{{ filterNames|json_encode|e('js', 'utf-8') }}')"
         procedure-id="{{ procedure }}"
         current-user-id="{{ currentUser.ident }}"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -18,7 +18,6 @@
     {% endfor %}
 
     <list-statements
-        class="u-mv-0_5"
         current-user-id="{{ currentUser.ident }}"
         :is-source-and-coupled-procedure="{{ templateVars.isSourceAndCoupledProcedure == 1 ? 'true' : 'false' }}"
         procedure-id="{{ procedure }}"


### PR DESCRIPTION
**Ticket:** [DPLAN-11460](https://demoseurope.youtrack.cloud/issue/DPLAN-11460/Fullscreen-mode-fur-die-Abschnittsliste-und-die-STN-Liste-implementieren)

**Description:** To improve the usability of the STN and Segments tables, it was decided to introduce a fullscreen mode, which can be useful when all columns are displayed and have enough space

![image](https://github.com/demos-europe/demosplan-core/assets/110987766/4cbfe104-f0e5-4d73-be97-a84452d60a70)
![image](https://github.com/demos-europe/demosplan-core/assets/110987766/5f7943a8-300e-41c3-b302-13e1fa9378a2)

Fullscreen mode:
![image](https://github.com/demos-europe/demosplan-core/assets/110987766/9e67fc77-4d56-489a-9c25-5ba5bd7e3935)

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
