### PR TITLE
chore (refs DPLAN-603): throttle password reset requests

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -10,3 +10,8 @@ framework:
             policy: 'token_bucket'
             limit: 2
             rate: { interval: '60 minutes', amount: 1 }
+        # limit password reset requests
+        user_password_reset:
+            policy: 'token_bucket'
+            limit: 5
+            rate: { interval: '15 minutes', amount: 2 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -4040,6 +4040,7 @@ warning.topic.in.use: "Das Thema {topicname} kann nicht gelöscht werden, weil e
 warning.topic.renamed: "Das Thema {topicname} konnte nicht umbenannt werden."
 warning.use.login: "Anmeldung fehlgeschlagen. Bitte nutzen Sie Ihren Nutzendennamen, um sich anzumelden."
 warning.user.register.throttle: "Es können im Moment keine weiteren Accounts angelegt werden. Bitte versuchen Sie es später erneut."
+warning.user.pass.reset.throttle: "Es können keine weiteren Passwort zurücksetzen Anfragen gestellt werden. Bitte versuchen Sie es später erneut."
 warning.virus.found: "In der Datei {filename} wurde ein Virus gefunden."
 warning.gisLayerCategory.delete.because.of.children: "Die Kategorie {categoryName} konnte nicht gelöscht werden, weil sie noch Kategorien oder Kartenebenen enthält."
 warning.gisLayer.automatic.removed.from.group: "Die Kartenebene \"{gisLayerName}\" wurde aus der Sichtbarkeitsgruppe gelöst, weil es nicht erlaubt ist, die Kartenebene in der Beteiligungsebene auszublenden."


### PR DESCRIPTION
### Ticket DPLAN-603

Similar to #3011 the number of password reset requests needs to be throttled

### How to review/test
code review or try to reset the password more than 5 times in 15 Minutes

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
