### PR TITLE
fix: Interpret String as String

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/alternative_login.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/alternative_login.html.twig
@@ -9,7 +9,7 @@
         {% block content %}
             <saml-login-form
                 :is-saml="{{ useSaml|json_encode }}"
-                :saml-login-path="{{ gatewayURL }}"
+                saml-login-path="{{ gatewayURL }}"
                 :csrf-token="{{ csrf_token('authenticate')|json_encode }}">
                 {# Using the |raw filter in this special case is needed, as html tags are returned. #}
                 {{ extensionPointMarkup('formExtraFields')|raw }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/citizen_register_form.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/citizen_register_form.html.twig
@@ -8,7 +8,7 @@
         {% block content %}
             <citizen-register-form
                 :is-saml="{{ useSaml|json_encode }}"
-                :saml-login-path="{{ gatewayURL }}"
+                saml-login-path="{{ gatewayURL }}"
                 :csrf-token="{{ csrf_token('register-user')|json_encode }}">
                 {{ extensionPointMarkup('formExtraFields')|raw }}
             </citizen-register-form>


### PR DESCRIPTION
If we got a real string from TWIG, we can't try to compute it.