### PR TITLE
fix(refs dplan-11963): Set layervisibility if the feature is off

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1118,6 +1118,11 @@ feature_map_attribution:
     expose: true
     loginRequired: true
     parent: area_admin_map
+feature_map_baselayer:
+    label: 'Allow configuring baselayers'
+    expose: true
+    loginRequired: true
+    parent: area_admin_map
 feature_map_category:
     expose: true
     label: 'Kategorien in Kartenlayer'
@@ -1173,6 +1178,11 @@ feature_map_new_statement:
     label: 'Planzeichnung Neue Stellungnahme'
     loginRequired: false
     parent: area_map_participation_area
+feature_map_print_layer:
+    expose: true
+    label: 'Allow setting of print layers'
+    loginRequired: false
+    parent: area_admin_map
 feature_map_search_location:
     expose: true
     label: 'Darf ein User nach ORT/PLZ suchen können?'

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -66,69 +66,78 @@
 
                 {% block layerType %}
                     {%- apply spaceless %}
-                        <ul class="layout__item u-4-of-5 o-list bg-color--grey-light-2 u-p-0_5 u-mb">
-                            <li>
-                                <label class="u-mb-0_25 cursor-pointer">
-                                    <input
-                                        type="radio"
-                                        name="r_type"
-                                        data-cy="base"
-                                        value="base"
-                                        {% if gislayer.type|default('') == 'base' %}checked="checked"{% endif %}
-                                    >
-                                    {{ "map.base"|trans }}
-                                </label>
-                            </li>
-                            <li>
-                                <label class="u-mb-0_25 cursor-pointer">
-                                    <input
-                                        type="radio"
-                                        name="r_type"
-                                        data-cy="overlay"
-                                        value="overlay"
-                                        {% if gislayer.type|default('') != 'base' %}checked="checked"{% endif %}>
-                                    {{ "overlay"|trans }}
-                                </label>
-                                {% if hasPermission('area_public_participation') and hasPermission('feature_map_use_territory') %}
-                                    <ul class="u-pl">
-                                        <li>
-                                            <label
-                                                class="u-mb-0_25 cursor-pointer"
-                                                title="Mit Planzeichnung können Sie einen B-Plan anlegen. Dieser wird ein-/ausblendbar über die Grundkarten gelegt.">
-                                                <input
-                                                    type="checkbox"
-                                                    id="bPlan"
-                                                    name="r_bplan"
-                                                    data-cy="r_bplan"
-                                                    data-requires="[name=r_type][value=overlay]"
-                                                    data-to-disable="#scope"
-                                                    value="1"
-                                                    {% if gislayer.bplan|default(false) == true %}checked="checked"{% endif %}
-                                                >
-                                                {{ "drawing"|trans }}
-                                            </label>
-                                        </li>
-                                        <li>
-                                            <label
-                                                class="u-mb-0_25 cursor-pointer"
-                                                title="Geltungsbereich zeigt nur in der Beteiligungsebene die Umrandung des Plans über der Grundkarte an.">
-                                                <input
-                                                    type="checkbox"
-                                                    id="scope"
-                                                    name="r_scope"
-                                                    data-cy="r_scope"
-                                                    data-requires="[name=r_type][value=overlay]"
-                                                    data-to-disable="#bPlan"
-                                                    value="1"
-                                                    {% if gislayer.scope|default(false) == true %}checked="checked"{% endif %}
-                                                >
-                                                {{ "layer.territory"|trans }}
-                                            </label>
-                                        </li>
-                                    </ul>
-                                {% endif %}
-                            </li>
-                        </ul>
+                        {% if hasPermission('feature_map_baselayer') %}
+                            <ul class="layout__item u-4-of-5 o-list bg-color--grey-light-2 u-p-0_5 u-mb">
+                                <li>
+                                    <label class="u-mb-0_25 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="r_type"
+                                            data-cy="base"
+                                            value="base"
+                                            {% if gislayer.type|default('') == 'base' %}checked="checked"{% endif %}
+                                        >
+                                        {{ "map.base"|trans }}
+                                    </label>
+                                </li>
+                                <li>
+                                    <label class="u-mb-0_25 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="r_type"
+                                            data-cy="overlay"
+                                            value="overlay"
+                                            {% if gislayer.type|default('') != 'base' %}checked="checked"{% endif %}>
+                                        {{ "overlay"|trans }}
+                                    </label>
+                                    {% if hasPermission('area_public_participation') and hasPermission('feature_map_use_territory') %}
+                                        <ul class="u-pl">
+                                            <li>
+                                                <label
+                                                    class="u-mb-0_25 cursor-pointer"
+                                                    title="Mit Planzeichnung können Sie einen B-Plan anlegen. Dieser wird ein-/ausblendbar über die Grundkarten gelegt.">
+                                                    <input
+                                                        type="checkbox"
+                                                        id="bPlan"
+                                                        name="r_bplan"
+                                                        data-cy="r_bplan"
+                                                        data-requires="[name=r_type][value=overlay]"
+                                                        data-to-disable="#scope"
+                                                        value="1"
+                                                        {% if gislayer.bplan|default(false) == true %}checked="checked"{% endif %}
+                                                    >
+                                                    {{ "drawing"|trans }}
+                                                </label>
+                                            </li>
+                                            <li>
+                                                <label
+                                                    class="u-mb-0_25 cursor-pointer"
+                                                    title="Geltungsbereich zeigt nur in der Beteiligungsebene die Umrandung des Plans über der Grundkarte an.">
+                                                    <input
+                                                        type="checkbox"
+                                                        id="scope"
+                                                        name="r_scope"
+                                                        data-cy="r_scope"
+                                                        data-requires="[name=r_type][value=overlay]"
+                                                        data-to-disable="#bPlan"
+                                                        value="1"
+                                                        {% if gislayer.scope|default(false) == true %}checked="checked"{% endif %}
+                                                    >
+                                                    {{ "layer.territory"|trans }}
+                                                </label>
+                                            </li>
+                                        </ul>
+                                    {% endif %}
+                                </li>
+                            </ul>
+                        {% else %}
+                            <input
+                                type="hidden"
+                                name="r_type"
+                                data-cy="overlay"
+                                value="overlay"
+                                checked>
+                        {% endif %}
 
                         {% if hasPermission('feature_xplan_defaultlayers') %}
                             <label class="layout__item u-1-of-5 u-mb-0_5 cursor-pointer"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -231,58 +231,66 @@
                     ]
                 }) }}
             {% endif %}
+            {% if hasPermission('feature_map_print_layer') %}
+                <label class="u-mb-0_5">
+                    <input
+                        data-cy="editMapLayerPrint"
+                        type="checkbox"
+                        name="r_print"
+                        value="1"
+                        {% if gislayer.print is defined and gislayer.print == 1 %}checked{% endif %}>
+                    {{ "explanation.gislayer.print"|trans }}
+                    {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
+                        helpText: 'explanation.gislayer.print.help'|trans,
+                        cssClasses:'float-right u-mt-0_125'
+                    } %}
+                </label>
+            {% endif %}
+            {% if hasPermission('feature_map_layer_visibility') %}
+                <label class="u-mb-0_5">
+                    <input
+                        data-cy="editMapLayerDefaultVisibility"
+                        type="checkbox"
+                        name="r_default_visibility"
+                        value="1"
+                        {% if gislayer.HasDefaultVisibility is defined and gislayer.HasDefaultVisibility == 1 %}checked{% endif %}
+                        {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}disabled{% endif %}
+                    >
+                    {{ "explanation.gislayer.default.visibility"|trans }}
+                    {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}
+                        {% if gislayer.HasDefaultVisibility is defined and gislayer.HasDefaultVisibility == 1 %}
+                            <input type="hidden" name="r_default_visibility" value="1">
+                        {% endif %}
+                        <br /><span class="hint">{{ "explanation.gislayer.visibility.group.locked"|trans }}</span>
+                    {% endif %}
+                </label>
 
-            <label class="u-mb-0_5">
+                <label class="u-mb-0_5">
+                    <input
+                        id="user_toggle_visibility"
+                        data-cy="editMapLayerToggleVisibility"
+                        type="checkbox"
+                        name="r_user_toggle_visibility"
+                        value="1"
+                        {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}disabled{% endif %}
+                        {% if (gislayer.userToggleVisibility is defined and gislayer.userToggleVisibility == 1) %}checked{% endif %}
+                    >
+                    {{ "explanation.gislayer.usertoggle.visibility"|trans }}
+                    {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}
+                        {% if (gislayer.userToggleVisibility is defined and gislayer.userToggleVisibility == 1) %}
+                            <input type="hidden" name="r_user_toggle_visibility" value="1">
+                        {% endif %}
+                        <br /><span class="hint">{{ "explanation.gislayer.visibility.group.locked"|trans }}</span>
+                    {% endif %}
+                </label>
+            {% else %}
                 <input
-                    data-cy="editMapLayerPrint"
-                    type="checkbox"
-                    name="r_print"
-                    value="1"
-                    {% if gislayer.print is defined and gislayer.print == 1 %}checked{% endif %}>
-                {{ "explanation.gislayer.print"|trans }}
-                {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                    helpText: 'explanation.gislayer.print.help'|trans,
-                    cssClasses:'float-right u-mt-0_125'
-                } %}
-            </label>
-
-            <label class="u-mb-0_5">
-                <input
-                    data-cy="editMapLayerDefaultVisibility"
-                    type="checkbox"
+                    type="hidden"
                     name="r_default_visibility"
+                    data-cy="mapLayerDefaultVisibility"
                     value="1"
-                    {% if gislayer.HasDefaultVisibility is defined and gislayer.HasDefaultVisibility == 1 %}checked{% endif %}
-                    {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}disabled{% endif %}
-                >
-                {{ "explanation.gislayer.default.visibility"|trans }}
-                {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}
-                    {% if gislayer.HasDefaultVisibility is defined and gislayer.HasDefaultVisibility == 1 %}
-                        <input type="hidden" name="r_default_visibility" value="1">
-                    {% endif %}
-                    <br /><span class="hint">{{ "explanation.gislayer.visibility.group.locked"|trans }}</span>
-                {% endif %}
-            </label>
-
-            <label class="u-mb-0_5">
-                <input
-                    id="user_toggle_visibility"
-                    data-cy="editMapLayerToggleVisibility"
-                    type="checkbox"
-                    name="r_user_toggle_visibility"
-                    value="1"
-                    {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}disabled{% endif %}
-                    {% if (gislayer.userToggleVisibility is defined and gislayer.userToggleVisibility == 1) %}checked{% endif %}
-                >
-                {{ "explanation.gislayer.usertoggle.visibility"|trans }}
-                {% if gislayer.visibilityGroupId is defined and gislayer.visibilityGroupId != '' %}
-                    {% if (gislayer.userToggleVisibility is defined and gislayer.userToggleVisibility == 1) %}
-                        <input type="hidden" name="r_user_toggle_visibility" value="1">
-                    {% endif %}
-                    <br /><span class="hint">{{ "explanation.gislayer.visibility.group.locked"|trans }}</span>
-                {% endif %}
-            </label>
-
+                    checked>
+            {% endif %}
             <label class="u-mt u-mb-0_5">
                 <input type="checkbox" name="r_enabled" value="1" {% if gislayer.enabled is defined and gislayer.enabled == 1  %}checked{% endif %}>
                 {{ "explanation.gislayer.enabled"|trans }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -14,69 +14,78 @@
                 <label class="u-mt-0_5 u-mb-0_5">
                     {{ "map"|trans }}*
                 </label>
-                <ul class="layout__item u-4-of-5 o-list bg-color--grey-light-2 u-p-0_5 u-mb">
-                    <li>
-                        <label class="cursor-pointer u-mb-0_25" title="Mit Grundkarte können Sie weitere Karten anlegen.">
-                            <input
-                                type="radio"
-                                name="r_type"
-                                data-cy="base"
-                                value="base"
-                                required
-                                {% if templateVars.inData.r_layer|default() == "base" %}checked{% endif %}
-                            >
-                            {{ "map.base"|trans }}
-                        </label>
+               {% if hasPermission('feature_map_baselayer') %}
+                    <ul class="layout__item u-4-of-5 o-list bg-color--grey-light-2 u-p-0_5 u-mb">
+                        <li>
+                            <label class="cursor-pointer u-mb-0_25" title="Mit Grundkarte können Sie weitere Karten anlegen.">
+                                <input
+                                    type="radio"
+                                    name="r_type"
+                                    data-cy="base"
+                                    value="base"
+                                    required
+                                    {% if templateVars.inData.r_layer|default() == "base" %}checked{% endif %}
+                                >
+                                {{ "map.base"|trans }}
+                            </label>
 
-                    </li>
-                    <li>
-                        <label class="cursor-pointer u-mb-0_25" title="Mit Overlay erstellen Sie weitere Ebenen (Layer) ein-/ausblendbar über den Grundkarten.">
-                            <input
-                                type="radio"
-                                name="r_type"
-                                data-cy="overlay"
-                                value="overlay"
-                                required
-                                {% if templateVars.inData.r_layer|default() != "base" %}checked{% endif %}
-                            >
-                            {{ "overlay"|trans }}
-                        </label>
-                        <ul class="u-pl">
-                            {% if hasPermission('area_public_participation') and hasPermission('feature_map_use_territory') %}
-                                <li>
-                                    <label class="cursor-pointer u-mb-0_25" title="Mit Planzeichnung können Sie einen B-Plan anlegen. Dieser wird ein-/ausblendbar über die Grundkarten gelegt.">
-                                        <input
-                                            type="checkbox"
-                                            id="bPlan"
-                                            name="r_bplan"
-                                            data-cy="r_bplan"
-                                            data-requires="[name=r_type][value=overlay]"
-                                            data-to-disable="#scope"
-                                            value="1"
-                                            {% if gislayer.bplan|default(false) == true %}checked="checked"{% endif %}
-                                        >
-                                        {{ "drawing"|trans }}
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="cursor-pointer u-mb-0_25" title="Geltungsbereich zeigt nur in der Beteiligungsebene die Umrandung des Plans über der Grundkarte an.">
-                                        <input
-                                            type="checkbox"
-                                            id="scope"
-                                            name="r_scope"
-                                            data-cy="r_scope"
-                                            data-requires="[name=r_type][value=overlay]"
-                                            data-to-disable="#bPlan"
-                                            value="1"
-                                            {% if gislayer.scope|default(false) == true %}checked="checked"{% endif %}
-                                        >
-                                        {{ "layer.territory"|trans }}
-                                    </label>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </li>
-                </ul>
+                        </li>
+                        <li>
+                            <label class="cursor-pointer u-mb-0_25" title="Mit Overlay erstellen Sie weitere Ebenen (Layer) ein-/ausblendbar über den Grundkarten.">
+                                <input
+                                    type="radio"
+                                    name="r_type"
+                                    data-cy="overlay"
+                                    value="overlay"
+                                    required
+                                    {% if templateVars.inData.r_layer|default() != "base" %}checked{% endif %}
+                                >
+                                {{ "overlay"|trans }}
+                            </label>
+                            <ul class="u-pl">
+                                {% if hasPermission('area_public_participation') and hasPermission('feature_map_use_territory') %}
+                                    <li>
+                                        <label class="cursor-pointer u-mb-0_25" title="Mit Planzeichnung können Sie einen B-Plan anlegen. Dieser wird ein-/ausblendbar über die Grundkarten gelegt.">
+                                            <input
+                                                type="checkbox"
+                                                id="bPlan"
+                                                name="r_bplan"
+                                                data-cy="r_bplan"
+                                                data-requires="[name=r_type][value=overlay]"
+                                                data-to-disable="#scope"
+                                                value="1"
+                                                {% if gislayer.bplan|default(false) == true %}checked="checked"{% endif %}
+                                            >
+                                            {{ "drawing"|trans }}
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="cursor-pointer u-mb-0_25" title="Geltungsbereich zeigt nur in der Beteiligungsebene die Umrandung des Plans über der Grundkarte an.">
+                                            <input
+                                                type="checkbox"
+                                                id="scope"
+                                                name="r_scope"
+                                                data-cy="r_scope"
+                                                data-requires="[name=r_type][value=overlay]"
+                                                data-to-disable="#bPlan"
+                                                value="1"
+                                                {% if gislayer.scope|default(false) == true %}checked="checked"{% endif %}
+                                            >
+                                            {{ "layer.territory"|trans }}
+                                        </label>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </li>
+                    </ul>
+                {% else %}
+                    <input
+                        type="hidden"
+                        name="r_type"
+                        data-cy="overlay"
+                        value="overlay"
+                        checked>
+                {% endif %}
                 {% if hasPermission('feature_xplan_defaultlayers') %}
                     <label
                         class="layout__item u-1-of-5 cursor-pointer"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -155,7 +155,7 @@
             }) }}
         {% endif %}
 
-        {% if hasPermission('feature_map_layer_visibility') %}
+        {% if hasPermission('feature_map_print_layer') %}
             <label class="u-mb-0_5">
                 <input
                     type="checkbox"
@@ -165,6 +165,8 @@
                     {% if templateVars.inData.r_print|default() == 1 %}checked{% endif %}>
                 {{ "explanation.gislayer.print"|trans }}
             </label>
+        {% endif %}
+        {% if hasPermission('feature_map_layer_visibility') %}
             <label class="u-mb-0_5">
                 <input
                     type="checkbox"
@@ -185,6 +187,13 @@
                     checked>
                 {{ "explanation.gislayer.usertoggle.visibility"|trans }}
             </label>
+        {% else %}
+            <input
+                type="hidden"
+                name="r_default_visibility"
+                data-cy="mapLayerDefaultVisibility"
+                value="1"
+                checked>
         {% endif %}
 
         <label class="u-mt u-mb-0_5">


### PR DESCRIPTION
### Ticket
DPLAN-11963

With the fix, A created/ updated Layer should be displayed in the "segements" Map if the permission to set the visibility (feature_map_layer_visibility) is off.

I didn't change the template ecxept of the `if hasPermission` and the following else-blocks