### PR TITLE
fix (DPLAN-11584) use method with procedure id to open pdf view correctly

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -326,7 +326,7 @@
                     class="o-hellip break-words u-mb-0_25"
                     target="_blank"
                     rel="noopener"
-                    href="{{ path("core_file", { 'hash': news.pdf|getFile('hash') }) }}">
+                    href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) }}">
                     <i class="fa fa-file-o"></i>
                     {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                     {% if ( news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/procedure_newslist.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/procedure_newslist.html.twig
@@ -30,7 +30,7 @@
                 class="{{ 'font-size-smaller float-right max-w-full'|prefixClass }}"
                 target="_blank"
                 rel="noopener"
-                href="{{ path("core_file", { 'hash': news.pdf|getFile('hash') }) }}"
+                href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) }}"
                 title="Download {{ news.pdftitle|default(news.pdf|getFile('name')) }} {% if (news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %} ({{- news.pdf|getFile('size') }} {{ news.pdf|getFile('mimeType') -}}){% endif %}">
                 <i class="{{ 'fa fa-file'|prefixClass }}" aria-hidden="true"></i>
                 {{ news.pdftitle|default(news.pdf|getFile('name')) }}


### PR DESCRIPTION
### Ticket https://demoseurope.youtrack.cloud/issue/DPLAN-11584/Hochgeladene-Mitteilung-PDF-Datei-kann-nicht-geoffnet-werden

Description:
- The file was gotten using core_file. Instead. core_file_procedure must be used to generate the correct url where the file is hosted

### How to review/test
- Go as described in ticket
- Make sure you check the News configuration (upload pdf) and also in the Public View

Delete the checkbox if it doesn't apply/isn't necessary.

- [ x] Move the tickets on the board accordingly

