### PR TITLE
bug(refs DPLAN-1910): Use js delete instead of Vue.delete

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -360,7 +360,7 @@ export default {
         this.deleteOrganisation(id)
           .then(() => {
             // Remove deleted item from itemSelections
-            Vue.delete(this.itemSelections, id)
+            delete this.itemSelections[id]
             // Confirm notification for organisations is done in BE
           })
       })

--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -206,7 +206,7 @@ export default {
             this.deleteUser(id)
               .then(() => {
                 // Remove deleted item from itemSelections
-                Vue.delete(this.itemSelections, id)
+                delete this.itemSelections[id]
                 dplan.notify.notify('confirm', Translator.trans('confirm.user.deleted'))
               })
           })


### PR DESCRIPTION
### Ticket
DPLAN-1910

Vue.delete is removed in Vue3. Better use standard JS delete operator.

