### PR TITLE
bug (ref DPLAN-1970) Remove duplicated breadcrumbs

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Services/Breadcrumb/Breadcrumb.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Breadcrumb/Breadcrumb.php
@@ -72,7 +72,7 @@ class Breadcrumb
      * @param array|null  $procedure
      * @param bool        $isOwner
      */
-    public function getMarkup(User $user = null, $titleKey = null, $procedure = null, $isOwner = false): string
+    public function getMarkup(?User $user = null, $titleKey = null, $procedure = null, $isOwner = false): string
     {
         // Override title only if title hasn't been set before
         if (null !== $titleKey && $titleKey !== $this->title) {

--- a/demosplan/DemosPlanCoreBundle/Services/Breadcrumb/Breadcrumb.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Breadcrumb/Breadcrumb.php
@@ -121,18 +121,23 @@ class Breadcrumb
                 }
             } else {
                 foreach ($this->userRoles as $role) {
-                    match ($role) {
-                        Role::PROCEDURE_DATA_INPUT => $markup .= $this->getSnippetMarkup(
+                    $result = match ($role) {
+                        Role::PROCEDURE_DATA_INPUT => $this->getSnippetMarkup(
                             $this->getRouter()->generate('DemosPlan_procedure_list_data_input_orga_procedures'),
                             $this->translator->trans('procedure'),
                             $liCounter++
                         ),
-                        default => $markup .= $this->getSnippetMarkup(
+                        default => $this->getSnippetMarkup(
                             $this->getRouter()->generate('core_home'),
                             $this->translator->trans('participation'),
                             $liCounter++
                         ),
                     };
+
+                    if ($result) {
+                        $markup .= $result;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-1970/Breadcrumbs-durcheinander-kaputt

**Description:**
- The bug  was introduced by exchanging the `match` function instead of the `switch` function (see here 92d24a2899d895fadc1cb057d994330113b922ef)
- The match function does not break inside a foreach, the switch function can break (using break (2)) to stop the switch function and the foreach
- Because the match function is used, then when a user has 2 roles, the breadcrumb is added twice.
- I wanted to keep the match function, that is why I added the if else. I want to keep the match function in case more user roles are added in the future with a custom breadcrumb

### How to review/test
- Go to ewm and login with a user that has 2 or more roles
- Then you should see the duplicated breadcrumbs are gone
- Also test with a user  that has 1 role to be safe


Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
