### PR TITLE
F dplan 11494 request segmentation after statements are committed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -15,7 +15,6 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Import\Statement;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
-use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedViaExcelEventInterface;
 use demosplan\DemosPlanCoreBundle\Constraint\DateStringConstraint;
 use demosplan\DemosPlanCoreBundle\Constraint\MatchingFieldValueInSegments;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\GdprConsent;
@@ -27,7 +26,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\EntityValidator\SegmentValidator;
 use demosplan\DemosPlanCoreBundle\EntityValidator\TagValidator;
-use demosplan\DemosPlanCoreBundle\Event\Statement\StatementCreatedViaExcelEvent;
 use demosplan\DemosPlanCoreBundle\Exception\CopyException;
 use demosplan\DemosPlanCoreBundle\Exception\DuplicatedTagTitleException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
@@ -50,7 +48,6 @@ use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\Querying\Contracts\PathException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraint;
@@ -102,7 +99,6 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
         private readonly DqlConditionFactory $conditionFactory,
         private readonly EntityManagerInterface $entityManager,
         ElementsService $elementsService,
-        private readonly EventDispatcherInterface $eventDispatcher,
         OrgaService $orgaService,
         private readonly PlaceService $placeService,
         private readonly SegmentValidator $segmentValidator,
@@ -265,12 +261,6 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
 
                 ++$counter;
             }
-
-            // this event allows to send segmentation proposals requests
-            $this->eventDispatcher->dispatch(
-                new StatementCreatedViaExcelEvent($generatedStatement),
-                StatementCreatedViaExcelEventInterface::class
-            );
 
             unset($segments[$statementId]);
         }


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11494/Nach-Excel-Import-von-verschlagworteten-Abschnitten-werden-trotzdem-keine-Vorschlage-bei-Slicing-Tagging-angezeigt


Description: 
request segmentation after statements are committed: dispatch 'StatementCreatedViaExcelEvent' after statements are committed.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

