### PR TITLE
F dplan 11443 add additional fields procedure  map setting

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
@@ -37,6 +37,7 @@ use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerProjection
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultProjection
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $globalAvailableScales
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $publicSearchAutoZoom
  *
  * @template-extends MagicResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,ProcedureSettingsInterface>
  */

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
@@ -33,7 +33,7 @@ use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultMapExtent
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $useGlobalInformationUrl
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerUrl
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerNames
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerLayerNames
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerProjection
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultProjection
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $globalAvailableScales

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
@@ -32,6 +32,11 @@ use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultBoundingBox
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultMapExtent
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $useGlobalInformationUrl
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerUrl
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerNames
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerProjection
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultProjection
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $globalAvailableScales
  *
  * @template-extends MagicResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,ProcedureSettingsInterface>
  */

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
@@ -25,6 +25,7 @@ use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $informationUrl
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $copyright
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $availableScales
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $availableProjections
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $showOnlyOverlayCategory
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $coordinate
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $territory

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -92,23 +92,23 @@ class ProcedureMapSettingResourceType extends DplanResourceType
             ->readable(false, $this->getAvailableProjections(...));
 
         $configBuilder->baseLayerUrl
-            ->readable(false, fn (ProcedureSettings $procedureSetting): string  => $this->globalConfig->getMapAdminBaselayer());
+            ->readable(false, fn (ProcedureSettings $procedureSetting): string => $this->globalConfig->getMapAdminBaselayer());
 
         $configBuilder->baseLayerNames
-            ->readable(false, fn (ProcedureSettings $procedureSetting): array  => $this->convertToListOfString($this->globalConfig->getMapAdminBaselayerLayers()));
+            ->readable(false, fn (ProcedureSettings $procedureSetting): array => $this->convertToListOfString($this->globalConfig->getMapAdminBaselayerLayers()));
 
         $configBuilder->baseLayerProjection
-            ->readable(false, fn (ProcedureSettings $procedureSetting): string  => MapService::PSEUDO_MERCATOR_PROJECTION_LABEL);
+            ->readable(false, fn (ProcedureSettings $procedureSetting): string => MapService::PSEUDO_MERCATOR_PROJECTION_LABEL);
 
         $configBuilder->defaultProjection
-            ->readable(false, fn (ProcedureSettings $procedureSetting): array  => $this->globalConfig->getMapDefaultProjection());
+            ->readable(false, fn (ProcedureSettings $procedureSetting): array => $this->globalConfig->getMapDefaultProjection());
 
         $configBuilder->publicSearchAutoZoom
             ->readable(false, function (ProcedureSettings $procedureSetting): float {
                 Assert::numeric($this->globalConfig->getMapPublicSearchAutozoom());
+
                 return (float) $this->globalConfig->getMapPublicSearchAutozoom();
             });
-
 
         if ($this->currentUser->hasPermission('feature_layer_groups_alternate_visibility')) {
             $configBuilder->showOnlyOverlayCategory
@@ -294,19 +294,19 @@ class ProcedureMapSettingResourceType extends DplanResourceType
     {
         $rawAvailableProjections = $this->globalConfig->getMapAvailableProjections();
 
-        $availableProjections = array_map(function($availableProjection) {
-            return $this->createAvailableProjectionVO($availableProjection) ;
+        $availableProjections = array_map(function ($availableProjection) {
+            return $this->createAvailableProjectionVO($availableProjection);
         }, $rawAvailableProjections);
 
         return $availableProjections;
-
-
     }
 
-    protected function createAvailableProjectionVO(array $availableProjection): AvailableProjectionVO {
+    protected function createAvailableProjectionVO(array $availableProjection): AvailableProjectionVO
+    {
         $availableProjectionVO = new AvailableProjectionVO();
         $availableProjectionVO->setLabel($availableProjection['label']);
         $availableProjectionVO->setValue($availableProjection['value']);
+
         return $availableProjectionVO->lock();
     }
 
@@ -345,7 +345,6 @@ class ProcedureMapSettingResourceType extends DplanResourceType
 
         return $baseLayerNames;
     }
-
 
     public function getEntityClass(): string
     {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -94,7 +94,7 @@ class ProcedureMapSettingResourceType extends DplanResourceType
         $configBuilder->baseLayerUrl
             ->readable(false, fn (ProcedureSettings $procedureSetting): string => $this->globalConfig->getMapAdminBaselayer());
 
-        $configBuilder->baseLayerNames
+        $configBuilder->baseLayerLayerNames
             ->readable(false, fn (ProcedureSettings $procedureSetting): array => $this->convertToListOfString($this->globalConfig->getMapAdminBaselayerLayers()));
 
         $configBuilder->baseLayerProjection

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -158,14 +158,12 @@ class ProcedureMapSettingResourceType extends DplanResourceType
                 ->readable(false, fn (ProcedureSettings $procedureSettings): ?array => $this->convertJsonToCoordinates($procedureSettings->getTerritory()));
         }
 
-        if ($this->currentUser->hasPermission('field_master_procedure_default_bounding_box')) {
-            $configBuilder->defaultBoundingBox
-                ->readable(false, function (ProcedureSettings $procedureSetting): ?array {
-                    $masterTemplateMapSetting = $this->masterTemplateService->getMasterTemplate()->getSettings();
+        $configBuilder->defaultBoundingBox
+            ->readable(false, function (ProcedureSettings $procedureSetting): ?array {
+                $masterTemplateMapSetting = $this->masterTemplateService->getMasterTemplate()->getSettings();
 
-                    return $this->convertFlatListToCoordinates($masterTemplateMapSetting->getBoundingBox(), true);
-                });
-        }
+                return $this->convertFlatListToCoordinates($masterTemplateMapSetting->getBoundingBox(), true);
+            });
 
         $configBuilder->defaultMapExtent
             ->readable(false, function (ProcedureSettings $procedureSetting): ?array {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -305,9 +305,8 @@ class ProcedureMapSettingResourceType extends DplanResourceType
 
     protected function createAvailableProjectionVO(array $availableProjection): AvailableProjectionVO {
         $availableProjectionVO = new AvailableProjectionVO();
-        $availableProjectionVO->setKey($availableProjection['label']);
         $availableProjectionVO->setLabel($availableProjection['label']);
-        $availableProjectionVO->setProjection($availableProjection['value']);
+        $availableProjectionVO->setValue($availableProjection['value']);
         return $availableProjectionVO->lock();
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -103,6 +103,12 @@ class ProcedureMapSettingResourceType extends DplanResourceType
         $configBuilder->defaultProjection
             ->readable(false, fn (ProcedureSettings $procedureSetting): array  => $this->globalConfig->getMapDefaultProjection());
 
+        $configBuilder->publicSearchAutoZoom
+            ->readable(false, function (ProcedureSettings $procedureSetting): float {
+                Assert::numeric($this->globalConfig->getMapPublicSearchAutozoom());
+                return (float) $this->globalConfig->getMapPublicSearchAutozoom();
+            });
+
 
         if ($this->currentUser->hasPermission('feature_layer_groups_alternate_visibility')) {
             $configBuilder->showOnlyOverlayCategory

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -286,7 +286,7 @@ class ProcedureMapSettingResourceType extends DplanResourceType
     }
 
     /**
-     * @return list<int>
+     * @return list<AvailableProjectionVO>
      */
     protected function getAvailableProjections(): array
     {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureMapSettingResourceType.php
@@ -20,6 +20,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceTyp
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\MasterTemplateService;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\ProcedureMapSettingResourceConfigBuilder;
+use demosplan\DemosPlanCoreBundle\ValueObject\Procedure\AvailableProjectionVO;
 use demosplan\DemosPlanCoreBundle\ValueObject\SettingsFilter;
 use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use Webmozart\Assert\Assert;
@@ -82,6 +83,9 @@ class ProcedureMapSettingResourceType extends DplanResourceType
             ->readable();
         $configBuilder->availableScales
             ->readable(false, $this->getAvailableScales(...));
+
+        $configBuilder->availableProjections
+            ->readable(false, $this->getAvailableProjections(...));
 
         if ($this->currentUser->hasPermission('feature_layer_groups_alternate_visibility')) {
             $configBuilder->showOnlyOverlayCategory
@@ -258,6 +262,30 @@ class ProcedureMapSettingResourceType extends DplanResourceType
     protected function getAvailableScales(): array
     {
         return $this->convertToListOfInt(str_replace(['[', ']'], '', (string) $this->globalConfig->getMapPublicAvailableScales()));
+    }
+
+    /**
+     * @return list<int>
+     */
+    protected function getAvailableProjections(): array
+    {
+        $rawAvailableProjections = $this->globalConfig->getMapAvailableProjections();
+
+        $availableProjections = array_map(function($availableProjection) {
+            return $this->createAvailableProjectionVO($availableProjection) ;
+        }, $rawAvailableProjections);
+
+        return $availableProjections;
+
+
+    }
+
+    protected function createAvailableProjectionVO(array $availableProjection): AvailableProjectionVO {
+        $availableProjectionVO = new AvailableProjectionVO();
+        $availableProjectionVO->setKey($availableProjection['label']);
+        $availableProjectionVO->setLabel($availableProjection['label']);
+        $availableProjectionVO->setProjection($availableProjection['value']);
+        return $availableProjectionVO->lock();
     }
 
     protected function convertListOfIntToString(array $values): string

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
@@ -24,5 +24,4 @@ class AvailableProjectionVO extends ValueObject
 {
     protected string $label;
     protected string $value;
-
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject\Procedure;
+
+use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
+
+/**
+ * @method string getKey()
+ * @method void   setKey(string $key)
+ * @method string getLabel()
+ * @method void   setLabel(string $label)
+ * @method string getProjection()
+ * @method void   setProjection(string $projection)
+ */
+class AvailableProjectionVO extends ValueObject
+{
+    protected string $key;
+    protected string $label;
+    protected string $projection;
+
+}

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Procedure/AvailableProjectionVO.php
@@ -15,17 +15,14 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject\Procedure;
 use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
 
 /**
- * @method string getKey()
- * @method void   setKey(string $key)
  * @method string getLabel()
  * @method void   setLabel(string $label)
- * @method string getProjection()
- * @method void   setProjection(string $projection)
+ * @method string getValue()
+ * @method void   setValue(string $projection)
  */
 class AvailableProjectionVO extends ValueObject
 {
-    protected string $key;
     protected string $label;
-    protected string $projection;
+    protected string $value;
 
 }


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11443/Permissions-checken-ResourceType-vorbereiten

Description:
- For the Kartenausschnitt, the following ProcedureMapSettings resource type is created with following fields:

Following fields needed to be added:
-     availableProjections -> in api request has the same name
-     baseLayer -> baseLayerUrl
-     baseLayerLayers - > baseLayerNames
-     baseLayerProjection -> in api request has the same name
-     defaultProjection -> in api request has the same name
-     globalAvailableScales -> in api request has the same name
-     publicSearchAutoZoom -> in api request has the same name

Those fields are only readable (as they from from yml)


### How to review/test
- Use PHPStorm HttpClient
- Create GET api calls like (only  through Procedure resourcetype get api using include=mapSetting the ProcedureMapSetting resourcetype is available
```
GET {project_url}/api/2.0/Procedure/{procedure_id}?
    include=mapSetting&
    fields[Procedure]=mapSetting&
    fields[ProcedureMapSetting]=
    boundingBox,
    mapExtent,
    scales,
    informationUrl,
    copyright,
    showOnlyOverlayCategory,
    availableScales,
    coordinate,
    territory,
    defaultBoundingBox,
    defaultMapExtent,
    useGlobaInformationUrl,
    availableProjections,
    baseLayerUrl,
    baseLayerNames,
    baseLayerProjection,
    defaultProjection,
    globalAvailableScales,
    publicSearchAutoZoom
```

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
