### PR TITLE
Include Tailwind Preflight as separate file

### DIFF
--- a/client/css/index.css
+++ b/client/css/index.css
@@ -1,7 +1,5 @@
-/**
- * @noinspection
- * PHPStorm complains about unset css vars in rendered css. This is irritating and can be suppressed.
- */
+/* stylelint-disable */
+@config '../../tailwind.config.js';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/client/css/preflight.css
+++ b/client/css/preflight.css
@@ -1,0 +1,3 @@
+/* stylelint-disable */
+@config '../../tailwind.preflight.config.js';
+@tailwind base;

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -88,6 +88,7 @@ const bundlesConfig = merge(baseConfig, {
     return {
       style: config.stylesEntryPoint,
       'style-public': config.publicStylesEntryPoint,
+      'preflight': './client/css/preflight.css',
       'demosplan-ui': './client/css/index.css',
       ...bundleEntryPoints(config.clientBundleGlob)
     }

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/_base.dplan.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/_base.dplan.scss
@@ -36,19 +36,6 @@ html {
     scroll-behavior: smooth;
 }
 
-html.fixtinyfixed {
-    &,
-    body {
-        @include media-query('palm') {
-            //  these are due to focus jumping bug in fixed elements on iOs
-            //  https://remysharp.com/2012/05/24/issues-with-position-fixed-scrolling-on-ios#focus-jumping
-            -webkit-overflow-scrolling: touch !important;
-            overflow: auto !important;
-            height: 100% !important;
-        }
-    }
-}
-
 body {
     min-height: 100%; // ensures complete display of absolutely positioned flyouts
     background: $dp-color-background-default;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,10 @@ const config = {
     './projects/**/templates/**/*.twig',
     './templates/bundles/DemosPlanCoreBundle/**/*.twig',
     './addons/vendor/demos-europe/demosplan-addon-*/client/**/*.{js,vue}'
-  ]
+  ],
+  corePlugins: {
+    preflight: false,
+  }
 }
 
 module.exports = config

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,8 @@ const config = {
   ],
   corePlugins: {
     preflight: false,
-  }
+  },
+  important: false
 }
 
 module.exports = config

--- a/tailwind.preflight.config.js
+++ b/tailwind.preflight.config.js
@@ -3,6 +3,7 @@
  * It is configured to only output the "css reset" of Tailwind.
  */
 const config = {
+  content: ['./suppress-no-content-configured-warning-in-console/'],
   corePlugins: {
     preflight: true,
   },

--- a/tailwind.preflight.config.js
+++ b/tailwind.preflight.config.js
@@ -1,0 +1,11 @@
+/**
+ * This Tailwind config is used by ./client/css/preflight.css.
+ * It is configured to only output the "css reset" of Tailwind.
+ */
+const config = {
+  corePlugins: {
+    preflight: true,
+  },
+  plugins: [],
+}
+module.exports = config

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/404.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/404.html.twig
@@ -17,7 +17,7 @@
     {% endblock %}
 
     {# Styles. Leave in header until critical css is in place. #}
-    {{ webpackBundles(['demosplan-ui.css', 'style-public.css']) }}
+    {{ webpackBundles(['preflight.css', 'style-public.css', 'demosplan-ui.css']) }}
 
     <title>{{ pageTitle('404.title') }}</title>
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -31,7 +31,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundles(['demosplan-ui.css', 'style.css']) }}
+            {{ webpackBundles(['preflight.css', 'style.css', 'demosplan-ui.css']) }}
         {% endblock stylesheets %}
 
         {% block component_header %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
@@ -28,7 +28,7 @@
 
         {# Styles. Leave in header until critical css is in place. #}
         {% block stylesheets %}
-            {{ webpackBundles(['demosplan-ui.css', 'style-public.css']) }}
+            {{ webpackBundles(['preflight.css', 'style-public.css', 'demosplan-ui.css']) }}
         {% endblock stylesheets %}
 
         {% block component_header %}


### PR DESCRIPTION
The (slightly opinionated) tailwind browser reset, "preflight", sets some defaults that we want to
override with the project css. However, as we also want to include the tailwind utility classes last
(to get rid of making them !important), the preflight styles need to be separately included, not within the same file as the utility classes.

To illustrate the change, here is a before/after comparison of the order and contents of Styles included in demosplan:

**Before:**

- **demosplan-ui.css**
  - Tailwindcss Preflight (with opinionated defaults)
  - Tailwindcss Utilities (with !important, to win over styles included later in the document while having the same specificity)
- **style.css (or, style-public.css)**
  - Base styles (overriding the opinionated defaults of Tailwind, as configured with Scss variables)
  - All the other exciting stuff (see core_style.scss)

**After:**

- **preflight.css**
  - Tailwindcss Preflight (with opinionated defaults)
- **style.css (or, style-public.css)**
  - Base styles (overriding the opinionated defaults of Tailwind, as configured with Scss variables)
  - All the other exciting stuff (see core_style.scss)
- **demosplan-ui.css**
  - Tailwindcss Utilities (no more !important needed, because now included later in the document)

Other things changed when "driving by":
- PHPStorm seems to know @tailwind in current versions
- html.fixtinyfixed seems to no longer be used

### How to review/test
After running `yarn dev:<project>` locally,  things should look as before.
