### PR TITLE
fix(refs DPLAN-11435): Fetch Lost Hash to request userFilterSets

### DIFF
--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -321,6 +321,11 @@ export default {
             originalStatementsCount: el.attributes.originalStatementsCount,
             statementsCount: el.attributes.statementsCount
           }))
+        })
+        .catch(e => {
+          console.error(e)
+        })
+        .finally(() => {
           this.isLoading = false
         })
     },

--- a/client/js/store/statement/Filter.js
+++ b/client/js/store/statement/Filter.js
@@ -298,15 +298,20 @@ const Filter = {
     /**
      * Get UserFilterSets for current procedure
      */
-    getUserFilterSetsAction ({ commit, state }) {
-      return dpApi({
-        method: 'GET',
-        url: Routing.generate('api_resource_list', { resourceType: 'UserFilterSet' })
-      }).then(this.api.checkResponse)
-        .then(data => {
-          commit('updateUserFilterSets', data)
-        }).catch(() => {
-          console.error('filter.saveFilterSet.load.error')
+    getUserFilterSetsAction ({ commit }) {
+      const url = Routing.generate('api_resource_list', { resourceType: 'UserFilterSet' })
+      const params = {
+        include: 'filterSet',
+        fields: {
+          UserFilterSet: ['filterSet', 'name'].join(),
+          FilterSet: ['hash', 'name'].join()
+        }
+      }
+      return dpApi.get(url, params)
+        .then(this.api.checkResponse)
+        .then(data => commit('updateUserFilterSets', data))
+        .catch((err) => {
+          console.error('filter.saveFilterSet.load.error', err)
         })
     },
 

--- a/tests/frontend/unit/__mocks__/UserFilterSetResource.mock.js
+++ b/tests/frontend/unit/__mocks__/UserFilterSetResource.mock.js
@@ -1,0 +1,16 @@
+export const UserFilterSetResource = {
+  data: [{
+    attributes: {
+      name: 'my Name'
+    },
+    relationships: {
+      filterSet: {
+        data: { id: '1' }
+      }
+    }
+  }],
+  included: [
+    { id: '1', attributes: { hash: 'hash1' } },
+    { id: '2', attributes: { hash: 'hash2' } }
+  ]
+}

--- a/tests/frontend/unit/store/Filter.spec.js
+++ b/tests/frontend/unit/store/Filter.spec.js
@@ -10,6 +10,7 @@
 import { createLocalVue } from '@vue/test-utils'
 import Filter from '@DpJs/store/statement/Filter'
 import { filterList } from '../__mocks__/Filter.mock'
+import { UserFilterSetResource } from '../__mocks__/UserFilterSetResource.mock'
 import Vuex from 'vuex'
 
 describe('FilterStore', () => {
@@ -50,5 +51,16 @@ describe('FilterStore', () => {
     store.state.filterList = filterList
 
     expect(store.getters.filterByType('b')[0].attributes.options.find(option => option.count === 0)).toBe(undefined)
+  })
+
+  it('returns the correct filter hash for a given UserFilterSet', () => {
+    // Mock state
+    const userFilterSet = UserFilterSetResource.data[0]
+    store.state.userFilterSets = UserFilterSetResource
+    // Call the getter with the mocked state and user filter set
+    const result = store.getters.userFilterSetFilterHash(userFilterSet)
+
+    // Assert that the result is as expected
+    expect(result).toBe('hash1')
   })
 })


### PR DESCRIPTION
It looks like the response from the API changed, so we have to adjust the request to match the json:api specs more strict.

**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11435/gespeicherte-Filterkombinationen-laden-nicht-A-Tabelle

With this fix, saved filterSets should be loadable again. (A-table as FPA)


### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
