### PR TITLE
feat(refs DPLAN-3570): add permissions for map settings

### DIFF
--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -37,9 +37,9 @@
       :max-extent="procedureMapSettings.attributes.defaultMapExtent"
       :procedure-id="procedureId"
       :procedure-coordinates="procedureMapSettings.attributes.coordinate"
-      :procedure-territory="procedureMapSettings.attributes.territory"
+      :procedure-init-territory="procedureMapSettings.attributes.territory"
       :scales="procedureMapSettings.attributes.availableScales"
-      @update="setExtent" />
+      @field:update="setField" />
 
     <div class="layout__item">
       <map-admin-scales
@@ -80,18 +80,6 @@
         hint: Translator.trans('explanation.gislayer.layergroup.toggle.alternating.visibility.extended'),
         text: Translator.trans('explanation.gislayer.layergroup.toggle.alternating.visibility')
       }" />
-
-    <input
-      aria-hidden="true"
-      name="r_territory"
-      type="hidden"
-      :value="JSON.stringify(procedureMapSettings.attributes.territory)">
-
-    <input
-      aria-hidden="true"
-      name="r_coordinate"
-      type="hidden"
-      :value="procedureMapSettings.attributes.coordinate">
 
     <div class="layout__item u-1-of-1 text-right u-mt-0_5 space-inline-s">
       <input
@@ -175,7 +163,7 @@ export default {
           mapExtent: [],
           boundingBox: [],
           scales: [],
-          territory: '{}'
+          territory: {}
         }
       }
     }
@@ -256,6 +244,10 @@ export default {
         payload.data.attributes.boundingBox = convertExtentToObject(updateData.boundingBox)
       }
 
+      if (hasPermission('area_procedure_adjustments_general_location')) {
+        payload.data.attributes.coordinate = convertExtentToObject(updateData.coordinate)
+      }
+
       if (hasPermission('feature_layer_groups_alternate_visibility')) {
         payload.data.attributes.layerGroupsAlternateVisibility = updateData.layerGroupsAlternateVisibility
       }
@@ -284,8 +276,8 @@ export default {
         })
     },
 
-    setExtent ({ field, extent }) {
-      this.procedureMapSettings.attributes[field] = extent
+    setField ({ field, data }) {
+      this.procedureMapSettings.attributes[field] = data
     }
   },
 

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -240,7 +240,7 @@ export default {
     },
 
     center () {
-      return this.procedureCoordinates ? this.procedureCoordinates : false
+      return this.procedureCoordinates?.length > 0 ? this.procedureCoordinates : false
     }
   },
 

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -51,12 +51,12 @@
           <dp-ol-map-set-extent
             data-cy="mapDefaultBounds"
             translation-key="map.default.bounds"
-            @extentSet="data => emitFieldUpdate({ field: 'boundingBox', extent: data })" />
+            @extentSet="data => emitFieldUpdate({ field: 'boundingBox', data: data })" />
           <dp-ol-map-set-extent
             v-if="hasPermission('feature_map_max_extent')"
             data-cy="boundsApply"
             translation-key="bounds.apply"
-            @extentSet="data => emitFieldUpdate({ field: 'mapExtent', extent: data })" />
+            @extentSet="data => emitFieldUpdate({ field: 'mapExtent', data: data })" />
           <dp-contextual-help
             class="float-right"
             :text="Translator.trans('text.mapsection')" />

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -53,6 +53,7 @@
             translation-key="map.default.bounds"
             @extentSet="data => setExtent({ field: 'boundingBox', extent: data })" />
           <dp-ol-map-set-extent
+            v-if="hasPermission('feature_map_max_extent')"
             data-cy="boundsApply"
             translation-key="bounds.apply"
             @extentSet="data => setExtent({ field: 'mapExtent', extent: data })" />

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -185,9 +185,9 @@ export default {
     },
 
     procedureCoordinates: {
+      type: Array,
       required: false,
-      type: String,
-      default: ''
+      default: () => []
     },
 
     procedureId: {
@@ -205,7 +205,7 @@ export default {
 
   data () {
     return {
-      coordinate: this.procedureCoordinates.split(','),
+      coordinate: this.procedureCoordinates,
       drawingStyles: {
         mapExtent: JSON.stringify({
           fillColor: 'rgba(0,0,0,0.1)',
@@ -223,7 +223,7 @@ export default {
 
   computed: {
     procedureCoordinatesFeature () {
-      if (this.procedureCoordinates !== '') {
+      if (this.procedureCoordinates.length > 0) {
         return {
           type: 'FeatureCollection',
           features: [{
@@ -240,15 +240,7 @@ export default {
     },
 
     center () {
-      if (this.procedureCoordinates) {
-        const array = this.procedureCoordinates.split(',')
-        return [
-          Number(array[0]),
-          Number(array[1])
-        ]
-      } else {
-        return false
-      }
+      return this.procedureCoordinates ? this.procedureCoordinates : false
     }
   },
 

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -51,12 +51,12 @@
           <dp-ol-map-set-extent
             data-cy="mapDefaultBounds"
             translation-key="map.default.bounds"
-            @extentSet="data => setExtent({ field: 'boundingBox', extent: data })" />
+            @extentSet="data => emitFieldUpdate({ field: 'boundingBox', extent: data })" />
           <dp-ol-map-set-extent
             v-if="hasPermission('feature_map_max_extent')"
             data-cy="boundsApply"
             translation-key="bounds.apply"
-            @extentSet="data => setExtent({ field: 'mapExtent', extent: data })" />
+            @extentSet="data => emitFieldUpdate({ field: 'mapExtent', extent: data })" />
           <dp-contextual-help
             class="float-right"
             :text="Translator.trans('text.mapsection')" />
@@ -83,7 +83,7 @@
               strokeLineDash: [4,4],
               strokeLineWidth: 3
             }"
-            :features="initTerritory"
+            :features="procedureInitTerritory"
             icon-class="fa fa-pencil-square-o"
             :label="Translator.trans('map.territory.define')"
             name="Territory"
@@ -197,10 +197,10 @@ export default {
       default: ''
     },
 
-    procedureTerritory: {
+    procedureInitTerritory: {
+      type: Object,
       required: false,
-      type: String,
-      default: '{}'
+      default: () => {}
     }
   },
 
@@ -216,9 +216,8 @@ export default {
           strokeLineWidth: 3
         })
       },
-      initTerritory: JSON.parse(this.procedureTerritory),
       isActive: '',
-      territory: JSON.parse(this.procedureTerritory)
+      territory: {}
     }
   },
 
@@ -254,17 +253,19 @@ export default {
   methods: {
     updateTerritory (data) {
       this.territory = JSON.parse(data)
+      this.emitFieldUpdate({ field: 'territory', data: this.territory })
     },
 
     updateCoordinates (data) {
       const features = JSON.parse(data).features
       if (JSON.parse(data).features.length > 0) {
         this.coordinate = features[0].geometry.coordinates
+        this.emitFieldUpdate({ field: 'coordinate', data: this.coordinate })
       }
     },
 
-    setExtent (data) {
-      this.$emit('update', data)
+    emitFieldUpdate (data) {
+      this.$emit('field:update', data)
     }
   }
 }

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -70,7 +70,7 @@ export default {
                 mapExtent: convertExtentToFlatArray(data.mapExtent) ?? defaultMapExtent, // Maximum extent of the map
                 boundingBox: convertExtentToFlatArray(data.boundingBox) ?? defaultBoundingBox, // Extent on load of the map
                 scales: data.scales?.map(scale => ({ label: `1:${scale.toLocaleString()}`, value: scale })) ?? [],
-                territory: data.territory ?? '{}'
+                territory: data.territory ?? {}
               },
               id: response.data.included[0].id,
               type: 'ProcecdureMapSetting'

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -51,7 +51,7 @@ export default {
             const procedureMapSettings = {
               attributes: {
                 availableScales: data.availableScales.map(scale => ({ label: `1:${scale.toLocaleString('de-DE')}`, value: scale })) ?? [],
-                coordinate: data.coordinate ?? '',
+                coordinate: convertExtentToFlatArray(data.coordinate) ?? '',
                 copyright: data.copyright ?? '',
                 defaultBoundingBox: defaultBoundingBox,
                 defaultMapExtent: defaultMapExtent,
@@ -60,7 +60,7 @@ export default {
                 showOnlyOverlayCategory: data.showOnlyOverlayCategory ?? false,
                 mapExtent: convertExtentToFlatArray(data.mapExtent) ?? defaultMapExtent, // Maximum extent of the map
                 boundingBox: convertExtentToFlatArray(data.boundingBox) ?? defaultBoundingBox, // Extent on load of the map
-                scales: data.scales.map(scale => ({ label: `1:${scale.toLocaleString()}`, value: scale })) ?? [],
+                scales: data.scales?.map(scale => ({ label: `1:${scale.toLocaleString()}`, value: scale })) ?? [],
                 territory: data.territory ?? '{}'
               },
               id: response.data.included[0].id,

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -12,16 +12,25 @@ export default {
         const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'Procedure' })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
-          'copyright',
           'defaultBoundingBox',
           'defaultMapExtent',
-          'featureInfoUrl',
-          'informationUrl',
-          'mapExtent',
           'scales'
         ]
         if (hasPermission('area_procedure_adjustments_general_location')) {
           procedureMapSettingFields.push('coordinate')
+        }
+
+        if (hasPermission('feature_map_max_extent')) {
+          procedureMapSettingFields.push('mapExtent')
+        }
+
+        if (hasPermission('feature_map_feature_info')) {
+          procedureMapSettingFields.push('informationUrl')
+          procedureMapSettingFields.push('featureInfoUrl')
+        }
+
+        if (hasPermission('feature_map_attribution')) {
+          procedureMapSettingFields.push('copyright')
         }
 
         if (hasPermission('feature_map_use_territory')) {


### PR DESCRIPTION
### Ticket
DPLAN-3570

- Add missing permissions for fields
- Remove redundant input fields for territory and coordinate
- Add updating for territory and coordinates
- Show translation if there is no (default) map extent/boundingbox

### How to review/test
Verfahren -> Planunterlagen und Planzeichnung -> Startkartenausschnitt -> Geltungsbereich und Ortsbezug zeichnen -> Edit and save should work as expected