### PR TITLE
chore: set project migrations as migrated on container setup

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
@@ -47,7 +47,7 @@ class ContainerInitCommand extends CoreCommand
         private readonly CustomerService $customerService,
         private readonly UserService $userService,
         ParameterBagInterface $parameterBag,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
     }

--- a/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
@@ -38,7 +38,7 @@ class ContainerInitCommand extends CoreCommand
     private const OPTION_CUSTOMER_CONFIG = 'customerConfig';
 
     protected static $defaultName = 'dplan:container:init';
-    protected static $defaultDescription = 'Perform startup tasks as an init container in kubernetes setup';
+    protected static $defaultDescription = 'Perform startup tasks that may be used e.g. as an init container in kubernetes setup';
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -57,7 +57,7 @@ class ContainerInitCommand extends CoreCommand
         $this
            ->setHelp(
                <<<EOT
-Perform startup tasks as an init container in kubernetes setup. Usage:
+Perform startup tasks that may be used e.g. as an init container in kubernetes setup. Usage:
     php bin/<project> dplan:container:init
 EOT
            );

--- a/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use DomainException;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use PDOException;
@@ -83,12 +84,16 @@ class InitDbCommand extends CoreCommand
 
         $fixtureGroup = $input->getOption('with-fixtures');
         $fixtureSuccess = true;
+        $projectMigrationsSuccess = true;
         if (null !== $fixtureGroup) {
             $application = $this->getApplication();
             $input = new StringInput('doctrine:fixtures:load -n --group '.$fixtureGroup);
             $fixtureSuccess = $application->run($input, $output);
+            // set project migrations as migrated
+            $input = new StringInput('doctrine:migrations:version --add --all --configuration ' .DemosPlanPath::getProjectPath('app/config/project_migrations.yml'));
+            $projectMigrationsSuccess = $application->run($input, $output);
         }
 
-        return ($schemaSuccess && $sessionsTableSuccess && $fixtureSuccess) ? Command::SUCCESS : Command::FAILURE;
+        return ($schemaSuccess && $sessionsTableSuccess && $fixtureSuccess && $projectMigrationsSuccess) ? Command::SUCCESS : Command::FAILURE;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
@@ -33,7 +33,7 @@ class InitDbCommand extends CoreCommand
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly SessionHandlerInterface $sessionHandler,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
     }
@@ -90,7 +90,7 @@ class InitDbCommand extends CoreCommand
             $input = new StringInput('doctrine:fixtures:load -n --group '.$fixtureGroup);
             $fixtureSuccess = $application->run($input, $output);
             // set project migrations as migrated
-            $input = new StringInput('doctrine:migrations:version --add --all --configuration ' .DemosPlanPath::getProjectPath('app/config/project_migrations.yml'));
+            $input = new StringInput('doctrine:migrations:version --add --all --configuration '.DemosPlanPath::getProjectPath('app/config/project_migrations.yml'));
             $projectMigrationsSuccess = $application->run($input, $output);
         }
 


### PR DESCRIPTION
project migrations needs to be set as migrated when a project is newly build from fixtures. The database is set up from scratch and migrations will not work and will do more harm than help