### PR TITLE
fix(refs DPLAN-11646): Expose Permission to control setting the map_max_extent

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1139,11 +1139,12 @@ feature_map_layer_legend_file:
     loginRequired: false
     parent: area_map_participation_area
 feature_map_max_extent:
-        description: |-
-            Restrict the access to get the max extension of the public map (in the admin area)
-        label: 'Restrict the access to get the max extension of the public map (in the admin area)'
-        loginRequired: true
-        parent: area_admin_map
+    description: |-
+        Restrict the access to get the max extension of the public map (in the admin area)
+    label: 'Restrict the access to get the max extension of the public map (in the admin area)'
+    expose: true
+    loginRequired: true
+    parent: area_admin_map
 feature_map_new_statement:
     expose: true
     label: 'Planzeichnung Neue Stellungnahme'


### PR DESCRIPTION
### Ticket
DPLAN-11646






<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The usage of the permission was before only in the twig context and is moved to vue now. while moving, it has been forgotten to expose the permission.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

in a project where setting the max-extent should be possible, goto the mapsettings and search for the possibility to set the max extent




<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [x] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
