### PR TITLE
chore: remove deprecated guard authentication

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -42,9 +42,8 @@ security:
             pattern: ^/api/ai
             stateless: true
             provider: ai_provider
-            guard:
-                authenticators:
-                    - demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\AiApiAuthenticator
+            jwt:
+                authenticator: demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\AiApiAuthenticator
         api_ai_auth_jwt:
             pattern: ^/api/ai/auth
             stateless: true
@@ -57,9 +56,8 @@ security:
             pattern: ^/api/\d.+
             stateless: true
             provider: api_provider
-            guard:
-                authenticators:
-                    - demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\ApiAuthenticator
+            jwt:
+                authenticator: demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\ApiAuthenticator
         saml:
             pattern: ^/saml
             saml:

--- a/config/services.yml
+++ b/config/services.yml
@@ -230,10 +230,11 @@ services:
         arguments:
             - !tagged dplan.data.generator
 
+    demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\ApiAuthenticator:
+        parent: lexik_jwt_authentication.security.jwt_authenticator
+
     demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\AiApiAuthenticator:
-        autowire: true
-        public: false
-        parent: lexik_jwt_authentication.security.guard.jwt_token_authenticator
+        parent: lexik_jwt_authentication.security.jwt_authenticator
 
     demosplan\DemosPlanCoreBundle\EventDispatcher\TraceableEventDispatcher: ~
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/AiApiAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/AiApiAuthenticator.php
@@ -10,12 +10,12 @@
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\ChainTokenExtractor;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\QueryParameterTokenExtractor;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
 
-class AiApiAuthenticator extends JWTTokenAuthenticator
+class AiApiAuthenticator extends JWTAuthenticator
 {
     /**
      * Jwt payload may be given as URL query parameter "jwt".

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/ApiAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/ApiAuthenticator.php
@@ -10,8 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
 
-class ApiAuthenticator extends JWTTokenAuthenticator
+class ApiAuthenticator extends JWTAuthenticator
 {
 }


### PR DESCRIPTION
Symfony Guard system has been deprecated since a while. New Authenticator system should be used instead.


### How to review/test
Use any (internal) api route and check whether it still works. If one does any other should as well

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
