### PR TITLE
chore: check whether role to grant the permission is allowed in the given orga type

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -236,6 +236,13 @@ class AccessControlService extends CoreService
                 continue;
             }
 
+            // check whether role to grant the permission is allowed in the given orga type
+            // to avoid e.g. granting planner permission to institution orga
+            if (array_key_exists($orgaTypeInCustomer, OrgaTypeInterface::ORGATYPE_ROLE) &&
+                !in_array($role->getCode(), OrgaTypeInterface::ORGATYPE_ROLE[$orgaTypeInCustomer],true)) {
+                continue;
+            }
+
             // Do not store permission if it is dryrun
             if (false === $dryRun) {
                 $this->createPermission($permissionToEnable, $orgaInCustomer, $customer, $role);


### PR DESCRIPTION
### Ticket
DPLAN-11556

Check whether role to grant the permission is allowed in the given orga type to avoid e.g. granting planner permission to institution orga

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
run command dplan:permission:enable:customer-orga-role with a plnner role in dry-run and ensure that no institution only orgas are listed

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
