### PR TITLE
fix (refs DPLAN-11422): add composer_lock_for_minor_demosplan_addon_update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "cocur/slugify": "^4.0",
         "composer/package-versions-deprecated": "1.11.99.5",
         "demos-europe/edt-extra": "^0.24.0",
-        "demos-europe/demosplan-addon": "^0",
+        "demos-europe/demosplan-addon": "^0.24",
         "doctrine/annotations": "^2.0",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7db374306092bef14d473b2c6b1f859",
+    "content-hash": "bd5e6de9f3c3027499b51f72bee6414f",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1359,16 +1359,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.24",
+            "version": "v0.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "05dc06dca9e1999d8e790d236e5f4d55b6a998a7"
+                "reference": "178f29d5b3bcc00c059e48c4cee91e4bb16a78a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/05dc06dca9e1999d8e790d236e5f4d55b6a998a7",
-                "reference": "05dc06dca9e1999d8e790d236e5f4d55b6a998a7",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/178f29d5b3bcc00c059e48c4cee91e4bb16a78a5",
+                "reference": "178f29d5b3bcc00c059e48c4cee91e4bb16a78a5",
                 "shasum": ""
             },
             "require": {
@@ -1432,9 +1432,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.24"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.24.1"
             },
-            "time": "2024-02-02T08:47:35+00:00"
+            "time": "2024-05-21T13:52:29+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",


### PR DESCRIPTION
Ticket:
https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/15514

Description:
add composer_lock_for_minor_demosplan_addon_update

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
