### PR TITLE
fix(refs DPLAN-3570): Add resetbutton to map settings

### DIFF
--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -98,15 +98,16 @@
         type="submit"
         @click="() => save(true)" />
       <dp-button
+        v-if="hasPermission('area_admin_single_document')"
         color="secondary"
         data-cy="abort"
         :href="Routing.generate('DemosPlan_element_administration', { procedure: procedureId })"
         :text="Translator.trans('abort')" />
       <dp-button
+        v-else
         color="secondary"
         data-cy="reset"
         :text="Translator.trans('reset')"
-        variant="outline"
         @click="reset" />
     </div>
   </div>

--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -82,35 +82,41 @@
       }" />
 
     <div class="layout__item u-1-of-1 text-right u-mt-0_5 space-inline-s">
-      <input
-        class="btn btn--primary"
+      <dp-button
+        data-cy="save"
         :disabled="!areScalesSuitable"
-        type="submit"
         name="saveConfig"
-        :value="Translator.trans('save')"
-        @click="() => save()">
-      <input
-        v-if="hasPermission('area_admin_single_document')"
-        class="btn btn--primary"
-        :disabled="!areScalesSuitable"
+        :text="Translator.trans('save')"
         type="submit"
+        @click="() => save()" />
+      <dp-button
+        v-if="hasPermission('area_admin_single_document')"
+        data-cy="saveAndReturn"
+        :disabled="!areScalesSuitable"
         name="submit_item_return_button"
-        :value="Translator.trans('save.and.return.to.list')"
-        @click="() => save(true)">
-      <a
-        class="btn btn--secondary"
-        :href="Routing.generate('DemosPlan_element_administration', { procedure: procedureId })">
-        {{ Translator.trans('abort') }}
-      </a>
+        :text="Translator.trans('save.and.return.to.list')"
+        type="submit"
+        @click="() => save(true)" />
+      <dp-button
+        color="secondary"
+        data-cy="abort"
+        :href="Routing.generate('DemosPlan_element_administration', { procedure: procedureId })"
+        :text="Translator.trans('abort')" />
+      <dp-button
+        color="secondary"
+        data-cy="reset"
+        :text="Translator.trans('reset')"
+        variant="outline"
+        @click="reset" />
     </div>
   </div>
 </template>
 <script>
-import { checkResponse, dpApi, DpCheckbox, DpInput } from '@demos-europe/demosplan-ui'
+import { checkResponse, dpApi, DpButton, DpCheckbox, DpInput } from '@demos-europe/demosplan-ui'
+import { mapActions, mapState } from 'vuex'
 import { Attribution } from 'ol/control'
 import convertExtentToObject from '../map/utils/convertExtentToObject'
 import { fromExtent } from 'ol/geom/Polygon'
-import { mapActions } from 'vuex'
 import MapAdminScales from './MapAdminScales'
 import MapView from '@DpJs/components/map/map/MapView'
 
@@ -118,6 +124,7 @@ export default {
   name: 'MapAdmin',
 
   components: {
+    DpButton,
     DpCheckbox,
     DpInput,
     MapAdminScales,
@@ -170,6 +177,10 @@ export default {
   },
 
   computed: {
+    ...mapState('ProcedureMapSettings', {
+      originalProcedureMapSettings: 'procedureMapSettings'
+    }),
+
     attributionControl () {
       return new Attribution({ collapsible: false })
     },
@@ -221,6 +232,10 @@ export default {
 
   methods: {
     ...mapActions('ProcedureMapSettings', ['fetchProcedureMapSettings']),
+
+    reset () {
+      this.procedureMapSettings = this.originalProcedureMapSettings
+    },
 
     save (returnToOverview = false) {
       const url = Routing.generate('api_resource_update', { resourceType: 'ProcedureMapSetting', resourceId: this.procedureMapSettings.id })

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -6,6 +6,16 @@ export default {
 
   name: 'ProcedureMapSettings',
 
+  state: {
+    procedureMapSettings: {}
+  },
+
+  mutations: {
+    setItem (state, { key, value }) {
+      state[key] = value
+    }
+  },
+
   actions: {
     fetchProcedureMapSettings ({ commit }, procedureId) {
       try {
@@ -76,6 +86,7 @@ export default {
               type: 'ProcecdureMapSetting'
             }
 
+            commit('setItem', { key: 'procedureMapSettings', value: procedureMapSettings })
             return procedureMapSettings
           })
       } catch (e) {

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -133,6 +133,7 @@ area_admin_protocol:
 area_admin_single_document:
     label: 'Verwalten Planungsdokumente'
     loginRequired: true
+    expose: true
     parent: area_admin
 area_admin_statement_list:
     description: 'New list with Statements belonging to a Procedure showing basic info for each Statement so the planner can have a quick overview of the status of the Procedure.'


### PR DESCRIPTION
### Ticket
DPLAN-3570

on the mapSettingspage there now is a "reset" Button. It should reset the settings  (not the map zoom) to the data stored before saved. 


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
