### PR TITLE
f DPLAN-11596 copy blueprint legend while procedure creation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -734,7 +734,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      */
     public function getAuthorizedUsers(
         $procedureId,
-        User $user = null,
+        ?User $user = null,
         $excludeUser = false,
         $excludeProcedureAuthorizedUsers = true
     ): Collection {
@@ -1778,7 +1778,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     /**
      * @throws CustomerNotFoundException
      */
-    public function calculateCopyMasterId(string $incomingCopyMasterId = null): string
+    public function calculateCopyMasterId(?string $incomingCopyMasterId = null): string
     {
         // use global default blueprint as default anyway:
         $masterTemplateId = $this->getMasterTemplateId();
@@ -2381,7 +2381,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */
-    public function isUserAuthorized(string $procedureId, User $user = null): bool
+    public function isUserAuthorized(string $procedureId, ?User $user = null): bool
     {
         if (null === $user) {
             $user = $this->currentUser->getUser();
@@ -2711,7 +2711,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     }
 
     /**
-     * Will copy legend file and reference it to the created procedure
+     * Will copy legend file and reference it to the created procedure.
      *
      * @throws Exception
      */
@@ -2721,7 +2721,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
             $blueprint = $this->getProcedureWithCertainty($blueprintId);
             $legendStringFromBlueprint = $blueprint->getSettings()->getPlanPDF();
 
-            if ($legendStringFromBlueprint === '') {
+            if ('' === $legendStringFromBlueprint) {
                 return;
             }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2729,8 +2729,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
             $copiedFile = $this->fileService->copyByFileString($legendStringFromBlueprint, $newProcedure->getId());
 
             // set planPDF with the referenced legends file and update procedure setting
-            $newProcedurePlanPdf = 'kopie_von'.$copiedFile->getName().':'.$copiedFile->getId().':'.$copiedFile->getMimetype();
-
+            $newProcedurePlanPdf = $copiedFile->getFileString();
             $newProcedureSettings = $newProcedure->getSettings();
 
             $newProcedureSettings->setPlanPDF($newProcedurePlanPdf);

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -14,6 +14,7 @@ use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostNewProcedureCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureDeletedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureUpdatedEventInterface;
@@ -71,6 +72,7 @@ use demosplan\DemosPlanCoreBundle\Repository\BoilerplateGroupRepository;
 use demosplan\DemosPlanCoreBundle\Repository\BoilerplateRepository;
 use demosplan\DemosPlanCoreBundle\Repository\ElementsRepository;
 use demosplan\DemosPlanCoreBundle\Repository\EntityContentChangeRepository;
+use demosplan\DemosPlanCoreBundle\Repository\FileRepository;
 use demosplan\DemosPlanCoreBundle\Repository\GisLayerCategoryRepository;
 use demosplan\DemosPlanCoreBundle\Repository\InstitutionMailRepository;
 use demosplan\DemosPlanCoreBundle\Repository\NewsRepository;
@@ -163,6 +165,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     protected $fieldConfigurator;
 
     public function __construct(
+        private readonly FileRepository $fileRepository,
         private readonly BoilerplateCategoryRepository $boilerplateCategoryRepository,
         private readonly BoilerplateGroupRepository $boilerplateGroupRepository,
         private readonly BoilerplateRepository $boilerplateRepository,
@@ -2693,6 +2696,9 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
         // copy NotificationReceiver (Email to counties T433)
         $this->notificationReceiverRepository->copy($blueprintId, $newProcedure->getId());
 
+        // copy procedure legend file.
+        $this->copyLegend($blueprintId, $newProcedure);
+
         // copy demosplan\DemosPlanCoreBundle\Entity\Setting.php: (not procedure.settings)
         $this->settingRepository->copy($blueprintId, $newProcedure);
 
@@ -2702,6 +2708,36 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
         $additionalDataEvent = $this->eventDispatcher->dispatch(new NewProcedureAdditionalDataEvent($newProcedure));
 
         return $additionalDataEvent->getProcedure();
+    }
+
+    /**
+     * Will copy legend file and reference it to the created procedure
+     *
+     * @throws Exception
+     */
+    private function copyLegend($blueprintId, ProcedureInterface $newProcedure): void
+    {
+        try {
+            $blueprint = $this->getProcedureWithCertainty($blueprintId);
+            $legendStringFromBlueprint = $blueprint->getSettings()->getPlanPDF();
+
+            if ($legendStringFromBlueprint === '') {
+                return;
+            }
+
+            // copy legend
+            $copiedFile = $this->fileService->copyByFileString($legendStringFromBlueprint, $newProcedure->getId());
+
+            // set planPDF with the referenced legends file and update procedure setting
+            $newProcedurePlanPdf = 'kopie_von'.$copiedFile->getName().':'.$copiedFile->getId().':'.$copiedFile->getMimetype();
+
+            $newProcedureSettings = $newProcedure->getSettings();
+
+            $newProcedureSettings->setPlanPDF($newProcedurePlanPdf);
+        } catch (Exception $e) {
+            $this->logger->warning('Copy legends file failed. Message: ', [$e]);
+            throw $e;
+        }
     }
 
     private function copyPlaces(string $sourceProcedureTemplateId, Procedure $targetProcedure): void


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11596

Description: 
we have till now a universal legend which references only the to blueprint procedure and can not be applied anymore to all other procedures. To make the legend available, the method 'copyLegend' copy the blueprint legend file and make it refer to the created procedure.



Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
