### PR TITLE
chore: trim on null is deprecated

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragment.php
@@ -1439,7 +1439,7 @@ class StatementFragment extends CoreEntity implements UuidEntityInterface, State
             $this->paragraphTitle = $this->paragraph->getTitle();
         }
 
-        return trim($this->paragraphTitle);
+        return trim($this->paragraphTitle ?? '');
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragmentVersion.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/StatementFragmentVersion.php
@@ -678,7 +678,7 @@ class StatementFragmentVersion extends CoreEntity implements UuidEntityInterface
     public function getParagraphTitle()
     {
         if ($this->paragraph instanceof ParagraphVersionInterface) {
-            return trim($this->paragraph->getTitle());
+            return trim($this->paragraph->getTitle() ?? '');
         }
 
         return '';


### PR DESCRIPTION
Minor improvement, passing null to trim is deprecated


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
check the logs e.g. during elasticsearch populate

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
