### PR TITLE
fix (ref DPLAN-11370) Escape special chars to diplay file name using latex

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
@@ -64,7 +64,7 @@
                 {{ "file"|trans|latex|raw }}: &
                 {% if statement.files|default([])|length > 0 %}
                     {% for file in statement.files %}
-                        {{ file|getFile('name')|raw }}
+                        {{ file|getFile('name')|latex|raw }}
                     {% endfor%}
                 {% else %}
                     {{ "notspecified"|trans|latex|raw }}


### PR DESCRIPTION
### Ticket https://demoseurope.youtrack.cloud/issue/DPLAN-11370/Dateiname-von-hochgeladener-Datei-wird-verandert

Description:

1. The name of the file was not escaped
2. Now using Latex filter in the template it will be scape, so if the file name is _hello_.png, then the name will be displayed with underscore and not italic

### How to review/test
- Follow the steps described in the ticket
- Make sure you use a file that has space in the name, or has unserscore _ in the name

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
