### PR TITLE
fix(DPLAN-1965): improve error validation of the Datepicker

### DIFF
--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -162,7 +162,8 @@
           for="startdate"
           :hint="Translator.trans('explanation.date.procedure')"
           :required="hasPermission('field_required_procedure_end_date')"
-          :text="Translator.trans('period')" />
+          :text="Translator.trans('period')"
+          :tooltip="Translator.trans('explanation.date.format')" />
 
         <dp-date-range-picker
           class="u-2-of-4"
@@ -171,6 +172,7 @@
           end-id="enddate"
           end-name="r_enddate"
           data-cy="newProcedureForm"
+          :data-dp-validate-error-fieldname="Translator.trans('period')"
           :required="hasPermission('field_required_procedure_end_date')"
           :calendars-after="2"
           enforce-plausible-dates />

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1364,6 +1364,7 @@ explanation.data.protection.before.vote: "Die Stellungnahme muss für den öffen
 explanation.data.user.change: "Sollten sich Ihre Daten geändert haben, ändern Sie sie bitte vor der Einreichung der Stellungnahme(n) im <a class=\"o-link--default\" href=\"{href}\"><i class=\"fa fa-external-link\" aria-hidden=\"true\"></i> {label}</a> unter Menüpunkt \"Benutzerprofil/Daten ändern\" (Sie verlassen diese Seite)."
 explanation.data.user.change.portal: "Sollte sich Ihr Name oder Ihre E-Mail-Adresse geändert haben, ändern Sie sie bitte vor der Einreichung der Stellungnahme(n) unter \"<a href=\"{url}\">{label}</a>\"."
 explanation.data.user: "Hier können Sie Ihre persönlichen Daten einsehen, mit denen Sie registriert sind."
+explanation.date.format: "Bitte beachten Sie: Das erwartete Datumsformat ist 'dd.mm.yyyy'"
 explanation.date.procedure: ""
 explanation.date.empty: "Wird der Zeitraum leer gelassen, setzt das System automatisch das aktuelle Datum ein."
 explanation.drawing.configuration: "Die Konfiguration der Karten, Pläne und Legende erfolgt unter nachfolgendem Link im Menü „Planzeichnung“."


### PR DESCRIPTION
**Ticket:** [DPLAN-1965](https://demoseurope.youtrack.cloud/issue/DPLAN-1965/Invalid-Inputs-beim-Verfahrenerstellen-werfen-nicht-die-richtigen-Fehlernachrichten)

**Description:** This PR adds an error field name to the `DpDateRangePicker` and includes a tooltip on the 'Zeitraum' label with an explanation about the accepted date format.

### How to review/test
Neues Verfahren erstellen -> Pflichtfelder ausfüllen -> in Datumsfeldern invalid Inputs geben

### Linked PRs (optional)

- [Demosplan-ui](https://github.com/demos-europe/demosplan-ui/pull/841) 


- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
