### PR TITLE
fix (DPLAN-11957) Create permission to display options

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1135,6 +1135,13 @@ feature_map_feature_info:
     expose: true
     loginRequired: true
     parent: area_admin_map
+feature_map_layer_visibility:
+    description: |-
+        Manage visibility settings related to the map layer (in the admin area)
+    label: 'Manage visibility settings related to the map layer (in the admin area)'
+    expose: true
+    loginRequired: true
+    parent: area_admin_map
 feature_map_hint:
     expose: true
     label: Kartenhinweis

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -155,35 +155,37 @@
             }) }}
         {% endif %}
 
-        <label class="u-mb-0_5">
-            <input
-                type="checkbox"
-                name="r_print"
-                data-cy="newMapLayerPrint"
-                value="1"
-                {% if templateVars.inData.r_print|default() == 1 %}checked{% endif %}>
-            {{ "explanation.gislayer.print"|trans }}
-        </label>
-        <label class="u-mb-0_5">
-            <input
-                type="checkbox"
-                name="r_default_visibility"
-                data-cy="mapLayerDefaultVisibility"
-                value="1"
-                checked> {# @todo SM Wie können die Werte nach einer fehlerhaften Eingabe übernommen werden? #}
-            {{ "explanation.gislayer.default.visibility"|trans }}
-        </label>
+        {% if hasPermission('feature_map_options') %}
+            <label class="u-mb-0_5">
+                <input
+                    type="checkbox"
+                    name="r_print"
+                    data-cy="newMapLayerPrint"
+                    value="1"
+                    {% if templateVars.inData.r_print|default() == 1 %}checked{% endif %}>
+                {{ "explanation.gislayer.print"|trans }}
+            </label>
+            <label class="u-mb-0_5">
+                <input
+                    type="checkbox"
+                    name="r_default_visibility"
+                    data-cy="mapLayerDefaultVisibility"
+                    value="1"
+                    checked> {# @todo SM Wie können die Werte nach einer fehlerhaften Eingabe übernommen werden? #}
+                {{ "explanation.gislayer.default.visibility"|trans }}
+            </label>
 
-        <label class="u-mb-0_5">
-            <input
-                id="user_toggle_visibility"
-                type="checkbox"
-                name="r_user_toggle_visibility"
-                data-cy="newMapLayerUserToggleVisibility"
-                value="1"
-                checked>
-            {{ "explanation.gislayer.usertoggle.visibility"|trans }}
-        </label>
+            <label class="u-mb-0_5">
+                <input
+                    id="user_toggle_visibility"
+                    type="checkbox"
+                    name="r_user_toggle_visibility"
+                    data-cy="newMapLayerUserToggleVisibility"
+                    value="1"
+                    checked>
+                {{ "explanation.gislayer.usertoggle.visibility"|trans }}
+            </label>
+        {% endif %}
 
         <label class="u-mt u-mb-0_5">
             <input

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -155,7 +155,7 @@
             }) }}
         {% endif %}
 
-        {% if hasPermission('feature_map_options') %}
+        {% if hasPermission('feature_map_layer_visibility') %}
             <label class="u-mb-0_5">
                 <input
                     type="checkbox"


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-11957/Verschiedene-Kartenmoglichkeiten-gelten-nicht-fur-EWM

Create permissions instead of overriding the template to display checkboxes

### How to review/test
- test ewm: there should not be the checkboxes
- test other project e.g. blp there should be the checkboxes