### PR TITLE
chore: Set concrete Version for demosplan-addon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "cebe/php-openapi": "^1.5",
         "cocur/slugify": "^4.0",
         "composer/package-versions-deprecated": "1.11.99.5",
-        "demos-europe/demosplan-addon": "^0",
+        "demos-europe/demosplan-addon": "^0.35",
         "doctrine/annotations": "^2.0",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",


### PR DESCRIPTION
**Ticket** DPLAN-11655

We should set the Version always explicit. With that its easier to change versions in between branches etc.