### PR TITLE
chore: Bump Yarn@4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,5 +186,6 @@
   ],
   "resolutions": {
     "@mapbox/mapbox-gl-style-spec": "13.14.0"
-  }
+  },
+  "packageManager": "yarn@4.2.2"
 }


### PR DESCRIPTION
with the new container 1.8.45 we have yarn@4.2.2 to use that properly, we have to declaire it in the package.json