### PR TITLE
feat (DPLAN-3268): Little refactoring of SegmentsExportController

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -11,10 +11,11 @@
 namespace demosplan\DemosPlanCoreBundle\Controller\Segment;
 
 use Cocur\Slugify\Slugify;
-use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
+use demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Exception\StatementNotFoundException;
+use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiActionService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\NameGenerator;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
@@ -23,6 +24,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Segment\SegmentsExporter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Logic\ZipExportService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
+use Doctrine\ORM\Query\QueryException;
 use Exception;
 use PhpOffice\PhpWord\IOFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,13 +34,19 @@ use ZipStream\ZipStream;
 
 class SegmentsExportController extends BaseController
 {
+    private const OUTPUT_DESTINATION = 'php://output';
+
     /**
      * @throws StatementNotFoundException
      * @throws Exception
-     *
-     * @DplanPermissions("feature_segments_of_statement_list")
      */
-    #[Route(name: 'dplan_segments_export', methods: 'GET', path: '/verfahren/{procedureId}/{statementId}/abschnitte/export', options: ['expose' => true])]
+    #[DplanPermissions('feature_segments_of_statement_list')]
+    #[Route(
+        path: '/verfahren/{procedureId}/{statementId}/abschnitte/export',
+        name: 'dplan_segments_export',
+        options: ['expose' => true],
+        methods: 'GET'
+    )]
     public function exportAction(
         NameGenerator $nameGenerator,
         ProcedureHandler $procedureHandler,
@@ -53,7 +61,7 @@ class SegmentsExportController extends BaseController
         $response = new StreamedResponse(
             static function () use ($procedure, $statement, $exporter) {
                 $exportedDoc = $exporter->export($procedure, $statement);
-                $exportedDoc->save('php://output');
+                $exportedDoc->save(self::OUTPUT_DESTINATION);
             }
         );
 
@@ -67,9 +75,16 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @DplanPermissions("feature_segments_of_statement_list")
+     * @throws QueryException
+     * @throws UserNotFoundException
      */
-    #[Route(name: 'dplan_statement_segments_export', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/gruppiert', options: ['expose' => true])]
+    #[DplanPermissions('feature_segments_of_statement_list')]
+    #[Route(
+        path: '/verfahren/{procedureId}/abschnitte/export/gruppiert',
+        name: 'dplan_statement_segments_export',
+        options: ['expose' => true],
+        methods: 'GET'
+    )]
     public function exportByStatementsFilterAction(
         NameGenerator $nameGenerator,
         SegmentsByStatementsExporter $exporter,
@@ -81,12 +96,14 @@ class SegmentsExportController extends BaseController
     ): StreamedResponse {
         $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);
         /** @var Statement[] $statementEntities */
-        $statementEntities = array_values($requestHandler->getObjectsByQueryParams($request->query, $statementResourceType)->getList());
+        $statementEntities = array_values(
+            $requestHandler->getObjectsByQueryParams($request->query, $statementResourceType)->getList()
+        );
 
         $response = new StreamedResponse(
             static function () use ($procedure, $statementEntities, $exporter) {
                 $exportedDoc = $exporter->exportAll($procedure, ...$statementEntities);
-                $exportedDoc->save('php://output');
+                $exportedDoc->save(self::OUTPUT_DESTINATION);
             }
         );
 
@@ -96,9 +113,19 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @DplanPermissions("feature_admin_assessmenttable_export_statement_generic_xlsx")
+     * @throws UserNotFoundException
+     * @throws QueryException
+     * @throws Exception
      */
-    #[Route(name: 'dplan_statement_xls_export', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/xlsx', options: ['expose' => true])]
+    #[DplanPermissions(
+        'feature_admin_assessmenttable_export_statement_generic_xlsx'
+    )]
+    #[Route(
+        path: '/verfahren/{procedureId}/abschnitte/export/xlsx',
+        name: 'dplan_statement_xls_export',
+        options: ['expose' => true],
+        methods: 'GET'
+    )]
     public function exportByStatementsFilterXlsAction(
         JsonApiActionService $jsonApiActionService,
         NameGenerator $nameGenerator,
@@ -109,7 +136,9 @@ class SegmentsExportController extends BaseController
         string $procedureId
     ): StreamedResponse {
         /** @var Statement[] $statementEntities */
-        $statementEntities = array_values($jsonApiActionService->getObjectsByQueryParams($request->query, $statementResourceType)->getList());
+        $statementEntities = array_values(
+            $jsonApiActionService->getObjectsByQueryParams($request->query, $statementResourceType)->getList()
+        );
 
         $response = new StreamedResponse(
             static function () use ($statementEntities, $exporter) {
@@ -134,9 +163,16 @@ class SegmentsExportController extends BaseController
     }
 
     /**
-     * @DplanPermissions("feature_segments_of_statement_list")
+     * @throws QueryException
+     * @throws UserNotFoundException
+     * @throws Exception
      */
-    #[Route(name: 'dplan_statement_segments_export_packaged', methods: 'GET', path: '/verfahren/{procedureId}/abschnitte/export/gepackt', options: ['expose' => true])]
+    #[DplanPermissions('feature_segments_of_statement_list')]
+    #[Route(path: '/verfahren/{procedureId}/abschnitte/export/gepackt',
+        name: 'dplan_statement_segments_export_packaged',
+        options: ['expose' => true],
+        methods: 'GET'
+    )]
     public function exportPackagedStatementsAction(
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
@@ -154,23 +190,31 @@ class SegmentsExportController extends BaseController
         // properties of the statements and segments are exposed is hardcoded by the actual
         // exporter.
         $statementResult = $requestHandler->getObjectsByQueryParams($request->query, $statementResourceType);
+        /** @var Statement[] $statements */
         $statements = array_values($statementResult->getList());
         $statements = $exporter->mapStatementsToPathInZip($statements);
 
         return $zipExportService->buildZipStreamResponse(
             $exporter->getSynopseFileName($procedure, 'zip'),
             static function (ZipStream $zipStream) use ($statements, $exporter, $zipExportService, $procedure): void {
-                array_map(static function (Statement $statement, string $filePathInZip) use ($exporter, $zipExportService, $zipStream, $procedure): void {
-                    $docx = $exporter->exportStatementSegmentsInSeparateDocx($statement, $procedure);
-                    $writer = IOFactory::createWriter($docx);
-                    $zipExportService->addWriterToZipStream(
-                        $writer,
-                        $filePathInZip,
-                        $zipStream,
-                        'statement_segments_zip_export',
-                        '.docx'
-                    );
-                }, $statements, array_keys($statements));
+                array_map(
+                    static function (
+                        Statement $statement,
+                        string $filePathInZip
+                    ) use ($exporter, $zipExportService, $zipStream, $procedure): void {
+                        $docx = $exporter->exportStatementSegmentsInSeparateDocx($statement, $procedure);
+                        $writer = IOFactory::createWriter($docx);
+                        $zipExportService->addWriterToZipStream(
+                            $writer,
+                            $filePathInZip,
+                            $zipStream,
+                            'statement_segments_zip_export',
+                            '.docx'
+                        );
+                    },
+                    $statements,
+                    array_keys($statements)
+                );
             }
         );
     }


### PR DESCRIPTION


### Ticket
DPLAN-3268


- use DplanPermissions Attribute instead of deprecated annotation
- add line breaks to avoid too long code line to improve readability
- add throw tags where missing
- add constant for string to improve maintainability

### How to review/test
Code Review


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
