### PR TITLE
chore: create addonZips dir if it does not exist

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -103,6 +103,8 @@ class AddonInstallFromZipCommand extends CoreCommand
         $folder = $input->getOption('folder');
         $branch = $input->getOption('branch');
 
+        $this->createDirectoryIfNecessary(DemosPlanPath::getRootPath($folder));
+
         if (null === $path) {
             try {
                 if ($input->getOption('local')) {


### PR DESCRIPTION
Just a small quality of life improvement that creates the addonZips folder if it does not exist yet

### How to review/test
delete the folder if it exists and install an addon from github

### Linked PRs (optional)
<!-- List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

### Tasks (optional)
<!-- A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
