### PR TITLE
f DPLAN-11794 use customer id instead array 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -876,6 +876,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
                 && !$endedInternalProcedure['master'] && !$endedInternalProcedure['deleted']) {
                 $endedInternalProcedure['phase'] = $internalPhaseKey;
                 $endedInternalProcedure['phaseName'] = $internalPhaseName;
+                $endedInternalProcedure['customer'] = $endedInternalProcedure['customer']['id'];
 
                 $updatedProcedure = $this->procedureService->updateProcedure($endedInternalProcedure);
                 $changedInternalProcedures->push($updatedProcedure);
@@ -899,6 +900,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
                 && !$endedExternalProcedure['master'] && !$endedExternalProcedure['deleted']) {
                 $endedExternalProcedure['publicParticipationPhase'] = $externalPhaseKey;
                 $endedExternalProcedure['publicParticipationPhaseName'] = $externalPhaseName;
+                $endedExternalProcedure['customer'] = $endedExternalProcedure['customer']['id'];
 
                 $updatedProcedure = $this->procedureService->updateProcedure($endedExternalProcedure);
                 $changedExternalProcedures->push($updatedProcedure);


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11794/Ravensburg-Prod-Automatische-Phasenumstellung-funktioniert-nicht


Description: customer have to be a customer object or a customer id, otherwise procedures will be not able to be updated


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Update documentation
- [X] Link all relevant tickets

