### PR TITLE
feat (DPLAN-11765) Check customer subdomain instead of globalconfig (default) subdomain

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
@@ -57,7 +57,6 @@ final class OrgaStatusInCustomerFactory extends ModelFactory
 {
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
-     *
      */
     public function __construct()
     {
@@ -66,7 +65,6 @@ final class OrgaStatusInCustomerFactory extends ModelFactory
 
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
-     *
      */
     protected function getDefaults(): array
     {

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
@@ -58,7 +58,6 @@ final class OrgaStatusInCustomerFactory extends ModelFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      *
-     * @todo inject services if required
      */
     public function __construct()
     {
@@ -68,7 +67,6 @@ final class OrgaStatusInCustomerFactory extends ModelFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
      *
-     * @todo add your default values here
      */
     protected function getDefaults(): array
     {
@@ -85,9 +83,7 @@ final class OrgaStatusInCustomerFactory extends ModelFactory
      */
     protected function initialize(): self
     {
-        return $this
-            // ->afterInstantiate(function(OrgaStatusInCustomer $orgaStatusInCustomer): void {})
-        ;
+        return $this;
     }
 
     protected static function getClass(): string

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaTypeFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaTypeFactory.php
@@ -56,7 +56,6 @@ final class OrgaTypeFactory extends ModelFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
      *
-     * @todo inject services if required
      */
     public function __construct()
     {
@@ -66,7 +65,6 @@ final class OrgaTypeFactory extends ModelFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
      *
-     * @todo add your default values here
      */
     protected function getDefaults(): array
     {
@@ -81,9 +79,7 @@ final class OrgaTypeFactory extends ModelFactory
      */
     protected function initialize(): self
     {
-        return $this
-            // ->afterInstantiate(function(OrgaType $orgaType): void {})
-        ;
+        return $this;
     }
 
     protected static function getClass(): string

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaTypeFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaTypeFactory.php
@@ -55,7 +55,6 @@ final class OrgaTypeFactory extends ModelFactory
 {
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
-     *
      */
     public function __construct()
     {
@@ -64,7 +63,6 @@ final class OrgaTypeFactory extends ModelFactory
 
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
-     *
      */
     protected function getDefaults(): array
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -20,7 +20,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository;
-use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use Webmozart\Assert\Assert;
 
 /**
@@ -37,7 +36,6 @@ class AccessControlService extends CoreService
     public function __construct(
         private readonly AccessControlRepository $accessControlPermissionRepository,
         private readonly RoleHandler $roleHandler,
-        private readonly GlobalConfig $globalConfig
     ) {
     }
 
@@ -128,15 +126,15 @@ class AccessControlService extends CoreService
     }
 
     /**
-     * Checks if the given permission is allowed for the organization type.
+     * Checks if the given permission is allowed for the organization type in that customer
      *
      * Returns true if the permission is allowed for the organization type or if the permission is not 'CREATE_PROCEDURES_PERMISSION'.
      * Returns false if the permission is 'CREATE_PROCEDURES_PERMISSION' and the organization type is not 'PLANNING_AGENCY'.
      */
-    public function checkPermissionForOrgaType(string $permissionToCheck, OrgaInterface $orga): bool
+    public function checkPermissionForOrgaType(string $permissionToCheck, OrgaInterface $orga, CustomerInterface $customer): bool
     {
         if (self::CREATE_PROCEDURES_PERMISSION === $permissionToCheck) {
-            return in_array(OrgaTypeInterface::PLANNING_AGENCY, $orga->getTypes($this->globalConfig->getSubdomain(), true));
+            return in_array(OrgaTypeInterface::PLANNING_AGENCY, $orga->getTypes($customer->getSubdomain(), true));
         }
 
         return true;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2124,13 +2124,9 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     /**
      * If orga has the permission, add current orga to authorized planning offices to given procedure.
      *
-     * @param string $currentUserId
-     *
-     * @return Procedure
-     *
      * @throws Exception
      */
-    protected function addCurrentOrgaToPlanningOffices(Procedure $newProcedure, $currentUserId)
+    protected function addCurrentOrgaToPlanningOffices(Procedure $newProcedure, string $currentUserId): Procedure
     {
         $currentUser = $this->userService->getSingleUser($currentUserId);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -2134,7 +2134,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     {
         $currentUser = $this->userService->getSingleUser($currentUserId);
 
-        if ($this->accessControlPermissionService->checkPermissionForOrgaType(AccessControlService::CREATE_PROCEDURES_PERMISSION, $currentUser->getOrga())
+        if ($this->accessControlPermissionService->checkPermissionForOrgaType(AccessControlService::CREATE_PROCEDURES_PERMISSION, $currentUser->getOrga(), $this->customerService->getCurrentCustomer())
             && $this->accessControlPermissionService->permissionExist(AccessControlService::CREATE_PROCEDURES_PERMISSION, $currentUser->getOrga(), $this->customerService->getCurrentCustomer(), $currentUser->getRoles())) {
             $newProcedure->addPlanningOffice($currentUser->getOrga());
         }

--- a/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
+++ b/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * All rights reserved
  */
 
-namespace Tests\Project\AccessControlPermission\Unit;
+namespace Tests\Core\AccessControlPermission;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaStatusInCustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
@@ -100,7 +100,7 @@ class AccessControlServiceTest extends UnitTestCase
 
         // Assert
         self::assertInstanceOf(AccessControl::class, $accessControlPermission);
-        self::assertEquals($permissionToCheck, $accessControlPermission->getPermissionName());
+        self::assertSame($permissionToCheck, $accessControlPermission->getPermissionName());
     }
 
     public function testDuplicatePermissionCreationThrowsException(): void
@@ -122,7 +122,7 @@ class AccessControlServiceTest extends UnitTestCase
         $permissions = $this->sut->getPermissions($this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertEmpty($permissions);
+        self::assertEmpty($permissions);
 
         // Arrange
         $this->sut->createPermission($permissionToCheckA, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
@@ -132,8 +132,8 @@ class AccessControlServiceTest extends UnitTestCase
         $permissions = $this->sut->getPermissions($this->testOrga->object(), $this->testCustomer->object(), [RoleInterface::PRIVATE_PLANNING_AGENCY]);
 
         // Assert
-        $this->assertIsArray($permissions);
-        $this->assertCount(2, $permissions);
+        self::assertIsArray($permissions);
+        self::assertCount(2, $permissions);
     }
 
     public function testHasPermission(): void
@@ -146,7 +146,7 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->permissionExist($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertFalse($hasPermission);
+        self::assertFalse($hasPermission);
 
         // Arrange
         $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
@@ -155,7 +155,7 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->permissionExist($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertTrue($hasPermission);
+        self::assertTrue($hasPermission);
     }
 
     public function testDoesNotHavePermissionCreateProceduresPermission(): void
@@ -173,7 +173,7 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->permissionExist($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertFalse($hasPermission);
+        self::assertFalse($hasPermission);
 
         // Arrange
         $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
@@ -182,7 +182,7 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->checkPermissionForOrgaType($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object());
 
         // Assert
-        $this->assertFalse($hasPermission);
+        self::assertFalse($hasPermission);
     }
 
     public function testHasPermissionCreateProceduresPermission(): void
@@ -195,7 +195,7 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->permissionExist($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertFalse($hasPermission);
+        self::assertFalse($hasPermission);
 
         // Arrange
         $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
@@ -204,6 +204,6 @@ class AccessControlServiceTest extends UnitTestCase
         $hasPermission = $this->sut->permissionExist($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $roleCodes);
 
         // Assert
-        $this->assertTrue($hasPermission);
+        self::assertTrue($hasPermission);
     }
 }

--- a/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
+++ b/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
@@ -32,7 +32,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Tests\Base\UnitTestCase;
 use Zenstruck\Foundry\Proxy;
 
-class AccessControlPermissionServiceTest extends UnitTestCase
+class AccessControlServiceTest extends UnitTestCase
 {
     /**
      * @var AccessControlService|null
@@ -69,7 +69,7 @@ class AccessControlPermissionServiceTest extends UnitTestCase
 
         $this->testOrga = OrgaFactory::createOne();
         $this->testCustomer = CustomerFactory::createOne();
-        $this->testCustomer->setSubdomain($this->globalConfig->getSubdomain());
+        $this->testCustomer->setSubdomain('bb');
         $this->testCustomer->save();
 
         $this->testOrgaStatusInCustomer = OrgaStatusInCustomerFactory::createOne();
@@ -179,7 +179,7 @@ class AccessControlPermissionServiceTest extends UnitTestCase
         $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
 
         // Act
-        $hasPermission = $this->sut->checkPermissionForOrgaType($permissionToCheck, $this->testOrga->object());
+        $hasPermission = $this->sut->checkPermissionForOrgaType($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object());
 
         // Assert
         $this->assertFalse($hasPermission);


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-11765/Wenn-Planungsburo-Verfahren-anlegen-darf-bekommt-der-Benutzer-ein-Fehlermeldung-beim-erstellen-von-ein-Verfahren

Description:
- In the file demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php line 134 check the subdomain of the current customer instead of the default config so that the orgaType for the current customer is returned correctly.
- Adjust also demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php line 2137 so that current customer is passed to the AccessControlService method

### How to review/test
- Run the tests tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
- Activate checkbox for an orga using customer support role and then login with a planing agency orga to create procedures


### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/3091

Delete the checkbox if it doesn't apply/isn't necessary.

- [x ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
