### PR TITLE
F dplan 11955 adjust translation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -637,11 +637,12 @@ class DemosPlanDocumentController extends BaseController
         MapService $mapService,
         ProcedureHandler $procedureHandler,
         Request $request,
-        string $procedure)
+        string $procedure,
+        TranslatorInterface $translator)
     {
         $templateVars = [];
         $session = $request->getSession();
-        $title = 'elements.dashboard';
+        $title = $translator->trans('elements.dashboard');
 
         $currentProcedureArray = $currentProcedureService->getProcedureArray();
 


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-11955/Text-im-Reiter-Element-soll-Karteneinstellungen-heissen

Adjust translation for title