### PR TITLE
chore (refs DPLAN-11547): Tus path needs to be relative - ewm_release

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/js/dplan.settings.js.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/js/dplan.settings.js.twig
@@ -17,7 +17,7 @@ window.dplan = {
     },
 
     paths                   : {
-        tusEndpoint          : "{{url('tus_upload') }}", {# global path for file uploader endpoint #}
+        tusEndpoint          : "{{path('tus_upload') }}", {# global path for file uploader endpoint #}
         urlPathPrefix       : "{{ urlPathPrefix|default('') }}"
     },
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11547/Dateien-auf-bauleitplanung.muenchen.de-konnen-nicht-hochgeladen-werden

When specific organisations have special domains that are mapped to a certain orga page in a customer the absolute url path may show to the customer, which will lead to cors errors. Due to them a file upload will not be possible

How to review/test
upload any file. The upload methods are all same