### PR TITLE
fix(refs DPLAN-11707): add file resource type

### DIFF
--- a/client/js/bundles/user/customerSettings.js
+++ b/client/js/bundles/user/customerSettings.js
@@ -18,6 +18,6 @@ const components = {
   CustomerSettings
 }
 
-const apiStores = ['branding', 'customer', 'customerContact', 'customerLoginSupportContact']
+const apiStores = ['branding', 'customer', 'customerContact', 'customerLoginSupportContact', 'file']
 
 initialize(components, {}, apiStores)

--- a/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
@@ -141,7 +141,6 @@ export default {
     },
 
     saveBrandingSettings () {
-
       if (!this.uploadedFileId) {
         this.isBusy = false
 
@@ -157,7 +156,7 @@ export default {
         },
         relationships: {
           logo: {
-            data: this.isLogoDeleted ? null : { id: this.uploadedFileId, type: 'file' }
+            data: this.isLogoDeleted ? null : { id: this.uploadedFileId, type: 'File' }
           }
         }
       }

--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -100,6 +100,11 @@ export const VuexApiRoutes = [
     ]
   },
   {
+    module: 'file',
+    action: 'list',
+    url: '/2.0/File'
+  },
+  {
     module: 'report',
     action: 'list',
     url: '/1.0/reports/{procedureId}/{group}',


### PR DESCRIPTION
### Ticket
[DPLAN-11707](https://demoseurope.youtrack.cloud/issue/DPLAN-11707/Prod-DiPlanBeteiligung-BB-Konfiguration-nicht-moglich) (ADO [16894](https://www.dev.diplanung.de/DefaultCollection/DiPlan%20Incidents/_workitems/edit/16894))

To omit the error "vuex: module namespace not found..." the File module must be added as an apiStore. Also, the "File" relationship must be uppercase.

### How to review/test
Login as "Mandanten-Administration" (Horst Hohenfeld in diplanbau-release). Go to "Plattform-Einstellungen", delete the branding logo, reload page, upload a new logo. This should basically work. Console errors "[vuex] module namespace not found in mapState(): file/" and subsequent errors should be gone.

### PR Checklist

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
