### PR TITLE
fix(refs DPLAN-11685): fix css in assessmentTable

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -302,8 +302,8 @@
 
         <!--  statement tab  -->
         <div
-          class="bg-color-light flow-root"
-          v-show="tab === 'statement'">
+          v-show="tab === 'statement'"
+          class="bg-color-light">
           <!--  status / priorities  -->
           <dp-item-row
             v-if="hasPermission('field_statement_status') || hasPermission('field_statement_priority')"
@@ -649,7 +649,7 @@
         <!-- Fragments Tab -->
         <div
           v-if="hasPermission('area_statements_fragment')"
-          class="bg-color-light flow-root"
+          class="bg-color-light"
           v-show="tab==='fragments'">
           <div class="layout--flush u-p-0_5 u-pt-0_25 border--top u-nojs-show--block">
             <div class="layout__item c-at-item__row-icon color--grey" /><!--


### PR DESCRIPTION
### Ticket
[DPLAN-11685](https://demoseurope.youtrack.cloud/issue/DPLAN-11685/ROBOB-Anzeige-der-Datensatze-funktioniert-nicht)

`flow-root` does not play nice with `v-show` as it is set to `!important`.

### How to review/test
In the assessment table, toggling between statement and fragments should result in the statements (or fragments) being exclusively shown in the content area of each card. The "derzeit sind keine Datensätze an der Stellungnahme vorhanden" sentence should only show in the fragment view of the card, and only if there are really no fragments.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
