### PR TITLE
fix(refs DPLAN-11741): avoid loading/fetching addons multiple times

### DIFF
--- a/client/js/components/addon/AddonWrapper.vue
+++ b/client/js/components/addon/AddonWrapper.vue
@@ -47,7 +47,6 @@ export default {
 
   methods: {
     loadComponents () {
-      console.log('Loading addons for hook ' + this.hookName, window.dplan.loadedAddons)
       if (window.dplan.loadedAddons[this.hookName]) {
         return
       }

--- a/client/js/components/addon/AddonWrapper.vue
+++ b/client/js/components/addon/AddonWrapper.vue
@@ -47,10 +47,12 @@ export default {
 
   methods: {
     loadComponents () {
+      console.log('Loading addons for hook ' + this.hookName, window.dplan.loadedAddons)
       if (window.dplan.loadedAddons[this.hookName]) {
         return
       }
 
+      window.dplan.loadedAddons[this.hookName] = true
       dpRpc('addons.assets.load', { hookName: this.hookName })
         .then(response => checkResponse(response))
         .then(response => {
@@ -84,7 +86,6 @@ export default {
           }
 
           this.$emit('addons:loaded', this.loadedAddons)
-          window.dplan.loadedAddons[this.hookName] = true
         })
     }
   },

--- a/client/js/components/addon/AddonWrapper.vue
+++ b/client/js/components/addon/AddonWrapper.vue
@@ -47,6 +47,10 @@ export default {
 
   methods: {
     loadComponents () {
+      if (window.dplan.loadedAddons[this.hookName]) {
+        return
+      }
+
       dpRpc('addons.assets.load', { hookName: this.hookName })
         .then(response => checkResponse(response))
         .then(response => {
@@ -80,6 +84,7 @@ export default {
           }
 
           this.$emit('addons:loaded', this.loadedAddons)
+          window.dplan.loadedAddons[this.hookName] = true
         })
     }
   },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/js/dplan.settings.js.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/js/dplan.settings.js.twig
@@ -25,6 +25,7 @@ window.dplan = {
     projectCoreVersion      : "{{ projectCoreVersion|default('') }}",
     projectName             : "{{ projectName|default('') }}",
     projectVersion          : "{{ projectVersion|default('') }}",
+    loadedAddons            : {},
     loggedIn                : Boolean({{ loggedin|default(0) }}),
     currentUserId           : "{{ currentUser.id|default }}",
     currentUser             : {


### PR DESCRIPTION
### Ticket
DPLAN-11741


Addons have been loaded every time the component got mounted