### PR TITLE
B d2133 remove search bar

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -114,18 +114,26 @@ class DemosPlanAssessmentTableController extends BaseController
         $rParams = $assessmentHandler->getFormValues($request->request->all());
 
         // handle the filterHash thing → always returns FilterSet Entity, except → see next comment
-        $firstFilterSet = $filterSetService->findHashedQueryWithHash($filterHash);
+        $findHash = $filterSetService->findHashedQueryWithHash($filterHash);
         if ($filterHash) {
-            $storedQuery = $firstFilterSet->getStoredQuery();
+            $storedQuery = $findHash->getStoredQuery();
             if (
                 $rParams['search'] === $storedQuery->getSearchWord()
             ) {
-                $filterSet = $firstFilterSet;
+                $filterSet = $findHash;
             } else {
+                /*
+                * If rParams contain filters, those win against the hash in url.
+                * Doing this via redirect to same action.
+                */
                 $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId, null, $original);
                 $this->setHashforEmptyFilters($request, $assessmentHandler, $procedureId, $filterSet);
             }
         } else {
+            /*
+            * If rParams contain filters, those win against the hash in url.
+            * Doing this via redirect to same action.
+            */
             $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId, null, $original);
             $this->setHashforEmptyFilters($request, $assessmentHandler, $procedureId, $filterSet);
         }
@@ -133,24 +141,6 @@ class DemosPlanAssessmentTableController extends BaseController
 
 
         $type = self::HASH_TYPE_ASSESSMENT;
-
-        /*
-         * If rParams contain filters, those win against the hash in url.
-         * Doing this via redirect to same action.
-
-        if (null === $filterSet) {
-            $request = $this->updateFilterSetParametersInRequest($request, $assessmentHandler);
-            $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId, null, $original);
-
-            return $this->redirectToRoute(
-                'dplan_assessmenttable_view_table',
-                [
-                    'procedureId' => $procedureId,
-                    'filterHash'  => $filterSet->getHash(),
-                    '_fragment'   => $request->query->get('fragment', ''),
-                ]
-            );
-        }*/
 
         // Get the AssessmentQueryValueObject → holds all we need
         /** @var AssessmentTableQuery $assessmentTableQuery */

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -138,8 +138,6 @@ class DemosPlanAssessmentTableController extends BaseController
             $this->setHashforEmptyFilters($request, $assessmentHandler, $procedureId, $filterSet);
         }
 
-
-
         $type = self::HASH_TYPE_ASSESSMENT;
 
         // Get the AssessmentQueryValueObject → holds all we need
@@ -287,6 +285,7 @@ class DemosPlanAssessmentTableController extends BaseController
     private function setHashforEmptyFilters(Request $request, AssessmentHandler $assessmentHandler, string $procedureId, HashedQuery $filterSet)
     {
         $request = $this->updateFilterSetParametersInRequest($request, $assessmentHandler);
+
         return $this->redirectToRoute(
             'dplan_assessmenttable_view_table',
             [

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -198,7 +198,6 @@ class DemosPlanAssessmentTableController extends BaseController
         // Put viewMode and filterHash in templateVars
         /** @var AssessmentTableViewMode|null $viewMode */
         $viewMode = $original ? null : $assessmentTableQuery->getViewMode();
-        $assessmentHandler->updateHashListInSession($procedureId, $viewMode?false:true, $filterSet, $rParams);
         $rParams = $statementService->integrateFilterSetIntoArray(
             $filterSet,
             $rParams,


### PR DESCRIPTION
### Ticket https://demoseurope.youtrack.cloud/issue/DPLAN-2133/Suchbegriff-in-A-tabelle-wird-nicht-geloscht


Description: The word search word is called a column in the HashQuery table, so we need to create a new hash after the page refreshing, otherwise the page will be loaded with the same has been adjusted.

### How to review/test
Search Word should be removed from search bar after refreshing page

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
