### PR TITLE
chore: improve list performance

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ProcedureAccessEvaluator.php
@@ -52,6 +52,11 @@ class ProcedureAccessEvaluator
      */
     public function isOwningProcedure(User $user, Procedure $procedure): bool
     {
+        // guests can not own procedures
+        if ($user->isGuestOnly()) {
+            return false;
+        }
+
         $ownsProcedureConditionFactory = new OwnsProcedureConditionFactory(
             $this->conditionFactory,
             $this->globalConfig,

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureResourceType.php
@@ -192,6 +192,10 @@ final class ProcedureResourceType extends DplanResourceType implements Procedure
             $properties[] = $this->createAttribute($this->coordinate)->readable()->aliasedPath($this->settings->coordinate);
             $properties[] = $this->createAttribute($this->externalDescription)->readable()->aliasedPath($this->externalDesc);
             $properties[] = $this->createAttribute($this->statementSubmitted)->readable(false, function (Procedure $procedure): int {
+                // guests can not have any draft statements
+                if ($this->currentUser->getUser()->isGuestOnly()) {
+                    return 0;
+                }
                 $userFilter = new StatementListUserFilter();
                 $userFilter->setSubmitted(true)->setReleased(true);
                 $statementResult = $this->draftStatementService->getDraftStatementList(


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11522/blp-Liste-der-Verfahren-auf-der-Startseite-ladt-sehr-lang

Loading the list of procedures has a very poor performance, taking almost 10 Seconds for a list of only 388 procedures. Two main bottlenecks could be avoided for guest users, as they can neither have DraftStatements nor can they own procedures. Logged in users won't have such a long list, so the performance does (usually) not bite. 
This PR reduces the time to fetch the List for guest users from 9.57s to 1.48s which is still slow but feasible. More performance optimizations can be achieved later on, to keep this PR small I only focused on guest users.

![image](https://github.com/demos-europe/demosplan-core/assets/57546580/f02122ce-d3d6-4396-940c-b3008c9057bd)


### How to review/test
code review and visit blp homepage

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
