### PR TITLE
chore (refs DPLAN-11855): support file paths with procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphExporter.php
@@ -100,7 +100,7 @@ class ParagraphExporter
                     if (is_file($file->getAbsolutePath())) {
                         $this->logger->info('Pdf: Bild auf der Platte gefunden');
                         $fileContent = file_get_contents($file->getAbsolutePath());
-                        $pictures['picture'.$i] = $file->getHash().'###'.$file->getFileName().'###'.base64_encode($fileContent);
+                        $pictures['picture'.$i] = $match.'###'.$file->getFileName().'###'.base64_encode($fileContent);
                         ++$i;
                     }
                 } catch (Exception) {

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -456,7 +456,7 @@ class LatexExtension extends ExtensionBase
             // build placeholderstring
             $currentImageTex = 'IMAGEPLACEHOLDER-';
 
-            preg_match('|src=[\\\'"](\/app_dev\.php)?\/file\/([\w-]*)[\\\'"]|', (string) $imageMatch, $src);
+            preg_match('|src=[\\\'"](\/app_dev\.php)?\/file\/([\w-]*[\/\w-]*)[\\\'"]|', (string) $imageMatch, $src);
             $currentImageTex .= $src[2] ?? '';
 
             // only add width and height if both are provided
@@ -532,7 +532,13 @@ class LatexExtension extends ExtensionBase
             // Wenn du ein oder mehrere Bilder gefunden hast gehe sie durch
             foreach ($imageMatches[1] as $matchKey => $match) {
                 $parts = explode('\&', $match);
-                $fileHash = $parts[0];
+                // if contains / explode
+                if(str_contains($parts[0], '/')) {
+                    $parts = explode('/', $parts[0]);
+                    $fileHash = $parts[1];
+                } else {
+                    $fileHash = $parts[0];
+                }
                 // Bestimme die Größe des Bildes
                 if (isset($parts[1]) && isset($parts[2])) {
                     $widthParts = explode('=', $parts[1]);
@@ -555,11 +561,11 @@ class LatexExtension extends ExtensionBase
 \\
 ';
                 // Ersetze die \ durch \\ im Regex
-                $pregReplacePatternFileinfo = '/'.str_replace(
+                $pregReplacePatternFileinfo = '|'.str_replace(
                     '\\',
                     '\\\\',
                     $imageMatches[0][$matchKey]
-                ).'IMAGEPLACEHOLDEREND/';
+                ).'IMAGEPLACEHOLDEREND|';
                 // Füge das Latexmarkup ein
                 $text = preg_replace(
                     $pregReplacePatternFileinfo,

--- a/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
+++ b/tests/backend/core/Core/Unit/Utilities/Twig/LatexExtensionTest.php
@@ -311,6 +311,11 @@ class LatexExtensionTest extends UnitTestCase
         $resultString = $this->sut->prepareImage($textToTest);
         $this->assertSame($expected, $resultString);
 
+        $textToTest = "<img src='/file/baf2cdc3-675b-4213-badb-686c13eeaf97/6e5f465d-0400-4d1f-8768-703990a358d9' >";
+        $expected = 'IMAGEPLACEHOLDER-baf2cdc3-675b-4213-badb-686c13eeaf97/6e5f465d-0400-4d1f-8768-703990a358d9IMAGEPLACEHOLDEREND';
+        $resultString = $this->sut->prepareImage($textToTest);
+        $this->assertSame($expected, $resultString);
+
         $textToTest = "<img src='/app_dev.php/file/6e5f465d-0400-4d1f-8768-703990a358d9' >";
         $expected = 'IMAGEPLACEHOLDER-6e5f465d-0400-4d1f-8768-703990a358d9IMAGEPLACEHOLDEREND';
         $resultString = $this->sut->prepareImage($textToTest);
@@ -357,6 +362,13 @@ class LatexExtensionTest extends UnitTestCase
     public function testImageHtmlTagLatexOutput()
     {
         $textToTest = "<img src='/file/6e5f465d-0400-4d1f-8768-703990a358d9' >";
+        $preparedString = $this->sut->prepareImage($textToTest);
+        $resultString = $this->sut->outputImage($this->sut->latexFilter($preparedString));
+        $res = explode("\n", $resultString);
+        $expected = '\includegraphics{6e5f465d-0400-4d1f-8768-703990a358d9}';
+        $this->assertSame($expected, $res[3]);
+
+        $textToTest = "<img src='/file/baf2cdc3-675b-4213-badb-686c13eeaf97/6e5f465d-0400-4d1f-8768-703990a358d9' >";
         $preparedString = $this->sut->prepareImage($textToTest);
         $resultString = $this->sut->outputImage($this->sut->latexFilter($preparedString));
         $res = explode("\n", $resultString);


### PR DESCRIPTION
### Ticket
DPLAN-11855

Exports did not support file action with procedure check, which lead to missing pictures in exports.

### How to review/test
Upload a file in a paragraph and export the procedure

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
