### PR TITLE
bug(refs DPLAN-1879): Add aria-live for accessibility

### DIFF
--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -17,9 +17,9 @@
         v-model="currentAutocompleteSearch"
         :class="prefixClass('c-proceduresearch__search-field')"
         data-cy="searchProcedureMapForm:procedureSearch"
+        height="34px"
         label="value"
         name="search"
-        :height="'34px'"
         :options="autocompleteOptions"
         :placeholder="Translator.trans('procedure.public.search.placeholder')"
         :route-generator="(searchString) => {

--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -195,6 +195,7 @@
         <h2
           v-if="isSearch"
           id="searchResultHeading"
+          aria-live="polite"
           role="status"
           :class="prefixClass('layout__item font-size-h2 u-pr u-mb c-proceduresearch__result')">
           Die Suche nach <span :class="prefixClass('c-proceduresearch__term weight--bold')">{{ currentSearch }}</span> hatte {{ resultCount }} Ergebnis

--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -12,39 +12,39 @@
     <div :class="prefixClass('c-proceduresearch__search-wrapper layout__item flex')">
       <dp-autocomplete
         v-if="dplan.settings.useOpenGeoDb"
-        data-cy="searchProcedureMapForm:procedureSearch"
-        name="search"
         id="procedure_search"
-        :class="prefixClass('c-proceduresearch__search-field')"
         ref="autocomplete"
         v-model="currentAutocompleteSearch"
+        :class="prefixClass('c-proceduresearch__search-field')"
+        data-cy="searchProcedureMapForm:procedureSearch"
+        label="value"
+        name="search"
+        :height="'34px'"
+        :options="autocompleteOptions"
+        :placeholder="Translator.trans('procedure.public.search.placeholder')"
         :route-generator="(searchString) => {
           return Routing.generate('DemosPlan_procedure_public_suggest_procedure_location_json', {
             maxResults: 12,
             query: searchString
           })
         }"
-        :height="'34px'"
-        :options="autocompleteOptions"
-        :placeholder="Translator.trans('procedure.public.search.placeholder')"
         @search-changed="updateSuggestions"
-        @selected="search => setValueAndSubmitForm({ target: { value: search.value } }, 'search')"
         @searched="search => setValueAndSubmitForm({ target: { value: search } }, 'search')"
-        label="value" />
+        @selected="search => setValueAndSubmitForm({ target: { value: search.value } }, 'search')" />
 
       <template v-else>
-        <label
-          for="procedure_search_simple"
-          class="hide-visually"
-          v-html="Translator.trans('procedure.public.search.placeholder')" />
         <dp-input
-          :class="prefixClass('c-proceduresearch__search-field')"
           id="procedure_search_simple"
+          v-model="currentAutocompleteSearch"
+          :class="prefixClass('c-proceduresearch__search-field')"
+          :label="{
+            hidden: true,
+            text: Translator.trans('procedure.public.search.placeholder')
+          }"
           name="search"
-          width="auto"
-          @enter="form.search = currentAutocompleteSearch; submitForm();"
           :placeholder="Translator.trans('procedure.public.search.placeholder')"
-          v-model="currentAutocompleteSearch" />
+          width="auto"
+          @enter="form.search = currentAutocompleteSearch; submitForm();" />
       </template>
 
       <button

--- a/client/js/components/procedure/publicindex/drawer/Drawer.vue
+++ b/client/js/components/procedure/publicindex/drawer/Drawer.vue
@@ -23,6 +23,7 @@
         <div class="c-publicindex__drawer-nav">
           <strong
             v-if="currentView !== 'DpDetailView'"
+            aria-live="polite"
             class="inline-block"
             data-cy="participationProcedures">
             {{ procedureCount }} {{ Translator.trans('participation.procedures') }}


### PR DESCRIPTION
### Ticket
DPLAN-1879

The aria-live attribute is used to indicate that an element will be updated, and the screen reader should announce the changes. The value "polite" means that the screen reader will wait until it has finished speaking before announcing updates.
