### PR TITLE
bug (ref 11416) Set ToOneRelationshipConfigBuilderInterface to elements

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
@@ -22,6 +22,7 @@ use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterEmailAddress @deprecated Move into StatementSubmitData resource type or something similar
@@ -61,7 +62,7 @@ use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isManual
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, File> $files @deprecated Use {@link StatementResourceType::$attachments} instead (needs implementation changes)
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Segment> $segments
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $paragraphOriginal
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, StatementFragment> $fragmentsElements @deprecated Create a {@link StatementFragment} relationship instead
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterPostalCode


### PR DESCRIPTION
**Ticket:** [DPLAN-11416](https://demoseurope.youtrack.cloud/issue/DPLAN-11416/StageStellungnahmen-in-Abwagungstabellen-nicht-verfugbar)

Set ToOneRelationshipConfigBuilderInterface to elements (as it was wrongly configured toMany)

### How to review/test
Access the AssessmentTable of a procedure which includes statements without an related element.



### PR Checklist
[cherrypicked](https://github.com/demos-europe/demosplan-core/pull/2799) 

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
