### PR TITLE
fix: Adjust Type Casing for APi Types

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/CreateCommentForm.vue
+++ b/client/js/components/procedure/StatementSegmentsList/CreateCommentForm.vue
@@ -146,20 +146,20 @@ export default {
                 data: payloadRel.place?.data?.id
                   ? {
                       id: payloadRel.place.data.id,
-                      type: 'place'
+                      type: 'Place'
                     }
                   : null
               },
               segment: {
                 data: {
                   id: payloadRel.segment.data.id,
-                  type: 'statementSegment'
+                  type: 'StatementSegment'
                 }
               },
               submitter: {
                 data: {
                   id: payloadRel.submitter.data.id,
-                  type: 'user'
+                  type: 'User'
                 }
               }
             }
@@ -170,7 +170,7 @@ export default {
             action: 'add',
             value: {
               id: id,
-              type: 'segmentComment'
+              type: 'SegmentComment'
             }
           }
 

--- a/client/js/components/user/DpOrganisationList/DpOrganisationFormFields.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationFormFields.vue
@@ -810,7 +810,7 @@ export default {
               data: [
                 {
                   id: '',
-                  type: 'customer'
+                  type: 'Customer'
                 }
               ]
             },
@@ -818,7 +818,7 @@ export default {
               data: [
                 {
                   id: '',
-                  type: 'department'
+                  type: 'Department'
                 }
               ]
             }

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -298,7 +298,7 @@ export default {
     changeUserDepartment (departmentId) {
       this.localUser.relationships.department.data = {
         id: departmentId,
-        type: 'department'
+        type: 'Department'
       }
 
       this.$emit('user-update', this.localUser)
@@ -349,7 +349,7 @@ export default {
 
       this.fetchOrgaById(orgaId).then((orga) => {
         this.setOrga(orga.data.data)
-        if (hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
+        if (this.currentUserOrga.id && hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
           allowedRoles = this.organisations[this.currentUserOrga.id].relationships.allowedRoles.list()
         }
       })
@@ -474,7 +474,7 @@ export default {
           currentSlug: {
             data: {
               id: payloadRel.currentSlug.data.id,
-              type: 'slug'
+              type: 'Slug'
             }
           },
           departments: {
@@ -482,7 +482,7 @@ export default {
               ? payloadRel.departments.data.map(el => {
                 return {
                   ...el,
-                  type: 'department'
+                  type: 'Department'
                 }
               })
               : null

--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -12,7 +12,7 @@
  */
 const api1_0Routes = [
   {
-    module: 'orga',
+    module: 'Orga',
     action: 'update',
     url: '/1.0/organisation/{id}',
     parameters: [
@@ -20,12 +20,12 @@ const api1_0Routes = [
     ]
   },
   {
-    module: 'orga',
+    module: 'Orga',
     action: 'create',
     url: '/1.0/organisation/'
   },
   {
-    module: 'orga',
+    module: 'Orga',
     action: 'delete',
     url: '/1.0/organisation/{id}',
     parameters: [
@@ -47,20 +47,7 @@ const api1_0Routes = [
     ]
   },
   {
-    module: 'user',
-    action: 'list',
-    url: '/1.0/user/'
-  },
-  {
-    module: 'user',
-    action: 'get',
-    url: '/1.0/user/{userId}',
-    parameters: [
-      'userId'
-    ]
-  },
-  {
-    module: 'user',
+    module: 'User',
     action: 'update',
     url: '/1.0/user/{id}',
     parameters: [
@@ -68,31 +55,20 @@ const api1_0Routes = [
     ]
   },
   {
-    module: 'user',
+    module: 'User',
     action: 'create',
     url: '/1.0/user/'
   },
   {
-    module: 'user',
+    module: 'User',
     action: 'delete',
     url: '/1.0/user/{id}',
     parameters: [
       'id'
     ]
   },
-
   {
-    module: 'faqCategory',
-    action: 'list',
-    url: '/1.0/FaqCategory/'
-  },
-  {
-    module: 'faq',
-    action: 'list',
-    url: '/1.0/faq/'
-  },
-  {
-    module: 'faq',
+    module: 'Faq',
     action: 'delete',
     url: '/1.0/faq/{id}',
     parameters: [
@@ -100,12 +76,17 @@ const api1_0Routes = [
     ]
   },
   {
-    module: 'faq',
+    module: 'Faq',
     action: 'update',
     url: '/1.0/faq/{id}',
     parameters: [
       'id'
     ]
+  },
+  {
+    module: 'FaqCategory',
+    action: 'list',
+    url: '/1.0/FaqCategory/'
   }
 ]
 

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -38,7 +38,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
   Vue.use(Vuex)
 
   const staticModules = { notify, ...storeModules }
-  const VuexApiRoutes = api1_0Routes.concat(generateApi2_0Routes(apiStoreModules))
+  const VuexApiRoutes = [...generateApi2_0Routes(apiStoreModules), ...api1_0Routes]
   // This should probably be replaced with an adapter to our existing routes
   const router = new StaticRouter(VuexApiRoutes)
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ReportEntryResourceType.php
@@ -53,7 +53,7 @@ class ReportEntryResourceType extends DplanResourceType
 
     public static function getName(): string
     {
-        return 'Report';
+        return 'report';
     }
 
     public function getEntityClass(): string


### PR DESCRIPTION
we have to carefully check if the Types for API 1.0 Routes have to be Pascal or camel. So do, some don't.
And with that and since to type doesn't get transformed anymore, we had to adjust the casing for `report` in the backend. Along there where couple of occurrences, where changing to Pascal simply got overseen.

### Ticket
DPLAN-11889
-- DPLAN-11828
-- DPLAN-11886
-- DPLAN-11896
-- DPLAN-11897
-- DPLAN-11900
-- DPLAN-11902