### PR TITLE
chore (refs DPLAN-12006): copy the FAQ from one customer to another

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
@@ -96,7 +96,7 @@ class CopyFaqCommand extends CoreCommand
 
             $output->info('Copied ' . $categoryCount . ' FAQ categories with ' . $faqCount . ' FAQs.');
             $timeSaved = ceil(($categoryCount * 30 + $faqCount * 45)/60);
-            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and a lots of nerves.");
+            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and lots of nerves.");
 
             return Command::SUCCESS;
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
@@ -94,7 +94,7 @@ class CopyFaqCommand extends CoreCommand
 
             $output->info('Copied '.$categoryCount.' FAQ categories with '.$faqCount.' FAQs.');
             $timeSaved = ceil(($categoryCount * 30 + $faqCount * 45) / 60);
-            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and a lots of nerves.");
+            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and lots of nerves.");
 
             return Command::SUCCESS;
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
@@ -30,7 +30,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CopyFaqCommand extends CoreCommand
 {
-
     protected static $defaultName = 'dplan:data:copy-faq';
     protected static $defaultDescription = 'Copies the FAQ from one customer to another.';
 
@@ -42,7 +41,7 @@ class CopyFaqCommand extends CoreCommand
         private readonly FaqRepository $faqRepository,
         private readonly EntityManagerInterface $entityManager,
         ParameterBagInterface $parameterBag,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($parameterBag, $name);
         $this->helper = new QuestionHelper();
@@ -64,15 +63,14 @@ class CopyFaqCommand extends CoreCommand
             $faqCategories = collect($this->faqCategoryRepository->getFaqCategoriesByCustomer($fromCustomer));
             // only "valid" faq categories should be copied
             $faqCategories = $faqCategories->filter(
-                static fn (FaqCategory $faqCategory) =>
-                    in_array($faqCategory->getType(), FaqCategoryInterface::FAQ_CATEGORY_TYPES_MANDATORY, true)
+                static fn (FaqCategory $faqCategory) => in_array($faqCategory->getType(), FaqCategoryInterface::FAQ_CATEGORY_TYPES_MANDATORY, true)
                     || $faqCategory->isCustom()
             );
 
             $categoryCount = 0;
             $faqCount = 0;
             foreach ($faqCategories as $faqCategory) {
-                $categoryCount++;
+                ++$categoryCount;
                 $copiedFaqCategory = new FaqCategory();
                 $copiedFaqCategory->setCustomer($toCustomer);
                 $copiedFaqCategory->setTitle($faqCategory->getTitle());
@@ -81,7 +79,7 @@ class CopyFaqCommand extends CoreCommand
 
                 $faqs = $this->faqRepository->findBy(['faqCategory' => $faqCategory]);
                 foreach ($faqs as $faq) {
-                    $faqCount++;
+                    ++$faqCount;
                     $copiedFaq = new Faq();
                     $copiedFaq->setCategory($copiedFaqCategory);
                     $copiedFaq->setEnabled($faq->getEnabled());
@@ -94,9 +92,9 @@ class CopyFaqCommand extends CoreCommand
 
             $this->entityManager->flush();
 
-            $output->info('Copied ' . $categoryCount . ' FAQ categories with ' . $faqCount . ' FAQs.');
-            $timeSaved = ceil(($categoryCount * 30 + $faqCount * 45)/60);
-            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and lots of nerves.");
+            $output->info('Copied '.$categoryCount.' FAQ categories with '.$faqCount.' FAQs.');
+            $timeSaved = ceil(($categoryCount * 30 + $faqCount * 45) / 60);
+            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and a lots of nerves.");
 
             return Command::SUCCESS;
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Data;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\FaqCategoryInterface;
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
+use demosplan\DemosPlanCoreBundle\Entity\Faq;
+use demosplan\DemosPlanCoreBundle\Entity\FaqCategory;
+use demosplan\DemosPlanCoreBundle\Repository\FaqCategoryRepository;
+use demosplan\DemosPlanCoreBundle\Repository\FaqRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class CopyFaqCommand extends CoreCommand
+{
+
+    protected static $defaultName = 'dplan:data:copy-faq';
+    protected static $defaultDescription = 'Copies the FAQ from one customer to another.';
+
+    protected QuestionHelper $helper;
+
+    public function __construct(
+        private readonly Helpers $helpers,
+        private readonly FaqCategoryRepository $faqCategoryRepository,
+        private readonly FaqRepository $faqRepository,
+        private readonly EntityManagerInterface $entityManager,
+        ParameterBagInterface $parameterBag,
+        string $name = null
+    ) {
+        parent::__construct($parameterBag, $name);
+        $this->helper = new QuestionHelper();
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output = new SymfonyStyle($input, $output);
+        $output->writeln('Copying FAQ from one customer to another.');
+        $output->writeln('Choose customer to copy from');
+        $fromCustomer = $this->helpers->askCustomer($input, $output);
+        $output->writeln('Choose customer to copy to');
+        $toCustomer = $this->helpers->askCustomer($input, $output);
+
+        try {
+            $faqCategories = collect($this->faqCategoryRepository->getFaqCategoriesByCustomer($fromCustomer));
+            // only "valid" faq categories should be copied
+            $faqCategories = $faqCategories->filter(
+                static fn (FaqCategory $faqCategory) =>
+                    in_array($faqCategory->getType(), FaqCategoryInterface::FAQ_CATEGORY_TYPES_MANDATORY, true)
+                    || $faqCategory->isCustom()
+            );
+
+            $categoryCount = 0;
+            $faqCount = 0;
+            foreach ($faqCategories as $faqCategory) {
+                $categoryCount++;
+                $copiedFaqCategory = new FaqCategory();
+                $copiedFaqCategory->setCustomer($toCustomer);
+                $copiedFaqCategory->setTitle($faqCategory->getTitle());
+                $copiedFaqCategory->setType($faqCategory->getType());
+                $this->entityManager->persist($copiedFaqCategory);
+
+                $faqs = $this->faqRepository->findBy(['faqCategory' => $faqCategory]);
+                foreach ($faqs as $faq) {
+                    $faqCount++;
+                    $copiedFaq = new Faq();
+                    $copiedFaq->setCategory($copiedFaqCategory);
+                    $copiedFaq->setEnabled($faq->getEnabled());
+                    $copiedFaq->setRoles($faq->getRoles()->toArray());
+                    $copiedFaq->setText($faq->getText());
+                    $copiedFaq->setTitle($faq->getTitle());
+                    $this->entityManager->persist($copiedFaq);
+                }
+            }
+
+            $this->entityManager->flush();
+
+            $output->info('Copied ' . $categoryCount . ' FAQ categories with ' . $faqCount . ' FAQs.');
+            $timeSaved = ceil(($categoryCount * 30 + $faqCount * 45)/60);
+            $output->success("Faq where successfully copied. Saved approx $timeSaved minutes and a lots of nerves.");
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            // Print Exception
+            $output->error('Something went wrong during faq copy: '.$e->getMessage());
+        }
+
+        return Command::FAILURE;
+    }
+}


### PR DESCRIPTION
### Ticket
DPLAN-12006

Copying FAQ from one customer to another is a really annoying and tedious task. This command eases the pain

### How to review/test
You probably want to create a new customer via `bin(<projedct> dplan:data:generate-customer`, see that it has no faq and run bin/<project> dplan:data:copy-faq` and be happy about all the faq

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
