### PR TITLE
chore: only suggest allowed roles in command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
@@ -46,7 +46,7 @@ class RegisterUserForCustomerCommand extends CoreCommand
         ParameterBagInterface $parameterBag,
         private readonly RoleRepository $roleRepository,
         private readonly UserRepository $userRepository,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
         $this->helper = new QuestionHelper();

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
@@ -61,7 +61,7 @@ class RegisterUserForCustomerCommand extends CoreCommand
             return Command::FAILURE;
         }
         $customer = $this->helpers->askCustomer($input, $output);
-        $roles = $this->helpers->askRoles($input, $output);
+        $roles = $this->helpers->askRoles($input, $output, $this->parameterBag->get('roles_allowed'));
 
         try {
             // add user to customer

--- a/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
@@ -34,7 +34,6 @@ class Helpers
 
     public function __construct(
         private readonly CustomerRepository $customerRepository,
-        private readonly GlobalConfigInterface $globalConfig,
         private readonly RoleRepository $roleRepository
     ) {
         $this->helper = new QuestionHelper();
@@ -43,7 +42,7 @@ class Helpers
     /**
      * @return array<int, Role>
      */
-    public function askRoles(InputInterface $input, OutputInterface $output): array
+    public function askRoles(InputInterface $input, OutputInterface $output, array $rolesAllowed): array
     {
         $availableRolesCollection = collect($this->roleRepository->findAll());
         $rolesSelection = $availableRolesCollection
@@ -52,6 +51,10 @@ class Helpers
                 $code = $role->getCode();
 
                 return [$code => $name];
+            })
+            // filter roles that are not allowed
+            ->filter(static function (string $name, string $code) use ($rolesAllowed) {
+                return in_array($code, $rolesAllowed, true);
             })
             ->all();
         $questionRoles = new ChoiceQuestion(

--- a/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Helpers/Helpers.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Helpers;
 
-use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
@@ -58,7 +58,7 @@ class UserCreateCommand extends CoreCommand
         $customer = $this->helpers->askCustomer($input, $output);
         $orga = $this->askOrga($customer->getId(), $input, $output);
         $department = $this->askDepartment($orga->getId(), $input, $output);
-        $roles = $this->helpers->askRoles($input, $output);
+        $roles = $this->helpers->askRoles($input, $output, $this->parameterBag->get('roles_allowed'));
 
         // Create user
         $data = [

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
@@ -43,7 +43,7 @@ class UserCreateCommand extends CoreCommand
         private readonly OrgaRepository $orgaRepository,
         ParameterBagInterface $parameterBag,
         private readonly UserRepository $userRepository,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
         $this->helper = new QuestionHelper();

--- a/tests/backend/core/Core/Functional/RegisterUserForCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/RegisterUserForCustomerCommandTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 namespace Tests\Core\Core\Functional;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,7 +24,6 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
 {
     public function testSuccessfulExecute(): void
     {
-        self::markSkippedForCIIntervention();
 
         /** @var User $user */
         $user = $this->fixtures->getReference(LoadUserData::TEST_USER_FP_ONLY);
@@ -37,7 +36,7 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
             [
                 $user->getLogin(),
                 $newCustomer->getSubdomain(),
-                Role::PLANNING_AGENCY_ADMIN.','.Role::PUBLIC_AGENCY_COORDINATION,
+                RoleInterface::PLANNING_AGENCY_ADMIN.','.RoleInterface::PUBLIC_AGENCY_COORDINATION,
             ]
         );
 
@@ -48,11 +47,11 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
         // the output of the command in the console
         $output = $commandTester->getDisplay();
         static::assertStringContainsString('User successfully registered for customer', $output);
+        static::assertStringNotContainsString(RoleInterface::API_AI_COMMUNICATOR, $output);
     }
 
     public function testInvalidUserExecute(): void
     {
-        self::markSkippedForCIIntervention();
 
         $commandTester = $this->getCommandTester();
 
@@ -68,7 +67,6 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
 
     public function testInvalidCustomerExecute(): void
     {
-        self::markSkippedForCIIntervention();
 
         /** @var User $user */
         $user = $this->fixtures->getReference(LoadUserData::TEST_USER_FP_ONLY);
@@ -82,7 +80,7 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
                 $user->getLogin(),
                 'invalid customer',
                 $newCustomer->getSubdomain(),
-                Role::PUBLIC_AGENCY_SUPPORT,
+                RoleInterface::PUBLIC_AGENCY_SUPPORT,
             ]
         );
 

--- a/tests/backend/core/Core/Functional/RegisterUserForCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/RegisterUserForCustomerCommandTest.php
@@ -24,7 +24,6 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
 {
     public function testSuccessfulExecute(): void
     {
-
         /** @var User $user */
         $user = $this->fixtures->getReference(LoadUserData::TEST_USER_FP_ONLY);
         /** @var Customer $newCustomer */
@@ -52,7 +51,6 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
 
     public function testInvalidUserExecute(): void
     {
-
         $commandTester = $this->getCommandTester();
 
         $commandTester->setInputs(
@@ -67,7 +65,6 @@ class RegisterUserForCustomerCommandTest extends FunctionalTestCase
 
     public function testInvalidCustomerExecute(): void
     {
-
         /** @var User $user */
         $user = $this->fixtures->getReference(LoadUserData::TEST_USER_FP_ONLY);
         /** @var Customer $newCustomer */


### PR DESCRIPTION
When creating a user or granting permissions to another customer only defined allowed roles in project should be suggested