### PR TITLE
chore (refs DPLAN-2743): Add aria-label for map.

### DIFF
--- a/client/js/components/procedure/publicindex/map/Map.vue
+++ b/client/js/components/procedure/publicindex/map/Map.vue
@@ -11,6 +11,7 @@
   <l-map
     class="c-publicindex__map isolate"
     ref="map"
+    :aria-label="Translator.trans('map')"
     :zoom="initialZoom"
     :center="initialLocation"
     :min-zoom="7"


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-2743/Barrierefreiheit-Karte-hat-keine-Alt-text

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- Add aria-label for map.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Go to BLP Lokal, check for map div container.
- Now with `aria-label="Karte"` attribute.