### PR TITLE
DPLAN-11647 ducktest firefox setting

### DIFF
--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -788,6 +788,50 @@ export default {
 
   mounted () {
     this.getInitialData()
+
+    /*
+     * Display a warning for firefox if "privacy.resistFingerprinting" is enabled,
+     * because openLayers' getFeaturesAtPixel() will not behave correctly then.
+     */
+    useResistFingerprintingDuckTest((isEnabled) => {
+      if (isEnabled) {
+        dplan.notify.notify('error', Translator.trans('warning.resistFingerPrinting'))
+      }
+    })
   }
+}
+
+const useResistFingerprintingDuckTest = (callback) => {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+
+  // Draw something on the canvas
+  ctx.fillStyle = 'rgb(0,0,0)'
+  ctx.fillRect(0, 0, 10, 10)
+
+  // Convert canvas to data URL
+  const dataUrl = canvas.toDataURL()
+
+  // Check if the produced data URL corresponds to the expected black square
+  const image = new Image()
+
+  image.onload = function () {
+    // Draw the image onto a new canvas to read the pixel values
+    const testCanvas = document.createElement('canvas')
+    const testCtx = testCanvas.getContext('2d')
+    testCanvas.width = image.width
+    testCanvas.height = image.height
+    testCtx.drawImage(image, 0, 0)
+
+    // Check the first pixel
+    const pixelData = testCtx.getImageData(0, 0, 1, 1).data
+
+    // If the pixel is black, we assume that resistFingerprinting is disabled
+    const resistFingerprintingEnabled = !(pixelData[0] === 0 && pixelData[1] === 0 && pixelData[2] === 0)
+
+    callback(resistFingerprintingEnabled)
+  }
+
+  image.src = dataUrl
 }
 </script>

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/03/Version20240318172346.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/03/Version20240318172346.php
@@ -33,7 +33,6 @@ class Version20240318172346 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-
         // mariadb 10.1 needs to drop the foreign key before changing the column
         $this->addSql('ALTER TABLE _procedure DROP FOREIGN KEY FK_D1A01D0299091188');
         $this->addSql('ALTER TABLE _procedure DROP FOREIGN KEY FK_D1A01D0230F7E25B');

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3986,6 +3986,7 @@ warning.password.weak: "Ihr Passwort ist leicht zu erraten. Bitte ändern Sie es
 warning.phase.voting.not.possible: "In dieser Phase können keine {points} vergeben werden!"
 warning.privacy.confirm: "Bitte bestätigen Sie, dass Sie keine anderen Personen namentlich genannt oder beschrieben haben."
 warning.procedure.proposal.notfound: "Der Verfahrensvorschlag konnte nicht gefunden werden."
+warning.resistFingerPrinting: "Um alle Funktionen dieser Seite nutzen zu können, deaktivieren Sie in Ihrem Browser die Einstellung \"privacy.resistFingerprinting\" unter \"about:config\"."
 warning.search.query.invalid: "Folgende Zeichen haben eine Sonderfunktion und können deshalb nicht ohne Weiteres verwendet werden:<br /><br /><strong> . ? + * | &lbrace; &rbrace; [ ] ( ) \" \\ # @ & < > ~ </strong><br /><br />Sonderzeichen können aufgrund ihrer besonderen Funktion nicht gefunden werden.<br /><br />Wenn ein Sonderzeichen in Ihrer Suche enthalten ist, schreiben Sie \"\\\" vor das Zeichen.<br />Haben Sie z.B. ein \"?\" in Ihrer Suche, müssen Sie \"\\?\" eingeben."
 warning.segment.needLock.generic: "Dieser Abschnitt ist zur Zeit in Bearbeitung. Um ihn zu bearbeiten, müssen Sie den Abschnitt zunächst für sich beanspruchen."
 warning.select.entries: "Bitte wählen Sie Einträge aus."


### PR DESCRIPTION
### Ticket 
https://demoseurope.youtrack.cloud/issue/DPLAN-11647/Klick-Problem-auf-der-Seite-Importierte-Stellungnahmen-uberprufen-Schulung

The reason for this bug lies in the firefox setting "privacy.resistFingerprinting" when enabled leads to the openLayers method "forEachFeatureAtPixel" to fail. This cannot be fixed on our side. See discussions at openlayers and mozilla:

- https://support.mozilla.org/de/questions/1398931
- https://github.com/openlayers/openlayers/issues/14363

The best we can do (this is implemented here) is to inform users that something will not work with the current settings.

### How to review/test
When loading the view in Firefox with "privacy.resistFingerprinting" set to true, an error notification should appear that reads:
**Um alle Funktionen dieser Seite nutzen zu können, deaktivieren Sie in Ihrem Browser die Einstellung "privacy.resistFingerprinting" unter "about:config".**

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
