### PR TITLE
fix: Remove adding none-existing folder in updateCommand

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UpdateCommand.php
@@ -124,8 +124,6 @@ EOT
                 ->addShell($composerCmd, $rootPath)
                 // load yarn dependencies
                 ->addShell(['yarn', 'install', '--frozen-lockfile'], $rootPath)
-                ->addShell(['yarn', 'add', 'file:client/ui'], $rootPath)
-                ->addShell(['yarn', 'add', 'file:client/js-utils'], $rootPath)
                 ->run();
         }
 


### PR DESCRIPTION
This looks like some leftovers from decades ago