### PR TITLE
feature (ref 11961): allow to delete Gislayer

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -92,6 +92,7 @@ const LayersStore = {
      * @param element|Object {'id': elementId, 'categoryId': parentId, 'relationshipType': categories|gisLayers }
      */
     removeElement (state, element) {
+      console.log('remove Element', element)
       const included = state.apiData.included
       let relationships
       let indexRelationships = []
@@ -106,7 +107,7 @@ const LayersStore = {
       if (indexParent >= 0) {
         relationships = state.apiData.included[indexParent].relationships[element.relationshipType].data
       } else {
-        relationships = state.apiData.data.relationships[element.relationshipType].data
+        relationships = state.apiData.data[0].relationships[element.relationshipType].data
       }
 
       // Get index of data in relationships based on above switch

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -92,7 +92,6 @@ const LayersStore = {
      * @param element|Object {'id': elementId, 'categoryId': parentId, 'relationshipType': categories|gisLayers }
      */
     removeElement (state, element) {
-      console.log('remove Element', element)
       const included = state.apiData.included
       let relationships
       let indexRelationships = []

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerCategoryResourceType.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\EntityPath\Paths;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use EDT\PathBuilding\End;
@@ -60,7 +61,17 @@ final class GisLayerCategoryResourceType extends DplanResourceType
 
     protected function getAccessConditions(): array
     {
-        return [];
+        $currentProcedure = $this->currentProcedureService->getProcedure();
+        if (null === $currentProcedure) {
+            return [$this->conditionFactory->false()];
+        }
+
+        $procedureId = $currentProcedure->getId();
+
+        return [
+            $this->conditionFactory->propertyHasValue($procedureId, Paths::gisLayerCategory()->procedure->id),
+            $this->conditionFactory->propertyHasValue(false, Paths::gisLayerCategory()->procedure->deleted),
+        ];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -86,7 +86,7 @@ final class GisLayerResourceType extends DplanResourceType
 
     public function isDeleteAllowed(): bool
     {
-        return true;
+        return $this->currentUser->hasPermission('area_map_participation_area');
     }
 
     public function isGetAllowed(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -101,7 +101,17 @@ final class GisLayerResourceType extends DplanResourceType
 
     protected function getAccessConditions(): array
     {
-        return [];
+        $currentProcedure = $this->currentProcedureService->getProcedure();
+        if (null === $currentProcedure) {
+            return [$this->conditionFactory->false()];
+        }
+
+        $procedureId = $currentProcedure->getId();
+
+        return [
+            $this->conditionFactory->propertyHasValue($procedureId, Paths::gisLayer()->category->procedure->id),
+            $this->conditionFactory->propertyHasValue(false, Paths::gisLayer()->category->procedure->deleted),
+        ];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -84,6 +84,11 @@ final class GisLayerResourceType extends DplanResourceType
         return true;
     }
 
+    public function isDeleteAllowed(): bool
+    {
+        return true;
+    }
+
     public function isGetAllowed(): bool
     {
         return $this->currentUser->hasPermission('area_map_participation_area');


### PR DESCRIPTION
### Ticket: 
DPLAN-11961


Description: get access to delete GisLayer

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
