### PR TITLE
refacor: Create api2.0 Routes Dynamically

### DIFF
--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -10,7 +10,7 @@
 /*
  * Hardcoded API 1.0 Routes
  */
-const api1Routes = [
+const api1_0Routes = [
   {
     module: 'report',
     action: 'list',
@@ -83,7 +83,7 @@ const api1Routes = [
   }
 ]
 
-const generateApiRoutes = (apiModules) => {
+const generateApi2_0Routes = (apiModules) => {
   const routes = []
 
   apiModules.forEach(typeName => {
@@ -130,4 +130,4 @@ const generateApiRoutes = (apiModules) => {
   return routes
 }
 
-export { api1Routes, generateApiRoutes }
+export { api1_0Routes, generateApi2_0Routes }

--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -7,103 +7,10 @@
  * All rights reserved
  */
 
-export const VuexApiRoutes = [
-  {
-    module: 'branding',
-    action: 'list',
-    url: '/2.0/Branding'
-  },
-  {
-    module: 'branding',
-    action: 'update',
-    url: '/2.0/Branding/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customer',
-    action: 'create',
-    url: '/2.0/Customer'
-  },
-  {
-    module: 'customer',
-    action: 'list',
-    url: '/2.0/Customer'
-  },
-  {
-    module: 'customer',
-    action: 'delete',
-    url: '/2.0/Customer/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customer',
-    action: 'update',
-    url: '/2.0/Customer/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customerContact',
-    action: 'create',
-    url: '/2.0/CustomerContact'
-  },
-  {
-    module: 'customerContact',
-    action: 'delete',
-    url: '/2.0/CustomerContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customerContact',
-    action: 'list',
-    url: '/2.0/CustomerContact'
-  },
-  {
-    module: 'customerContact',
-    action: 'update',
-    url: '/2.0/CustomerContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customerLoginSupportContact',
-    action: 'create',
-    url: '/2.0/CustomerLoginSupportContact'
-  },
-  {
-    module: 'customerLoginSupportContact',
-    action: 'delete',
-    url: '/2.0/CustomerLoginSupportContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'customerLoginSupportContact',
-    action: 'list',
-    url: '/2.0/CustomerLoginSupportContact'
-  },
-  {
-    module: 'customerLoginSupportContact',
-    action: 'update',
-    url: '/2.0/CustomerLoginSupportContact/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'file',
-    action: 'list',
-    url: '/2.0/File'
-  },
+/*
+ * Hardcoded API 1.0 Routes
+ */
+const api1Routes = [
   {
     module: 'report',
     action: 'list',
@@ -147,51 +54,11 @@ export const VuexApiRoutes = [
       'id'
     ]
   },
-  {
-    module: 'department',
-    action: 'list',
-    url: '/2.0/Department'
-  },
-  {
-    module: 'assignableUser',
-    action: 'list',
-    url: '/2.0/AssignableUser'
-  },
-  {
-    module: 'orga',
-    action: 'list',
-    url: '/2.0/Orga'
-  },
-  {
-    module: 'orga',
-    action: 'update',
-    url: '/1.0/organisation/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'orga',
-    action: 'create',
-    url: '/1.0/organisation/'
-  },
-  {
-    module: 'orga',
-    action: 'delete',
-    url: '/1.0/organisation/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'role',
-    action: 'list',
-    url: '/1.0/role/'
-  },
+
   {
     module: 'faqCategory',
     action: 'list',
-    url: '/1.0/faq-category/'
+    url: '/1.0/FaqCategory/'
   },
   {
     module: 'faq',
@@ -213,137 +80,54 @@ export const VuexApiRoutes = [
     parameters: [
       'id'
     ]
-  },
-  {
-    module: 'invitableToeb',
-    action: 'list',
-    url: '/2.0/InvitableToeb'
-  },
-  {
-    module: 'invitableInstitution',
-    action: 'list',
-    url: '/2.0/InvitableInstitution'
-  },
-  {
-    module: 'invitableInstitution',
-    action: 'update',
-    url: '/2.0/InvitableInstitution/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'place',
-    action: 'list',
-    url: '/2.0/Place'
-  },
-  {
-    module: 'segmentComment',
-    action: 'list',
-    url: '/2.0/SegmentComment'
-  },
-  {
-    module: 'statementSegment',
-    action: 'list',
-    url: '/2.0/StatementSegment'
-  },
-  {
-    module: 'statementSegment',
-    action: 'update',
-    url: '/2.0/StatementSegment/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'statement',
-    action: 'list',
-    url: '/2.0/Statement'
-  },
-  {
-    module: 'statement',
-    action: 'get',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'statement',
-    action: 'update',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'statement',
-    action: 'delete',
-    url: '/2.0/Statement/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'statementAttachment',
-    action: 'create',
-    url: '/2.0/StatementAttachment'
-  },
-  {
-    module: 'tag',
-    action: 'list',
-    url: '/2.0/Tag'
-  },
-  {
-    module: 'institutionTag',
-    action: 'create',
-    url: '/2.0/InstitutionTag'
-  },
-  {
-    module: 'institutionTag',
-    action: 'list',
-    url: '/2.0/InstitutionTag'
-  },
-  {
-    module: 'institutionTag',
-    action: 'update',
-    url: '/2.0/InstitutionTag/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'institutionTag',
-    action: 'delete',
-    url: '/2.0/InstitutionTag/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'tagTopic',
-    action: 'list',
-    url: '/2.0/TagTopic'
-  },
-  {
-    module: 'elements',
-    action: 'list',
-    url: '/2.0/Elements'
-  },
-  {
-    module: 'elements',
-    action: 'update',
-    url: '/2.0/Elements/{id}',
-    parameters: [
-      'id'
-    ]
-  },
-  {
-    module: 'elements',
-    action: 'delete',
-    url: '/2.0/Elements/{id}',
-    parameters: [
-      'id'
-    ]
   }
 ]
+
+const generateApiRoutes = (apiModules) => {
+  const routes = []
+
+  apiModules.forEach(typeName => {
+    routes.push({
+      module: typeName,
+      action: 'list',
+      url: `/2.0/${typeName}`
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'get',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'update',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'create',
+      url: `/2.0/${typeName}`
+    })
+
+    routes.push({
+      module: typeName,
+      action: 'delete',
+      url: `/2.0/${typeName}/{id}`,
+      parameters: [
+        'id'
+      ]
+    })
+  })
+
+  return routes
+}
+
+export { api1Routes, generateApiRoutes }

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -12,7 +12,7 @@ import { initJsonApiPlugin, prepareModuleHashMap, StaticRouter } from '@efrane/v
 import notify from './Notify'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { api1Routes, generateApiRoutes } from './VuexApiRoutes'
+import { api1_0Routes, generateApi2_0Routes } from './VuexApiRoutes'
 
 function registerPresetModules (store, presetStoreModules) {
   if (Object.keys(presetStoreModules).length > 0) {
@@ -38,7 +38,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
   Vue.use(Vuex)
 
   const staticModules = { notify, ...storeModules }
-  const VuexApiRoutes = api1Routes.concat(generateApiRoutes(apiStoreModules))
+  const VuexApiRoutes = api1_0Routes.concat(generateApi2_0Routes(apiStoreModules))
   // This should probably be replaced with an adapter to our existing routes
   const router = new StaticRouter(VuexApiRoutes)
 

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -12,7 +12,7 @@ import { initJsonApiPlugin, prepareModuleHashMap, StaticRouter } from '@efrane/v
 import notify from './Notify'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { VuexApiRoutes } from './VuexApiRoutes'
+import { api1Routes, generateApiRoutes } from './VuexApiRoutes'
 
 function registerPresetModules (store, presetStoreModules) {
   if (Object.keys(presetStoreModules).length > 0) {
@@ -38,7 +38,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
   Vue.use(Vuex)
 
   const staticModules = { notify, ...storeModules }
-
+  const VuexApiRoutes = api1Routes.concat(generateApiRoutes(apiStoreModules))
   // This should probably be replaced with an adapter to our existing routes
   const router = new StaticRouter(VuexApiRoutes)
 


### PR DESCRIPTION
This is a cherry-pick from https://github.com/demos-europe/demosplan-core/pull/3217 to allow targeting main straight away.

