### PR TITLE
chore (refs DPLAN-1078): add missing gatewayURL

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -1179,6 +1179,7 @@ class DemosPlanProcedureController extends BaseController
                 'organisation'       => $organization,
                 'procedureMainEmail' => $procedureMainEmail,
             ],
+            'gatewayURL'             => $this->globalConfig->getGatewayURL(),
         ];
 
         return $this->twig


### PR DESCRIPTION
### Ticket
DPLAN-1078

Twig referenced to a variable gatewayURL that was not passed to the template because the template is rendered explicitly via php and not as usually as "normal" twig code where the `DefaultTwigVariablesService` enhances a bunch of variables.

### How to review/test
See reproduction way in ticket

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
