### PR TITLE
chore (refs DPLAN-12006): register default users for new customer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
@@ -62,7 +62,7 @@ class GenerateCustomerCommand extends CoreCommand
         ParameterBagInterface $parameterBag,
         private readonly RoleRepository $roleRepository,
         private readonly UserService $userService,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
         $this->helper = new QuestionHelper();

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
@@ -12,9 +12,16 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\EntryAlreadyExistsException;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
+use demosplan\DemosPlanCoreBundle\Repository\RoleRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use InvalidArgumentException;
@@ -53,6 +60,8 @@ class GenerateCustomerCommand extends CoreCommand
         private readonly CustomerService $customerService,
         private readonly EntityManagerInterface $entityManager,
         ParameterBagInterface $parameterBag,
+        private readonly RoleRepository $roleRepository,
+        private readonly UserService $userService,
         string $name = null
     ) {
         parent::__construct($parameterBag, $name);
@@ -96,7 +105,8 @@ class GenerateCustomerCommand extends CoreCommand
 
         try {
             // create customer
-            $this->customerService->createCustomer($name, $subdomain);
+            $customer = $this->customerService->createCustomer($name, $subdomain);
+            $this->registerDefaultUsers($customer);
             $this->entityManager->flush();
 
             $output->writeln(
@@ -156,5 +166,25 @@ class GenerateCustomerCommand extends CoreCommand
         }
 
         return $subdomain;
+    }
+
+    private function registerDefaultUsers(Customer $customer): void
+    {
+        // register AiApiUser and AnonymousUser
+        $this->registerUser($customer, AiApiUser::AI_API_USER_LOGIN, RoleInterface::API_AI_COMMUNICATOR);
+        $this->registerUser($customer, UserInterface::ANONYMOUS_USER_LOGIN, RoleInterface::CITIZEN);
+    }
+
+    private function registerUser(Customer $customer, string $login, string $roleString): void
+    {
+        $user = $this->userService->findDistinctUserByEmailOrLogin($login);
+        if ($user instanceof User) {
+            // add user to customer
+            $user->setDplanroles(
+                $this->roleRepository->getUserRolesByCodes([$roleString]),
+                $customer
+            );
+            $this->userService->updateUserObject($user);
+        }
     }
 }


### PR DESCRIPTION
### Ticket
DPLAN-12006

When the exist the citizen user and the ai api user should be automatically registered to avoid errors

### How to review/test
create a new customer via `bin/<project> dplan:data:generate-customer` it should contain two users

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
