### PR TITLE
chore: install addon via branch

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -84,7 +84,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         $this->addOption('no-enable', '', InputOption::VALUE_NONE, 'Do not immediately enable addon during installation');
         $this->addOption('local', '', InputOption::VALUE_NONE, 'Only use locally available addons, do not connect GitHub');
         $this->addOption('github', '', InputOption::VALUE_NONE, 'Directly load addons from GitHub');
-        $this->addOption('branch', '', InputOption::VALUE_NONE, 'Install specific branch from GitHub');
+        $this->addOption('branch', 'b', InputOption::VALUE_REQUIRED, 'Install specific branch from GitHub');
         $this->addOption('repos', '', InputOption::VALUE_NONE, 'Call demosplan addon repository');
         $this->addOption('force-download', '', InputOption::VALUE_NONE, 'Force download repository from GitHub');
         $this->addOption('folder', '', InputOption::VALUE_REQUIRED, 'Folder to read addon zips from', 'addonZips');
@@ -423,7 +423,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         return $path;
     }
 
-    private function loadFromGithub(InputInterface $input, SymfonyStyle $output, mixed $folder, bool $branch): string
+    private function loadFromGithub(InputInterface $input, SymfonyStyle $output, mixed $folder, ?string $branch): string
     {
         try {
             $ghToken = $this->parameterBag->get('github_token');
@@ -457,7 +457,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         $repo = $questionHelper->ask($input, $output, $question);
 
         // default: show tags
-        if (false === $branch) {
+        if (null === $branch) {
             // fetch a list of available tags
             $ghUrl = 'https://api.github.com/repos/demos-europe/'.$repo.'/tags';
             $tag = $this->getGithubItem($ghUrl, $ghOptions, $input, $output);
@@ -465,9 +465,6 @@ class AddonInstallFromZipCommand extends CoreCommand
             // tags are prefixed with v, but the zip file in GitHub is not
             $path = DemosPlanPath::getRootPath($folder).'/'.$repo.'-'.str_replace('v', '', $tag).'.zip';
         } else {
-            // fetch a list of available branches
-            $ghUrl = sprintf('https://api.github.com/repos/demos-europe/%s/branches', $repo);
-            $branch = $this->getGithubItem($ghUrl, $ghOptions, $input, $output);
             $zipUrl = sprintf('https://github.com/demos-europe/%s/archive/refs/heads/%s.zip', $repo, $branch);
             $path = DemosPlanPath::getRootPath($folder).'/'.$repo.'-'.$branch.'.zip';
         }


### PR DESCRIPTION
Addon Branch list is not fetched from GitHub any more as it was too long to handle it.
Instead, a branch name needs to be passed into the command.



<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
install an addon via bin/<project> dplan:addon:install --branch <branchName>

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
