### PR TITLE
bug (refs DPLAN-11551): Show procedure phase depending on role

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -123,19 +123,22 @@
                             </h3>
 
                                 {% if ownsProcedure(proceduresettings) %}
-                                    {# Display procedure phase of institutions to enable planner user to quickly check correct settings #}
+                                    {# Display procedure phase of institutions and citizens to enable planner user to quickly check correct settings #}
                                     {{ getProcedurePhase(proceduresettings, 'internal') }}
                                     {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'internal'), ['c-infolist__help u-ml-0_25'|prefixClass]) -}}
                                     {{ '\n'|nl2br }}
+                                    {{ getProcedurePhase(proceduresettings, 'public') }}
+                                    {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['c-infolist__help u-ml-0_25'|prefixClass]) -}}
+                                {% else %}
+                                    {# Display procedure phase and help depending on role #}
+                                    {{ getProcedurePhase(proceduresettings) }}
+                                    {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings), ['c-infolist__help u-ml-0_25'|prefixClass]) -}}
                                 {% endif %}
 
                                 {# Display a "legal notice" for institutions #}
                                 {% if hasPermission('feature_procedure_legal_notice_read') and proceduresettings.settings.legalNotice|default != '' %}
                                     ({{ proceduresettings.settings.legalNotice }})
                                 {% endif %}
-                                {# Display public procedure phase without login or logged as citizen  #}
-                                {{ getProcedurePhase(proceduresettings, 'public') }}
-                                {{- contextualHelp('help.public.detail.phase.'~ getProcedurePhaseKey(proceduresettings, 'public'), ['c-infolist__help u-ml-0_25'|prefixClass]) -}}
                         </div><!--
                     {% endif %}
 


### PR DESCRIPTION
### Ticket
DPLAN-11551

- Procedure owners should see both phases
- public and invited institutions should see phase depending on role (invited institutions should see internal phase and not public one)

### How to review/test
Login as FA: 
Verfahren -> Grundeinstellungen -> Verfahrensschrit Inistitutionen -> Öffentliche Auslegung
Verfahren -> Grundeinstellungen -> Verfahrensschrit Öffentlichkeit -> Konfiguration
Verfahren -> Institutionen verwalten -> Institution hinzufügen

Login as IK from the institution you added:
Verfahren -> Verfahren ansehen -> Verfahrensschritt should be Öffentliche Auslegung

