### PR TITLE
feat (DPLAN-11785) Create NewOrgaCreated event and add listener to ca…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -48,7 +48,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use UnexpectedValueException;
-use Webmozart\Assert\Assert;
 
 class DemosPlanOrganisationAPIController extends APIController
 {
@@ -329,7 +328,6 @@ class DemosPlanOrganisationAPIController extends APIController
             $canCreateProcedures = null;
             if ($permissions->hasPermission('feature_manage_procedure_creation_permission')
                 && array_key_exists('canCreateProcedures', $orgaDataArray)) {
-
                 $role = $roleHandler->getRoleByCode(RoleInterface::PRIVATE_PLANNING_AGENCY);
 
                 try {
@@ -340,7 +338,7 @@ class DemosPlanOrganisationAPIController extends APIController
                 } catch (NullPointerException $e) {
                     $this->logger->warning('Role was not found in Customer. Permission is not created', [
                         'roleName'   => RoleInterface::PRIVATE_PLANNING_AGENCY,
-                        'permission' => AccessControlService::CREATE_PROCEDURES_PERMISSION
+                        'permission' => AccessControlService::CREATE_PROCEDURES_PERMISSION,
                     ]);
                 }
             }
@@ -408,7 +406,6 @@ class DemosPlanOrganisationAPIController extends APIController
             $canCreateProcedures = null;
             if ($permissions->hasPermission('feature_manage_procedure_creation_permission') && is_array($orgaDataArray['attributes'])
                 && array_key_exists('canCreateProcedures', $orgaDataArray['attributes'])) {
-
                 $role = $roleHandler->getRoleByCode(RoleInterface::PRIVATE_PLANNING_AGENCY);
 
                 try {
@@ -422,10 +419,9 @@ class DemosPlanOrganisationAPIController extends APIController
                 } catch (NullPointerException $e) {
                     $this->logger->warning('Role was not found in Customer. Permission is not created', [
                         'roleName'   => RoleInterface::PRIVATE_PLANNING_AGENCY,
-                        'permission' => AccessControlService::CREATE_PROCEDURES_PERMISSION
+                        'permission' => AccessControlService::CREATE_PROCEDURES_PERMISSION,
                     ]);
                 }
-
             }
 
             $updatedOrga = $userHandler->updateOrga($orgaId, $orgaDataArray);

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -336,7 +336,6 @@ class DemosPlanOrganisationAPIController extends APIController
                     $canCreateProcedures = true;
                     $accessControlPermission->createPermission(AccessControlService::CREATE_PROCEDURES_PERMISSION, $newOrga, $customerHandler->getCurrentCustomer(), $role);
                 }
-
             }
 
             try {
@@ -345,8 +344,6 @@ class DemosPlanOrganisationAPIController extends APIController
             } catch (Exception $e) {
                 $this->logger->warning('Could not successfully perform orga created event', [$e]);
             }
-
-
 
             $item = $this->resourceService->makeItemOfResource($newOrga, OrgaResourceType::getName());
 
@@ -439,15 +436,12 @@ class DemosPlanOrganisationAPIController extends APIController
 
                 $item = $this->resourceService->makeItemOfResource($updatedOrga, OrgaResourceType::getName());
 
-
                 try {
                     $newOrgaCreatedEvent = new OrgaAdminEditedEvent($updatedOrga, $canCreateProcedures);
                     $eventDispatcher->dispatch($newOrgaCreatedEvent);
                 } catch (Exception $e) {
                     $this->logger->warning('Could not successfully perform orga created event', [$e]);
                 }
-
-
 
                 return $this->renderResource($item);
             }

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -336,7 +336,6 @@ class DemosPlanOrganisationAPIController extends APIController
                 }
             }
 
-
             try {
                 $newOrgaCreatedEvent = new NewOrgaCreatedEvent($newOrga);
                 $eventDispatcher->dispatch($newOrgaCreatedEvent);

--- a/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the package demosplan.
  *

--- a/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Event\User;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
+class NewOrgaCreatedEvent extends DPlanEvent
+{
+
+    protected OrgaInterface $orga;
+    public function __construct(Orga $newOrga) {
+        $this->orga = $newOrga;
+    }
+
+    public function getOrganisation(): OrgaInterface
+    {
+        return $this->orga;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/User/NewOrgaCreatedEvent.php
@@ -16,9 +16,10 @@ use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
 
 class NewOrgaCreatedEvent extends DPlanEvent
 {
-
     protected OrgaInterface $orga;
-    public function __construct(Orga $newOrga) {
+
+    public function __construct(Orga $newOrga)
+    {
         $this->orga = $newOrga;
     }
 

--- a/demosplan/DemosPlanCoreBundle/Event/User/OrgaAdminEditedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/User/OrgaAdminEditedEvent.php
@@ -16,15 +16,15 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
 
-class NewOrgaCreatedEvent extends DPlanEvent
+class OrgaAdminEditedEvent extends DPlanEvent
 {
     protected OrgaInterface $orga;
 
     protected ?bool $canCreateProcedures;
 
-    public function __construct(Orga $newOrga, ?bool $canCreateProcedures)
+    public function __construct(Orga $updatedOrga, ?bool $canCreateProcedures)
     {
-        $this->orga = $newOrga;
+        $this->orga = $updatedOrga;
         $this->canCreateProcedures = $canCreateProcedures;
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -61,7 +61,11 @@ class AccessControlService extends CoreService
         foreach ($roles as $roleName) {
             // Try to find an existing permission with the given parameters
 
-            $role = $this->getRoleByCode($roleName);
+            $role = $this->roleHandler->getRoleByCode($roleName);
+
+            if ($role === null) {
+                continue;
+            }
 
             $permissions = $this->getEnabledPermissionNames($role, $orga, $customer, null);
 
@@ -71,24 +75,6 @@ class AccessControlService extends CoreService
 
         // Return the permissions array
         return $enabledPermissions;
-    }
-
-    private function getRoleByCode(string $roleCode): RoleInterface
-    {
-        $roles = $this->roleHandler->getUserRolesByCodes([$roleCode]);
-
-        try {
-            Assert::count($roles, 1);
-        } catch (InvalidArgumentException $e) {
-            // Log the warning
-            $this->logger->warning('More than one role found for the given role name. Using the first one.', [
-                'roleName' => $roleCode,
-                'roles'    => $roles,
-            ]);
-        }
-
-        // Use the first role
-        return $roles[0];
     }
 
     private function getEnabledPermissionNames(?RoleInterface $role, ?OrgaInterface $orga, ?CustomerInterface $customer, ?string $permissionName): array

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -20,8 +20,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository;
-use Webmozart\Assert\Assert;
-use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * This file is part of the package demosplan.
@@ -63,7 +61,7 @@ class AccessControlService extends CoreService
 
             $role = $this->roleHandler->getRoleByCode($roleName);
 
-            if ($role === null) {
+            if (null === $role) {
                 continue;
             }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -174,7 +174,6 @@ class AccessControlService extends CoreService
         return !empty($permissions);
     }
 
-
     public function addPermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void
     {
         $role = $this->roleHandler->getRoleByCode($roleName);
@@ -195,7 +194,6 @@ class AccessControlService extends CoreService
         }
 
         $this->removePermission(self::CREATE_PROCEDURES_PERMISSION, $orga, $customer, $role);
-
     }
 
     public function enablePermissionCustomerOrgaRole(string $permissionToEnable, CustomerInterface $customer, RoleInterface $role, bool $dryRun = false): array
@@ -221,6 +219,5 @@ class AccessControlService extends CoreService
         }
 
         return $updatedOrgas;
-
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -159,20 +159,22 @@ class AccessControlService extends CoreService
         return !empty($permissions);
     }
 
-    public function addPermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void {
+    public function addPermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void
+    {
         $role = $this->roleHandler->getRoleByCode($roleName);
 
-        if ($role === null) {
+        if (null === $role) {
             return;
         }
 
         $this->createPermission(self::CREATE_PROCEDURES_PERMISSION, $orga, $customer, $role);
     }
 
-    public function removePermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void {
+    public function removePermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void
+    {
         $role = $this->roleHandler->getRoleByCode($roleName);
 
-        if ($role === null) {
+        if (null === $role) {
             return;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -158,4 +158,24 @@ class AccessControlService extends CoreService
 
         return !empty($permissions);
     }
+
+    public function addPermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void {
+        $role = $this->roleHandler->getRoleByCode($roleName);
+
+        if ($role === null) {
+            return;
+        }
+
+        $this->createPermission(self::CREATE_PROCEDURES_PERMISSION, $orga, $customer, $role);
+    }
+
+    public function removePermissionToGivenRole(OrgaInterface $orga, CustomerInterface $customer, string $roleName): void {
+        $role = $this->roleHandler->getRoleByCode($roleName);
+
+        if ($role === null) {
+            return;
+        }
+
+        $this->removePermission(self::CREATE_PROCEDURES_PERMISSION, $orga, $customer, $role);
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -196,6 +196,8 @@ class AccessControlService extends CoreService
 
         $this->removePermission(self::CREATE_PROCEDURES_PERMISSION, $orga, $customer, $role);
 
+    }
+
     public function enablePermissionCustomerOrgaRole(string $permissionToEnable, CustomerInterface $customer, RoleInterface $role, bool $dryRun = false): array
     {
         // enable permission for all orga on the given customer and role

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -48,20 +48,19 @@ class AccessControlService extends CoreService
             $permission->setCustomer($customer);
             $permission->setRole($role);
             $this->accessControlPermissionRepository->add($permission);
-            return $permission;
 
+            return $permission;
         } catch (UniqueConstraintViolationException $exception) {
             $this->logger->warning('Unique constraint violation occurred while trying to create a permission.', [
-                'exception' => $exception->getMessage(),
+                'exception'      => $exception->getMessage(),
                 'permissionName' => $permissionName,
-                'orga' => $orga->getId(),
-                'customer' => $customer->getId(),
-                'role' => $role->getId(),
+                'orga'           => $orga->getId(),
+                'customer'       => $customer->getId(),
+                'role'           => $role->getId(),
             ]);
         }
 
         return null;
-
     }
 
     public function getPermissions(?OrgaInterface $orga, ?CustomerInterface $customer, array $roles): array

--- a/demosplan/DemosPlanCoreBundle/Logic/User/RoleHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/RoleHandler.php
@@ -10,10 +10,12 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
+use Webmozart\Assert\Assert;
 
 class RoleHandler extends CoreHandler
 {
@@ -70,5 +72,27 @@ class RoleHandler extends CoreHandler
     public function getUserRolesByGroupCodes(array $codes): array
     {
         return $this->roleService->getUserRolesByGroupCodes($codes);
+    }
+
+    public function getRoleByCode(string $roleCode): ?RoleInterface
+    {
+        $roles = $this->getUserRolesByCodes([$roleCode]);
+
+        if (empty($roles)) {
+            return null;
+        }
+
+        try {
+            Assert::count($roles, 1);
+        } catch (\Webmozart\Assert\InvalidArgumentException $e) {
+            // Log the warning
+            $this->logger->warning('More than one role found for the given role name. Using the first one.', [
+                'roleName' => $roleCode,
+                'roles'    => $roles,
+            ]);
+        }
+
+        // Use the first role
+        return $roles[0];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -309,7 +309,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 'area_preferences',  // Einstellungen
                 'feature_admin_delete_procedure',  // Verfahren loeschen
                 'feature_admin_export_procedure',  // Verfahren exportieren
-                'feature_admin_new_procedure',  // Neues Verfahren anlegen
                 'feature_procedure_export_include_public_interest_bodies_member_list',
                 'feature_json_api_get', // allow get requests to generic api
             ]);

--- a/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
+++ b/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
@@ -38,6 +38,7 @@ class AccessControlServiceTest extends UnitTestCase
      * @var AccessControlService|null
      */
     protected $sut;
+
     protected RoleHandler|Proxy|null $roleHandler;
 
     protected GlobalConfig|Proxy|null $globalConfig;
@@ -106,9 +107,9 @@ class AccessControlServiceTest extends UnitTestCase
     public function testDuplicatePermissionCreationThrowsException(): void
     {
         $permissionToCheck = 'my_permission';
-        $this->expectException(UniqueConstraintViolationException::class);
         $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
-        $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
+        $createdPermission = $this->sut->createPermission($permissionToCheck, $this->testOrga->object(), $this->testCustomer->object(), $this->testRole);
+        $this->assertNull($createdPermission);
     }
 
     public function testGetPermissions(): void

--- a/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
+++ b/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
@@ -28,7 +28,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Tests\Base\UnitTestCase;
 use Zenstruck\Foundry\Proxy;
 


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-11785/blp-additional-roles-should-not-have-hard-coded-permission

Description:

1. The permissions `feature_admin_new_procedure` should be dynamically set for every role only in the blp project.
2. Some roles have that permission hard-coded in the Permissions.php in core
3. The permission has been removed from core and migrated to each Permissions.php project (except BLP)
4. Below the roles that had this permission hard-coded:
5.  `HEARING_AUTHORITY_ADMIN` and `PLANNING_AGENCY_ADMIN` had the permission in Permissions.php in core
6. `CUSTOMER_MASTER_USER` had the permission in Permissions.php in blp
7. In order to make this permission dynamic, these 3 roles get the permission whenever a new orga is created. In order to do  that, there is an event `NewOrgaCreatedEvent` that is triggered everytime that a new orga is created.
8. The event has 2 parameters: orga and the flag `canCreateProcedures`
9. The flag can be set as true, false or null.
10. There is a listener in blp folder` OrganisationCreateSubscriber` that listens the event and decides based on the flag if the permission should be added for the `HEARING_AUTHORITY_ADMIN` and `PLANNING_AGENCY_ADMIN` and `CUSTOMER_MASTER_USER` roles.
11. Similar approach is happening when the `OrgaAdminEditedEvent` is triggered. There is a listener in blp folder` OrganisationCreateSubscriber` that listens the event and decides based on the flag if the permission should be added for the `HEARING_AUTHORITY_ADMIN` and `PLANNING_AGENCY_ADMIN` and `CUSTOMER_MASTER_USER`


### How to review/test
Case 1:
- using Support role Create an orga in BLP and checkbox the flag: Darf Verfahren anlegen
- then you can see in the table access_controll that there should be 3 entry permissions (it depends if the 3 roles are created in the DB)

Case 2:
- using Support role update an orga in BLP (where you can login later) and checkbox the flag: Darf Verfahren anlegen
- then you can see in the table access_controll that there should be 3 entry permissions (it depends if the 3 roles are created in the DB)
- Then login to that orga, you should be able to create Verfahren
- Then uncheck the box.
- Then login to that orga, you should not be able to create Verfahren

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/3216


- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
