### PR TITLE
bug(refs DPLAN-1909): Add whitespace normal for multiselect

### DIFF
--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -107,7 +107,7 @@
       <dp-multiselect
         :id="userId + ':userRoles'"
         ref="rolesDropdown"
-        class="u-mb-0_5"
+        class="u-mb-0_5 whitespace-normal"
         :custom-label="option =>`${ roles[option.id].attributes.name }`"
         data-cy="role"
         label="name"


### PR DESCRIPTION
### Ticket
DPLAN-1909


We need whitespace normal for the multiselect, because otherwise the tags overflow the input.


### How to review/test
Login as support -> Nutzende -> tags for role should stay inside the input and not overflow
