### PR TITLE
fix(DPLAN-11899): unable to search users

### DIFF
--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -225,20 +225,35 @@ export default {
     getItemsByPage (page) {
       this.isLoading = true
       page = page || this.currentPage
+      const userFilter = {
+        firstnameFilter: {
+          condition: {
+            path: 'firstname',
+            operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
+            value: this.searchValue,
+            memberOf: 'name'
+          }
+        },
+        lastnameFilter: {
+          condition: {
+            path: 'lastname',
+            operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
+            value: this.searchValue,
+            memberOf: 'name'
+          }
+        },
+        name: {
+          group: {
+            conjunction: 'OR'
+          }
+        }
+      }
 
       this.userList({
         page: {
           number: page ?? 1
         },
-        filter: {
-          firstnameFilter: {
-            condition: {
-              path: 'firstname',
-              operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
-              value: this.searchValue
-            }
-          }
-        },
+        filter: userFilter,
         include: ['roles', 'orga', 'department', 'orga.allowedRoles'].join()
       })
         .then(() => {

--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -231,14 +231,13 @@ export default {
           number: page ?? 1
         },
         filter: {
-          namefilter: {
+          firstnameFilter: {
             condition: {
               path: 'firstname',
               operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
               value: this.searchValue
             }
-          }
-        },
+          },
         include: ['roles', 'orga', 'department', 'orga.allowedRoles'].join()
       })
         .then(() => {

--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -237,7 +237,8 @@ export default {
               operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
               value: this.searchValue
             }
-          },
+          }
+        },
         include: ['roles', 'orga', 'department', 'orga.allowedRoles'].join()
       })
         .then(() => {

--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -223,9 +223,6 @@ export default {
     }, 500),
 
     getItemsByPage (page) {
-      const search = {
-        value: this.searchValue
-      }
       this.isLoading = true
       page = page || this.currentPage
 
@@ -233,7 +230,15 @@ export default {
         page: {
           number: page ?? 1
         },
-        search: (this.searchValue !== '') ? search : {},
+        filter: {
+          namefilter: {
+            condition: {
+              path: 'firstname',
+              operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
+              value: this.searchValue
+            }
+          }
+        },
         include: ['roles', 'orga', 'department', 'orga.allowedRoles'].join()
       })
         .then(() => {


### PR DESCRIPTION
### Ticket
[DPLAN-11931](https://demoseurope.youtrack.cloud/issue/DPLAN-11931/Suche-auf-der-Nutzende-Verwalten-Seite-funktioniert-nicht)

**Description:** This PR adjusts the search URL parameters for the route User list 2.0. 

The question: should it be searchable by **first** and **last** names? If yes, it does not work when I add a second filter with the `path: 'lastname'` or does it work differently?

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
