### PR TITLE
bug(refs DPLAN-11849): Set boundingbox only if it exists

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -495,7 +495,7 @@ export default {
       this.updateMapInstance()
 
       // If startkartenausschnitt is defined by user, show it on mounted
-      if (this._options.initialExtent && JSON.stringify(this.maxExtent) !== JSON.stringify(this.initialExtent)) {
+      if (this._options.initialExtent.length > 0 && JSON.stringify(this.maxExtent) !== JSON.stringify(this.initialExtent)) {
         this.map.getView().fit(this.initialExtent, { size: this.map.getSize() })
         // If it is not defined, but procedure has coordinates, zoom the map to the coordinates
       } else if (this.initCenter) {

--- a/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
@@ -166,24 +166,6 @@ export default {
       }
     },
 
-    features () {
-      /*
-       *  Transform the value that is saved as a string into valid GeoJSON
-       *  to be able to use it with a generic vector layer component
-       */
-      return {
-        boundingBox: this.mapData.boundingBox
-          ? {
-              type: 'Feature',
-              geometry: {
-                type: 'Polygon',
-                coordinates: fromExtent(JSON.parse(`[${this.mapData.boundingBox}]`)).getCoordinates()
-              }
-            }
-          : null
-      }
-    },
-
     lineData () {
       return {
         type: 'FeatureCollection',
@@ -222,7 +204,7 @@ export default {
           this.$nextTick(() => {
             this.setCenterAndExtent()
           })
-        } else if (this.mapData.boundingBox) {
+        } else if (this.mapData.boundingBox.length > 0) {
           this.$nextTick(() => {
             this.setInitExtent()
           })


### PR DESCRIPTION
### Ticket
DPLAN-11849

- Boundingbox is an array, so we need to check for length
- Remove unused features ()

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Choose a procedure where the initial extent is not set yet (Karteneinstellungen -> Startkartenausschnitt)
Verfahren -> Abschnitte -> Erwiderung verfassen -> Ortsbezug -> There should be a map

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Move the tickets on the board accordingly

