### PR TITLE
feature (ref ADO-16632): create factory for cockpit story

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/BoilerplateCategoryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/BoilerplateCategoryFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Factory;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\BoilerplateCategoryInterface;
+use DemosEurope\DemosplanAddon\Contracts\Factory\BoilerplateCategoryFactoryInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory;
+
+class BoilerplateCategoryFactory implements BoilerplateCategoryFactoryInterface
+{
+    public function createBoilerplateCategory(): BoilerplateCategoryInterface
+    {
+        return new BoilerplateCategory();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/BoilerplateFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/BoilerplateFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Factory;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\BoilerplateInterface;
+use DemosEurope\DemosplanAddon\Contracts\Factory\BoilerplateFactoryInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
+
+class BoilerplateFactory implements BoilerplateFactoryInterface
+{
+    public function createBoilerplate(): BoilerplateInterface
+    {
+        return new Boilerplate();
+    }
+}


### PR DESCRIPTION
### Ticket: https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/16632

Description: create two factory for Boilerplate and BoilerplateCategory to use in Cckpit

### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- https://github.com/demos-europe/demosplan-addon/pull/112
- https://github.com/demos-europe/demosplan-addon-xbauleitplanung/pull/30

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
