### PR TITLE
refacor: Create api2.0 Routes Dynamically

### DIFF
--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -10,7 +10,7 @@
 /*
  * Hardcoded API 1.0 Routes
  */
-const api1Routes = [
+const api1_0Routes = [
   {
     module: 'report',
     action: 'list',
@@ -83,7 +83,7 @@ const api1Routes = [
   }
 ]
 
-const generateApiRoutes = (apiModules) => {
+const generateApi2_0Routes = (apiModules) => {
   const routes = []
 
   apiModules.forEach(typeName => {
@@ -130,4 +130,4 @@ const generateApiRoutes = (apiModules) => {
   return routes
 }
 
-export { api1Routes, generateApiRoutes }
+export { api1_0Routes, generateApi2_0Routes }

--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -7,103 +7,10 @@
  * All rights reserved
  */
 
-export const VuexApiRoutes = [
-  {
-    module: 'Branding',
-    action: 'list',
-    url: '/2.0/Branding'
-  },
-  {
-    module: 'Branding',
-    action: 'update',
-    url: '/2.0/Branding/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Customer',
-    action: 'create',
-    url: '/2.0/Customer'
-  },
-  {
-    module: 'Customer',
-    action: 'list',
-    url: '/2.0/Customer'
-  },
-  {
-    module: 'Customer',
-    action: 'delete',
-    url: '/2.0/Customer/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Customer',
-    action: 'update',
-    url: '/2.0/Customer/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'CustomerContact',
-    action: 'create',
-    url: '/2.0/CustomerContact'
-  },
-  {
-    module: 'CustomerContact',
-    action: 'delete',
-    url: '/2.0/CustomerContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'CustomerContact',
-    action: 'list',
-    url: '/2.0/CustomerContact'
-  },
-  {
-    module: 'CustomerContact',
-    action: 'update',
-    url: '/2.0/CustomerContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'CustomerLoginSupportContact',
-    action: 'create',
-    url: '/2.0/CustomerLoginSupportContact'
-  },
-  {
-    module: 'CustomerLoginSupportContact',
-    action: 'delete',
-    url: '/2.0/CustomerLoginSupportContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'CustomerLoginSupportContact',
-    action: 'list',
-    url: '/2.0/CustomerLoginSupportContact'
-  },
-  {
-    module: 'CustomerLoginSupportContact',
-    action: 'update',
-    url: '/2.0/CustomerLoginSupportContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'file',
-    action: 'list',
-    url: '/2.0/File'
-  },
+/*
+ * Hardcoded API 1.0 Routes
+ */
+const api1Routes = [
   {
     module: 'report',
     action: 'list',
@@ -114,12 +21,12 @@ export const VuexApiRoutes = [
     ]
   },
   {
-    module: 'User',
+    module: 'user',
     action: 'list',
     url: '/1.0/user/'
   },
   {
-    module: 'User',
+    module: 'user',
     action: 'get',
     url: '/1.0/user/{userId}',
     parameters: [
@@ -127,7 +34,7 @@ export const VuexApiRoutes = [
     ]
   },
   {
-    module: 'User',
+    module: 'user',
     action: 'update',
     url: '/1.0/user/{id}',
     parameters: [
@@ -135,71 +42,31 @@ export const VuexApiRoutes = [
     ]
   },
   {
-    module: 'User',
+    module: 'user',
     action: 'create',
     url: '/1.0/user/'
   },
   {
-    module: 'User',
+    module: 'user',
     action: 'delete',
     url: '/1.0/user/{id}',
     parameters: [
       'id'
     ]
   },
+
   {
-    module: 'Department',
-    action: 'list',
-    url: '/2.0/Department'
-  },
-  {
-    module: 'AssignableUser',
-    action: 'list',
-    url: '/2.0/AssignableUser'
-  },
-  {
-    module: 'Orga',
-    action: 'list',
-    url: '/2.0/Orga'
-  },
-  {
-    module: 'Orga',
-    action: 'update',
-    url: '/1.0/organisation/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Orga',
-    action: 'create',
-    url: '/1.0/organisation/'
-  },
-  {
-    module: 'Orga',
-    action: 'delete',
-    url: '/1.0/organisation/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Role',
-    action: 'list',
-    url: '/1.0/role/'
-  },
-  {
-    module: 'FaqCategory',
+    module: 'faqCategory',
     action: 'list',
     url: '/1.0/FaqCategory/'
   },
   {
-    module: 'Faq',
+    module: 'faq',
     action: 'list',
     url: '/1.0/faq/'
   },
   {
-    module: 'Faq',
+    module: 'faq',
     action: 'delete',
     url: '/1.0/faq/{id}',
     parameters: [
@@ -207,143 +74,60 @@ export const VuexApiRoutes = [
     ]
   },
   {
-    module: 'Faq',
+    module: 'faq',
     action: 'update',
     url: '/1.0/faq/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'InvitableToeb',
-    action: 'list',
-    url: '/2.0/InvitableToeb'
-  },
-  {
-    module: 'InvitableInstitution',
-    action: 'list',
-    url: '/2.0/InvitableInstitution'
-  },
-  {
-    module: 'InvitableInstitution',
-    action: 'update',
-    url: '/2.0/InvitableInstitution/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Place',
-    action: 'list',
-    url: '/2.0/Place'
-  },
-  {
-    module: 'SegmentComment',
-    action: 'list',
-    url: '/2.0/SegmentComment'
-  },
-  {
-    module: 'StatementSegment',
-    action: 'list',
-    url: '/2.0/StatementSegment'
-  },
-  {
-    module: 'StatementSegment',
-    action: 'update',
-    url: '/2.0/StatementSegment/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Statement',
-    action: 'list',
-    url: '/2.0/Statement'
-  },
-  {
-    module: 'Statement',
-    action: 'get',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Statement',
-    action: 'update',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Statement',
-    action: 'delete',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'StatementAttachment',
-    action: 'create',
-    url: '/2.0/StatementAttachment'
-  },
-  {
-    module: 'Tag',
-    action: 'list',
-    url: '/2.0/Tag'
-  },
-  {
-    module: 'InstitutionTag',
-    action: 'create',
-    url: '/2.0/InstitutionTag'
-  },
-  {
-    module: 'InstitutionTag',
-    action: 'list',
-    url: '/2.0/InstitutionTag'
-  },
-  {
-    module: 'InstitutionTag',
-    action: 'update',
-    url: '/2.0/InstitutionTag/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'InstitutionTag',
-    action: 'delete',
-    url: '/2.0/InstitutionTag/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'TagTopic',
-    action: 'list',
-    url: '/2.0/TagTopic'
-  },
-  {
-    module: 'Elements',
-    action: 'list',
-    url: '/2.0/Elements'
-  },
-  {
-    module: 'Elements',
-    action: 'update',
-    url: '/2.0/Elements/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'Elements',
-    action: 'delete',
-    url: '/2.0/Elements/{id}',
     parameters: [
       'id'
     ]
   }
 ]
+
+const generateApiRoutes = (apiModules) => {
+  const routes = []
+
+  apiModules.forEach(typeName => {
+    routes.push({
+      module: typeName,
+      action: 'list',
+      url: `/2.0/${typeName}`
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'get',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'update',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'create',
+      url: `/2.0/${typeName}`
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'delete',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+  })
+
+  return routes
+}
+
+export { api1Routes, generateApiRoutes }

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -12,7 +12,7 @@ import { initJsonApiPlugin, prepareModuleHashMap, StaticRouter } from '@efrane/v
 import notify from './Notify'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { api1Routes, generateApiRoutes } from './VuexApiRoutes'
+import { api1_0Routes, generateApi2_0Routes } from './VuexApiRoutes'
 
 function registerPresetModules (store, presetStoreModules) {
   if (Object.keys(presetStoreModules).length > 0) {
@@ -38,7 +38,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
   Vue.use(Vuex)
 
   const staticModules = { notify, ...storeModules }
-  const VuexApiRoutes = api1Routes.concat(generateApiRoutes(apiStoreModules))
+  const VuexApiRoutes = api1_0Routes.concat(generateApi2_0Routes(apiStoreModules))
   // This should probably be replaced with an adapter to our existing routes
   const router = new StaticRouter(VuexApiRoutes)
 

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -12,7 +12,7 @@ import { initJsonApiPlugin, prepareModuleHashMap, StaticRouter } from '@efrane/v
 import notify from './Notify'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { VuexApiRoutes } from './VuexApiRoutes'
+import { api1Routes, generateApiRoutes } from './VuexApiRoutes'
 
 function registerPresetModules (store, presetStoreModules) {
   if (Object.keys(presetStoreModules).length > 0) {
@@ -38,7 +38,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
   Vue.use(Vuex)
 
   const staticModules = { notify, ...storeModules }
-
+  const VuexApiRoutes = api1Routes.concat(generateApiRoutes(apiStoreModules))
   // This should probably be replaced with an adapter to our existing routes
   const router = new StaticRouter(VuexApiRoutes)
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@demos-europe/demosplan-ui": "^0.3.17",
     "@demos-europe/dp-consent": "^1.1.2",
-    "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#7d70712dd3fccd2532312ae5dd19b1542e2aadfe",
+    "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd",
     "@masterportal/masterportalapi": "^2.19.2",
     "@sentry/browser": "^8.2.1",
     "@sentry/integrations": "^7.114.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,9 +1434,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@efrane/vuex-json-api@github:eFrane/vuex-json-api#7d70712dd3fccd2532312ae5dd19b1542e2aadfe":
+"@efrane/vuex-json-api@github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd":
   version "0.1.0"
-  resolved "https://codeload.github.com/eFrane/vuex-json-api/tar.gz/7d70712dd3fccd2532312ae5dd19b1542e2aadfe"
+  resolved "https://codeload.github.com/eFrane/vuex-json-api/tar.gz/19c2354ad97c17bdda02358dc9ee4a2ffce181dd"
   dependencies:
     deep-object-diff "^1.1.9"
     json-api-normalizer "^1.0"
@@ -2326,9 +2326,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "20.14.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.0.tgz#49ceec7b34f8621470cff44677fa9d461a477f17"
-  integrity sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==
+  version "20.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.1.tgz#2434dbcb1f039e31f2c0e9969da93f52cf6348f3"
+  integrity sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==
   dependencies:
     undici-types "~5.26.4"
 
@@ -4369,9 +4369,9 @@ editorconfig@^0.15.3:
     sigmund "^1.0.1"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.788"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.788.tgz#a3545959d5cfa0a266d3e551386c040be34e7e06"
-  integrity sha512-ubp5+Ev/VV8KuRoWnfP2QF2Bg+O2ZFdb49DiiNbz2VmgkIqrnyYaqIOqj8A6K/3p1xV0QcU5hBQ1+BmB6ot1OA==
+  version "1.4.789"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.789.tgz#fec941cb753ee139da562a5a8ff31fc3e828b411"
+  integrity sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==
 
 emitter-component@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
With That, we don't have to register the routes manually in the VuexApiRoutes.js. Now they get build during the store initialization depending on the entrypoint