### PR TITLE
feature (ref dplan-11471): set entry point for Redakteur role

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Platform/EntryPointDecider.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Platform/EntryPointDecider.php
@@ -97,8 +97,7 @@ class EntryPointDecider implements EntryPointDeciderInterface
                 break;
 
             case $user->hasRole(Role::CONTENT_EDITOR):
-                $redirectUrlName = $this->globalConfig->getEntrypointRouteRtedit();
-                $entrypointRoute->setRoute($redirectUrlName);
+                $entrypointRoute->setRoute('DemosPlan_faq_administration_faq');
                 $this->logger->info('Entrypoint content editor');
                 break;
 


### PR DESCRIPTION
 **Ticket:** [https://yaits.demos-deutschland.de/Txxyyzz -->](https://demoseurope.youtrack.cloud/issue/DPLAN-11471/Anmeldung-fuhrt-zum-Fehler-bei-Nutzern-deren-Rolle-geandert-wurde)

Description: reset entry point for Redactor

### How to review/test
login as a redactor 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
