### PR TITLE
chore: use listeners for permission setup

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/AccessProcedureListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/AccessProcedureListener.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\EventListener;
+
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+
+#[AsEventListener(event: 'kernel.controller', priority: 6)]
+class AccessProcedureListener
+{
+
+    public function __construct(
+        private readonly CurrentProcedureService $currentProcedureService,
+        private readonly PermissionsInterface $permissions,
+    )
+    {
+    }
+
+    public function onKernelController(ControllerEvent $controllerEvent): void
+    {
+        if (null === $this->currentProcedureService->getProcedure()) {
+            return;
+        }
+
+        $this->permissions->setProcedurePermissions();
+        // check whether user may participate in this procedure via Consultation Token
+        // this is temporary and will be better be solved via an SecurityVoter
+        $invitedProcedures = $controllerEvent->getRequest()->getSession()->get('invitedProcedures', []);
+        $this->permissions->evaluateUserInvitedInProcedure($invitedProcedures);
+
+        // check whether user has access to the procedure
+        $this->permissions->checkProcedurePermission();
+    }
+
+}

--- a/demosplan/DemosPlanCoreBundle/EventListener/CheckPermissionListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/CheckPermissionListener.php
@@ -10,48 +10,47 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventListener;
 
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Controller\APIController;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions as AnnotationDplanPermissions;
 use demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions as AttributeDplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
-use demosplan\DemosPlanCoreBundle\Logic\InitializeService;
+use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedGuestException;
 use Doctrine\Common\Annotations\Reader;
 use Exception;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
 
 /**
- * Perform initial Permissionchecks (former initialize()).
+ * Perform initial Permission checks (former initialize()).
+ * Permissions are initially set in {@link ConfigurePermissionsListener },
+ * Procedure permissions are enhanced in {@link AccessProcedureListener }, general
+ * procedure access check is also done in {@link AccessProcedureListener }.
  */
 class CheckPermissionListener
 {
-    /** @var Reader */
-    protected $reader;
-    /**
-     * @var InitializeService
-     */
-    protected $initializeService;
-    /**
-     * @var RouterInterface
-     */
-    protected $router;
-
-    public function __construct(Reader $reader, InitializeService $initializeService, RouterInterface $router)
-    {
-        $this->initializeService = $initializeService;
-        $this->reader = $reader;
-        $this->router = $router;
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly PermissionsInterface $permissions,
+        private readonly Reader $reader,
+        private readonly RequestStack $requestStack,
+        private readonly RouterInterface $router
+    ) {
     }
 
     /**
      * @throws ReflectionException
      */
-    public function onControllerRequest(ControllerEvent $event)
+    public function onControllerRequest(ControllerEvent $event): void
     {
         /*
          * $controller passed can be either a class or a Closure.
@@ -76,8 +75,8 @@ class CheckPermissionListener
         try {
             $dplanPermissions = $this->getDplanPermissions($reflectionMethod);
 
-            // perform initialize with permissions from attribute or annotation
-            $this->initializeService->initialize($dplanPermissions);
+            // check permission with permissions from attribute or annotation
+            $this->checkPermission($dplanPermissions);
         } catch (Exception $e) {
             // fallback if everything fails
             $redirectResponse = new RedirectResponse($this->router->generate('core_home'));
@@ -117,5 +116,23 @@ class CheckPermissionListener
         }
 
         return $dplanPermissions;
+    }
+
+    private function checkPermission($dplanPermissions): void
+    {
+        try {
+            $this->permissions->checkPermissions($dplanPermissions);
+        } catch (AccessDeniedException $e) {
+            // Wenn der User vorher keine Session hatte, ist eher die Session abgelaufen,
+            // als dass es ein echtes AccessDenied ist
+            if (null === $this->requestStack->getCurrentRequest()?->getSession()->getId()) {
+                $this->logger->info('Access Denied nach nicht vorhandener Session: ', [$e]);
+                throw new AccessDeniedGuestException();
+            }
+            throw $e;
+        } catch (Exception $e) {
+            $this->logger->error('Session Initialization not successful', [$e]);
+            throw new SessionUnavailableException('Session Initialization not successful: '.$e);
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/EventListener/ConfigurePermissionsListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ConfigurePermissionsListener.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\EventListener;
+
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: 'kernel.controller', priority: 7)]
+class ConfigurePermissionsListener
+{
+    public function __construct(
+        private readonly CurrentUserService $currentUserService,
+        private readonly PermissionsInterface $permissions,
+    )
+    {
+    }
+
+    public function onKernelController(): void
+    {
+        $user = $this->currentUserService->getUser();
+        $this->permissions->initPermissions($user);
+    }
+
+}

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/DetermineProcedureSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/DetermineProcedureSubscriber.php
@@ -57,10 +57,6 @@ class DetermineProcedureSubscriber implements EventSubscriberInterface
 
             if ($procedure instanceof Procedure) {
                 $this->currentProcedureService->setProcedure($procedure);
-
-                // check whether user may participate in this procedure via Consultation Token
-                // this is temporary and will be better be solved via an SecurityVoter
-                $this->permissions->evaluateUserInvitedInProcedure($procedure, $request->getSession());
             }
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/InitializeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/InitializeService.php
@@ -10,56 +10,22 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
-use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
-use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Contracts\Services\InitializeServiceInterface;
-use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedGuestException;
-use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
-use demosplan\DemosPlanCoreBundle\Traits\IsProfilableTrait;
-use Exception;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
 
 class InitializeService implements InitializeServiceInterface
 {
-    use IsProfilableTrait;
 
     public function __construct(
-        private readonly CurrentUserService $currentUserService,
         private readonly LoggerInterface $logger,
-        private readonly MessageBagInterface $messageBag,
-        private readonly PermissionsInterface $permissions,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
+    /**
+     * @deprecated CheckPermissionListener is used to perform initial Permission checks.
+     */
     public function initialize(array $context): void
     {
-        try {
-            $request = $this->requestStack->getCurrentRequest();
-
-            if (!$request instanceof Request) {
-                return;
-            }
-
-            $user = $this->currentUserService->getUser();
-            $this->permissions->initPermissions($user, $context);
-            $this->permissions->checkProcedurePermission();
-            $this->permissions->checkPermissions($context);
-        } catch (AccessDeniedException $e) {
-            // Wenn der User vorher keine Session hatte, ist eher die Session abgelaufen,
-            // als dass es ein echtes AccessDenied ist
-            if (null === $request->getSession()->getId()) {
-                $this->logger->info('Access Denied nach nicht vorhandener Session: ', [$e]);
-                throw new AccessDeniedGuestException();
-            }
-            throw $e;
-        } catch (Exception $e) {
-            $this->logger->error('Session Initialization not successful', [$e]);
-            throw new SessionUnavailableException('Session Initialization not successful: '.$e);
-        }
+        $this->logger->warning('Call to deprecated InitializeService', ['trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)]);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -154,10 +154,9 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * @deprecated see deprecation on property userInvitedInProcedure
      */
-    public function evaluateUserInvitedInProcedure(Procedure $procedure, Session $session): void
+    public function evaluateUserInvitedInProcedure(array $invitedProcedures): void
     {
-        $invitedProcedures = $session->get('invitedProcedures', []);
-        if (\in_array($procedure->getId(), $invitedProcedures, true)) {
+        if (\in_array($this->procedure?->getId(), $invitedProcedures, true)) {
             $this->userInvitedInProcedure = true;
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/ProjectPermissions.php
@@ -24,7 +24,7 @@ abstract class ProjectPermissions extends Permissions implements ProjectPermissi
         return $this;
     }
 
-    protected function setProcedurePermissions(): void
+    public function setProcedurePermissions(): void
     {
         parent::setProcedurePermissions();
 


### PR DESCRIPTION
Permissions are initially set in ConfigurePermissionsListener, Procedure permissions are enhanced in AccessProcedureListener, general procedure access check is also done in AccessProcedureListener.

Nothing new is introduced in this PR, only shifted to listeners.

### How to review/test
Browse the app, permissions within and outside procedures should work as before

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
