### PR TITLE
feat(refs DPLAN-4020): Add Overview Page to Mapsettings

### DIFF
--- a/config/menus.yml
+++ b/config/menus.yml
@@ -319,9 +319,14 @@ submenu_procedures:
             data-extern-dataport: 'documentsAndMapSettings'
     map_settings:
         label: 'map_settings.menu'
-        path: 'DemosPlan_map_administration_map'
+        path: 'DemosPlan_map_administration_overview'
+        child_paths: [
+            'DemosPlan_map_administration_gislayer',
+            'DemosPlan_map_administration_gislayer_new',
+            'DemosPlan_map_administration_map',
+        ]
         permission: ['area_admin_initial_map_view'] # Only controls the menu item. 'area_admin_map' is required for the map settings
-        path_params: [ 'procedureId' ]
+        path_params: ['procedureId']
         link_attributes:
             data-cy: 'mapSettings'
     invitable_institution_administer:

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -642,7 +642,7 @@ class DemosPlanDocumentController extends BaseController
         ProcedureHandler $procedureHandler,
         Request $request,
         EventDispatcherInterface $eventDispatcher,
-        $procedure
+        String $procedure
     ) {
         $result = [];
         $templateVars = [];

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -625,8 +625,6 @@ class DemosPlanDocumentController extends BaseController
      *
      * @DplanPermissions("area_admin_single_document")
      *
-     * @param string $procedure
-     *
      * @return Response
      *
      * @throws Exception
@@ -642,7 +640,7 @@ class DemosPlanDocumentController extends BaseController
         ProcedureHandler $procedureHandler,
         Request $request,
         EventDispatcherInterface $eventDispatcher,
-        String $procedure
+        string $procedure
     ) {
         $result = [];
         $templateVars = [];
@@ -1209,8 +1207,8 @@ class DemosPlanDocumentController extends BaseController
                 $this->getMessageBag()->add('confirm', 'confirm.plandocument.category.saved');
 
                 return $this->redirectToRoute('DemosPlan_elements_administration_edit', [
-                  'procedure' => $procedure,
-                  'elementId' => $storageResult['ident'],
+                    'procedure' => $procedure,
+                    'elementId' => $storageResult['ident'],
                 ]);
             }
         }
@@ -1233,9 +1231,9 @@ class DemosPlanDocumentController extends BaseController
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanDocument/elements_admin_edit.html.twig',
             [
-            'procedure'    => $procedure,
-            'templateVars' => $templateVars,
-            'title'        => $title,
+                'procedure'    => $procedure,
+                'templateVars' => $templateVars,
+                'title'        => $title,
             ]
         );
     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -60,7 +60,7 @@ class DemosPlanMapController extends BaseController
         CurrentProcedureService $currentProcedureService,
         MapService $mapService,
         ProcedureHandler $procedureHandler,
-        String $procedureId
+        string $procedureId
     ) {
         $templateVars = [];
         $procedure = $procedureId; // To use the same Template as in DocumentController

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -46,6 +46,42 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DemosPlanMapController extends BaseController
 {
     /**
+     * Map Settings Overview.
+     *
+     * @DplanPermissions("area_admin_map")
+     *
+     * @return Response
+     *
+     * @throws Exception
+     */
+    #[Route(name: 'DemosPlan_map_administration_overview', path: '/verfahren/{procedureId}/verwalten/karten')]
+    public function elementAdminListAction(
+        Breadcrumb $breadcrumb,
+        CurrentProcedureService $currentProcedureService,
+        MapService $mapService,
+        ProcedureHandler $procedureHandler,
+        String $procedureId
+    ) {
+        $templateVars = [];
+        $procedure = $procedureId; // To use the same Template as in DocumentController
+        $title = 'maps.dashboard';
+
+        $currentProcedureArray = $currentProcedureService->getProcedureArray();
+        $templateVars['procedure'] = $procedureHandler->getProcedure($procedureId);
+
+        $templateVars['contextualHelpBreadcrumb'] = $breadcrumb->getContextualHelp($title);
+        $mapOptions = $mapService->getMapOptions($procedureId);
+        $templateVars['procedureDefaultInitialExtent'] = $mapOptions->getProcedureDefaultInitialExtent();
+
+        $procedureSettings = $currentProcedureArray['settings'];
+
+        return $this->renderTemplate(
+            '@DemosPlanCore/DemosPlanDocument/elements_admin_list.html.twig',
+            compact('templateVars', 'procedure', 'title', 'procedureSettings')
+        );
+    }
+
+    /**
      * //improve T12925
      * Karte zum Verwalten der Karteneigenschaften wie BoundingBox & Startkartenausschnitt.
      *


### PR DESCRIPTION
### Ticket
DPLAN-4020

The menu on the right hand side has to point to an overview page instead of the map settings itself, because we want to extend that section to allow creating and editing layer-settings.



<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Clicking on "Karteneinstellungen" should lead to a minimap with some links

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
