### PR TITLE
Fix(DPLAN-11518): adjust fullscreen-mode layout when a bulk-edit is displayed

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -12,7 +12,11 @@
     <dp-sticky-element
       border
       class="py-2"
-      :class="{ 'fixed top-0 left-0 w-full h-1/6 px-2': isFullscreen }">
+      :class="[
+        { 'fixed top-0 left-0 w-full px-2': isFullscreen },
+        { 'h-1/4': selectedItemsCount > 0 && isFullscreen },
+        { 'h-1/6': selectedItemsCount === 0 && isFullscreen }
+      ]">
       <div class="flex items-start mb-2">
         <custom-search
           ref="customSearch"
@@ -101,7 +105,11 @@
       <dp-data-table
         v-if="items"
         class="overflow-x-auto"
-        :class="{ 'px-2 overflow-y-scroll h-5/6': isFullscreen }"
+        :class="[
+          { 'px-2 overflow-y-scroll': isFullscreen },
+          { 'h-3/4': selectedItemsCount > 0 && isFullscreen },
+          { 'h-5/6': selectedItemsCount === 0 && isFullscreen }
+        ]"
         has-flyout
         :header-fields="headerFields"
         is-resizable

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -8,15 +8,11 @@
 </license>
 
 <template>
-  <div :class="{ 'top-0 left-0 w-full h-full fixed z-fixed bg-white': isFullscreen }">
+  <div :class="{ 'top-0 left-0 flex flex-col w-full h-full fixed z-fixed bg-white': isFullscreen }">
     <dp-sticky-element
       border
-      class="py-2"
-      :class="[
-        { 'fixed top-0 left-0 w-full px-2': isFullscreen },
-        { 'h-1/4': selectedItemsCount > 0 && isFullscreen },
-        { 'h-1/6': selectedItemsCount === 0 && isFullscreen }
-      ]">
+      class="pt-2 pb-3"
+      :class="{ 'fixed top-0 left-0 w-full px-2': isFullscreen }">
       <div class="flex items-start mb-2">
         <custom-search
           ref="customSearch"
@@ -106,11 +102,7 @@
         <dp-data-table
           ref="dataTable"
           class="overflow-x-auto"
-          :class="[
-            { 'px-2 overflow-y-scroll': isFullscreen },
-            { 'h-3/4': selectedItemsCount > 0 && isFullscreen },
-            { 'h-5/6': selectedItemsCount === 0 && isFullscreen }
-          ]"
+          :class="isFullscreen ? 'px-2 overflow-y-scroll h-5/6 grow' : '-mt-3'"
           has-flyout
           :header-fields="headerFields"
           is-resizable

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -102,7 +102,7 @@
         <dp-data-table
           ref="dataTable"
           class="overflow-x-auto"
-          :class="isFullscreen ? 'px-2 overflow-y-scroll h-5/6 grow' : '-mt-3'"
+          :class="isFullscreen ? 'px-2 overflow-y-scroll grow' : '-mt-3'"
           has-flyout
           :header-fields="headerFields"
           is-resizable

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -8,11 +8,11 @@
 </license>
 
 <template>
-  <div :class="{ 'top-0 left-0 w-full h-full fixed z-fixed bg-white': isFullscreen }">
+  <div :class="{ 'top-0 left-0 flex flex-col w-full h-full fixed z-fixed bg-white': isFullscreen }">
     <dp-sticky-element
       border
-      class="py-2"
-      :class="{ 'fixed top-0 left-0 w-full h-1/6 px-2': isFullscreen }">
+      class="pt-2 pb-3"
+      :class="{ 'fixed top-0 left-0 w-full px-2': isFullscreen }">
       <div class="flex items-center justify-between mb-2">
         <div class="flex">
           <search-modal
@@ -108,7 +108,7 @@
       <dp-data-table
         v-if="items"
         data-cy="listStatements"
-        :class="{ 'px-2 overflow-y-scroll h-5/6': isFullscreen }"
+        :class="{ 'px-2 overflow-y-scroll grow': isFullscreen }"
         has-flyout
         :is-selectable="isSourceAndCoupledProcedure"
         :header-fields="headerFields"


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11518/Textuberlappung-im-Vollbildmodus-wenn-man-einen-Abschnitt-auswahlt

**Description:** This PR adjusts the layout of the fullscreen mode when a bulk-edit is displayed. As the sticky element has a fixed position, its height should be set to properly position the table and avoid overlapping with these two elements.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
