### PR TITLE
feat(DPLAN-24505): adjust PersonalData component

### DIFF
--- a/client/js/components/user/portalUser/PersonalData.vue
+++ b/client/js/components/user/portalUser/PersonalData.vue
@@ -10,12 +10,14 @@
 <template>
   <div>
     <dl class="description-list u-mb-0_5">
-      <dt class="weight--bold">
-        {{ Translator.trans('username') }}
-      </dt>
-      <dd class="u-mb color--grey">
-        {{ userData.userName }}
-      </dd>
+      <template v-if="!hasIdentityProvider">
+        <dt class="weight--bold">
+          {{ Translator.trans('username') }}
+        </dt>
+        <dd class="u-mb color--grey">
+          {{ userData.userName }}
+        </dd>
+      </template>
 
       <template v-if="hasPermission('area_mydata_organisation')">
         <dt class="weight--bold">
@@ -44,12 +46,15 @@
       <dd class="u-mb color--grey">
         {{ userData.firstName }}
       </dd>
-      <dt class="weight--bold">
-        {{ Translator.trans('email') }}
-      </dt>
-      <dd class="u-mb color--grey">
-        {{ userData.email }}
-      </dd>
+
+      <template v-if="!hasIdentityProvider">
+        <dt class="weight--bold">
+          {{ Translator.trans('email') }}
+        </dt>
+        <dd class="u-mb color--grey">
+          {{ userData.email }}
+        </dd>
+      </template>
     </dl>
 
     <input
@@ -110,6 +115,16 @@ export default {
   },
 
   props: {
+  /**
+   * If the User logs in through a service provider (via Keycloak), the username becomes cryptic and can be confusing.
+   * Therefor we want to hide it from the user.
+   */
+    hasIdentityProvider: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     isDailyDigestEnabled: {
       type: Boolean,
       default: true


### PR DESCRIPTION
### Ticket: 

https://yaits.demos-deutschland.de/T24505

**Description:** Add `hasIdentityProvider` check to `PersonalData` component and replace inline template with `PersonalData` in BLP project's portal_profile.html.twig file.


### How to review/test
login > Meine Daten

### Linked PRs (optional)
[demosplan-project-blp](https://github.com/demos-europe/demosplan-project-blp/pull/1) --> This is an updated PR from 2022

- [x] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
