### PR TITLE
feat (DPLAN-11470) adjust command to take orga type into account

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -35,7 +35,6 @@ class AccessControlService extends CoreService
 {
     public const CREATE_PROCEDURES_PERMISSION = 'feature_admin_new_procedure';
 
-
     public function __construct(
         private readonly AccessControlRepository $accessControlPermissionRepository,
         private readonly RoleHandler $roleHandler,
@@ -216,30 +215,24 @@ class AccessControlService extends CoreService
             if (null !== $updatedOrga) {
                 $updatedOrgas[] = $updatedOrga;
             }
-
         }
 
         return $updatedOrgas;
     }
 
-
     /**
-    $orgatype = getorgatype
-
-    $orgatypeForRole = getOrgaTypebasedonRole
-    if $orgatype === $orgatypeForRole --> add permission
-
+     * $orgatype = getorgatype.
+     *
+     * $orgatypeForRole = getOrgaTypebasedonRole
+     * if $orgatype === $orgatypeForRole --> add permission
      */
-
-    private function addPermissionBasedOnOrgaType(string $permissionToEnable, RoleInterface $role, OrgaInterface $orgaInCustomer, CustomerInterface $customer, bool $dryRun): ?OrgaInterface {
-
+    private function addPermissionBasedOnOrgaType(string $permissionToEnable, RoleInterface $role, OrgaInterface $orgaInCustomer, CustomerInterface $customer, bool $dryRun): ?OrgaInterface
+    {
         $orgaTypesInCustomer = $orgaInCustomer->getTypes($customer->getSubdomain(), true);
         foreach ($orgaTypesInCustomer as $orgaTypeInCustomer) {
-
-            if (self::CREATE_PROCEDURES_PERMISSION === $permissionToEnable &&
-                OrgaTypeInterface::PLANNING_AGENCY === $orgaTypeInCustomer &&
-                RoleInterface::PRIVATE_PLANNING_AGENCY !== $role->getCode()){
-
+            if (self::CREATE_PROCEDURES_PERMISSION === $permissionToEnable
+                && OrgaTypeInterface::PLANNING_AGENCY === $orgaTypeInCustomer
+                && RoleInterface::PRIVATE_PLANNING_AGENCY !== $role->getCode()) {
                 continue;
             }
 
@@ -252,8 +245,7 @@ class AccessControlService extends CoreService
             return $orgaInCustomer;
         }
 
-        //Return null if no orga is impacted
+        // Return null if no orga is impacted
         return null;
     }
-
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -220,13 +220,11 @@ class AccessControlService extends CoreService
         return $updatedOrgas;
     }
 
-
     private function addPermissionBasedOnOrgaType(string $permissionToEnable, RoleInterface $role, OrgaInterface $orgaInCustomer, CustomerInterface $customer, bool $dryRun): ?OrgaInterface
     {
         $orgaTypesInCustomer = $orgaInCustomer->getTypes($customer->getSubdomain(), true);
         foreach ($orgaTypesInCustomer as $orgaTypeInCustomer) {
-
-            //If permission is 'CREATE_PROCEDURES_PERMISSION' and orga type is 'PLANNING_AGENCY' and role is not 'PRIVATE_PLANNING_AGENCY', skip it
+            // If permission is 'CREATE_PROCEDURES_PERMISSION' and orga type is 'PLANNING_AGENCY' and role is not 'PRIVATE_PLANNING_AGENCY', skip it
             if (self::CREATE_PROCEDURES_PERMISSION === $permissionToEnable
                 && OrgaTypeInterface::PLANNING_AGENCY === $orgaTypeInCustomer
                 && RoleInterface::PRIVATE_PLANNING_AGENCY !== $role->getCode()) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -220,16 +220,13 @@ class AccessControlService extends CoreService
         return $updatedOrgas;
     }
 
-    /**
-     * $orgatype = getorgatype.
-     *
-     * $orgatypeForRole = getOrgaTypebasedonRole
-     * if $orgatype === $orgatypeForRole --> add permission
-     */
+
     private function addPermissionBasedOnOrgaType(string $permissionToEnable, RoleInterface $role, OrgaInterface $orgaInCustomer, CustomerInterface $customer, bool $dryRun): ?OrgaInterface
     {
         $orgaTypesInCustomer = $orgaInCustomer->getTypes($customer->getSubdomain(), true);
         foreach ($orgaTypesInCustomer as $orgaTypeInCustomer) {
+
+            //If permission is 'CREATE_PROCEDURES_PERMISSION' and orga type is 'PLANNING_AGENCY' and role is not 'PRIVATE_PLANNING_AGENCY', skip it
             if (self::CREATE_PROCEDURES_PERMISSION === $permissionToEnable
                 && OrgaTypeInterface::PLANNING_AGENCY === $orgaTypeInCustomer
                 && RoleInterface::PRIVATE_PLANNING_AGENCY !== $role->getCode()) {


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-11470/3-0-BB-Als-Fachplanung-Administration-mochte-ich-keine-neuen-Verfahren-mehr-anlegen-konnen-um-falschliches-Anlegen-in-BLP-zu

Description:
- When the command is run to enable permission for all in a particular customer - role, we should check that which orga type has the orga and if it corresponds to the role given in the command.
- It is like that because we want to avoid cases like:
-- command enables permission CREATE_PROCEDURE for customer XXX and Role PLANNING_AGENCY_ADMIN, and there are orgas that have type Planingburo where actually the role PLANNING_AGENCY_ADMIN is not allowed.

### How to review/test
- Using customer support role, find and orga that only has the type PlanungBuro and is accepted in the customer
- Run command bin/blp dplan:permission:enable:customer-orga-role YOUR_CUSTOMER_ID YOUR_ROLE_ID CREATE_PROCEDURES_PERMISSION --dry-run
- You should not see the orga listed in the command
- Then change the type of the orga, you should see the orga



Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
