### PR TITLE
allow multiple ids in permission:enable command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
@@ -46,4 +46,9 @@ class DisablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerO
             $dryRun
         );
     }
+
+    protected function getActionName(): string
+    {
+        return 'disabled';
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -46,4 +46,9 @@ class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOr
             $dryRun
         );
     }
+
+    protected function getActionName(): string
+    {
+        return 'enabled';
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -12,14 +12,11 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Permission;
 
-use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
-use demosplan\DemosPlanCoreBundle\Exception\RoleNotFoundException;
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
@@ -32,40 +29,21 @@ class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOr
 
     public function __construct(
         ParameterBagInterface $parameterBag,
-        private readonly CustomerService $customerService,
-        private readonly RoleService $roleService,
+        CustomerService $customerService,
+        RoleService $roleService,
         private readonly AccessControlService $accessControlPermissionService,
         ?string $name = null
     ) {
-        parent::__construct($parameterBag, $name);
+        parent::__construct($parameterBag, $customerService, $roleService, $name);
     }
 
-    /**
-     * @throws RoleNotFoundException
-     * @throws CustomerNotFoundException
-     */
-    public function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecuteAction(string $permissionChoice, CustomerInterface $customerChoice, RoleInterface $roleChoice, mixed $dryRun): array
     {
-        $customerId = $input->getArgument('customerId');
-        $roleId = $input->getArgument('roleId');
-        $permissionName = $input->getArgument('permission');
-        $dryRun = $input->getOption('dry-run');
-
-        $customerChoice = $this->customerService->findCustomerById($customerId);
-        $roleChoice = $this->roleService->getRole($roleId);
-        $permissionChoice = $this->getConstantValueByName($permissionName);
-
-        // Return Exception for RoleChoice as Customer already throws exception if null, and permission exception is handled in getConstantValueByName
-        if (null === $roleChoice) {
-            throw new RoleNotFoundException('Role not found');
-        }
-
-        $updatedOrgas = $this->accessControlPermissionService->enablePermissionCustomerOrgaRole($permissionChoice, $customerChoice, $roleChoice, $dryRun);
-
-        $this->displayUpdatedOrgas($output, $updatedOrgas);
-
-        $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'enabled');
-
-        return Command::SUCCESS;
+        return $this->accessControlPermissionService->enablePermissionCustomerOrgaRole(
+            $permissionChoice,
+            $customerChoice,
+            $roleChoice,
+            $dryRun
+        );
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -109,7 +109,7 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
 
                 $this->displayUpdatedOrgas($output, $updatedOrgas);
 
-                $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'disabled');
+                $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, $this->getActionName());
             }
         }
 
@@ -136,4 +136,5 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
     }
 
     abstract protected function doExecuteAction(string $permissionChoice, CustomerInterface $customerChoice, RoleInterface $roleChoice, mixed $dryRun): array;
+    abstract protected function getActionName(): string;
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -15,12 +15,18 @@ namespace demosplan\DemosPlanCoreBundle\Command\Permission;
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
+use demosplan\DemosPlanCoreBundle\Exception\RoleNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * This Command is the parent class for enable and disable permission commands.
@@ -30,15 +36,15 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
     public function configure(): void
     {
         $this->addArgument(
-            'customerId',
+            'customerIds',
             InputArgument::REQUIRED,
-            'The ID of the customer you want to adjust the permission.'
+            'The Ids of the customer you want to adjust the permission, comma separated.'
         );
 
         $this->addArgument(
-            'roleId',
+            'roleIds',
             InputArgument::REQUIRED,
-            'The ID of the role you want to adjust the permission.'
+            'The Ids of the role you want to adjust the permission, comma separated.'
         );
 
         $this->addArgument(
@@ -55,6 +61,15 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
         );
     }
 
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        protected readonly CustomerService $customerService,
+        protected readonly RoleService $roleService,
+        ?string $name = null
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
     protected function displayOutcome(OutputInterface $output, $dryRun, array $updatedOrgas, CustomerInterface $customerChoice, RoleInterface $roleChoice, string $action): void
     {
         $output->writeln('******************************************************');
@@ -64,6 +79,41 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
         $output->writeln('Permission has been '.$action.' for mentioned orgas on:');
         $output->writeln('Customer '.$customerChoice->getId().' '.$customerChoice->getName());
         $output->writeln('Role '.$roleChoice->getId().' '.$roleChoice->getName());
+    }
+
+    /**
+     * @throws RoleNotFoundException
+     * @throws CustomerNotFoundException
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $customerIdsString = $input->getArgument('customerIds');
+        $roleIdsString = $input->getArgument('roleIds');
+        $permissionName = $input->getArgument('permission');
+        $dryRun = $input->getOption('dry-run');
+
+        $roleIds = explode(',', $roleIdsString);
+        $customerIds = explode(',', $customerIdsString);
+        foreach ($roleIds as $roleId) {
+            foreach ($customerIds as $customerId) {
+                $customerChoice = $this->customerService->findCustomerById(trim($customerId));
+                $roleChoice = $this->roleService->getRole(trim($roleId));
+                $permissionChoice = $this->getConstantValueByName($permissionName);
+
+                // Return Exception for RoleChoice as Customer already throws exception if null, and permission exception is handled in getConstantValueByName
+                if (null === $roleChoice) {
+                    throw new RoleNotFoundException('Role not found');
+                }
+
+                $updatedOrgas = $this->doExecuteAction($permissionChoice, $customerChoice, $roleChoice, $dryRun);
+
+                $this->displayUpdatedOrgas($output, $updatedOrgas);
+
+                $this->displayOutcome($output, $dryRun, $updatedOrgas, $customerChoice, $roleChoice, 'disabled');
+            }
+        }
+
+        return Command::SUCCESS;
     }
 
     protected function displayUpdatedOrgas(OutputInterface $output, array $updatedOrgas): void
@@ -84,4 +134,6 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
 
         throw new InvalidArgumentException('Permission does not exit');
     }
+
+    abstract protected function doExecuteAction(string $permissionChoice, CustomerInterface $customerChoice, RoleInterface $roleChoice, mixed $dryRun): array;
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -210,6 +210,11 @@ class AccessControlService extends CoreService
                 continue;
             }
 
+            // do not store permission for default citizen organisation
+            if ($orgaInCustomer->isDefaultCitizenOrganisation()) {
+                continue;
+            }
+
             $updatedOrga = $this->addPermissionBasedOnOrgaType($permissionToEnable, $role, $orgaInCustomer, $customer, $dryRun);
 
             if (null !== $updatedOrga) {

--- a/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
@@ -63,8 +63,23 @@ class PermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
     protected function assertStringsInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
     {
         $commandTester->execute([
-            'customerId' => $this->testCustomer->getId(),
-            'roleId'     => $this->testRole->getId(),
+            'customerIds' => $this->testCustomer->getId(),
+            'roleIds'     => $this->testRole->getId(),
+            'permission' => 'CREATE_PROCEDURES_PERMISSION',
+            '--dry-run'  => $dryRun,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString($expectedMessage, $output);
+        $this->assertStringContainsString('Customer '.$this->testCustomer->getId().' '.$this->testCustomer->getName(), $output);
+        $this->assertStringContainsString('Role '.$this->testRole->getId().' '.$this->testRole->getName(), $output);
+    }
+
+    protected function assertStringArraysInCommandOutput(CommandTester $commandTester, bool $dryRun, string $expectedMessage): void
+    {
+        $commandTester->execute([
+            'customerIds' => sprintf('%s,%s', $this->testCustomer->getId(), $this->testCustomer->getId()),
+            'roleIds' => sprintf('%s,%s', $this->testRole->getId(), $this->testRole->getId()),
             'permission' => 'CREATE_PROCEDURES_PERMISSION',
             '--dry-run'  => $dryRun,
         ]);


### PR DESCRIPTION
### Ticket
DPLAN-11556

To avoid calling the permission:enable command 34 times a possibility is added to provide an array of customers and roles. Along the way a bug was fixed that citizen orga should not be provided with any permissions. Moreover code was deduplicated

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
