### PR TITLE
Add fixed scrollbar to SegmentList

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -98,145 +98,153 @@
       v-if="isLoading" />
 
     <template v-else>
-      <dp-data-table
-        v-if="items"
-        class="overflow-x-auto"
-        :class="{ 'px-2 overflow-y-scroll h-5/6': isFullscreen }"
-        has-flyout
-        :header-fields="headerFields"
-        is-resizable
-        is-selectable
-        :items="items"
-        :multi-page-all-selected="allSelectedVisually"
-        :multi-page-selection-items-total="allItemsCount"
-        :multi-page-selection-items-toggled="toggledItems.length"
-        :should-be-selected-items="currentlySelectedItems"
-        track-by="id"
-        @select-all="handleSelectAll"
-        @items-toggled="handleToggleItem">
-        <template v-slot:externId="rowData">
-          <v-popover trigger="hover focus">
-            <div class="whitespace-nowrap">
-              {{ rowData.attributes.externId }}
+      <template v-if="items">
+        <dp-data-table
+          ref="dataTable"
+          class="overflow-x-auto"
+          :class="{ 'px-2 overflow-y-scroll h-5/6': isFullscreen }"
+          has-flyout
+          :header-fields="headerFields"
+          is-resizable
+          is-selectable
+          :items="items"
+          :multi-page-all-selected="allSelectedVisually"
+          :multi-page-selection-items-total="allItemsCount"
+          :multi-page-selection-items-toggled="toggledItems.length"
+          :should-be-selected-items="currentlySelectedItems"
+          track-by="id"
+          @select-all="handleSelectAll"
+          @items-toggled="handleToggleItem">
+          <template v-slot:externId="rowData">
+            <v-popover trigger="hover focus">
+              <div class="whitespace-nowrap">
+                {{ rowData.attributes.externId }}
+              </div>
+              <template v-slot:popover>
+                <statement-meta-tooltip
+                  :assignable-users="assignableUsers"
+                  :statement="statementsObject[rowData.relationships.parentStatement.data.id]"
+                  :segment="rowData"
+                  :places="places" />
+              </template>
+            </v-popover>
+          </template>
+          <template v-slot:internId="rowData">
+            <div class="o-hellip__wrapper">
+              <div
+                class="o-hellip--nowrap text-right"
+                v-tooltip="statementsObject[rowData.relationships.parentStatement.data.id].attributes.internId"
+                dir="rtl">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.internId }}
+              </div>
             </div>
-            <template v-slot:popover>
-              <statement-meta-tooltip
-                :assignable-users="assignableUsers"
-                :statement="statementsObject[rowData.relationships.parentStatement.data.id]"
-                :segment="rowData"
-                :places="places" />
-            </template>
-          </v-popover>
-        </template>
-        <template v-slot:internId="rowData">
-          <div class="o-hellip__wrapper">
+          </template>
+          <template v-slot:submitter="rowData">
+            <ul class="o-list max-w-12">
+              <li
+                v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.authorName !== ''"
+                class="o-list__item o-hellip--nowrap">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.authorName }}
+              </li>
+              <li
+                v-else
+                class="o-list__item o-hellip--nowrap">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.submitName }}
+              </li>
+              <li
+                v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationName !== ''"
+                class="o-list__item o-hellip--nowrap">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationName }}
+              </li>
+            </ul>
+          </template>
+          <template v-slot:address="rowData">
+            <ul class="o-list">
+              <li
+                v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationStreet !== ''"
+                class="o-list__item o-hellip--nowrap">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationStreet }}
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationHouseNumber }}
+              </li>
+              <li
+                v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationPostalCode !== ''"
+                class="o-list__item o-hellip--nowrap">
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationPostalCode }}
+                {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationCity }}
+              </li>
+            </ul>
+          </template>
+          <template v-slot:place="rowData">
+            {{ placesObject[rowData.relationships.place.data.id].attributes.name }}
+          </template>
+          <template v-slot:text="rowData">
             <div
-              class="o-hellip--nowrap text-right"
-              v-tooltip="statementsObject[rowData.relationships.parentStatement.data.id].attributes.internId"
-              dir="rtl">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.internId }}
-            </div>
-          </div>
-        </template>
-        <template v-slot:submitter="rowData">
-          <ul class="o-list max-w-12">
-            <li
-              v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.authorName !== ''"
-              class="o-list__item o-hellip--nowrap">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.authorName }}
-            </li>
-            <li
-              v-else
-              class="o-list__item o-hellip--nowrap">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.submitName }}
-            </li>
-            <li
-              v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationName !== ''"
-              class="o-list__item o-hellip--nowrap">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationName }}
-            </li>
-          </ul>
-        </template>
-        <template v-slot:address="rowData">
-          <ul class="o-list">
-            <li
-              v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationStreet !== ''"
-              class="o-list__item o-hellip--nowrap">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationStreet }}
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationHouseNumber }}
-            </li>
-            <li
-              v-if="statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationPostalCode !== ''"
-              class="o-list__item o-hellip--nowrap">
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationPostalCode }}
-              {{ statementsObject[rowData.relationships.parentStatement.data.id].attributes.initialOrganisationCity }}
-            </li>
-          </ul>
-        </template>
-        <template v-slot:place="rowData">
-          {{ placesObject[rowData.relationships.place.data.id].attributes.name }}
-        </template>
-        <template v-slot:text="rowData">
-          <div
-            v-cleanhtml="rowData.attributes.text"
-            class="overflow-word-break c-styled-html" />
-        </template>
-        <template v-slot:recommendation="rowData">
-          <div v-cleanhtml="rowData.attributes.recommendation !== '' ? rowData.attributes.recommendation : '-'" />
-        </template>
-        <template v-slot:tags="rowData">
-          <span
-            :key="tag.id"
-            class="rounded-md"
-            v-for="tag in getTagsBySegment(rowData.id)"
-            style="color: #63667e; background: #EBE9E9; padding: 2px 4px; margin: 4px 2px; display: inline-block;">
-            {{ tag.attributes.title }}
-          </span>
-        </template>
-        <template v-slot:flyout="rowData">
-          <dp-flyout data-cy="segmentsList:flyoutEditMenu">
-            <a
-              :href="Routing.generate('dplan_statement_segments_list', {
-                action: 'editText',
-                procedureId: procedureId,
-                segment: rowData.id,
-                statementId: rowData.relationships.parentStatement.data.id
-              })"
-              data-cy="segmentsList:edit"
-              rel="noopener">
-              {{ Translator.trans('edit') }}
-            </a>
-            <a
-              v-if="hasPermission('feature_segment_recommendation_edit')"
-              :href="Routing.generate('dplan_statement_segments_list', {
-                procedureId: procedureId,
-                segment: rowData.id,
-                statementId: rowData.relationships.parentStatement.data.id
-              })"
-              data-cy="segmentsList:segmentsRecommendationsCreate"
-              rel="noopener">
-              {{ Translator.trans('segments.recommendations.create') }}
-            </a>
-            <!-- Version history view -->
-            <button
-              type="button"
-              class="btn--blank o-link--default"
-              data-cy="segmentsList:segmentVersionHistory"
-              @click.prevent="showVersionHistory(rowData.id, rowData.attributes.externId)">
-              {{ Translator.trans('history') }}
-            </button>
-            <a
-              v-if="hasPermission('feature_read_source_statement_via_api')"
-              :class="{'is-disabled': getOriginalPdfAttachmentHashBySegment(rowData) === null}"
-              data-cy="segmentsList:originalPDF"
-              target="_blank"
-              :href="Routing.generate('core_file_procedure', { hash: getOriginalPdfAttachmentHashBySegment(rowData), procedureId: procedureId })"
-              rel="noopener noreferrer">
-              {{ Translator.trans('original.pdf') }}
-            </a>
-          </dp-flyout>
-        </template>
-      </dp-data-table>
+              v-cleanhtml="rowData.attributes.text"
+              class="overflow-word-break c-styled-html" />
+          </template>
+          <template v-slot:recommendation="rowData">
+            <div v-cleanhtml="rowData.attributes.recommendation !== '' ? rowData.attributes.recommendation : '-'" />
+          </template>
+          <template v-slot:tags="rowData">
+            <span
+              :key="tag.id"
+              class="rounded-md"
+              v-for="tag in getTagsBySegment(rowData.id)"
+              style="color: #63667e; background: #EBE9E9; padding: 2px 4px; margin: 4px 2px; display: inline-block;">
+              {{ tag.attributes.title }}
+            </span>
+          </template>
+          <template v-slot:flyout="rowData">
+            <dp-flyout data-cy="segmentsList:flyoutEditMenu">
+              <a
+                :href="Routing.generate('dplan_statement_segments_list', {
+                  action: 'editText',
+                  procedureId: procedureId,
+                  segment: rowData.id,
+                  statementId: rowData.relationships.parentStatement.data.id
+                })"
+                data-cy="segmentsList:edit"
+                rel="noopener">
+                {{ Translator.trans('edit') }}
+              </a>
+              <a
+                v-if="hasPermission('feature_segment_recommendation_edit')"
+                :href="Routing.generate('dplan_statement_segments_list', {
+                  procedureId: procedureId,
+                  segment: rowData.id,
+                  statementId: rowData.relationships.parentStatement.data.id
+                })"
+                data-cy="segmentsList:segmentsRecommendationsCreate"
+                rel="noopener">
+                {{ Translator.trans('segments.recommendations.create') }}
+              </a>
+              <!-- Version history view -->
+              <button
+                type="button"
+                class="btn--blank o-link--default"
+                data-cy="segmentsList:segmentVersionHistory"
+                @click.prevent="showVersionHistory(rowData.id, rowData.attributes.externId)">
+                {{ Translator.trans('history') }}
+              </button>
+              <a
+                v-if="hasPermission('feature_read_source_statement_via_api')"
+                :class="{'is-disabled': getOriginalPdfAttachmentHashBySegment(rowData) === null}"
+                data-cy="segmentsList:originalPDF"
+                target="_blank"
+                :href="Routing.generate('core_file_procedure', { hash: getOriginalPdfAttachmentHashBySegment(rowData), procedureId: procedureId })"
+                rel="noopener noreferrer">
+                {{ Translator.trans('original.pdf') }}
+              </a>
+            </dp-flyout>
+          </template>
+        </dp-data-table>
+
+        <div
+          ref="scrollBar"
+          class="sticky bottom-0 left-0 right-0 -mt-3 overflow-x-scroll overflow-y-hidden">
+          <div />
+        </div>
+      </template>
 
       <div v-else>
         <p class="flash flash-info">
@@ -549,6 +557,21 @@ export default {
         })
     },
 
+    /**
+     * Adjust the width of the inner element of the footer scrollbar to the width of the Table.
+     */
+    updateScrollbarStyles () {
+      const tableWidth = window.getComputedStyle(this.dataTableElement).width
+      const tableContainerWidth = window.getComputedStyle(this.dataTableContainerElement).width
+
+      if (tableWidth > tableContainerWidth) {
+        this.scrollbar.classList.remove('hidden')
+        this.scrollbar.firstChild.setAttribute('style', 'width:' + tableWidth + ';height:1px;')
+      } else {
+        this.scrollbar.classList.add('hidden')
+      }
+    },
+
     fetchSegmentIds (payload) {
       return dpRpc('segment.load.id', payload)
         .then(response => checkResponse(response))
@@ -680,6 +703,36 @@ export default {
       this.resetSelection()
       this.applyQuery(1)
     }
+  },
+
+  created () {
+    this.$watch('isLoading', (isLoading) => {
+      if (isLoading) {
+        return
+      }
+
+      this.$nextTick(() => {
+        this.scrollbar = this.$refs.scrollBar
+        this.dataTableContainerElement = this.$refs.dataTable.$el
+        this.dataTableElement = this.$refs.dataTable.$refs.tableEl
+
+        // Bind behaviour and position of the footer scrollbar to the scroll position of the dataTableContainerElement.
+        this.scrollbar.addEventListener('scroll', () => {
+          this.dataTableContainerElement.scrollLeft = this.scrollbar.scrollLeft
+        })
+
+        this.dataTableContainerElement.addEventListener('scroll', () => {
+          this.scrollbar.scrollLeft = this.dataTableContainerElement.scrollLeft
+        })
+
+        // Observe changes to dataTable to update scrollbar accordingly
+        this.dataTableObserver = new ResizeObserver(this.updateScrollbarStyles.bind(this))
+        this.dataTableObserver.observe(this.dataTableElement)
+
+        // Set scrollbar width or conditionally hide it.
+        this.updateScrollbarStyles()
+      })
+    })
   },
 
   mounted () {

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -246,14 +246,10 @@
         </div>
       </template>
 
-      <div v-else>
-        <p class="flash flash-info">
-          <i
-            class="fa fa-info-circle"
-            aria-hidden="true" />
-          {{ Translator.trans('segments.none') }}
-        </p>
-      </div>
+      <dp-inline-notification
+        v-else
+        :message="Translator.trans('segments.none')"
+        type="info" />
     </template>
   </div>
 </template>
@@ -268,6 +264,7 @@ import {
   DpColumnSelector,
   DpDataTable,
   DpFlyout,
+  DpInlineNotification,
   DpLoading,
   DpPager,
   dpRpc,
@@ -283,6 +280,7 @@ import fullscreenModeMixin from '@DpJs/components/shared/mixins/fullscreenModeMi
 import lscache from 'lscache'
 import paginationMixin from '@DpJs/components/shared/mixins/paginationMixin'
 import StatementMetaTooltip from '@DpJs/components/statement/StatementMetaTooltip'
+import tableScrollbarMixin from '@DpJs/components/shared/mixins/tableScrollbarMixin'
 
 export default {
   name: 'SegmentsList',
@@ -294,6 +292,7 @@ export default {
     DpColumnSelector,
     DpDataTable,
     DpFlyout,
+    DpInlineNotification,
     DpLoading,
     DpPager,
     DpStickyElement,
@@ -306,7 +305,7 @@ export default {
     cleanhtml: CleanHtml
   },
 
-  mixins: [fullscreenModeMixin, paginationMixin, tableSelectAllItems],
+  mixins: [fullscreenModeMixin, paginationMixin, tableScrollbarMixin, tableSelectAllItems],
 
   props: {
     currentUserId: {
@@ -557,21 +556,6 @@ export default {
         })
     },
 
-    /**
-     * Adjust the width of the inner element of the footer scrollbar to the width of the Table.
-     */
-    updateScrollbarStyles () {
-      const tableWidth = window.getComputedStyle(this.dataTableElement).width
-      const tableContainerWidth = window.getComputedStyle(this.dataTableContainerElement).width
-
-      if (tableWidth > tableContainerWidth) {
-        this.scrollbar.classList.remove('hidden')
-        this.scrollbar.firstChild.setAttribute('style', 'width:' + tableWidth + ';height:1px;')
-      } else {
-        this.scrollbar.classList.add('hidden')
-      }
-    },
-
     fetchSegmentIds (payload) {
       return dpRpc('segment.load.id', payload)
         .then(response => checkResponse(response))
@@ -703,36 +687,6 @@ export default {
       this.resetSelection()
       this.applyQuery(1)
     }
-  },
-
-  created () {
-    this.$watch('isLoading', (isLoading) => {
-      if (isLoading) {
-        return
-      }
-
-      this.$nextTick(() => {
-        this.scrollbar = this.$refs.scrollBar
-        this.dataTableContainerElement = this.$refs.dataTable.$el
-        this.dataTableElement = this.$refs.dataTable.$refs.tableEl
-
-        // Bind behaviour and position of the footer scrollbar to the scroll position of the dataTableContainerElement.
-        this.scrollbar.addEventListener('scroll', () => {
-          this.dataTableContainerElement.scrollLeft = this.scrollbar.scrollLeft
-        })
-
-        this.dataTableContainerElement.addEventListener('scroll', () => {
-          this.scrollbar.scrollLeft = this.dataTableContainerElement.scrollLeft
-        })
-
-        // Observe changes to dataTable to update scrollbar accordingly
-        this.dataTableObserver = new ResizeObserver(this.updateScrollbarStyles.bind(this))
-        this.dataTableObserver.observe(this.dataTableElement)
-
-        // Set scrollbar width or conditionally hide it.
-        this.updateScrollbarStyles()
-      })
-    })
   },
 
   mounted () {

--- a/client/js/components/shared/mixins/tableScrollbarMixin.js
+++ b/client/js/components/shared/mixins/tableScrollbarMixin.js
@@ -1,0 +1,60 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+export default {
+  methods: {
+    /**
+     * Adjust the width of the inner element of the footer scrollbar to the width of the Table.
+     */
+    updateScrollbarStyles () {
+      const tableWidth = window.getComputedStyle(this.dataTableElement).width
+      const tableContainerWidth = window.getComputedStyle(this.dataTableContainerElement).width
+
+      if (tableWidth > tableContainerWidth) {
+        this.scrollbar.classList.remove('hidden')
+        this.scrollbar.firstChild.setAttribute('style', 'width:' + tableWidth + ';height:1px;')
+      } else {
+        this.scrollbar.classList.add('hidden')
+      }
+    }
+  },
+
+  created () {
+    /**
+     * Updating the scrollbar needs to wait for the dataTable items to load,
+     * as the table is only then present in its final width.
+     */
+    this.$watch('isLoading', (isLoading) => {
+      if (isLoading) {
+        return
+      }
+
+      this.$nextTick(() => {
+        this.scrollbar = this.$refs.scrollBar
+        this.dataTableContainerElement = this.$refs.dataTable.$el
+        this.dataTableElement = this.$refs.dataTable.$refs.tableEl
+
+        // Bind behaviour and position of the footer scrollbar to the scroll position of the dataTableContainerElement.
+        this.scrollbar.addEventListener('scroll', () => {
+          this.dataTableContainerElement.scrollLeft = this.scrollbar.scrollLeft
+        })
+
+        this.dataTableContainerElement.addEventListener('scroll', () => {
+          this.scrollbar.scrollLeft = this.dataTableContainerElement.scrollLeft
+        })
+
+        // Observe changes to dataTable to update scrollbar accordingly
+        this.dataTableObserver = new ResizeObserver(this.updateScrollbarStyles.bind(this))
+        this.dataTableObserver.observe(this.dataTableElement)
+
+        // Set scrollbar width or conditionally hide it.
+        this.updateScrollbarStyles()
+      })
+    })
+  }
+}

--- a/client/js/components/shared/mixins/tableScrollbarMixin.js
+++ b/client/js/components/shared/mixins/tableScrollbarMixin.js
@@ -6,10 +6,28 @@
  *
  * All rights reserved
  */
+/**
+ * This mixin is intended to show a fixed scrollbar below a dataTable that exceeds its container.
+ * Example usage:
+ *
+ * <dp-data-table
+ *   ref="dataTable"
+ *   class="overflow-x-auto"
+ *   <!-- other required attrs for dataTable... --> />
+ * <div
+ *   ref="scrollBar"
+ *   class="sticky bottom-0 left-0 right-0 -mt-3 overflow-x-scroll overflow-y-hidden">
+ *   <div />
+ * </div>
+ *
+ * Important thing to note is that both elements should have exactly the refs shown in the example.
+ * Also, within the using component, `isLoading` should be present within data.
+ */
 export default {
   methods: {
     /**
-     * Adjust the width of the inner element of the footer scrollbar to the width of the Table.
+     * Adjust the width of the inner element of the footer scrollbar to the width of the Table,
+     * conditionally hide or show scrollbar.
      */
     updateScrollbarStyles () {
       const tableWidth = window.getComputedStyle(this.dataTableElement).width

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -9,7 +9,6 @@
 
 <template>
   <div :class="{ 'top-0 left-0 w-full h-full fixed z-fixed bg-white': isFullscreen }">
-    <!-- Header -->
     <dp-sticky-element
       border
       class="py-2"
@@ -101,11 +100,13 @@
       </div>
     </dp-sticky-element>
 
-    <dp-loading v-if="isLoading" />
+    <dp-loading
+      class="u-mt"
+      v-if="isLoading" />
 
-    <!-- Statement list -->
-    <template v-if="!isLoading && items.length > 0">
+    <template v-else>
       <dp-data-table
+        v-if="items"
         data-cy="listStatements"
         :class="{ 'px-2 overflow-y-scroll h-5/6': isFullscreen }"
         has-flyout
@@ -289,12 +290,12 @@
           </div>
         </template>
       </dp-data-table>
-    </template>
 
-    <dp-inline-notification
-      v-else-if="!isLoading && items.length === 0"
-      :message="Translator.trans((this.searchValue === '' ? 'statements.none' : 'search.no.results'), {searchterm: this.searchValue})"
-      type="info" />
+      <dp-inline-notification
+        v-else
+        :message="Translator.trans((this.searchValue === '' ? 'statements.none' : 'search.no.results'), {searchterm: this.searchValue})"
+        type="info" />
+    </template>
   </div>
 </template>
 


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11516/Scroll-Handle-soll-unten-festgehalten-werden

This PR adds a scrollbar to the SegmentsList that is fixed to the bottom of the page also when not in fullscreen mode. It has been added as a mixin to be able to reuse it in other places. 

### How to review/test
When the dataTable is bigger than its container, a scrollbar should appear that is fixed to the bottom of the page:

![image](https://github.com/demos-europe/demosplan-core/assets/40452344/ddff8e0e-af41-4a1f-ac20-98508ef07b64)

### PR Checklist

- [X] Update documentation
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
