### PR TITLE
fix (refs ADO-16169): Adjust dockBlock of method to not be misleading.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2079,8 +2079,8 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     /**
      * Set authorized users to given procedure.
      * Will set at least the current user as authorized user to ensure one user will be authorized.
-     * Will set all users of organisation of the current user in case of given blueprint is the master blueprint.
      * Will set all authorized users of given blueprint.
+     * Will set only the current user in case of given blueprint is the master blueprint.
      *
      * @param string|Procedure $blueprint
      * @param string           $currentUserId


### PR DESCRIPTION
Ticket:
https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/16169

Description:
Adjust dockBlock of method to not be misleading.


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
