### PR TITLE
chore: remove menu highlighting that is not used any more

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1364,16 +1364,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.31",
+            "version": "v0.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "73cb9aa711b6dde215b802f1c433f759c146359f"
+                "reference": "f494d80b2d175c9281b9dd896dc3f6349ff5649e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/73cb9aa711b6dde215b802f1c433f759c146359f",
-                "reference": "73cb9aa711b6dde215b802f1c433f759c146359f",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/f494d80b2d175c9281b9dd896dc3f6349ff5649e",
+                "reference": "f494d80b2d175c9281b9dd896dc3f6349ff5649e",
                 "shasum": ""
             },
             "require": {
@@ -1437,9 +1437,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.31"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.32"
             },
-            "time": "2024-04-19T13:19:24+00:00"
+            "time": "2024-04-22T07:07:17+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -520,7 +520,6 @@ class DemosPlanStatementController extends BaseController
 
         if (true === $submitted) {
             $this->permissions->checkPermission('area_statements_final');
-            $this->permissions->setMenuhighlighting('area_statements_final');
             if ($requestPost->has('f_scope') && 'own' === $requestPost->get('f_scope')) {
                 $filters->setUserId($this->currentUser->getUser()->getId());
                 $scope = 'own';
@@ -535,14 +534,11 @@ class DemosPlanStatementController extends BaseController
         } elseif (true === $released) {
             if ('group' === $scope) {
                 $this->permissions->checkPermission('area_statements_released_group');
-                $this->permissions->setMenuhighlighting('area_statements_released_group');
             } else {
                 $this->permissions->checkPermission('area_statements_released');
-                $this->permissions->setMenuhighlighting('area_statements_released');
             }
         } else {
             $this->permissions->checkPermission('area_statements_draft');
-            $this->permissions->setMenuhighlighting('area_statements_draft');
         }
 
         // loeschen verarbeiten

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
@@ -10,15 +10,13 @@
 
 namespace demosplan\DemosPlanCoreBundle\Permissions;
 
-use function array_key_exists;
-
 use ArrayAccess;
-
-use const E_USER_DEPRECATED;
-
 use RuntimeException;
 
+use function array_key_exists;
 use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Permission Value Object.
@@ -54,7 +52,6 @@ class Permission implements ArrayAccess
      * @var bool general "is this permission enabled" check
      */
     protected $enabled = false;
-
 
     /**
      * @param string $name
@@ -195,7 +192,6 @@ class Permission implements ArrayAccess
 
     /**
      * @param string $offset
-     * @param mixed  $value
      *
      * @throws RuntimeException
      */

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permission.php
@@ -55,10 +55,6 @@ class Permission implements ArrayAccess
      */
     protected $enabled = false;
 
-    /**
-     * @var bool Used to control the menu bar
-     */
-    protected $active = false;
 
     /**
      * @param string $name
@@ -128,11 +124,6 @@ class Permission implements ArrayAccess
         return $this->enabled;
     }
 
-    public function isActive(): bool
-    {
-        return $this->active;
-    }
-
     public function isExposed(): bool
     {
         return $this->expose;
@@ -180,16 +171,6 @@ class Permission implements ArrayAccess
     public function disable(): void
     {
         $this->setEnabled(false);
-    }
-
-    /**
-     * @param bool $active
-     */
-    public function setActive($active): self
-    {
-        $this->active = $active;
-
-        return $this;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -134,13 +134,11 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Initialisiere die Permissions.
      */
-    public function initPermissions(UserInterface $user, ?array $context = null): PermissionsInterface
+    public function initPermissions(UserInterface $user): PermissionsInterface
     {
         $this->user = $user;
 
         $this->setInitialPermissions();
-
-        $this->initMenuhightlighting($context);
 
         // set Permissions which are user independent
         $this->setPlatformPermissions();
@@ -526,7 +524,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Setze die Rechte, die ein Verfahren betreffen.
      */
-    protected function setProcedurePermissions(): void
+    public function setProcedurePermissions(): void
     {
         // Ist Inhaberin des Verfahrens. Nur FP*-Rollen
         if ($this->ownsProcedure()) {
@@ -881,33 +879,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     }
 
     /**
-     * Setzt das initiale Set von kontxtbezogenen Menue-Highlights.
-     */
-    protected function initMenuhightlighting(?array $context = null): void
-    {
-        if (null !== $context) {
-            foreach ($context as $permission) {
-                $this->setMenuhighlighting($permission);
-            }
-        }
-    }
-
-    /**
-     * Setzt das Menue-Highlight eines einzelnen Permissions.
-     *
-     * @param string $permission
-     */
-    public function setMenuhighlighting($permission): void
-    {
-        // Nur "area_*"-Permissions bestimmen das Highlighting
-        if (false === \stripos($permission, 'area_')) {
-            return;
-        }
-
-        $this->permissions[$permission]->setActive(true);
-    }
-
-    /**
      * Setzt das initiale Set von Berechtigungen.
      */
     protected function setInitialPermissions(): void
@@ -986,7 +957,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     {
         // Prüfe, ob der User ins Verfahren darf
         if (null !== $this->procedure) {
-            $this->setProcedurePermissions();
+
 
             $readPermission = $this->hasPermissionsetRead();
             $owns = $this->ownsProcedure();

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -957,8 +957,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     {
         // Prüfe, ob der User ins Verfahren darf
         if (null !== $this->procedure) {
-
-
             $readPermission = $this->hasPermissionsetRead();
             $owns = $this->ownsProcedure();
             $apiUserMayAccess = $this->hasPermission('feature_procedure_api_access');

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -957,6 +957,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     {
         // Prüfe, ob der User ins Verfahren darf
         if (null !== $this->procedure) {
+            $this->setProcedurePermissions();
             $readPermission = $this->hasPermissionsetRead();
             $owns = $this->ownsProcedure();
             $apiUserMayAccess = $this->hasPermission('feature_procedure_api_access');

--- a/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
@@ -24,7 +24,7 @@ abstract class ProjectPermissions extends Permissions implements ProjectPermissi
         return $this;
     }
 
-    protected function setProcedurePermissions(): void
+    public function setProcedurePermissions(): void
     {
         parent::setProcedurePermissions();
 

--- a/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
@@ -15,9 +15,9 @@ use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 
 abstract class ProjectPermissions extends Permissions implements ProjectPermissionsInterface
 {
-    public function initPermissions(UserInterface $user, array $context = null): PermissionsInterface
+    public function initPermissions(UserInterface $user): PermissionsInterface
     {
-        parent::initPermissions($user, $context);
+        parent::initPermissions($user);
 
         $this->projectGlobalPermissions();
 

--- a/tests/backend/core/Core/Unit/Entity/PermissionTest.php
+++ b/tests/backend/core/Core/Unit/Entity/PermissionTest.php
@@ -30,7 +30,7 @@ class PermissionTest extends UnitTestCase
     /**
      * @var Permission
      */
-    protected $sut = null;
+    protected $sut;
 
     public function setUp(): void
     {
@@ -52,5 +52,4 @@ class PermissionTest extends UnitTestCase
 
         $this->sut['label'] = 'New Label';
     }
-
 }

--- a/tests/backend/core/Core/Unit/Entity/PermissionTest.php
+++ b/tests/backend/core/Core/Unit/Entity/PermissionTest.php
@@ -53,10 +53,4 @@ class PermissionTest extends UnitTestCase
         $this->sut['label'] = 'New Label';
     }
 
-    public function testCanChangeMutableValues()
-    {
-        self::assertFalse($this->sut->isActive());
-        $this->sut['active'] = true;
-        self::assertTrue($this->sut->isActive());
-    }
 }

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -3159,7 +3159,7 @@ class PermissionsTest extends FunctionalTestCase
                 $procedureRepositoryMock = $this->setUpProcedureRepositoryForTestCase($procedureMock);
                 $this->permissions->setProcedureRepository($procedureRepositoryMock);
             }
-            $this->permissions->initPermissions($user, ['area_demosplan']);
+            $this->permissions->initPermissions($user);
             if ($isInProcedure) {
                 $this->permissions->checkProcedurePermission();
             }

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -872,8 +872,8 @@ class PermissionsTest extends FunctionalTestCase
                     'field_statement_user_position',
                     'field_statement_user_state',
                     'role_participant',
-//                    'feature_user_add', //fixme: this permission was both here and in featuresAllowed. Please check.
-//                    'feature_user_edit', //fixme: this permission was both here and in featuresAllowed. Please check.
+                    //                    'feature_user_add', //fixme: this permission was both here and in featuresAllowed. Please check.
+                    //                    'feature_user_edit', //fixme: this permission was both here and in featuresAllowed. Please check.
                 ],
             ],
             'planning agency master user #2'    => [
@@ -2695,8 +2695,8 @@ class PermissionsTest extends FunctionalTestCase
                     'field_required_procedure_end_date',
                     'field_statement_submitter_email_address',
                     'role_participant',
-//                    'feature_user_add', //fixme: this permission was both here and in featuresAllowed. Please check.
-//                    'feature_user_edit', //fixme: this permission was both here and in featuresAllowed. Please check.
+                    //                    'feature_user_add', //fixme: this permission was both here and in featuresAllowed. Please check.
+                    //                    'feature_user_edit', //fixme: this permission was both here and in featuresAllowed. Please check.
                 ],
             ],
             // ################### Moderator###################
@@ -2858,7 +2858,7 @@ class PermissionsTest extends FunctionalTestCase
                     'area_statement_data_input_orga',
                     'feature_procedure_get_base_data',
                     'feature_procedure_single_document_upload_zip',
-//                  'feature_statement_data_input_orga', //fixme: permission is not set and it is unclear why this line is here - area_statement_data_input_orga instead is set - might be a mismatch
+                    //                  'feature_statement_data_input_orga', //fixme: permission is not set and it is unclear why this line is here - area_statement_data_input_orga instead is set - might be a mismatch
                 ],
                 'featuresDenied'                    => [
                     'area_admin',
@@ -2932,7 +2932,7 @@ class PermissionsTest extends FunctionalTestCase
                     'area_data_protection_text',
                     'area_demosplan',
                     'feature_procedure_single_document_upload_zip',
-//                  'feature_statement_data_input_orga', //fixme: permission is not set and it is unclear why this line is here - area_statement_data_input_orga instead is set - might be a mismatch
+                    //                  'feature_statement_data_input_orga', //fixme: permission is not set and it is unclear why this line is here - area_statement_data_input_orga instead is set - might be a mismatch
                 ],
                 'featuresDenied'                    => [
                     'area_admin',

--- a/tests/backend/core/Statement/Functional/StatementAnonymizeServiceTest.php
+++ b/tests/backend/core/Statement/Functional/StatementAnonymizeServiceTest.php
@@ -151,7 +151,7 @@ class StatementAnonymizeServiceTest extends FunctionalTestCase
         $this->logIn($user);
 
         $permissions = $this->sut->getPermissions();
-        $permissions->initPermissions($user, null);
+        $permissions->initPermissions($user);
         $permissions->enablePermissions(['feature_statements_fragment_edit']);
         $this->sut->setPermissions($permissions);
     }

--- a/tests/backend/core/Statement/Functional/StatementHandlerTest.php
+++ b/tests/backend/core/Statement/Functional/StatementHandlerTest.php
@@ -98,7 +98,7 @@ class StatementHandlerTest extends FunctionalTestCase
         $this->testProcedure = $this->getProcedureReference(LoadProcedureData::TESTPROCEDURE);
 
         $permissions = $this->sut->getPermissions();
-        $permissions->initPermissions($this->testUser, null);
+        $permissions->initPermissions($this->testUser);
         $permissions->enablePermissions(['feature_statements_fragment_edit']);
         $this->sut->setPermissions($permissions);
     }

--- a/tests/backend/core/Statement/Functional/StatementHandlerTest.php
+++ b/tests/backend/core/Statement/Functional/StatementHandlerTest.php
@@ -739,8 +739,8 @@ class StatementHandlerTest extends FunctionalTestCase
             'r_modifiedByUserId'       => $testUserId3,
             'r_modifiedByDepartmentId' => $testDepartmentId,
             'r_element'                => $testElementId1,
-//            'r_paragraph' => 'neuer Text eines frisch erstellen Datensatzes.',
-//            'r_document' => 'neuer Text eines frisch erstellen Datensatzes.',
+            //            'r_paragraph' => 'neuer Text eines frisch erstellen Datensatzes.',
+            //            'r_document' => 'neuer Text eines frisch erstellen Datensatzes.',
             'statementId'              => $statementId,
             'procedureId'              => $procedureId,
         ];


### PR DESCRIPTION
With the usage of the KnpLabs menu bundle the former mechanism is not used any more and could be removed

How to test:
navigate the app, highlighting should still work