### PR TITLE
B dplan 11776 catch assert exception

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -75,17 +75,17 @@ class AccessControlService extends CoreService
         return $enabledPermissions;
     }
 
-    private function getRoleByCode(string $roleCode): RoleInterface {
+    private function getRoleByCode(string $roleCode): RoleInterface
+    {
         $roles = $this->roleHandler->getUserRolesByCodes([$roleCode]);
 
         try {
             Assert::count($roles, 1);
         } catch (InvalidArgumentException $e) {
-
             // Log the warning
             $this->logger->warning('More than one role found for the given role name. Using the first one.', [
                 'roleName' => $roleCode,
-                'roles' => $roles,
+                'roles'    => $roles,
             ]);
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -17,6 +17,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
+use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository;
@@ -62,9 +63,7 @@ class AccessControlService extends CoreService
         foreach ($roles as $roleName) {
             // Try to find an existing permission with the given parameters
 
-            $roles = $this->roleHandler->getUserRolesByCodes([$roleName]);
-            Assert::count($roles, 1);
-            $role = $roles[0];
+            $role = $this->getRoleByCode($roleName);
 
             $permissions = $this->getEnabledPermissionNames($role, $orga, $customer, null);
 
@@ -74,6 +73,24 @@ class AccessControlService extends CoreService
 
         // Return the permissions array
         return $enabledPermissions;
+    }
+
+    private function getRoleByCode(string $roleCode): RoleInterface {
+        $roles = $this->roleHandler->getUserRolesByCodes([$roleCode]);
+
+        try {
+            Assert::count($roles, 1);
+        } catch (InvalidArgumentException $e) {
+
+            // Log the warning
+            $this->logger->warning('More than one role found for the given role name. Using the first one.', [
+                'roleName' => $roleCode,
+                'roles' => $roles,
+            ]);
+        }
+
+        // Use the first role
+        return $roles[0];
     }
 
     private function getEnabledPermissionNames(?RoleInterface $role, ?OrgaInterface $orga, ?CustomerInterface $customer, ?string $permissionName): array

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -17,12 +17,12 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
-use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * This file is part of the package demosplan.


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-11776/Eine-Rolle-kann-mehrere-Malen-hinzugefugt-sein-blp-ewm


Description:
- some projects like ewm or regio can have multiple roles with the same code stored in DB.
- Because of that, the assert line throws en exception.
- This PR catches the exception and return the first role found in the array

### How to review/test
- Log to ewm, blp, regio
- Login to any user
- make sure you can login


### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/3091

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
