### PR TITLE
F plan 11799 command disable permissions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Permission;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
+use demosplan\DemosPlanCoreBundle\Exception\RoleNotFoundException;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * This Command is used to disable a specific permission for a given customer, organization, and role.
+ */
+class DisablePermissionForCustomerOrgaRoleCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:permission:disable:customer-orga-role';
+    protected static $defaultDescription = 'Disables a specific permission for a given customer, organization, and role';
+
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly CustomerService $customerService,
+        private readonly RoleService $roleService,
+        private readonly AccessControlService $accessControlPermissionService,
+        ?string $name = null
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    public function configure(): void
+    {
+        $this->addArgument(
+            'customerId',
+            InputArgument::REQUIRED,
+            'The ID of the customer you want to disable the permission.'
+        );
+
+        $this->addArgument(
+            'roleId',
+            InputArgument::REQUIRED,
+            'The ID of the role you want to disable the permission.'
+        );
+
+        $this->addArgument(
+            'permission',
+            InputArgument::REQUIRED,
+            'The name of the permission to be disabled.'
+        );
+
+        $this->addOption(
+            'dry-run',
+            '',
+            InputOption::VALUE_NONE,
+            'Initiates a dry run with verbose output to see what would happen.'
+        );
+    }
+
+    /**
+     * @throws RoleNotFoundException
+     * @throws CustomerNotFoundException
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $customerId = $input->getArgument('customerId');
+        $roleId = $input->getArgument('roleId');
+        $permissionName = $input->getArgument('permission');
+        $dryRun = $input->getOption('dry-run');
+
+        $customerChoice = $this->customerService->findCustomerById($customerId);
+        $roleChoice = $this->roleService->getRole($roleId);
+        $permissionChoice = $this->getConstantValueByName($permissionName);
+
+        // Return Exception for RoleChoice as Customer already throws exception if null, and permission exception is handled in getConstantValueByName
+        if (null === $roleChoice) {
+            throw new RoleNotFoundException('Role not found');
+        }
+
+        $updatedOrgas = $this->accessControlPermissionService->disablePermissionCustomerOrgaRole($permissionChoice, $customerChoice, $roleChoice, $dryRun);
+
+        $this->displayUpdatedOrgas($output, $updatedOrgas);
+
+        $output->writeln('******************************************************');
+        $output->writeln($dryRun ? 'This is a dry run. No changes have been made to the database.' : 'Changes have been applied to the database.');
+        $output->writeln('******************************************************');
+        $output->writeln('Permission has been disabled for '.count($updatedOrgas).' orgas');
+        $output->writeln('Permission has been disabled for mentioned orgas on:');
+        $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
+        $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
+
+        return Command::SUCCESS;
+    }
+
+    private function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
+    {
+        foreach ($updatedOrgas as $orga) {
+            $output->writeln('Orga ID: '.$orga->getId());
+            $output->writeln('Orga Name: '.$orga->getName());
+        }
+    }
+
+    private function getConstantValueByName($constantName): string
+    {
+        $className = AccessControlService::class;
+        $constantFullName = $className.'::'.$constantName;
+        if (defined($constantFullName)) {
+            return constant($constantFullName);
+        }
+
+        throw new InvalidArgumentException('Permission does not exit');
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * This Command is used to disable a specific permission for a given customer, organization, and role.
  */
-class DisablePermissionForCustomerOrgaRoleCommand extends CoreCommand
+class DisablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOrgaRoleCommand
 {
     protected static $defaultName = 'dplan:permission:disable:customer-orga-role';
     protected static $defaultDescription = 'Disables a specific permission for a given customer, organization, and role';
@@ -44,33 +44,6 @@ class DisablePermissionForCustomerOrgaRoleCommand extends CoreCommand
         parent::__construct($parameterBag, $name);
     }
 
-    public function configure(): void
-    {
-        $this->addArgument(
-            'customerId',
-            InputArgument::REQUIRED,
-            'The ID of the customer you want to disable the permission.'
-        );
-
-        $this->addArgument(
-            'roleId',
-            InputArgument::REQUIRED,
-            'The ID of the role you want to disable the permission.'
-        );
-
-        $this->addArgument(
-            'permission',
-            InputArgument::REQUIRED,
-            'The name of the permission to be disabled.'
-        );
-
-        $this->addOption(
-            'dry-run',
-            '',
-            InputOption::VALUE_NONE,
-            'Initiates a dry run with verbose output to see what would happen.'
-        );
-    }
 
     /**
      * @throws RoleNotFoundException
@@ -107,22 +80,4 @@ class DisablePermissionForCustomerOrgaRoleCommand extends CoreCommand
         return Command::SUCCESS;
     }
 
-    private function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
-    {
-        foreach ($updatedOrgas as $orga) {
-            $output->writeln('Orga ID: '.$orga->getId());
-            $output->writeln('Orga Name: '.$orga->getName());
-        }
-    }
-
-    private function getConstantValueByName($constantName): string
-    {
-        $className = AccessControlService::class;
-        $constantFullName = $className.'::'.$constantName;
-        if (defined($constantFullName)) {
-            return constant($constantFullName);
-        }
-
-        throw new InvalidArgumentException('Permission does not exit');
-    }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
@@ -69,13 +69,7 @@ class DisablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerO
 
         $this->displayUpdatedOrgas($output, $updatedOrgas);
 
-        $output->writeln('******************************************************');
-        $output->writeln($dryRun ? 'This is a dry run. No changes have been made to the database.' : 'Changes have been applied to the database.');
-        $output->writeln('******************************************************');
-        $output->writeln('Permission has been disabled for '.count($updatedOrgas).' orgas');
-        $output->writeln('Permission has been disabled for mentioned orgas on:');
-        $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
-        $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
+        $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'disabled');
 
         return Command::SUCCESS;
     }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * This Command is used to enable a specific permission for a given customer, organization, and role.
  */
-class EnablePermissionForCustomerOrgaRoleCommand extends CoreCommand
+class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOrgaRoleCommand
 {
     protected static $defaultName = 'dplan:permission:enable:customer-orga-role';
     protected static $defaultDescription = 'Enables a specific permission for a given customer, organization, and role';
@@ -44,33 +44,6 @@ class EnablePermissionForCustomerOrgaRoleCommand extends CoreCommand
         parent::__construct($parameterBag, $name);
     }
 
-    public function configure(): void
-    {
-        $this->addArgument(
-            'customerId',
-            InputArgument::REQUIRED,
-            'The ID of the customer you want to enable the permission.'
-        );
-
-        $this->addArgument(
-            'roleId',
-            InputArgument::REQUIRED,
-            'The ID of the role you want to enable the permission.'
-        );
-
-        $this->addArgument(
-            'permission',
-            InputArgument::REQUIRED,
-            'The name of the permission to be enabled'
-        );
-
-        $this->addOption(
-            'dry-run',
-            '',
-            InputOption::VALUE_NONE,
-            'Initiates a dry run with verbose output to see what would happen.'
-        );
-    }
 
     /**
      * @throws RoleNotFoundException
@@ -105,24 +78,5 @@ class EnablePermissionForCustomerOrgaRoleCommand extends CoreCommand
         $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
 
         return Command::SUCCESS;
-    }
-
-    private function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
-    {
-        foreach ($updatedOrgas as $orga) {
-            $output->writeln('Orga ID: '.$orga->getId());
-            $output->writeln('Orga Name: '.$orga->getName());
-        }
-    }
-
-    private function getConstantValueByName($constantName): string
-    {
-        $className = AccessControlService::class;
-        $constantFullName = $className.'::'.$constantName;
-        if (defined($constantFullName)) {
-            return constant($constantFullName);
-        }
-
-        throw new InvalidArgumentException('Permission does not exit');
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -66,8 +66,6 @@ class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOr
 
         $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'enabled');
 
-
-
         return Command::SUCCESS;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -69,13 +69,9 @@ class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOr
 
         $this->displayUpdatedOrgas($output, $updatedOrgas);
 
-        $output->writeln('******************************************************');
-        $output->writeln($dryRun ? 'This is a dry run. No changes have been made to the database.' : 'Changes have been applied to the database.');
-        $output->writeln('******************************************************');
-        $output->writeln('Permission has been enabled for '.count($updatedOrgas).' orgas');
-        $output->writeln('Permission has been enabled for mentioned orgas on:');
-        $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
-        $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
+        $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'enabled');
+
+
 
         return Command::SUCCESS;
     }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -55,20 +55,16 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
         );
     }
 
-    protected function displayOutcome( OutputInterface $output, $dryRun, array $updatedOrgas, CustomerInterface $customerChoice, RoleInterface $roleChoice, string $action): void
+    protected function displayOutcome(OutputInterface $output, $dryRun, array $updatedOrgas, CustomerInterface $customerChoice, RoleInterface $roleChoice, string $action): void
     {
-
         $output->writeln('******************************************************');
         $output->writeln($dryRun ? 'This is a dry run. No changes have been made to the database.' : 'Changes have been applied to the database.');
         $output->writeln('******************************************************');
-        $output->writeln('Permission has been ' . $action . ' for '. count($updatedOrgas).' orgas');
-        $output->writeln('Permission has been ' . $action . ' for mentioned orgas on:');
+        $output->writeln('Permission has been '.$action.' for '.count($updatedOrgas).' orgas');
+        $output->writeln('Permission has been '.$action.' for mentioned orgas on:');
         $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
         $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
-
     }
-
-
 
     protected function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
     {

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Permission;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
+use demosplan\DemosPlanCoreBundle\Exception\RoleNotFoundException;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * This Command is the parent class for enable and disable permission commands.
+ */
+abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
+{
+    public function configure(): void
+    {
+        $this->addArgument(
+            'customerId',
+            InputArgument::REQUIRED,
+            'The ID of the customer you want to adjust the permission.'
+        );
+
+        $this->addArgument(
+            'roleId',
+            InputArgument::REQUIRED,
+            'The ID of the role you want to adjust the permission.'
+        );
+
+        $this->addArgument(
+            'permission',
+            InputArgument::REQUIRED,
+            'The name of the permission to be adjusted.'
+        );
+
+        $this->addOption(
+            'dry-run',
+            '',
+            InputOption::VALUE_NONE,
+            'Initiates a dry run with verbose output to see what would happen.'
+        );
+    }
+
+    protected function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
+    {
+        foreach ($updatedOrgas as $orga) {
+            $output->writeln('Orga ID: '.$orga->getId());
+            $output->writeln('Orga Name: '.$orga->getName());
+        }
+    }
+
+    protected function getConstantValueByName($constantName): string
+    {
+        $className = AccessControlService::class;
+        $constantFullName = $className.'::'.$constantName;
+        if (defined($constantFullName)) {
+            return constant($constantFullName);
+        }
+
+        throw new InvalidArgumentException('Permission does not exit');
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Permission;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\RoleNotFoundException;
@@ -58,6 +60,21 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
             'Initiates a dry run with verbose output to see what would happen.'
         );
     }
+
+    protected function displayOutcome( OutputInterface $output, $dryRun, array $updatedOrgas, CustomerInterface $customerChoice, RoleInterface $roleChoice, string $action): void
+    {
+
+        $output->writeln('******************************************************');
+        $output->writeln($dryRun ? 'This is a dry run. No changes have been made to the database.' : 'Changes have been applied to the database.');
+        $output->writeln('******************************************************');
+        $output->writeln('Permission has been ' . $action . ' for '. count($updatedOrgas).' orgas');
+        $output->writeln('Permission has been ' . $action . ' for mentioned orgas on:');
+        $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
+        $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
+
+    }
+
+
 
     protected function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -201,4 +201,27 @@ class AccessControlService extends CoreService
 
         return $updatedOrgas;
     }
+
+    public function disablePermissionCustomerOrgaRole(string $permissionToEnable, CustomerInterface $customer, RoleInterface $role, bool $dryRun = false): array
+    {
+        $orgasInCustomer = $this->orgaService->getOrgasInCustomer($customer);
+        $updatedOrgas = [];
+
+        foreach ($orgasInCustomer as $orgaInCustomer) {
+            // If permisison is already stored, skip it
+            if (false === $this->permissionExist($permissionToEnable, $orgaInCustomer, $customer, [$role->getCode()])) {
+                continue;
+            }
+
+            // Do not remove permission if it is dryrun
+            if (false === $dryRun) {
+                $this->removePermission($permissionToEnable, $orgaInCustomer, $customer, $role);
+            }
+
+            // Save the impacted orga in the array
+            $updatedOrgas[] = $orgaInCustomer;
+        }
+
+        return $updatedOrgas;
+    }
 }

--- a/tests/backend/core/Core/Functional/Command/DisablePermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DisablePermissionForCustomerOrgaRoleCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional\Command;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Permission\DisablePermissionForCustomerOrgaRoleCommand;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaTypeFactory;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
+use demosplan\DemosPlanCoreBundle\Entity\User\Role;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+use Zenstruck\Foundry\Proxy;
+
+class DisablePermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
+{
+    protected CustomerService|Proxy|null $customerService;
+    protected OrgaService|Proxy|null $orgaService;
+    protected RoleService|Proxy|null $roleService;
+    protected AccessControlService|Proxy|null $accessControlService;
+    protected RoleHandler|Proxy|null $roleHandler;
+    private Orga|Proxy|null $testOrga;
+    private Role|Proxy|null $testRole;
+    private Customer|Proxy|null $testCustomer;
+    private OrgaType|Proxy|null $testOrgaType;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->roleHandler = $this->getContainer()->get(RoleHandler::class);
+        $this->customerService = $this->getContainer()->get(CustomerService::class);
+        $this->orgaService = $this->getContainer()->get(OrgaService::class);
+        $this->roleService = $this->getContainer()->get(RoleService::class);
+        $this->accessControlService = $this->getContainer()->get(AccessControlService::class);
+        $this->testRole = $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0];
+
+        $this->testOrgaType = OrgaTypeFactory::createOne();
+        $this->testOrgaType->setName(OrgaTypeInterface::PLANNING_AGENCY);
+        $this->testOrgaType->save();
+
+        $this->testOrga = OrgaFactory::createOne();
+        $this->testCustomer = CustomerFactory::createOne();
+    }
+
+    public function testExecute(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+
+        $application->add(new DisablePermissionForCustomerOrgaRoleCommand(
+            $this->createMock(ParameterBagInterface::class),
+            $this->customerService,
+            $this->roleService,
+            $this->accessControlService,
+        ));
+
+        $command = $application->find(DisablePermissionForCustomerOrgaRoleCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+
+        $this->assertStringsInCommandOutput($commandTester, true, 'This is a dry run. No changes have been made to the database.');
+        $this->assertStringsInCommandOutput($commandTester, false, 'Changes have been applied to the database.');
+
+        return $commandTester;
+    }
+
+    private function assertStringsInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
+    {
+        $commandTester->execute([
+            'customerId' => $this->testCustomer->getId(),
+            'roleId'     => $this->testRole->getId(),
+            'permission' => 'CREATE_PROCEDURES_PERMISSION',
+            '--dry-run'  => $dryRun,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString($expectedMessage, $output);
+        $this->assertStringContainsString('Customer '.$this->testCustomer->getId().' '.$this->testCustomer->getName(), $output);
+        $this->assertStringContainsString('Role '.$this->testRole->getId().' '.$this->testRole->getName(), $output);
+    }
+}

--- a/tests/backend/core/Core/Functional/Command/DisablePermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DisablePermissionForCustomerOrgaRoleCommandTest.php
@@ -12,56 +12,14 @@ declare(strict_types=1);
 
 namespace Tests\Core\Core\Functional\Command;
 
-use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
 use demosplan\DemosPlanCoreBundle\Command\Permission\DisablePermissionForCustomerOrgaRoleCommand;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaTypeFactory;
-use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
-use demosplan\DemosPlanCoreBundle\Entity\User\Role;
-use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
-use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
-use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Tests\Base\FunctionalTestCase;
-use Zenstruck\Foundry\Proxy;
 
-class DisablePermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
+
+class DisablePermissionForCustomerOrgaRoleCommandTest extends PermissionForCustomerOrgaRoleCommandTest
 {
-    protected CustomerService|Proxy|null $customerService;
-    protected OrgaService|Proxy|null $orgaService;
-    protected RoleService|Proxy|null $roleService;
-    protected AccessControlService|Proxy|null $accessControlService;
-    protected RoleHandler|Proxy|null $roleHandler;
-    private Orga|Proxy|null $testOrga;
-    private Role|Proxy|null $testRole;
-    private Customer|Proxy|null $testCustomer;
-    private OrgaType|Proxy|null $testOrgaType;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->roleHandler = $this->getContainer()->get(RoleHandler::class);
-        $this->customerService = $this->getContainer()->get(CustomerService::class);
-        $this->orgaService = $this->getContainer()->get(OrgaService::class);
-        $this->roleService = $this->getContainer()->get(RoleService::class);
-        $this->accessControlService = $this->getContainer()->get(AccessControlService::class);
-        $this->testRole = $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0];
-
-        $this->testOrgaType = OrgaTypeFactory::createOne();
-        $this->testOrgaType->setName(OrgaTypeInterface::PLANNING_AGENCY);
-        $this->testOrgaType->save();
-
-        $this->testOrga = OrgaFactory::createOne();
-        $this->testCustomer = CustomerFactory::createOne();
-    }
 
     public function testExecute(): CommandTester
     {
@@ -84,18 +42,4 @@ class DisablePermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
         return $commandTester;
     }
 
-    private function assertStringsInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
-    {
-        $commandTester->execute([
-            'customerId' => $this->testCustomer->getId(),
-            'roleId'     => $this->testRole->getId(),
-            'permission' => 'CREATE_PROCEDURES_PERMISSION',
-            '--dry-run'  => $dryRun,
-        ]);
-
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString($expectedMessage, $output);
-        $this->assertStringContainsString('Customer '.$this->testCustomer->getId().' '.$this->testCustomer->getName(), $output);
-        $this->assertStringContainsString('Role '.$this->testRole->getId().' '.$this->testRole->getName(), $output);
-    }
 }

--- a/tests/backend/core/Core/Functional/Command/EnablePermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/EnablePermissionForCustomerOrgaRoleCommandTest.php
@@ -12,56 +12,13 @@ declare(strict_types=1);
 
 namespace Tests\Core\Core\Functional\Command;
 
-use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
 use demosplan\DemosPlanCoreBundle\Command\Permission\EnablePermissionForCustomerOrgaRoleCommand;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaTypeFactory;
-use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
-use demosplan\DemosPlanCoreBundle\Entity\User\Role;
-use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
-use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
-use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Tests\Base\FunctionalTestCase;
-use Zenstruck\Foundry\Proxy;
 
-class EnablePermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
+class EnablePermissionForCustomerOrgaRoleCommandTest extends PermissionForCustomerOrgaRoleCommandTest
 {
-    protected CustomerService|Proxy|null $customerService;
-    protected OrgaService|Proxy|null $orgaService;
-    protected RoleService|Proxy|null $roleService;
-    protected AccessControlService|Proxy|null $accessControlService;
-    protected RoleHandler|Proxy|null $roleHandler;
-    private Orga|Proxy|null $testOrga;
-    private Role|Proxy|null $testRole;
-    private Customer|Proxy|null $testCustomer;
-    private OrgaType|Proxy|null $testOrgaType;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->roleHandler = $this->getContainer()->get(RoleHandler::class);
-        $this->customerService = $this->getContainer()->get(CustomerService::class);
-        $this->orgaService = $this->getContainer()->get(OrgaService::class);
-        $this->roleService = $this->getContainer()->get(RoleService::class);
-        $this->accessControlService = $this->getContainer()->get(AccessControlService::class);
-        $this->testRole = $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0];
-
-        $this->testOrgaType = OrgaTypeFactory::createOne();
-        $this->testOrgaType->setName(OrgaTypeInterface::PLANNING_AGENCY);
-        $this->testOrgaType->save();
-
-        $this->testOrga = OrgaFactory::createOne();
-        $this->testCustomer = CustomerFactory::createOne();
-    }
 
     public function testExecute(): CommandTester
     {
@@ -84,18 +41,4 @@ class EnablePermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
         return $commandTester;
     }
 
-    private function assertStringsInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
-    {
-        $commandTester->execute([
-            'customerId' => $this->testCustomer->getId(),
-            'roleId'     => $this->testRole->getId(),
-            'permission' => 'CREATE_PROCEDURES_PERMISSION',
-            '--dry-run'  => $dryRun,
-        ]);
-
-        $output = $commandTester->getDisplay();
-        $this->assertStringContainsString($expectedMessage, $output);
-        $this->assertStringContainsString('Customer '.$this->testCustomer->getId().' '.$this->testCustomer->getName(), $output);
-        $this->assertStringContainsString('Role '.$this->testRole->getId().' '.$this->testRole->getName(), $output);
-    }
 }

--- a/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional\Command;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Permission\DisablePermissionForCustomerOrgaRoleCommand;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaTypeFactory;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
+use demosplan\DemosPlanCoreBundle\Entity\User\Role;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+use Zenstruck\Foundry\Proxy;
+
+class PermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
+{
+    protected CustomerService|Proxy|null $customerService;
+    protected OrgaService|Proxy|null $orgaService;
+    protected RoleService|Proxy|null $roleService;
+    protected AccessControlService|Proxy|null $accessControlService;
+    protected RoleHandler|Proxy|null $roleHandler;
+    protected Orga|Proxy|null $testOrga;
+    protected Role|Proxy|null $testRole;
+    protected Customer|Proxy|null $testCustomer;
+    protected OrgaType|Proxy|null $testOrgaType;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->roleHandler = $this->getContainer()->get(RoleHandler::class);
+        $this->customerService = $this->getContainer()->get(CustomerService::class);
+        $this->orgaService = $this->getContainer()->get(OrgaService::class);
+        $this->roleService = $this->getContainer()->get(RoleService::class);
+        $this->accessControlService = $this->getContainer()->get(AccessControlService::class);
+        $this->testRole = $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0];
+
+        $this->testOrgaType = OrgaTypeFactory::createOne();
+        $this->testOrgaType->setName(OrgaTypeInterface::PLANNING_AGENCY);
+        $this->testOrgaType->save();
+
+        $this->testOrga = OrgaFactory::createOne();
+        $this->testCustomer = CustomerFactory::createOne();
+    }
+
+    protected function assertStringsInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
+    {
+        $commandTester->execute([
+            'customerId' => $this->testCustomer->getId(),
+            'roleId'     => $this->testRole->getId(),
+            'permission' => 'CREATE_PROCEDURES_PERMISSION',
+            '--dry-run'  => $dryRun,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString($expectedMessage, $output);
+        $this->assertStringContainsString('Customer '.$this->testCustomer->getId().' '.$this->testCustomer->getName(), $output);
+        $this->assertStringContainsString('Role '.$this->testRole->getId().' '.$this->testRole->getName(), $output);
+    }
+}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-11799/Befehl-zum-Deaktivieren-Permissions

Description:
1. We want a command that given customer id, role id, and permission, it disables this permission for all the orgas under the given customer and role.
2. The command has customerID roleID and permissionName parameters
3. The command also offers a dry-run, which does not execute the update, it only prints the impacted orgas
4. If customer or role or permission are not found, it throws an exception

### How to review/test
1. Type bin/blp dplan:permission:disable:customer-orga-role YOUR_CUSTOMER_ID YOUR_ROLE_ID CREATE_PROCEDURES_PERMISSION --dry-run
2. Adjust param to insert ids based on your db
3. then check if the printed orgas are also removed in the access_control DB

### Related PRs
Related to already merged PR about enabling permissions https://github.com/demos-europe/demosplan-core/pull/3216

Delete the checkbox if it doesn't apply/isn't necessary.

- [x ] Tests updated/created
- [ ] Link all relevant tickets
- [ x] Move the tickets on the board accordingly
