### PR TITLE
Fix dplan 11494 update pi proposals with excel imported tags

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Event/Statement/StatementCreatedViaExcelEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/StatementCreatedViaExcelEvent.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * This file is part of the package demosplan.
  *

--- a/demosplan/DemosPlanCoreBundle/Event/Statement/StatementCreatedViaExcelEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/StatementCreatedViaExcelEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Event\Statement;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedViaExcelEventInterface;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
+class StatementCreatedViaExcelEvent extends DPlanEvent implements StatementCreatedViaExcelEventInterface
+{
+    protected StatementInterface $statement;
+
+    public function __construct(StatementInterface $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    public function getStatement(): StatementInterface
+    {
+        return $this->statement;
+    }
+}


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-11494/Nach-Excel-Import-von-verschlagworteten-Abschnitten-werden-trotzdem-keine-Vorschlage-bei-Slicing-Tagging-angezeigt

Description: 

PI proposals have to be updated with the new Excel imported tags. The 'StatementCreatedViaExcelEvent' will be dispatched with every new already segmented generated statement and a segmentation request will be send to DATA.
The only purpose to do that here is to get a pi segments proposal resource url from Data which is needed while sending segmentation confirmation request and passing imported tagged sections with Excel to DATA to make them available in the next segmentation proposals.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Update documentation
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
