### PR TITLE
Feat(dplan-3297): add tooltip for the email text

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
@@ -94,7 +94,8 @@
             <div class="{{ 'u-mb-0_75'|prefixClass }}">
                 <dp-label
                     for="r_emailText"
-                    text="{{ 'email.body'|trans }}">
+                    text="{{ 'email.body'|trans }}"
+                    tooltip="{{ 'explanation.unregistered.publicagency.email.links'|trans }}">
                 </dp-label>
                 <dp-editor
                     id="r_emailText"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_unregistered_publicagency_email.html.twig
@@ -95,7 +95,7 @@
                 <dp-label
                     for="r_emailText"
                     text="{{ 'email.body'|trans }}"
-                    tooltip="{{ 'explanation.unregistered.publicagency.email.links'|trans }}">
+                    tooltip="{{ 'explanation.unregistered.publicagency.email'|trans }}">
                 </dp-label>
                 <dp-editor
                     id="r_emailText"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1541,6 +1541,7 @@ explanation.territory.help.edit: "Mit dem Werkzeug <strong>\"{editTool}\"</stron
 explanation.territory.help.delete.selected: "Durch Klick auf <strong>\"{deleteSelectedTool}\"</strong> löschen Sie die aktuell mit \"{editTool}\" ausgewählten Formen."
 explanation.territory.help.delete.all: "Durch Klick auf <strong>\"{deleteAllTool}\"</strong> löschen Sie alle Formen."
 explanation.territory.is.defined: "Sie haben bereits den <strong>GIS-Layer {layerName}</strong> als Geltungsbereich definiert. Dieser wird im öffentlichen Bereich dem hier eingezeichneten Geltungsbereich vorgezogen."
+explanation.unregistered.publicagency.email: "Der E-Mail-Text kann angepasst werden."
 explanation.upload.logo.dimensions: "Für eine optimale Darstellung sollte das Logo höchstens 300 x 100 Pixel (72dpi) groß sein. Sie können es im JPEG-, PNG- oder GIF-Format hochladen."
 explanation.url.set: "Diese Informationsseite ist unter dieser Webadresse <a href=\"/info/{infopageURL}\">{infopageURL}</a> aufrufbar."
 explanation.user.email: "Mit der E-Mail-Adresse meldet sich der/die Nutzer*in später bei {projectName} an."


### PR DESCRIPTION
### Ticket
[DPLAN-3297](https://demoseurope.youtrack.cloud/issue/DPLAN-3297/2-Als-Fachplanung-mochte-ich-Institutionen-per-E-Mail-zu-einem-Verfahren-einladen-konnen-obwohl-sie-noch-nicht-in-BLP)

**Description:** This PR adds a tooltip for the email text. It is required for the BLP project, but it also needs to be included in the core for other projects with some default text.

### How to review/test
Verfahren wählen > Institutionen verwalten > Unregistrierte Institutionen einladen (Tab) (>E-Mail Einladung Verfassen > Ihre Nachricht)

### Linked PRs 

- blp #{[PR-101](https://github.com/demos-europe/demosplan-project-blp/pull/101)}
- demosplan-ui #{[PR-851](https://github.com/demos-europe/demosplan-ui/pull/851)}

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
