### PR TITLE
feat: drop custom text-align mq utility classes

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_text.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_text.scss
@@ -11,12 +11,8 @@
 
 //  utility classes affecting text
 //
-//  .fontstyle--[normal|italic]
 //  .line-height--1_6
-//  .text-decoration-[none|underline]
-//  .[text|align]--[left|center|right|justify]{--[palm|desktop]}
 //  .weight--[normal|bold]
-//  .whitespace--[normal|nowrap]
 //  .line-clamp-3
 
 //  line height
@@ -49,32 +45,6 @@
         line-height: 2 !important;
     }
 }
-
-//  alignment
-$text-directions: (
-    'left',
-    'center',
-    'right',
-    'justify'
-);
-
-@each $direction in $text-directions {
-
-    // Loop over breakpoints defined in _settings.responsive.scss
-    @each $breakpoint in $breakpoints {
-
-        // Get the name of the breakpoint.
-        $alias: list.nth($breakpoint, 1);
-
-        @include media-query($alias) {
-
-            .text-#{$direction}-#{$alias} {
-                text-align: #{$direction} !important;
-            }
-        }
-    }
-}
-
 
 //  font-weight
 .weight,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index.html.twig
@@ -27,7 +27,7 @@
                 3. planners do not see any filters, but procedures they can administer  #}
         {% block procedurelist_header %}
             {% if not hasPermission('area_admin_procedures') %}
-                <h2 class="{{ 'c-proceduresearch__heading o-page__padded layout__item u-1-of-1 text-center text-left-palm font-size-h2 u-m-0'|prefixClass }}">
+                <h2 class="{{ 'c-proceduresearch__heading o-page__padded layout__item u-1-of-1 text-left sm:text-center font-size-h2 u-m-0'|prefixClass }}">
                     <span class="{{ 'border--bottom u-pv-0_75 u-ph block'|prefixClass }}">
                         {% if templateVars.useInternalFields == true %}
                             {{ "search.procedures.yours"|trans }}
@@ -37,7 +37,7 @@
                     </span>
                 </h2>
             {% else %}
-                <h2 class="{{ 'c-proceduresearch__heading o-page__padded layout__item u-1-of-1 text-center text-left-palm font-size-h2 u-m-0'|prefixClass }}">
+                <h2 class="{{ 'c-proceduresearch__heading o-page__padded layout__item u-1-of-1 text-left sm:text-center font-size-h2 u-m-0'|prefixClass }}">
                     <span class="{{ 'border--bottom u-pv-0_75 u-ph block'|prefixClass }}">
                         {{ "procedures.yours"|trans }}
                     </span>


### PR DESCRIPTION
As we now got Tailwind breakpoints working, these custom `text-align` mq classes can be dropped as well.

### How to review/test
May be tested on the home page of bobsh. The "In allen Beteiligungsverfahren suchen" Header should be left aligned in viewports smaller than 620px width.
