### PR TITLE
bug(refs DPLAN-1879): Use the right attribute for label prop

### DIFF
--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -38,7 +38,7 @@
           v-model="currentAutocompleteSearch"
           :class="prefixClass('c-proceduresearch__search-field')"
           :label="{
-            hidden: true,
+            hide: true,
             text: Translator.trans('procedure.public.search.placeholder')
           }"
           name="search"


### PR DESCRIPTION
### Ticket
DPLAN-1879

Attribute was changed from hidden to hide, see https://github.com/demos-europe/demosplan-ui/pull/894

