### PR TITLE
fix(refs DPLAN-11614): use XMLHttpRequest to getCapabilities

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -1544,20 +1544,25 @@ export default {
       const layerArray = Array.isArray(layer.attributes.layers) ? layer.attributes.layers : layer.attributes.layers.split(',')
       const url = this.addGetCapabilityParamToUrl(layer.attributes.url)
 
-      return $.ajax({
-        dataType: 'xml',
-        url: url || '',
-        async: false,
-        success: response => {
-          const result = this.parser.read(response)
-          const options = optionsFromCapabilities(result, {
-            layer: layerArray[0] || '',
-            matrixSet: layer.attributes.tileMatrixSet
-          })
+      let xml
 
-          return new WMTS({ ...options, layers: layerArray })
-        }
+      const xhr = new XMLHttpRequest()
+      xhr.open('GET', url, false)
+      xhr.send(null)
+
+      if (xhr.status === 200) {
+        xml = xhr.responseXML
+      } else {
+        throw new Error(`Error fetching WMTS source: ${xhr.statusText}`)
+      }
+
+      const result = this.parser.read(xml)
+      const options = optionsFromCapabilities(result, {
+        layer: layerArray[0] || '',
+        matrixSet: layer.attributes.tileMatrixSet
       })
+
+      return new WMTS({ ...options, layers: layerArray })
     },
 
     getWMSSource (layer) {


### PR DESCRIPTION
### Ticket
[DPLAN-11614](https://demoseurope.youtrack.cloud/issue/DPLAN-11614/ROBOB-Prod-und-Stage-Sobald-ein-WMTS-Layer-eingebunden-ist-werden-alle-Layer-nicht-mehr-dargestellt)

Cherrypicked from https://github.com/demos-europe/demosplan-core/pull/3180

As we do not want to refactor Map.vue to use async all over the place, this is the simplest way of getting synchronous WMTS requests to work.

Prior art:
- https://github.com/demos-europe/demosplan-core/pull/1876
- https://github.com/demos-europe/demosplan-core/pull/1866

### How to review/test
WMTS Maps should load and not break the view.
ected to this and explain the connection.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
