### PR TITLE
bug: fix browser tracing sentry

### DIFF
--- a/client/js/loadSentry.js
+++ b/client/js/loadSentry.js
@@ -8,13 +8,13 @@
  */
 
 import * as Sentry from '@sentry/browser'
-import { BrowserTracing } from '@sentry/tracing'
+import { browserTracingIntegration } from '@sentry/browser'
 
 export default function loadSentry () {
   if (window.dplan.sentryDsn !== '') {
     Sentry.init({
       dsn: window.dplan.sentryDsn,
-      integrations: [new BrowserTracing({
+      integrations: [browserTracingIntegration({
         attachProps: true,
         tracing: true,
         tracingOptions: {


### PR DESCRIPTION
After updating sentry, browser tracing was moved to browser package and is now exported as browserTracingIntegration.
