### PR TITLE
fix(refs DPLAN-11801): Prevent negative reports with content

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -110,6 +110,7 @@
               }"
               value="0" />
             <dp-radio
+              :disabled="canNotBeNegativeReport"
               name="r_isNegativeReport"
               id="negative_report_true"
               data-cy="statementModal:indicationerror"
@@ -130,15 +131,16 @@
             :required="formData.r_isNegativeReport !== '1'" />
           <dp-editor
             :class="prefixClass('u-mb')"
-            hidden-input="r_text"
             :data-dp-validate-error-fieldname="Translator.trans('statement.text.short')"
+            hidden-input="r_text"
             id="statementText"
+            ref="statementEditor"
+            :readonly="formData.r_isNegativeReport === '1'"
+            :required="formData.r_isNegativeReport !== '1'"
             :toolbar-items="{
               mark: true,
               strikethrough: true
             }"
-            ref="statementEditor"
-            :required="formData.r_isNegativeReport !== '1'"
             :value="formData.r_text || ''"
             @input="val => setStatementData({r_text: val})" />
         </div>
@@ -173,7 +175,6 @@
 
         <template v-if="hasPermission('field_statement_add_assignment') && hasPlanningDocuments">
           <p
-            v-if="formData.r_isNegativeReport === '0'"
             aria-hidden="true"
             :class="prefixClass('c-statement__formblock-title u-mb-0_25 weight--bold inline-block')">
             {{ Translator.trans('element.assigned') }}
@@ -193,8 +194,8 @@
               <span :class="prefixClass('hide-lap-up')" />
               <button
                 @click="removeDocumentRelation"
-                :href="Routing.generate( 'DemosPlan_procedure_public_detail', { procedure: procedureId }) + '#procedureDetailsDocumentlist'"
-                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up u-1-of-1-palm')">
+                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up u-1-of-1-palm')"
+                :href="Routing.generate( 'DemosPlan_procedure_public_detail', { procedure: procedureId }) + '#procedureDetailsDocumentlist'">
                 <i
                   aria-hidden="true"
                   :class="prefixClass('fa fa-trash')" />
@@ -202,7 +203,8 @@
               </button>
             </template>
             <button
-              v-else-if="formData.r_isNegativeReport === '0'"
+              v-else
+              :disabled="formData.r_isNegativeReport !== '0'"
               data-cy="statementModal:elementAssign"
               @click="gotoTab('procedureDetailsDocumentlist')"
               :class="prefixClass('btn--blank o-link--default text-left')">
@@ -235,6 +237,7 @@
             :key="formDefinition.key"
             :draft-statement-id="draftStatementId"
             :is-map-enabled="isMapEnabled"
+            :disabled="formData.r_isNegativeReport !== '0'"
             :required="formDefinition.required && formData.r_isNegativeReport !== '1'"
             :logged-in="loggedIn"
             :counties="counties" />
@@ -284,6 +287,7 @@
 
                 <dp-upload-files
                   id="upload_files"
+                  :disabled="formData.r_isNegativeReport !== '0'"
                   allowed-file-types="pdf-img-zip"
                   :basic-auth="dplan.settings.basicAuth"
                   :get-file-by-hash="hash => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedureId })"
@@ -906,6 +910,14 @@ export default {
       userId: 'userId'
     }),
 
+    canNotBeNegativeReport () {
+      return this.formData.r_element_id !== '' ||
+        this.formData.r_document_id !== '' ||
+        this.formData.r_text !== '' ||
+        this.formData.r_location !== '' ||
+        this.formData.uploadedFiles !== ''
+    },
+
     commentingIcon () {
       return this.continueWriting ? 'fa-commenting' : 'fa-comment'
     },
@@ -1289,12 +1301,12 @@ export default {
           if (response.status === 429) {
             dplan.notify.notify('error', Translator.trans('error.statement.not.saved.throttle'))
 
-            return false;
+            return false
           }
           if (response.status !== 200) {
             dplan.notify.notify('error', Translator.trans('error.statement.not.saved'))
 
-            return false;
+            return false
           }
           /*
            * Handling for successful responses

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
@@ -37,6 +37,7 @@
         class="u-mb-0_25"
         data-cy="formGroupMap:statementMapReference"
         :checked="isLocationSelected"
+        :disabled="disabled"
         @change="() => { const location = (statement.r_location_priority_area_key !== '' ? 'priority_area' :'point'); setStatementData({r_location: 'point', location_is_set: location})}"
         :label="{
           text: Translator.trans('statement.map.reference.add_on_map')
@@ -78,6 +79,7 @@
         name="r_location"
         class="u-mb-0_25"
         :checked="statement.r_location === 'county'"
+        :disabled="disabled"
         @change="() => { setStatementData({ r_location: 'county', location_is_set: 'county'}) }"
         value="county" />
       <select
@@ -139,6 +141,12 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     },
 
     loggedIn: {

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -136,5 +136,6 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
     }
 
     abstract protected function doExecuteAction(string $permissionChoice, CustomerInterface $customerChoice, RoleInterface $roleChoice, mixed $dryRun): array;
+
     abstract protected function getActionName(): string;
 }

--- a/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/PermissionForCustomerOrgaRoleCommandTest.php
@@ -65,8 +65,8 @@ class PermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
         $commandTester->execute([
             'customerIds' => $this->testCustomer->getId(),
             'roleIds'     => $this->testRole->getId(),
-            'permission' => 'CREATE_PROCEDURES_PERMISSION',
-            '--dry-run'  => $dryRun,
+            'permission'  => 'CREATE_PROCEDURES_PERMISSION',
+            '--dry-run'   => $dryRun,
         ]);
 
         $output = $commandTester->getDisplay();
@@ -79,9 +79,9 @@ class PermissionForCustomerOrgaRoleCommandTest extends FunctionalTestCase
     {
         $commandTester->execute([
             'customerIds' => sprintf('%s,%s', $this->testCustomer->getId(), $this->testCustomer->getId()),
-            'roleIds' => sprintf('%s,%s', $this->testRole->getId(), $this->testRole->getId()),
-            'permission' => 'CREATE_PROCEDURES_PERMISSION',
-            '--dry-run'  => $dryRun,
+            'roleIds'     => sprintf('%s,%s', $this->testRole->getId(), $this->testRole->getId()),
+            'permission'  => 'CREATE_PROCEDURES_PERMISSION',
+            '--dry-run'   => $dryRun,
         ]);
 
         $output = $commandTester->getDisplay();


### PR DESCRIPTION
- if negative report is set, it should not be possible to send any 'meaningful' data.
- on the other hand if there is already something selected / typed in, it should not be possible to select 'negative_report'

Can be tested on public detail if the procedure is in participation. Check especially the documents relation. for that You need some documents/elements with the posibility to reference them....