### PR TITLE
chore: login per keycloak via OAuth2ClientBundle

### DIFF
--- a/config/packages/knpu_oauth2_client.yaml
+++ b/config/packages/knpu_oauth2_client.yaml
@@ -4,6 +4,19 @@ knpu_oauth2_client:
         # will create service: "knpu.oauth2.client.keycloak"
         # an instance of: KnpU\OAuth2ClientBundle\Client\Provider\KeycloakClient
         # composer require stevenmaguire/oauth2-keycloak
+        keycloak:
+            # must be "keycloak" - it activates that type!
+            type: keycloak
+            # add and set these environment variables in your parameters.yml files
+            client_id: '%oauth_keycloak_client_id%'
+            client_secret: '%oauth_keycloak_client_secret%'
+            # a route name you'll create
+            redirect_route: connect_keycloak_check
+            redirect_params: {}
+            # Keycloak server URL
+            auth_server_url: '%oauth_keycloak_auth_server_url%'
+            # Keycloak realm
+            realm: '%oauth_keycloak_realm%'
         keycloak_ozg:
             # must be "keycloak" - it activates that type!
             type: keycloak

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Controller\Platform;
 
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -38,6 +39,27 @@ class KeycloakController extends AbstractController
      */
     #[Route(path: '/connect/keycloak_ozg/check', name: 'connect_keycloak_ozg_check')]
     public function connectCheckAction(Request $request, ClientRegistry $clientRegistry)
+    {
+        // ** if you want to *authenticate* the user, then
+        // leave this method blank and create a Guard authenticator
+    }
+
+    #[Route(path: '/connect/keycloak', name: 'connect_keycloak_start')]
+    public function connectKeycloakAction(ClientRegistry $clientRegistry): RedirectResponse
+    {
+        // will redirect to keycloak!
+        return $clientRegistry
+            ->getClient('keycloak') // key used in config/packages/knpu_oauth2_client.yaml
+            ->redirect(['openid'], []);
+    }
+
+    /**
+     * After going to keycloak, you're redirected back here
+     * because this is the "redirect_route" you configured
+     * in config/packages/knpu_oauth2_client.yaml.
+     */
+    #[Route(path: '/connect/keycloak/check', name: 'connect_keycloak_check')]
+    public function connectKeycloakCheckAction(Request $request, ClientRegistry $clientRegistry): void
     {
         // ** if you want to *authenticate* the user, then
         // leave this method blank and create a Guard authenticator

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
@@ -62,6 +62,6 @@ class KeycloakController extends AbstractController
     public function connectKeycloakCheckAction(Request $request, ClientRegistry $clientRegistry): void
     {
         // ** if you want to *authenticate* the user, then
-        // leave this method blank and create a Guard authenticator
+        // leave this method blank and create an authenticator
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -60,11 +60,9 @@ class KeycloakUserDataMapper
         if ($user instanceof User) {
             $this->logger->info('Found user in Keycloak request', ['data' => $keycloakUserData]);
 
-            // only orga needs to be updated as user data is not editable via idp
-            // as "Nutzerkonto X" is not implemented at the moment
             $this->updateOrgaWithKnownValues($user->getOrga(), $keycloakUserData);
 
-            return $user;
+            return $this->updateUserWithKnownValues($user, $keycloakUserData);
 
         }
 
@@ -268,5 +266,15 @@ class KeycloakUserDataMapper
         $orga->setGwId($keycloakUserData->getOrganisationId());
 
         return $this->orgaService->updateOrga($orga);
+    }
+
+    private function updateUserWithKnownValues(User $user, KeycloakUserData $keycloakUserData): User
+    {
+        $user->setEmail($keycloakUserData->getEmailAddress());
+        $user->setFirstname($keycloakUserData->getFirstName());
+        $user->setLastname($keycloakUserData->getLastName());
+        // do not update login, as it is used to identify the user
+
+        return $this->userService->updateUserObject($user);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
@@ -174,7 +175,7 @@ class KeycloakUserDataMapper
         $userFirstName = '';
         $userLastName = UserInterface::DEFAULT_ORGA_USER_NAME;
         $userEmail = $keycloakUserData->getEmailAddress();
-        $orgaTypeNames = [OrgaType::PUBLIC_AGENCY];
+        $orgaTypeNames = [OrgaTypeInterface::PUBLIC_AGENCY];
 
         $orga = $this->orgaService->createOrgaRegister(
             $orgaName,
@@ -182,7 +183,7 @@ class KeycloakUserDataMapper
             $userFirstName,
             $userLastName,
             $userEmail,
-            $this->customerService->getCurrentCustomer(),
+            $customer,
             $orgaTypeNames
         );
 

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -49,7 +49,6 @@ class KeycloakUserDataMapper
 
     /**
      * Maps incoming data to dplan:user.
-     * Creates.
      *
      * @throws Exception
      */
@@ -91,14 +90,14 @@ class KeycloakUserDataMapper
         $login = $keycloakUserData->getUserName();
 
         // check whether existing user needs to be updated.
-        // when user with email exists, update login field to saml login
-        // to allow Login via saml and dplan
+        // when user with email exists, update login field to idp login
+        // to allow Login via idp and dplan
 
         $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());
 
         if ($user instanceof User) {
             $this->logger->info('Tie existing user to Keycloak-Login');
-            // user exists with email. Just update login to tie user to saml and at the same time
+            // user exists with email. Just update login to tie user to idp and at the same time
             // allow to login locally via email
             $user->setLogin($login);
             $user->setProvidedByIdentityProvider(true);
@@ -210,7 +209,7 @@ class KeycloakUserDataMapper
             );
             $this->eventDispatcherPost->post($newOrgaRegisteredEvent);
         } catch (Exception $e) {
-            $this->logger->warning('Could not successfully perform orga registered from SAML event', [$e]);
+            $this->logger->warning('Could not successfully perform orga registered from OAuth login event', [$e]);
         }
 
         // Orga has exactly one master user so far

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -27,7 +27,6 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
-use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserDataInterface;
 use Exception;
 use Psr\Log\LoggerInterface;
 
@@ -63,7 +62,6 @@ class KeycloakUserDataMapper
             $this->updateOrgaWithKnownValues($user->getOrga(), $keycloakUserData);
 
             return $this->updateUserWithKnownValues($user, $keycloakUserData);
-
         }
 
         $this->logger->info('Eventually create new User from Keycloak', ['data' => $keycloakUserData]);
@@ -76,13 +74,14 @@ class KeycloakUserDataMapper
         // Does the payload carry an organisation?
         if ('' !== $keycloakUserData->getOrganisationName()) {
             $this->logger->info('User is Orgauser');
+
             return $this->getUserForOrga($keycloakUserData);
         }
 
         // otherwise we assume that it is a citizen
         $this->logger->info('User is citizen');
-        return $this->getUserForNewCitizen($keycloakUserData);
 
+        return $this->getUserForNewCitizen($keycloakUserData);
     }
 
     private function getUserForNewCitizen(KeycloakUserData $keycloakUserData): User

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -116,7 +116,6 @@ class KeycloakUserDataMapper
         }
 
         // orga is already registered in customer, return default user
-        // or acting user, if any is given
 
         $this->logger->info('Orga is already registered in customer');
         $orga = $orgas[0] ?? null;

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -166,8 +166,8 @@ class KeycloakUserDataMapper
 
         $orgaName = $keycloakUserData->getOrganisationName();
         $phone = '';
-        $userFirstName = '';
-        $userLastName = User::DEFAULT_ORGA_USER_NAME;
+        $userFirstName = $keycloakUserData->getFirstName();
+        $userLastName = $keycloakUserData->getLastName();
         $userEmail = $keycloakUserData->getEmailAddress();
         $orgaTypeNames = [OrgaType::PUBLIC_AGENCY];
 

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface as UserInterfaceDplan;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
@@ -130,7 +130,7 @@ class KeycloakUserDataMapper
         $users = $orga->getUsers();
 
         // return the orga default user
-        $user = $users->filter(fn (User $user) => UserInterfaceDplan::DEFAULT_ORGA_USER_NAME === $user->getLastname());
+        $user = $users->filter(fn (User $user) => UserInterface::DEFAULT_ORGA_USER_NAME === $user->getLastname());
 
         if (1 === $user->count()) {
             return $user->first();

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -89,22 +89,6 @@ class KeycloakUserDataMapper
     {
         $login = $keycloakUserData->getUserName();
 
-        // check whether existing user needs to be updated.
-        // when user with email exists, update login field to idp login
-        // to allow Login via idp and dplan
-
-        $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());
-
-        if ($user instanceof User) {
-            $this->logger->info('Tie existing user to Keycloak-Login');
-            // user exists with email. Just update login to tie user to idp and at the same time
-            // allow to login locally via email
-            $user->setLogin($login);
-            $user->setProvidedByIdentityProvider(true);
-
-            return $this->userService->updateUserObject($user);
-        }
-
         $this->logger->info('Create new User from Keycloak data');
 
         // user does not yet exist

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -52,7 +52,7 @@ class KeycloakUserDataMapper
      *
      * @throws Exception
      */
-    public function mapUserData(KeycloakUserDataInterface $keycloakUserData): UserInterface
+    public function mapUserData(KeycloakUserData $keycloakUserData): UserInterface
     {
         // login existing user
         $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -27,9 +27,9 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
+use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserDataInterface;
 use Exception;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Supposed to handle the request from @see KeycloakAuthenticator to log in a user. Therefore, the information from
@@ -53,7 +53,7 @@ class KeycloakUserDataMapper
      *
      * @throws Exception
      */
-    public function mapUserData(KeycloakUserData $keycloakUserData): UserInterface
+    public function mapUserData(KeycloakUserDataInterface $keycloakUserData): UserInterface
     {
         // login existing user
         $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());
@@ -180,8 +180,10 @@ class KeycloakUserDataMapper
 
         $orgaName = $keycloakUserData->getOrganisationName();
         $phone = '';
-        $userFirstName = $keycloakUserData->getFirstName();
-        $userLastName = $keycloakUserData->getLastName();
+        // we need to hardcode the initial user name here to be able to
+        // login as the default Orga user on login
+        $userFirstName = '';
+        $userLastName = UserInterface::DEFAULT_ORGA_USER_NAME;
         $userEmail = $keycloakUserData->getEmailAddress();
         $orgaTypeNames = [OrgaType::PUBLIC_AGENCY];
 
@@ -213,7 +215,7 @@ class KeycloakUserDataMapper
 
         // Orga has exactly one master user so far
         $user = $orga->getUsers()->first();
-        // set Orga Id as User login to be able to login as the default Orga user on login
+        // set Orga Email as User login to be able to login as the default Orga user on login
         $user->setLogin($keycloakUserData->getUserName());
         $user->setProvidedByIdentityProvider(true);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -55,6 +55,20 @@ class KeycloakUserDataMapper
      */
     public function mapUserData(KeycloakUserData $keycloakUserData): UserInterface
     {
+        // login existing user
+        $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());
+
+        if ($user instanceof User) {
+            $this->logger->info('Found user in Keycloak request', ['data' => $keycloakUserData]);
+
+            // only orga needs to be updated as user data is not editable via idp
+            // as "Nutzerkonto X" is not implemented at the moment
+            $this->updateOrgaWithKnownValues($user->getOrga(), $keycloakUserData);
+
+            return $user;
+
+        }
+
         $this->logger->info('Eventually create new User from Keycloak', ['data' => $keycloakUserData]);
 
         // At this state the login attempt may be from different Identity Providers (IdP).

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -74,7 +74,7 @@ class KeycloakUserDataMapper
 
     private function getUserForNewCitizen(KeycloakUserData $keycloakUserData): User
     {
-        $login = $keycloakUserData->getId();
+        $login = $keycloakUserData->getUserName();
 
         // check whether existing user needs to be updated.
         // when user with email exists, update login field to saml login
@@ -111,7 +111,7 @@ class KeycloakUserDataMapper
     private function getUserForOrga(KeycloakUserData $keycloakUserData): UserInterface
     {
         // in this context the given Id is the GatewayName of the organisation
-        $orgas = $this->orgaService->getOrgaByFields(['gatewayName' => $keycloakUserData->getUserName()]);
+        $orgas = $this->orgaService->getOrgaByFields(['gwId' => $keycloakUserData->getOrganisationId()]);
         if (null === $orgas || (is_array($orgas) && empty($orgas))) {
             return $this->createNewUserAndOrgaFromOrga($keycloakUserData);
         }
@@ -200,7 +200,7 @@ class KeycloakUserDataMapper
         // Orga has exactly one master user so far
         $user = $orga->getUsers()->first();
         // set Orga Id as User login to be able to login as the default Orga user on login
-        $user->setLogin($keycloakUserData->getId());
+        $user->setLogin($keycloakUserData->getUserName());
         $user->setProvidedByIdentityProvider(true);
 
         return $this->userService->updateUserObject($user);
@@ -239,7 +239,8 @@ class KeycloakUserDataMapper
         $orga->setCity($keycloakUserData->getLocalityName());
         $orga->setStreet($keycloakUserData->getStreet());
         $orga->setHouseNumber($keycloakUserData->getHouseNumber());
-        $orga->setGatewayName($keycloakUserData->getId());
+        $orga->setGatewayName($keycloakUserData->getOrganisationId());
+        $orga->setGwId($keycloakUserData->getOrganisationId());
 
         return $this->orgaService->updateOrga($orga);
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use Psr\Log\LoggerInterface;
@@ -57,6 +58,13 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
+        /** @var User $user */
+        $user = $token->getUser();
+        $this->logger->info('User was logged in via OAuth', ['id' => $user->getId(), 'roles' => $user->getDplanRolesString()]);
+
+        // propagate user login to session
+        $request->getSession()->set('userId', $user->getId());
+
         // change "app_homepage" to some route in your app
         $targetUrl = $this->router->generate('core_home_loggedin');
 

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
@@ -22,12 +22,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
-class KeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntrypointInterface
+class KeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
@@ -51,6 +50,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
 
         $userIdentifier = $accessToken->getToken();
         $resourceOwner = $client->fetchUserFromToken($accessToken);
+
         return new SelfValidatingPassport(
             $this->keycloakUserBadgeCreator->createKeycloakUserBadge($userIdentifier, $resourceOwner, $request)
         );
@@ -86,7 +86,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
      * Called when authentication is needed, but it's not sent.
      * This redirects to the 'login'.
      */
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new RedirectResponse(
             '/connect/keycloak_ozg', // might be the site, where users choose their oauth provider

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
@@ -69,9 +69,6 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
         $targetUrl = $this->router->generate('core_home_loggedin');
 
         return new RedirectResponse($targetUrl);
-
-        // or, on success, let the request continue to be handled by the controller
-        // return null;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
@@ -36,7 +36,6 @@ class KeycloakUserBadgeCreator
 
                 $this->entityManager->getConnection()->commit();
                 $this->logger->info('doctrine transaction commit.');
-                $s = $request->getSession();
                 $request->getSession()->set('userId', $user->getId());
 
                 return $user;

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
@@ -15,7 +24,6 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class KeycloakUserBadgeCreator
 {
-
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly KeycloakUserData $keycloakUserData,
@@ -23,6 +31,7 @@ class KeycloakUserBadgeCreator
         private readonly KeycloakUserDataMapper $keycloakUserDataMapper,
     ) {
     }
+
     public function createKeycloakUserBadge(string $userIdentifier, ResourceOwnerInterface $resourceOwner, Request $request): UserBadge
     {
         return new UserBadge($userIdentifier, function () use ($resourceOwner, $request) {

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
+
+use demosplan\DemosPlanCoreBundle\Logic\KeycloakUserDataMapper;
+use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+class KeycloakUserBadgeCreator
+{
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly KeycloakUserData $keycloakUserData,
+        private readonly LoggerInterface $logger,
+        private readonly KeycloakUserDataMapper $keycloakUserDataMapper,
+    ) {
+    }
+    public function createKeycloakUserBadge(string $userIdentifier, ResourceOwnerInterface $resourceOwner, Request $request): UserBadge
+    {
+        return new UserBadge($userIdentifier, function () use ($resourceOwner, $request) {
+            try {
+                $this->entityManager->getConnection()->beginTransaction();
+                $this->logger->info('Start of doctrine transaction.');
+
+                $this->keycloakUserData->fill($resourceOwner);
+                $this->logger->info('Found user data: '.$this->keycloakUserData);
+                $user = $this->keycloakUserDataMapper->mapUserData($this->keycloakUserData);
+
+                $this->entityManager->getConnection()->commit();
+                $this->logger->info('doctrine transaction commit.');
+                $s = $request->getSession();
+                $request->getSession()->set('userId', $user->getId());
+
+                return $user;
+            } catch (Exception $e) {
+                $this->entityManager->getConnection()->rollBack();
+                $this->logger->info('doctrine transaction rollback.');
+                $this->logger->error(
+                    'login failed',
+                    [
+                        'requestValues' => $this->keycloakUserData ?? null,
+                        'exception'     => $e,
+                    ]
+                );
+                throw new AuthenticationException('You shall not pass!');
+            }
+        });
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
-class OzgKeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntrypointInterface
+class OzgKeycloakAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
@@ -108,7 +108,7 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
      * Called when authentication is needed, but it's not sent.
      * This redirects to the 'login'.
      */
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new RedirectResponse(
             '/connect/keycloak_ozg', // might be the site, where users choose their oauth provider

--- a/demosplan/DemosPlanCoreBundle/ValueObject/CommonUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/CommonUserData.php
@@ -1,7 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace demosplan\DemosPlanCoreBundle\ValueObject;
+
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
@@ -16,7 +26,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
  */
 class CommonUserData extends ValueObject
 {
-
     protected string $firstName = '';
     protected string $lastName = '';
     /**
@@ -48,21 +57,21 @@ class CommonUserData extends ValueObject
     {
         $customerRoleRelationString = '';
         foreach ($this->customerRoleRelations as $subdomain => $roleNames) {
-            $customerRoleRelationString .= $subdomain . ': [' . implode(
-                    ', ',
-                    $roleNames
-                ) . '] ';
+            $customerRoleRelationString .= $subdomain.': ['.implode(
+                ', ',
+                $roleNames
+            ).'] ';
         }
 
         return
-            'userId: ' . $this->userId .
-            ', userName: ' . $this->userName .
-            ', firstName: ' . $this->firstName .
-            ', lastName: ' . $this->lastName .
-            ', organisationId: ' . $this->organisationId .
-            ', organisationName: ' . $this->organisationName .
-            ', emailAddress: ' . $this->emailAddress .
-            ', roles: ' . $customerRoleRelationString;
+            'userId: '.$this->userId.
+            ', userName: '.$this->userName.
+            ', firstName: '.$this->firstName.
+            ', lastName: '.$this->lastName.
+            ', organisationId: '.$this->organisationId.
+            ', organisationName: '.$this->organisationName.
+            ', emailAddress: '.$this->emailAddress.
+            ', roles: '.$customerRoleRelationString;
     }
 
     /**
@@ -96,12 +105,7 @@ class CommonUserData extends ValueObject
         }
 
         if ([] !== $missingMandatoryValues) {
-            throw new AuthenticationCredentialsNotFoundException(
-                implode(
-                    ', ',
-                    $missingMandatoryValues
-                ) . 'are missing in requestValues'
-            );
+            throw new AuthenticationCredentialsNotFoundException(implode(', ', $missingMandatoryValues).'are missing in requestValues');
         }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/CommonUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/CommonUserData.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+
+/**
+ * @method array  getCustomerRoleRelations()
+ * @method string getEmailAddress()
+ * @method string getUserName()
+ * @method string getUserId()
+ * @method string getOrganisationName()
+ * @method string getOrganisationId()
+ * @method string getFirstName()
+ * @method string getLastName()
+ */
+class CommonUserData extends ValueObject
+{
+
+    protected string $firstName = '';
+    protected string $lastName = '';
+    /**
+     * E-mail-address of the provided user.
+     */
+    protected string $emailAddress = '';
+    /**
+     * Name of the provided organisation.
+     */
+    protected string $organisationName = '';
+    /**
+     * Unique identifier of the provided organisation.
+     */
+    protected string $organisationId = '';
+    /**
+     * @var array<int, array<int,string>>
+     */
+    protected array $customerRoleRelations = [];
+    /**
+     * Unique abbreviation of chosen login name of the provided user.
+     */
+    protected string $userName = '';
+    /**
+     * Unique ID of the provided user.
+     */
+    protected string $userId = '';
+
+    public function __toString(): string
+    {
+        $customerRoleRelationString = '';
+        foreach ($this->customerRoleRelations as $subdomain => $roleNames) {
+            $customerRoleRelationString .= $subdomain . ': [' . implode(
+                    ', ',
+                    $roleNames
+                ) . '] ';
+        }
+
+        return
+            'userId: ' . $this->userId .
+            ', userName: ' . $this->userName .
+            ', firstName: ' . $this->firstName .
+            ', lastName: ' . $this->lastName .
+            ', organisationId: ' . $this->organisationId .
+            ', organisationName: ' . $this->organisationName .
+            ', emailAddress: ' . $this->emailAddress .
+            ', roles: ' . $customerRoleRelationString;
+    }
+
+    /**
+     * Checks for existing mandatory data.
+     */
+    public function checkMandatoryValuesExist(): void
+    {
+        $missingMandatoryValues = [];
+        if ('' === $this->userId) {
+            $missingMandatoryValues[] = 'userId';
+        }
+
+        if ('' === $this->userName) {
+            $missingMandatoryValues[] = 'userName';
+        }
+
+        if ('' === $this->emailAddress) {
+            $missingMandatoryValues[] = 'emailAddress';
+        }
+
+        if ('' === $this->organisationId) {
+            $missingMandatoryValues[] = 'organisationId';
+        }
+
+        if ('' === $this->firstName && '' === $this->lastName) {
+            $missingMandatoryValues[] = 'name';
+        }
+
+        if ([] === $this->customerRoleRelations) {
+            $missingMandatoryValues[] = 'roles';
+        }
+
+        if ([] !== $missingMandatoryValues) {
+            throw new AuthenticationCredentialsNotFoundException(
+                implode(
+                    ', ',
+                    $missingMandatoryValues
+                ) . 'are missing in requestValues'
+            );
+        }
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -12,23 +12,74 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject;
 
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use Stringable;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
-
+/**
+ * @method string getHouseNumber()
+ * @method string getId()
+ * @method string getLocalityName()
+ * @method string getPostalCode()
+ * @method string getStreet()
+ */
 class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
 {
+
+    protected string $id;
+    protected string $houseNumber;
+    protected string $localityName;
+    protected string $postalCode;
+    protected string $street;
+
     public function fill(ResourceOwnerInterface $resourceOwner): void
     {
         $userInformation = $resourceOwner->toArray();
 
         $this->emailAddress = $userInformation['email'] ?? '';
-        $this->firstName = $userInformation['given_name'] ?? '';
-        $this->lastName = $userInformation['family_name'] ?? '';
+        $this->firstName = $userInformation['givenName'] ?? '';
+        $this->houseNumber = $userInformation['houseNumber'] ?? '';
+        $this->id = $userInformation['ID'] ?? '';
+        $this->lastName = $userInformation['surname'] ?? '';
+        $this->localityName = $userInformation['localityName'] ?? '';
         $this->organisationId = $userInformation['organisationId'] ?? '';
         $this->organisationName = $userInformation['organisationName'] ?? '';
+        $this->postalCode = $userInformation['postalCode'] ?? '';
+        $this->street = $userInformation['street'] ?? '';
         $this->userId = $userInformation['sub'] ?? '';
         $this->userName = $userInformation['preferred_username'] ?? ''; // kind of "login" //has to be unique?
 
         $this->lock();
         $this->checkMandatoryValuesExist();
+    }
+
+    /**
+     * Checks for existing mandatory data.
+     */
+    public function checkMandatoryValuesExist(): void
+    {
+        $missingMandatoryValues = [];
+        if ('' === $this->emailAddress) {
+            $missingMandatoryValues[] = 'emailAddress';
+        }
+
+        if ('' === $this->firstName && '' === $this->lastName) {
+            $missingMandatoryValues[] = 'name';
+        }
+
+        if ('' === $this->userId) {
+            $missingMandatoryValues[] = 'userId';
+        }
+
+        if ('' === $this->userName) {
+            $missingMandatoryValues[] = 'userName';
+        }
+
+        if ([] !== $missingMandatoryValues) {
+            throw new AuthenticationCredentialsNotFoundException(
+                implode(
+                    ', ',
+                    $missingMandatoryValues
+                ) . ' are missing in requestValues'
+            );
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 
 /**
  * @method string getHouseNumber()
- * @method string getId()
  * @method string getLocalityName()
  * @method string getPostalCode()
  * @method string getStreet()
@@ -24,7 +23,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
 {
 
-    protected string $id;
     protected string $houseNumber;
     protected string $localityName;
     protected string $postalCode;
@@ -37,15 +35,14 @@ class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterfa
         $this->emailAddress = $userInformation['email'] ?? '';
         $this->firstName = $userInformation['givenName'] ?? '';
         $this->houseNumber = $userInformation['houseNumber'] ?? '';
-        $this->id = $userInformation['ID'] ?? '';
         $this->lastName = $userInformation['surname'] ?? '';
         $this->localityName = $userInformation['localityName'] ?? '';
-        $this->organisationId = $userInformation['organisationId'] ?? '';
+        $this->organisationId = $userInformation['organisationId'] ?? ''; // gets orga gwId
         $this->organisationName = $userInformation['organisationName'] ?? '';
         $this->postalCode = $userInformation['postalCode'] ?? '';
         $this->street = $userInformation['street'] ?? '';
-        $this->userId = $userInformation['sub'] ?? '';
-        $this->userName = $userInformation['preferred_username'] ?? ''; // kind of "login" //has to be unique?
+        $this->userId = $userInformation['sub'] ?? ''; // gets user gwId, always empty
+        $this->userName = $userInformation['email'] ?? ''; // gets user login
 
         $this->lock();
         $this->checkMandatoryValuesExist();

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -22,7 +22,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
  */
 class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
 {
-
     protected string $houseNumber;
     protected string $localityName;
     protected string $postalCode;
@@ -63,12 +62,7 @@ class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterfa
         }
 
         if ([] !== $missingMandatoryValues) {
-            throw new AuthenticationCredentialsNotFoundException(
-                implode(
-                    ', ',
-                    $missingMandatoryValues
-                ) . ' are missing in requestValues'
-            );
+            throw new AuthenticationCredentialsNotFoundException(implode(', ', $missingMandatoryValues).' are missing in requestValues');
         }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -65,14 +65,6 @@ class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterfa
             $missingMandatoryValues[] = 'name';
         }
 
-        if ('' === $this->userId) {
-            $missingMandatoryValues[] = 'userId';
-        }
-
-        if ('' === $this->userName) {
-            $missingMandatoryValues[] = 'userName';
-        }
-
         if ([] !== $missingMandatoryValues) {
             throw new AuthenticationCredentialsNotFoundException(
                 implode(

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This file is part of the package demosplan.

--- a/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/KeycloakUserData.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject;
+
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Stringable;
+
+
+class KeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
+{
+    public function fill(ResourceOwnerInterface $resourceOwner): void
+    {
+        $userInformation = $resourceOwner->toArray();
+
+        $this->emailAddress = $userInformation['email'] ?? '';
+        $this->firstName = $userInformation['given_name'] ?? '';
+        $this->lastName = $userInformation['family_name'] ?? '';
+        $this->organisationId = $userInformation['organisationId'] ?? '';
+        $this->organisationName = $userInformation['organisationName'] ?? '';
+        $this->userId = $userInformation['sub'] ?? '';
+        $this->userName = $userInformation['preferred_username'] ?? ''; // kind of "login" //has to be unique?
+
+        $this->lock();
+        $this->checkMandatoryValuesExist();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
@@ -13,46 +13,10 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use Stringable;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
-/**
- * @method array  getCustomerRoleRelations()
- * @method string getEmailAddress()
- * @method string getUserName()
- * @method string getUserId()
- * @method string getOrganisationName()
- * @method string getOrganisationId()
- * @method string getFirstName()
- * @method string getLastName()
- */
-class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterface, Stringable
+class OzgKeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
 {
-    /**
-     * @var array<int, array<int,string>>
-     */
-    protected array $customerRoleRelations = [];
-    /**
-     * E-mail-address of the provided user.
-     */
-    protected string $emailAddress = '';
-    /**
-     * Unique abbreviation of chosen login name of the provided user.
-     */
-    protected string $userName = '';
-    /**
-     * Unique ID of the provided user.
-     */
-    protected string $userId = '';
-    /**
-     * Name of the provided organisation.
-     */
-    protected string $organisationName = '';
-    /**
-     * Unique identifier of the provided organisation.
-     */
-    protected string $organisationId = '';
-    protected string $firstName = '';
-    protected string $lastName = '';
+
     private readonly string $keycloakGroupRoleString;
 
     public function __construct(ParameterBagInterface $parameterBag)
@@ -83,41 +47,6 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
     }
 
     /**
-     * Checks for existing mandatory data.
-     */
-    public function checkMandatoryValuesExist(): void
-    {
-        $missingMandatoryValues = [];
-        if ('' === $this->userId) {
-            $missingMandatoryValues[] = 'userId';
-        }
-
-        if ('' === $this->userName) {
-            $missingMandatoryValues[] = 'userName';
-        }
-
-        if ('' === $this->emailAddress) {
-            $missingMandatoryValues[] = 'emailAddress';
-        }
-
-        if ('' === $this->organisationId) {
-            $missingMandatoryValues[] = 'organisationId';
-        }
-
-        if ('' === $this->firstName && '' === $this->lastName) {
-            $missingMandatoryValues[] = 'name';
-        }
-
-        if ([] === $this->customerRoleRelations) {
-            $missingMandatoryValues[] = 'roles';
-        }
-
-        if ([] !== $missingMandatoryValues) {
-            throw new AuthenticationCredentialsNotFoundException(implode(', ', $missingMandatoryValues).'are missing in requestValues');
-        }
-    }
-
-    /**
      * Mapping of roles of customer based on string-comparison.
      * Example of data structure of $groups:
      * [
@@ -139,21 +68,4 @@ class OzgKeycloakUserData extends ValueObject implements KeycloakUserDataInterfa
         }
     }
 
-    public function __toString(): string
-    {
-        $customerRoleRelationString = '';
-        foreach ($this->customerRoleRelations as $subdomain => $roleNames) {
-            $customerRoleRelationString .= $subdomain.': ['.implode(', ', $roleNames).'] ';
-        }
-
-        return
-            'userId: '.$this->userId.
-            ', userName: '.$this->userName.
-            ', firstName: '.$this->firstName.
-            ', lastName: '.$this->lastName.
-            ', organisationId: '.$this->organisationId.
-            ', organisationName: '.$this->organisationName.
-            ', emailAddress: '.$this->emailAddress.
-            ', roles: '.$customerRoleRelationString;
-    }
 }

--- a/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/OzgKeycloakUserData.php
@@ -16,7 +16,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class OzgKeycloakUserData extends CommonUserData implements KeycloakUserDataInterface, Stringable
 {
-
     private readonly string $keycloakGroupRoleString;
 
     public function __construct(ParameterBagInterface $parameterBag)
@@ -67,5 +66,4 @@ class OzgKeycloakUserData extends CommonUserData implements KeycloakUserDataInte
             }
         }
     }
-
 }

--- a/tests/backend/base/FunctionalTestCase.php
+++ b/tests/backend/base/FunctionalTestCase.php
@@ -566,22 +566,22 @@ class FunctionalTestCase extends WebTestCase
         $mock = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->onlyMethods(
-                array(
+                [
                     'getConnection',
                     'getClassMetadata',
                     'close',
-                )
+                ]
             )
             ->getMock();
 
         $connectionMock = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->onlyMethods(
-                array(
+                [
                     'beginTransaction',
                     'commit',
                     'rollback',
-                )
+                ]
             )
             ->getMock();
 

--- a/tests/backend/base/FunctionalTestCase.php
+++ b/tests/backend/base/FunctionalTestCase.php
@@ -38,6 +38,7 @@ use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
@@ -558,6 +559,37 @@ class FunctionalTestCase extends WebTestCase
         $session->set('userId', $this->fixtures->getReference($userReferenceName)->getId());
 
         return $session;
+    }
+
+    public function getEntityManagerMock(): EntityManager
+    {
+        $mock = $this->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                array(
+                    'getConnection',
+                    'getClassMetadata',
+                    'close',
+                )
+            )
+            ->getMock();
+
+        $connectionMock = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                array(
+                    'beginTransaction',
+                    'commit',
+                    'rollback',
+                )
+            )
+            ->getMock();
+
+        $mock
+            ->method('getConnection')
+            ->willReturn($connectionMock);
+
+        return $mock;
     }
 
     protected function getConsultationTokenReference(string $name): ConsultationToken

--- a/tests/backend/core/Core/Functional/KeycloakUserBadgeCreatorTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserBadgeCreatorTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Logic\KeycloakUserDataMapper;
+use demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\KeycloakUserBadgeCreator;
+use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Tests\Base\FunctionalTestCase;
+use Tests\Base\MockMethodDefinition;
+
+class KeycloakUserBadgeCreatorTest  extends FunctionalTestCase
+{
+
+    protected ?KeycloakUserBadgeCreator $keycloakUserBadgeCreator;
+
+
+    protected function setUp(): void
+    {
+        $mockMethods = [
+            new MockMethodDefinition('getId', 'abcde'),
+        ];
+        $user = $this->getMock(User::class, $mockMethods);
+        $mockMethods = [
+            new MockMethodDefinition('mapUserData', $user),
+        ];
+        $keycloakUserDataMapper = $this->getMock(KeycloakUserDataMapper::class, $mockMethods);
+
+        $this->keycloakUserBadgeCreator = new KeycloakUserBadgeCreator(
+            $this->getEntityManagerMock(),
+            $this->createMock(KeycloakUserData::class),
+            $this->createMock(LoggerInterface::class),
+            $keycloakUserDataMapper
+        );
+    }
+
+
+
+    public function testAuthenticate()
+    {
+        $sessionMethods = [
+            new MockMethodDefinition('set', null),
+        ];
+        $sessionMock = $this->getMock(Session::class, $sessionMethods);
+        $mockMethods = [
+            new MockMethodDefinition('getSession', $sessionMock),
+        ];
+
+        $request = $this->getMock(Request::class, $mockMethods);
+
+        $userBadge = $this->keycloakUserBadgeCreator->createKeycloakUserBadge(
+            'userIdentifier',
+            $this->createMock(ResourceOwnerInterface::class),
+            $request
+        );
+        $this->assertTrue($userBadge->isResolved());
+        $this->assertEquals('userIdentifier', $userBadge->getUserIdentifier());
+        $this->assertInstanceOf(User::class, $userBadge->getUser());
+    }
+}

--- a/tests/backend/core/Core/Functional/KeycloakUserBadgeCreatorTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserBadgeCreatorTest.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
@@ -14,11 +23,9 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Tests\Base\FunctionalTestCase;
 use Tests\Base\MockMethodDefinition;
 
-class KeycloakUserBadgeCreatorTest  extends FunctionalTestCase
+class KeycloakUserBadgeCreatorTest extends FunctionalTestCase
 {
-
     protected ?KeycloakUserBadgeCreator $keycloakUserBadgeCreator;
-
 
     protected function setUp(): void
     {
@@ -38,8 +45,6 @@ class KeycloakUserBadgeCreatorTest  extends FunctionalTestCase
             $keycloakUserDataMapper
         );
     }
-
-
 
     public function testAuthenticate()
     {

--- a/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
@@ -55,18 +55,21 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
     public function testCreateNewPublicUser(): void
     {
         $attributes = [
-            'email' => 'test@example.com',
-            'givenName' => 'John',
-            'surname' => 'Doe',
-            'organisationId' => '',
-            'organisationName' => '',
-            'sub' => '456',
-            'preferred_username' => 'johndoe',
-            'houseNumber' => '10',
-            'ID' => '123456',
             'localityName' => 'Test City',
-            'postalCode' => '12345',
-            'street' => 'Test Street'
+            'ID' => '123456',
+            'houseNumber' => '10',
+            'givenName' => 'John',
+            'email' => 'test@example.com',
+            'surname' => 'Doe',
+            'organisationName' => '',
+            'street' => 'Test Street',
+            'orgaName' => '',
+
+//            'organisationId' => '',
+//            'sub' => '456',
+//            'preferred_username' => 'johndoe',
+//            'postalCode' => '12345',
+//            // orgaType UserAttribute PersTyp
         ];
         $resourceOwner = new KeycloakResourceOwner($attributes);
         $userData = new KeycloakUserData();
@@ -101,8 +104,8 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
         $user = $this->keycloakUserDataMapper->mapUserData($userData);
         self::assertInstanceOf(User::class, $user);
         $anonymousUser = new AnonymousUser();
-        self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
-        self::assertEquals($attributes['ID'][0], $user->getLogin());
+        self::assertNotEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
+        self::assertEquals($attributes['ID'], $user->getLogin());
     }
 
     public function testCreateNewUserFromServicekonto(): void
@@ -123,7 +126,7 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
         self::assertInstanceOf(User::class, $user);
         $anonymousUser = new AnonymousUser();
         self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
-        self::assertEquals($attributes['ID'][0], $user->getLogin());
+        self::assertEquals($attributes['ID'], $user->getLogin());
     }
 
     public function testCreateNewOrgaNoUser(): void

--- a/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
@@ -1,0 +1,195 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadCustomerData;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\EventDispatcher\EventDispatcherPostInterface;
+use demosplan\DemosPlanCoreBundle\Logic\KeycloakUserDataMapper;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
+use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Psr\Log\NullLogger;
+use Stevenmaguire\OAuth2\Client\Provider\KeycloakResourceOwner;
+use Tests\Base\FunctionalTestCase;
+use Tests\Base\MockMethodDefinition;
+
+class KeycloakUserDataMapperTest extends FunctionalTestCase
+{
+
+    private ?KeycloakUserDataMapper $keycloakUserDataMapper;
+
+    /**
+     * @var User
+     */
+    protected $citizenUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $customerMockMethods = [
+            new MockMethodDefinition('getCurrentCustomer', $this->fixtures->getReference(LoadCustomerData::BRANDENBURG)),
+        ];
+        $customerService = $this->getMock(CustomerService::class, $customerMockMethods);
+
+        $eventDispatcher = $this->getContainer()->get(EventDispatcherPostInterface::class);
+
+        $this->citizenUser = $this->fixtures->getReference(LoadUserData::TEST_USER_CITIZEN);
+
+        $orgaService = $this->getContainer()->get(OrgaService::class);
+
+        $roleHandler = $this->getContainer()->get(RoleHandler::class);
+
+        $userService = $this->getContainer()->get(UserService::class);
+
+        $this->keycloakUserDataMapper = new KeycloakUserDataMapper($customerService, $eventDispatcher, new NullLogger(), $orgaService, $roleHandler, $userService);
+    }
+
+    public function testCreateNewPublicUser(): void
+    {
+        $attributes = [
+            'email' => 'test@example.com',
+            'givenName' => 'John',
+            'surname' => 'Doe',
+            'organisationId' => '',
+            'organisationName' => '',
+            'sub' => '456',
+            'preferred_username' => 'johndoe',
+            'houseNumber' => '10',
+            'ID' => '123456',
+            'localityName' => 'Test City',
+            'postalCode' => '12345',
+            'street' => 'Test Street'
+        ];
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+        self::assertInstanceOf(User::class, $user);
+        $anonymousUser = new AnonymousUser();
+        self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
+        self::assertEquals($attributes['ID'], $user->getLogin());
+    }
+    public function testCreateNewOrgaUser(): void
+    {
+        $attributes = [
+            'email' => 'test@example.com',
+            'givenName' => 'John',
+            'surname' => 'Doe',
+            'organisationId' => '123',
+            'organisationName' => 'Test Organisation',
+            'sub' => '456',
+            'preferred_username' => 'johndoe',
+            'houseNumber' => '10',
+            'ID' => '123456',
+            'localityName' => 'Test City',
+            'postalCode' => '12345',
+            'street' => 'Test Street'
+        ];
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+        self::assertInstanceOf(User::class, $user);
+        $anonymousUser = new AnonymousUser();
+        self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
+        self::assertEquals($attributes['ID'][0], $user->getLogin());
+    }
+
+    public function testCreateNewUserFromServicekonto(): void
+    {
+        $attributes = [
+            'email'       => 'Sarah@connell.de',
+            'givenName'   => 'Sarah',
+            'bPK'         => 'VjEuQkI6OmRlLmFrZGIuYnBrLnNzb0Bsb2dpbi1zdGFnZS5iYXVsZWl0cGxhbnVuZy1vbmxpbmUuZGU6OmxvUlF1c25qTXQ0bVN4eUFtNExQZkZPbTdjd1JiWjRQc3FFNTltcERWbnc6OjIwMjItMDktMjNUMTU6MTQ6NTM=',
+            'surname'     => 'Connell',
+            'ID'          => 'loRQusnjMt4mSxyAm4LPfFOm7cwRbZ4PsqE59mpDVnw',
+            'sessionIndex'=> '54204e12-af28-4b20-806b-e21fced6ad8a::30065ff8-40b7-42b7-82c4-80c26d993959',
+        ];
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+        self::assertInstanceOf(User::class, $user);
+        $anonymousUser = new AnonymousUser();
+        self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
+        self::assertEquals($attributes['ID'][0], $user->getLogin());
+    }
+
+    public function testCreateNewOrgaNoUser(): void
+    {
+        $attributes = $this->getOrgaLoginAttributes();
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+        self::assertInstanceOf(User::class, $user);
+        $orga = $user->getOrga();
+        self::assertEquals($attributes['orgaName'][0], $orga->getName());
+        self::assertEquals($attributes['houseNumber'][0], $orga->getHouseNumber());
+        self::assertEquals($attributes['localityName'][0], $orga->getCity());
+        self::assertEquals($attributes['postalCode'][0], $orga->getPostalcode());
+        self::assertEquals($attributes['street'][0], $orga->getStreet());
+        self::assertEquals($attributes['ID'][0], $orga->getGatewayName());
+
+        self::assertEquals($attributes['ID'][0], $user->getLogin());
+    }
+
+    public function testUpdateOrga(): void
+    {
+        $attributes = $this->getOrgaLoginAttributes();
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+        self::assertInstanceOf(User::class, $user);
+
+        $attributes['localityName'] = ['Neustadt'];
+        $resourceOwner = new KeycloakResourceOwner($attributes);
+        $userData = new KeycloakUserData();
+        $userData->fill($resourceOwner);
+        $user = $this->keycloakUserDataMapper->mapUserData($userData);
+
+        $orga = $user->getOrga();
+        self::assertEquals($attributes['orgaName'][0], $orga->getName());
+        self::assertEquals($attributes['houseNumber'][0], $orga->getHouseNumber());
+        self::assertEquals($attributes['localityName'][0], $orga->getCity());
+        self::assertEquals($attributes['postalCode'][0], $orga->getPostalcode());
+        self::assertEquals($attributes['street'][0], $orga->getStreet());
+        self::assertEquals($attributes['ID'][0], $orga->getGatewayName());
+
+        self::assertEquals($attributes['ID'][0], $user->getLogin());
+    }
+
+    private function getOrgaLoginAttributes(): array
+    {
+        return [
+            'country'       => 'de',
+            'givenName'     => '',
+            'houseNumber'   => '14',
+            'ID'            => 'du-886227c04d14045c16c42d706427d8392fd64417',
+            'localityName'  => 'Erlangen',
+            'email'         => 'mail.needs@tobes.et',
+            'orgaMail'      => 'orgaMailneeds@tobes.et',
+            'orgaName'      => 'Franken Plus GmbH & Co. KGaA',
+            'orgaType'      => 'NNatPers',
+            'postalCode'    => '91058',
+            'street'        => 'Frauenweiherstr.',
+            'surname'       => '',
+        ];
+    }
+
+
+}

--- a/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataMapperTest.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
@@ -15,7 +24,6 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Psr\Log\NullLogger;
 use Stevenmaguire\OAuth2\Client\Provider\KeycloakResourceOwner;
 use Tests\Base\FunctionalTestCase;
@@ -23,7 +31,6 @@ use Tests\Base\MockMethodDefinition;
 
 class KeycloakUserDataMapperTest extends FunctionalTestCase
 {
-
     private ?KeycloakUserDataMapper $keycloakUserDataMapper;
 
     /**
@@ -56,13 +63,13 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
     public function testCreateNewPublicUser(): void
     {
         $attributes = [
-            'localityName' => 'Test City',
-            'houseNumber' => '10',
-            'givenName' => 'John',
-            'email' => 'test@example.com',
-            'surname' => 'Doe',
+            'localityName'     => 'Test City',
+            'houseNumber'      => '10',
+            'givenName'        => 'John',
+            'email'            => 'test@example.com',
+            'surname'          => 'Doe',
             'organisationName' => '',
-            'street' => 'Test Street',
+            'street'           => 'Test Street',
         ];
         $resourceOwner = new KeycloakResourceOwner($attributes);
         $userData = new KeycloakUserData();
@@ -74,20 +81,21 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
         self::assertEquals($anonymousUser->getOrga()->getId(), $user->getOrga()->getId());
         self::assertEquals($attributes['email'], $user->getLogin());
     }
+
     public function testCreateNewOrgaUser(): void
     {
         $attributes = [
-            'email' => 'test@example.com',
-            'givenName' => 'John',
-            'surname' => 'Doe',
-            'organisationId' => '123',
-            'organisationName' => 'Test Organisation',
-            'sub' => '456',
+            'email'              => 'test@example.com',
+            'givenName'          => 'John',
+            'surname'            => 'Doe',
+            'organisationId'     => '123',
+            'organisationName'   => 'Test Organisation',
+            'sub'                => '456',
             'preferred_username' => 'johndoe',
-            'houseNumber' => '10',
-            'localityName' => 'Test City',
-            'postalCode' => '12345',
-            'street' => 'Test Street'
+            'houseNumber'        => '10',
+            'localityName'       => 'Test City',
+            'postalCode'         => '12345',
+            'street'             => 'Test Street',
         ];
         $resourceOwner = new KeycloakResourceOwner($attributes);
         $userData = new KeycloakUserData();
@@ -168,26 +176,23 @@ class KeycloakUserDataMapperTest extends FunctionalTestCase
         self::assertEquals($attributes['street'], $orga->getStreet());
         self::assertEquals($attributes['organisationId'], $orga->getGatewayName());
         self::assertEquals($attributes['email'], $user->getLogin());
-
     }
 
     private function getOrgaLoginAttributes(): array
     {
         return [
-            'country'       => 'de',
-            'givenName'     => 'Organisation',
-            'surname'     => 'Administration',
-            'houseNumber'   => '14',
-            'localityName'  => 'Erlangen',
-            'email'         => 'mail.needs@tobes.et',
-            'orgaMail'      => 'orgaMailneeds@tobes.et',
-            'organisationName'      => 'Franken Plus GmbH & Co. KGaA',
+            'country'                   => 'de',
+            'givenName'                 => 'Organisation',
+            'surname'                   => 'Administration',
+            'houseNumber'               => '14',
+            'localityName'              => 'Erlangen',
+            'email'                     => 'mail.needs@tobes.et',
+            'orgaMail'                  => 'orgaMailneeds@tobes.et',
+            'organisationName'          => 'Franken Plus GmbH & Co. KGaA',
             'organisationId'            => 'du-886227c04d14045c16c42d706427d8392fd64417',
-            'orgaType'      => 'NNatPers',
-            'postalCode'    => '91058',
-            'street'        => 'Frauenweiherstr.',
+            'orgaType'                  => 'NNatPers',
+            'postalCode'                => '91058',
+            'street'                    => 'Frauenweiherstr.',
         ];
     }
-
-
 }

--- a/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
@@ -1,5 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Tests\Core\Core\Functional;
 
@@ -10,8 +19,7 @@ use Tests\Base\FunctionalTestCase;
 
 class KeycloakUserDataTest extends FunctionalTestCase
 {
-
-    const TEST_EMAIL = 'test@example.com';
+    public const TEST_EMAIL = 'test@example.com';
     private ?KeycloakUserData $keycloakUserData;
 
     protected function setUp(): void
@@ -24,16 +32,16 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
         $resourceOwner->method('toArray')
             ->willReturn([
-                'email' => self::TEST_EMAIL,
-                'givenName' => 'John',
-                'surname' => 'Doe',
-                'organisationId' => '123',
+                'email'            => self::TEST_EMAIL,
+                'givenName'        => 'John',
+                'surname'          => 'Doe',
+                'organisationId'   => '123',
                 'organisationName' => 'Test Organisation',
-                'sub' => '456',
-                'houseNumber' => '10',
-                'localityName' => 'Test City',
-                'postalCode' => '12345',
-                'street' => 'Test Street'
+                'sub'              => '456',
+                'houseNumber'      => '10',
+                'localityName'     => 'Test City',
+                'postalCode'       => '12345',
+                'street'           => 'Test Street',
             ]);
 
         $this->keycloakUserData->fill($resourceOwner);
@@ -58,7 +66,6 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $this->assertEquals('Test City', $this->keycloakUserData->getLocalityName());
         $this->assertEquals('12345', $this->keycloakUserData->getPostalCode());
         $this->assertEquals('Test Street', $this->keycloakUserData->getStreet());
-
     }
 
     public function testUserInformationIsCorrectlyFilledFromIncompleteResourceOwner(): void
@@ -66,14 +73,14 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
         $resourceOwner->method('toArray')
             ->willReturn([
-                'email' => self::TEST_EMAIL,
-                'givenName' => 'John',
-                'surname' => 'Doe',
-                'sub' => '456',
-                'houseNumber' => '',
+                'email'        => self::TEST_EMAIL,
+                'givenName'    => 'John',
+                'surname'      => 'Doe',
+                'sub'          => '456',
+                'houseNumber'  => '',
                 'localityName' => '',
-                'postalCode' => '',
-                'street' => ''
+                'postalCode'   => '',
+                'street'       => '',
             ]);
 
         $this->keycloakUserData->fill($resourceOwner);
@@ -95,15 +102,14 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
         $resourceOwner->method('toArray')
             ->willReturn([
-                'email' => '',
+                'email'     => '',
                 'givenName' => '',
-                'surname' => '',
-                'sub' => '',
+                'surname'   => '',
+                'sub'       => '',
             ]);
 
         $this->expectException(AuthenticationCredentialsNotFoundException::class);
 
         $this->keycloakUserData->fill($resourceOwner);
     }
-
 }

--- a/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Core\Core\Functional;
+
+use demosplan\DemosPlanCoreBundle\ValueObject\KeycloakUserData;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Tests\Base\FunctionalTestCase;
+
+class KeycloakUserDataTest extends FunctionalTestCase
+{
+
+    private ?KeycloakUserData $keycloakUserData;
+
+    protected function setUp(): void
+    {
+        $this->keycloakUserData = new KeycloakUserData();
+    }
+
+    public function testUserInformationIsCorrectlyFilledFromResourceOwner(): void
+    {
+        $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
+        $resourceOwner->method('toArray')
+            ->willReturn([
+                'email' => 'test@example.com',
+                'givenName' => 'John',
+                'surname' => 'Doe',
+                'organisationId' => '123',
+                'organisationName' => 'Test Organisation',
+                'sub' => '456',
+                'preferred_username' => 'johndoe',
+                'houseNumber' => '10',
+                'ID' => '123456',
+                'localityName' => 'Test City',
+                'postalCode' => '12345',
+                'street' => 'Test Street'
+            ]);
+
+        $this->keycloakUserData->fill($resourceOwner);
+
+        $this->assertEquals(
+            'test@example.com',
+            $this->keycloakUserData->getEmailAddress()
+        );
+        $this->assertEquals('John', $this->keycloakUserData->getFirstName());
+        $this->assertEquals('Doe', $this->keycloakUserData->getLastName());
+        $this->assertEquals(
+            '123',
+            $this->keycloakUserData->getOrganisationId()
+        );
+        $this->assertEquals(
+            'Test Organisation',
+            $this->keycloakUserData->getOrganisationName()
+        );
+        $this->assertEquals('456', $this->keycloakUserData->getUserId());
+        $this->assertEquals('johndoe', $this->keycloakUserData->getUserName());
+        $this->assertEquals('10', $this->keycloakUserData->getHouseNumber());
+        $this->assertEquals('123456', $this->keycloakUserData->getId());
+        $this->assertEquals('Test City', $this->keycloakUserData->getLocalityName());
+        $this->assertEquals('12345', $this->keycloakUserData->getPostalCode());
+        $this->assertEquals('Test Street', $this->keycloakUserData->getStreet());
+
+    }
+
+    public function testUserInformationIsCorrectlyFilledFromIncompleteResourceOwner(): void
+    {
+        $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
+        $resourceOwner->method('toArray')
+            ->willReturn([
+                'email' => 'test@example.com',
+                'givenName' => 'John',
+                'surname' => 'Doe',
+                'sub' => '456',
+                'preferred_username' => 'johndoe',
+                'houseNumber' => '',
+                'ID' => '',
+                'localityName' => '',
+                'postalCode' => '',
+                'street' => ''
+            ]);
+
+        $this->keycloakUserData->fill($resourceOwner);
+
+        $this->assertEquals(
+            'test@example.com',
+            $this->keycloakUserData->getEmailAddress()
+        );
+        $this->assertEquals('John', $this->keycloakUserData->getFirstName());
+        $this->assertEquals('Doe', $this->keycloakUserData->getLastName());
+        $this->assertEquals('', $this->keycloakUserData->getOrganisationId());
+        $this->assertEquals('', $this->keycloakUserData->getOrganisationName());
+        $this->assertEquals('456', $this->keycloakUserData->getUserId());
+        $this->assertEquals('johndoe', $this->keycloakUserData->getUserName());
+    }
+
+    public function testCheckMandatoryValuesExistThrowsExceptionWhenValuesAreMissing(): void
+    {
+        $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
+        $resourceOwner->method('toArray')
+            ->willReturn([
+                'email' => '',
+                'givenName' => '',
+                'surname' => '',
+                'sub' => '',
+                'preferred_username' => ''
+            ]);
+
+        $this->expectException(AuthenticationCredentialsNotFoundException::class);
+
+        $this->keycloakUserData->fill($resourceOwner);
+    }
+
+}

--- a/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
@@ -29,9 +29,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
                 'organisationId' => '123',
                 'organisationName' => 'Test Organisation',
                 'sub' => '456',
-                'preferred_username' => 'johndoe',
                 'houseNumber' => '10',
-                'ID' => '123456',
                 'localityName' => 'Test City',
                 'postalCode' => '12345',
                 'street' => 'Test Street'
@@ -54,9 +52,8 @@ class KeycloakUserDataTest extends FunctionalTestCase
             $this->keycloakUserData->getOrganisationName()
         );
         $this->assertEquals('456', $this->keycloakUserData->getUserId());
-        $this->assertEquals('johndoe', $this->keycloakUserData->getUserName());
+        $this->assertEquals('test@example.com', $this->keycloakUserData->getUserName());
         $this->assertEquals('10', $this->keycloakUserData->getHouseNumber());
-        $this->assertEquals('123456', $this->keycloakUserData->getId());
         $this->assertEquals('Test City', $this->keycloakUserData->getLocalityName());
         $this->assertEquals('12345', $this->keycloakUserData->getPostalCode());
         $this->assertEquals('Test Street', $this->keycloakUserData->getStreet());
@@ -72,9 +69,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
                 'givenName' => 'John',
                 'surname' => 'Doe',
                 'sub' => '456',
-                'preferred_username' => 'johndoe',
                 'houseNumber' => '',
-                'ID' => '',
                 'localityName' => '',
                 'postalCode' => '',
                 'street' => ''
@@ -91,7 +86,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $this->assertEquals('', $this->keycloakUserData->getOrganisationId());
         $this->assertEquals('', $this->keycloakUserData->getOrganisationName());
         $this->assertEquals('456', $this->keycloakUserData->getUserId());
-        $this->assertEquals('johndoe', $this->keycloakUserData->getUserName());
+        $this->assertEquals('test@example.com', $this->keycloakUserData->getUserName());
     }
 
     public function testCheckMandatoryValuesExistThrowsExceptionWhenValuesAreMissing(): void
@@ -103,7 +98,6 @@ class KeycloakUserDataTest extends FunctionalTestCase
                 'givenName' => '',
                 'surname' => '',
                 'sub' => '',
-                'preferred_username' => ''
             ]);
 
         $this->expectException(AuthenticationCredentialsNotFoundException::class);

--- a/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
+++ b/tests/backend/core/Core/Functional/KeycloakUserDataTest.php
@@ -11,6 +11,7 @@ use Tests\Base\FunctionalTestCase;
 class KeycloakUserDataTest extends FunctionalTestCase
 {
 
+    const TEST_EMAIL = 'test@example.com';
     private ?KeycloakUserData $keycloakUserData;
 
     protected function setUp(): void
@@ -23,7 +24,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
         $resourceOwner->method('toArray')
             ->willReturn([
-                'email' => 'test@example.com',
+                'email' => self::TEST_EMAIL,
                 'givenName' => 'John',
                 'surname' => 'Doe',
                 'organisationId' => '123',
@@ -38,7 +39,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $this->keycloakUserData->fill($resourceOwner);
 
         $this->assertEquals(
-            'test@example.com',
+            self::TEST_EMAIL,
             $this->keycloakUserData->getEmailAddress()
         );
         $this->assertEquals('John', $this->keycloakUserData->getFirstName());
@@ -52,7 +53,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
             $this->keycloakUserData->getOrganisationName()
         );
         $this->assertEquals('456', $this->keycloakUserData->getUserId());
-        $this->assertEquals('test@example.com', $this->keycloakUserData->getUserName());
+        $this->assertEquals(self::TEST_EMAIL, $this->keycloakUserData->getUserName());
         $this->assertEquals('10', $this->keycloakUserData->getHouseNumber());
         $this->assertEquals('Test City', $this->keycloakUserData->getLocalityName());
         $this->assertEquals('12345', $this->keycloakUserData->getPostalCode());
@@ -65,7 +66,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $resourceOwner = $this->createMock(ResourceOwnerInterface::class);
         $resourceOwner->method('toArray')
             ->willReturn([
-                'email' => 'test@example.com',
+                'email' => self::TEST_EMAIL,
                 'givenName' => 'John',
                 'surname' => 'Doe',
                 'sub' => '456',
@@ -78,7 +79,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $this->keycloakUserData->fill($resourceOwner);
 
         $this->assertEquals(
-            'test@example.com',
+            self::TEST_EMAIL,
             $this->keycloakUserData->getEmailAddress()
         );
         $this->assertEquals('John', $this->keycloakUserData->getFirstName());
@@ -86,7 +87,7 @@ class KeycloakUserDataTest extends FunctionalTestCase
         $this->assertEquals('', $this->keycloakUserData->getOrganisationId());
         $this->assertEquals('', $this->keycloakUserData->getOrganisationName());
         $this->assertEquals('456', $this->keycloakUserData->getUserId());
-        $this->assertEquals('test@example.com', $this->keycloakUserData->getUserName());
+        $this->assertEquals(self::TEST_EMAIL, $this->keycloakUserData->getUserName());
     }
 
     public function testCheckMandatoryValuesExistThrowsExceptionWhenValuesAreMissing(): void


### PR DESCRIPTION
### Ticket
DPLAN-11848

This PR moves the authentication from login via SAML per OneLoginSamlBundle to login per OAuth via OAuth2ClientBundle.

It is mostly a c&p from `SamlUserFactory`, `SamlUserProvider` and friends to new classes that use the OAuth2ClientBundle. Alon the way a lot of tests where added.
It uses the same basis of the value objects like the `OzgKeycloakAuthenticator`, but keeps the logic from the OneLoginSamlBundle whenever possible.

Later on it might be a good idea to merge `OzgKeycloakAuthenticator` and `KeycloakAuthenticator` (and subsequent classes), but to keep this PR as small as possible this was not done yet.

### How to review/test
code review or install the branch at the release server and test login

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
