### PR TITLE
chore (refs DPLAN-609): file uploads itself should not be checked for procedure permissions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/AccessProcedureListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/AccessProcedureListener.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\EventListener;
 
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use EFrane\TusBundle\Controller\TusController;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 
@@ -29,6 +30,12 @@ class AccessProcedureListener
     public function onKernelController(ControllerEvent $controllerEvent): void
     {
         if (null === $this->currentProcedureService->getProcedure()) {
+            return;
+        }
+
+        // file uploads itself should not be checked for procedure permissions
+        // permissions are checked during access
+        if ($controllerEvent->getController()[0] instanceof TusController) {
             return;
         }
 


### PR DESCRIPTION
### Ticket
DPLAN-609

File uploads failed because permissions are checked more strictly when `X-Demosplan-Procedure-Id` header is set. File uploads should not check procedure permissions even if the file is uploaded within a procedure, as permissions are checked during access.

I tried really hard to write a test for this but was not able to mock the `$controllerEvent->getController()` to return an array.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
upload a file in a procedure.

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
