### PR TITLE
feature (ref 1995): create a message for manually created statement

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -83,6 +83,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Grouping\EntityGrouper;
 use demosplan\DemosPlanCoreBundle\Logic\Grouping\StatementEntityGroup;
 use demosplan\DemosPlanCoreBundle\Logic\Grouping\StatementEntityGrouper;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiPaginationParser;
+use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\StatementReportEntryFactory;
@@ -409,6 +410,17 @@ class StatementService extends CoreService implements StatementServiceInterface
 
         /** @var StatementCreatedEvent $statementCreatedEvent */
         $statementCreatedEvent = $this->eventDispatcher->dispatch(new ManualOriginalStatementCreatedEvent($statement));
+
+        if (null !== $statementCreatedEvent) {
+            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
+                'confirm',
+                'confirm.statement.new',
+                ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
+                'dplan_procedure_statement_list',
+                ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
+                $statementCreatedEvent->getStatement()->getExternId()
+            ));
+        }
 
         // statement similarities are calculated?
         $statementSimilarities = $statementCreatedEvent->getStatementSimilarities();


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-1995/Confirm-Message-fehlt-nach-Speichern-einer-Direkteingabe


Description: Add message bag for confirm created directly statement

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
