### PR TITLE
fix(refs dplan 11843): Pass Procedure ID properly to documents editor

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
@@ -73,10 +73,9 @@
             :basic-auth="dplan.settings.basicAuth"
             class="u-mb"
             hidden-input="r_text"
-            procedure-id="{{ procedure }}"
             :required="true"
             :routes="{
-             getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
+             getFileByHash: (hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: '{{ procedure }}' })
             }"
             :toolbar-items="{
                 imageButton: true,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
@@ -64,7 +64,6 @@
             :basic-auth="dplan.settings.basicAuth"
             class="u-mb"
             hidden-input="r_text"
-            procedure-id="{{ procedure }}"
             :required="true"
             :routes="{
                getFileByHash: (hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: '{{ procedure }}' }),

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
@@ -67,7 +67,7 @@
             procedure-id="{{ procedure }}"
             :required="true"
             :routes="{
-               getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
+               getFileByHash: (hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: '{{ procedure }}' }),
             }"
             :toolbar-items="{
                 imageButton: true,


### PR DESCRIPTION
### Ticket
DPLAN-11843

The ProcedureId is static in this place and has to be used via twig. 