### PR TITLE
f-DPLAN-11656 include customer in query result 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -133,7 +133,7 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
      *
      * @throws Exception
      */
-    public function getFullList(bool $master = null, bool $idsOnly = false): array
+    public function getFullList(?bool $master = null, bool $idsOnly = false): array
     {
         try {
             $em = $this->getEntityManager();

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -1188,8 +1188,9 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
 
             $query = $this->getEntityManager()
                 ->createQueryBuilder()
-                ->select('procedure')
+                ->select('procedure', 'customer')
                 ->from(Procedure::class, 'procedure')
+                ->leftJoin('procedure.customer', 'customer') // assumes the relationship is set up like this
                 ->where('procedure.deleted = 0')
                 ->andWhere('procedure.master = 0')
                 ->andWhere($endDate.' < :currentDate')


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11656/Verfahren-werden-nicht-mehr-sichtbar-nach-Phasenumstellung

Description: 
while phases change procedure will be fetched and updated. Customer is missing when a procedure is fetched which caused that customer will be always null after updating

see  'generateObjectValues' in 'ProcedureRepository' to have better Idea how the customer will be handled.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

