### PR TITLE
feature (ref 11959): use Permissin for map options

### DIFF
--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -153,67 +153,66 @@
               </div>
           </div>
         </div>
-      </div>
-      <dp-draggable
-        v-if="false === this.isLoading && hasPermission('feature_map_layer_visibility')"
-        :opts="draggableOptionsForBaseLayer"
-        v-model="currentBaseList"
-        :class="{'color--grey': false === isEditable}">
-        <dp-admin-layer-list-item
-          v-for="(item, idx) in currentBaseList"
-          :key="item.id"
-          :element="item"
-          :sorting-type="currentTab"
-          :is-loading="(false === isEditable)"
-          layer-type="base"
-          data-cy="baseMapLayerListItem"
-          :index="idx" />
-      </dp-draggable>
-      <div v-if="hasPermission('feature_map_layer_visibility')" class="layout--flush u-mt u-mb">
-        <h3 class="layout__item w-1/3">
-          {{ Translator.trans('map.base.minimap') }}
-        </h3><!--
-     --><div class="layout__item w-2/3">
-          <select
-            class="o-form__control-select"
-            data-cy="adminLayerList:currentMinimapLayer"
-            v-model="currentMinimapLayer">
-            <option :value="{id: '', attributes: { name: 'default' }}">
-              {{ Translator.trans('selection.no') }}
-            </option>
-            <option
-              v-for="item in mapBaseList"
-              :key="item.id"
-              :value="item">
-              {{ item.attributes.name }}
-            </option>
-          </select>
+        <dp-draggable
+          v-if="false === this.isLoading"
+          :opts="draggableOptionsForBaseLayer"
+          v-model="currentBaseList"
+          :class="{'color--grey': false === isEditable}">
+          <dp-admin-layer-list-item
+            v-for="(item, idx) in currentBaseList"
+            :key="item.id"
+            :element="item"
+            :sorting-type="currentTab"
+            :is-loading="(false === isEditable)"
+            layer-type="base"
+            data-cy="baseMapLayerListItem"
+            :index="idx" />
+        </dp-draggable>
+        <div class="layout--flush u-mt u-mb">
+          <h3 class="layout__item w-1/3">
+            {{ Translator.trans('map.base.minimap') }}
+          </h3><!--
+      --><div class="layout__item w-2/3">
+            <select
+              class="o-form__control-select"
+              data-cy="adminLayerList:currentMinimapLayer"
+              v-model="currentMinimapLayer">
+              <option :value="{id: '', attributes: { name: 'default' }}">
+                {{ Translator.trans('selection.no') }}
+              </option>
+              <option
+                v-for="item in mapBaseList"
+                :key="item.id"
+                :value="item">
+                {{ item.attributes.name }}
+              </option>
+            </select>
+          </div>
+          <p class="font-size-small">
+            {{ Translator.trans('map.base.minimap.hint') }}
+          </p>
         </div>
-        <p class="font-size-small">
-          {{ Translator.trans('map.base.minimap.hint') }}
-        </p>
-      </div>
-
-      <div
-        class="text-right u-mv space-inline-s"
-        v-if="false === isLoading && hasPermission('feature_map_layer_visibility')">
-        <dp-button
-          data-cy="adminLayerList:save"
-          :busy="!isEditable"
-          :text="Translator.trans('save')"
-          @click="saveOrder" />
-        <dp-button
-          data-cy="adminLayerList:saveAndReturn"
-          :busy="!isEditable"
-          :text="Translator.trans('save.and.return.to.list')"
-          @click="saveOrder(true)" />
-        <button
-          class="btn btn--secondary"
-          data-cy="adminLayerList:resetOrder"
-          type="reset"
-          @click.prevent="resetOrder">
-          {{ Translator.trans('reset.order') }}
-        </button>
+        <div
+          class="text-right u-mv space-inline-s"
+          v-if="false === isLoading">
+          <dp-button
+            data-cy="adminLayerList:save"
+            :busy="!isEditable"
+            :text="Translator.trans('save')"
+            @click="saveOrder" />
+          <dp-button
+            data-cy="adminLayerList:saveAndReturn"
+            :busy="!isEditable"
+            :text="Translator.trans('save.and.return.to.list')"
+            @click="saveOrder(true)" />
+          <button
+            class="btn btn--secondary"
+            data-cy="adminLayerList:resetOrder"
+            type="reset"
+            @click.prevent="resetOrder">
+            {{ Translator.trans('reset.order') }}
+          </button>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -130,30 +130,32 @@
         {{ Translator.trans('no.data') }}
       </div>
 
-      <h3 class="u-mt">
-        {{ Translator.trans('map.bases') }}
-      </h3>
-      <!-- List-Head -->
-      <div class="color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5">
-        <div class="c-at-item__row-icon layout__item u-pl-0">
-          <!-- DragHandler -->
-        </div><!--
-     --><div class="layout--flush layout__item c-at-item__row">
-            <div class="layout__item w-10/12 u-pl-0_5">
-              {{ Translator.trans('description') }}
-            </div><!--
-         --><div class="layout__item w-1/12 text-right">
-            <i
-              class="fa fa-eye u-mr-0_5"
-              v-tooltip="Translator.trans('explanation.gislayer.visibility')" />
-            </div><!--
-         --><div class="layout__item w-1/12 text-right">
-                {{ Translator.trans('edit') }}
-            </div>
+      <div v-if="hasPermission('feature_map_layer_visibility')">
+        <h3 class="u-mt">
+          {{ Translator.trans('map.bases') }}
+        </h3>
+        <!-- List-Head -->
+        <div class="color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5">
+          <div class="c-at-item__row-icon layout__item u-pl-0">
+            <!-- DragHandler -->
+          </div><!--
+     -  -><div class="layout--flush layout__item c-at-item__row">
+              <div class="layout__item w-10/12 u-pl-0_5">
+                {{ Translator.trans('description') }}
+              </div><!--
+           --><div class="layout__item w-1/12 text-right">
+              <i
+                class="fa fa-eye u-mr-0_5"
+                v-tooltip="Translator.trans('explanation.gislayer.visibility')" />
+              </div><!--
+           --><div class="layout__item w-1/12 text-right">
+                  {{ Translator.trans('edit') }}
+              </div>
+          </div>
         </div>
       </div>
       <dp-draggable
-        v-if="false === this.isLoading"
+        v-if="false === this.isLoading && hasPermission('feature_map_layer_visibility')"
         :opts="draggableOptionsForBaseLayer"
         v-model="currentBaseList"
         :class="{'color--grey': false === isEditable}">
@@ -167,7 +169,7 @@
           data-cy="baseMapLayerListItem"
           :index="idx" />
       </dp-draggable>
-      <div class="layout--flush u-mt u-mb">
+      <div v-if="hasPermission('feature_map_layer_visibility')" class="layout--flush u-mt u-mb">
         <h3 class="layout__item w-1/3">
           {{ Translator.trans('map.base.minimap') }}
         </h3><!--
@@ -194,7 +196,7 @@
 
       <div
         class="text-right u-mv space-inline-s"
-        v-if="false === isLoading">
+        v-if="false === isLoading && hasPermission('feature_map_layer_visibility')">
         <dp-button
           data-cy="adminLayerList:save"
           :busy="!isEditable"

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -158,7 +158,7 @@
           :opts="draggableOptionsForBaseLayer"
           v-model="currentBaseList"
           :class="{'color--grey': false === isEditable}">
-          <admin-layer-list-item
+          <dp-admin-layer-list-item
             v-for="(item, idx) in currentBaseList"
             :key="item.id"
             :element="item"

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -139,7 +139,7 @@
           <div class="c-at-item__row-icon layout__item u-pl-0">
             <!-- DragHandler -->
           </div><!--
-     -  -><div class="layout--flush layout__item c-at-item__row">
+        --><div class="layout--flush layout__item c-at-item__row">
               <div class="layout__item w-10/12 u-pl-0_5">
                 {{ Translator.trans('description') }}
               </div><!--
@@ -158,7 +158,7 @@
           :opts="draggableOptionsForBaseLayer"
           v-model="currentBaseList"
           :class="{'color--grey': false === isEditable}">
-          <dp-admin-layer-list-item
+          <admin-layer-list-item
             v-for="(item, idx) in currentBaseList"
             :key="item.id"
             :element="item"


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11959/Grundkarten-und-Ubersichtskarte-nicht-funktionsfahig


Description: remove base map and overview map for ewm with permission

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
