### PR TITLE
f DPLAN-11684 add listWidth To TemplateVars and pass it on to the latex filter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
@@ -136,6 +136,7 @@ class ParagraphExporter
 
         $templateVars['list'] = ['documentlist' => $documentList];
         $templateVars['procedure'] = $procedure;
+        $templateVars['listwidth'] = 17;
 
         $content = $this->twig->render(
             '@DemosPlanCore/DemosPlanDocument/paragraph_list_export.tex.twig',

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
@@ -136,6 +136,8 @@ class ParagraphExporter
 
         $templateVars['list'] = ['documentlist' => $documentList];
         $templateVars['procedure'] = $procedure;
+        // the line width of lists inside the generated pdf differs and that depends on which circumstances. In this case
+        // the pdf vertical format view will not be split and the width has to be adjusted to 17 instead the default 7cm.
         $templateVars['listwidth'] = 17;
 
         $content = $this->twig->render(

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_list_export.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_list_export.tex.twig
@@ -9,6 +9,6 @@
 % {{ document.id }}
 {
 \section*{\textbf { {{ document.title|latex|raw }}  } }
-{{ document.text|latexPrepareImage|latex|latexOutputImage|raw }}
+{{ document.text|latexPrepareImage|latex(listwidth=templateVars.listwidth)|latexOutputImage|raw }}
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11684/BLP-Munchen-Bilder-sind-verzerrt-im-Ausdruck

Description: while paragraphs exporting, lists width had to be adjusted


