### PR TITLE
chore: symfony dependencies could be grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,7 +73,23 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: friendsofsymfony/jsrouting-bundle
         update-types: [ "version-update:semver-major" ]
-
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+        exclude-patterns:
+          - "symfony/cache-contracts"
+          - "symfony/deprecation-contracts"
+          - "symfony/event-dispatcher-contracts"
+          - "symfony/flex"
+          - "symfony/http-client-contracts"
+          - "symfony/maker-bundle"
+          - "symfony/monolog-bundle"
+          - "symfony/phpunit-bridge"
+          - "symfony/polyfill*"
+          - "symfony/psr-http-message-bridge"
+          - "symfony/service-contracts"
+          - "symfony/translation-contracts"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This PR introduces a dependency group for all symfony dependencies that are updated together. 

### How to review/test
List of excludes can be validated via `composer show`

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
