### PR TITLE
F dplan 11944 report pdfs

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
+
 use function Symfony\Component\String\u;
 
 /**
@@ -83,7 +84,6 @@ class DemosPlanReportController extends BaseController
         TranslatorInterface $translator,
         $procedureId
     ): Response {
-
         $procedure = $procedureHandler->getProcedure($procedureId);
         $slugify = new Slugify();
         $pdfName = $slugify->slugify($procedure->getName()).'.pdf';
@@ -99,8 +99,8 @@ class DemosPlanReportController extends BaseController
             foreach ($reportCategory['reportEntries'] as $reportEntry) {
                 $reportMessages[$reportCategoryTitle][$reportHeader][] = [
                     'creationDate' => $reportEntry->getCreated()->format('d.m.Y H:i:s'),
-                    'userName' => u($reportEntry->getUserName()),
-                    'message' => $messageConverter->convertMessage($reportEntry),
+                    'userName'     => u($reportEntry->getUserName()),
+                    'message'      => $messageConverter->convertMessage($reportEntry),
                 ];
             }
             if ([] === $reportMessages[$reportCategoryTitle][$reportHeader]) {
@@ -133,32 +133,32 @@ class DemosPlanReportController extends BaseController
 
         return $response;
 
-//        $slugify = new Slugify();
-//        $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);
-//
-//        $currentTime = Carbon::now();
-//        $reportMeta = [
-//            'name'       => $procedure->getName(),
-//            'exportDate' => $currentTime->format('d.m.Y'),
-//            'exportTime' => $currentTime->format('H:i'),
-//        ];
-//
-//        Settings::setPdfRendererPath($parameterBag->get('pdf_renderer_path'));
-//        Settings::setPdfRendererName($parameterBag->get('pdf_renderer_name'));
-//
-//        $response = new StreamedResponse(
-//            static function () use ($procedureId, $reportMeta, $reportService, $permissions) {
-//                $reportInfo = $reportService->getReportInfo($procedureId, $permissions);
-//                $pdfReport = $reportService->generateProcedureReport($reportInfo, $reportMeta);
-//                $pdfReport->save('php://output');
-//            }
-//        );
-//
-//        $pdfName = $slugify->slugify($procedure->getName()).'.pdf';
-//        $response->headers->set('Pragma', 'public');
-//        $response->headers->set('Content-Type', 'application/pdf; charset=utf-8');
-//        $response->headers->set('Content-Disposition', $nameGenerator->generateDownloadFilename($pdfName));
-//
-//        return $response;
+        //        $slugify = new Slugify();
+        //        $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);
+        //
+        //        $currentTime = Carbon::now();
+        //        $reportMeta = [
+        //            'name'       => $procedure->getName(),
+        //            'exportDate' => $currentTime->format('d.m.Y'),
+        //            'exportTime' => $currentTime->format('H:i'),
+        //        ];
+        //
+        //        Settings::setPdfRendererPath($parameterBag->get('pdf_renderer_path'));
+        //        Settings::setPdfRendererName($parameterBag->get('pdf_renderer_name'));
+        //
+        //        $response = new StreamedResponse(
+        //            static function () use ($procedureId, $reportMeta, $reportService, $permissions) {
+        //                $reportInfo = $reportService->getReportInfo($procedureId, $permissions);
+        //                $pdfReport = $reportService->generateProcedureReport($reportInfo, $reportMeta);
+        //                $pdfReport->save('php://output');
+        //            }
+        //        );
+        //
+        //        $pdfName = $slugify->slugify($procedure->getName()).'.pdf';
+        //        $response->headers->set('Pragma', 'public');
+        //        $response->headers->set('Content-Type', 'application/pdf; charset=utf-8');
+        //        $response->headers->set('Content-Disposition', $nameGenerator->generateDownloadFilename($pdfName));
+        //
+        //        return $response;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -108,9 +108,16 @@ class DemosPlanReportController extends BaseController
             }
         }
 
+        $currentTime = Carbon::now();
+        $exportedAt = [
+            'exportDate' => $currentTime->format('d.m.Y'),
+            'exportTime' => $currentTime->format('H:i'),
+        ];
+
         $content = $twig->render('@DemosPlanCore/DemosPlanReport/list.procedure.report.tex.twig', [
             'procedure'    => $procedure,
             'templateVars' => $reportMessages,
+            'exportedAt'   => $exportedAt,
             'title'        => 'DPlan',
         ]);
         $response = $serviceImporter->exportPdfWithRabbitMQ(base64_encode($content), []);

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -143,6 +143,22 @@ class LatexExtension extends ExtensionBase
                 return '';
             }
 
+            if (str_contains($text, "matisch am 29.11.2021")) {
+                $a = str_contains($text, "\xC2\xA0");
+                $b = str_contains($text, "\xA0");
+                $c = str_contains($text, "\xE2\x80\xAF");
+                $berak = 'here';
+            }
+            $text = str_replace(
+                [
+                  "\xA0", // &nbsp;
+                  "\xC2\xA0", // utf8 &nbsp;
+                  "\xE2\x80\xAF", // utf8 narrow non breaking space
+                ],
+                ' ',
+                $text
+            );
+
             $this->logger->debug('latexFilter start: '.$text);
             // replace tilde temporary
             $text = str_replace('~', 'LATEXtextasciitildeLATEX', $text);
@@ -244,8 +260,8 @@ class LatexExtension extends ExtensionBase
             $postlatex = [
                 '',
                 '\\\\', // "\\\\\n",
-                '\\\\', // "\\\\\n",
-                '\\\\', // "\\\\\n"
+                '\\newline', // "\\\\\n",
+                '\\newline', // "\\\\\n"
             ];
 
             // Kill situations in which a end{itemize} is directly followed by a latex paragraph feed
@@ -253,6 +269,7 @@ class LatexExtension extends ExtensionBase
 
             // Eliminate all occurences of carriage returns
             $text = preg_replace('_\\r_si', '', $text);
+
 
             $text = str_replace($posthtml, $postlatex, $text);
 

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -143,7 +143,7 @@ class LatexExtension extends ExtensionBase
                 return '';
             }
 
-            if (str_contains($text, "matisch am 29.11.2021")) {
+            if (str_contains($text, 'matisch am 29.11.2021')) {
                 $a = str_contains($text, "\xC2\xA0");
                 $b = str_contains($text, "\xA0");
                 $c = str_contains($text, "\xE2\x80\xAF");
@@ -151,9 +151,9 @@ class LatexExtension extends ExtensionBase
             }
             $text = str_replace(
                 [
-                  "\xA0", // &nbsp;
-                  "\xC2\xA0", // utf8 &nbsp;
-                  "\xE2\x80\xAF", // utf8 narrow non breaking space
+                    "\xA0", // &nbsp;
+                    "\xC2\xA0", // utf8 &nbsp;
+                    "\xE2\x80\xAF", // utf8 narrow non breaking space
                 ],
                 ' ',
                 $text
@@ -269,7 +269,6 @@ class LatexExtension extends ExtensionBase
 
             // Eliminate all occurences of carriage returns
             $text = preg_replace('_\\r_si', '', $text);
-
 
             $text = str_replace($posthtml, $postlatex, $text);
 
@@ -550,7 +549,7 @@ class LatexExtension extends ExtensionBase
             foreach ($imageMatches[1] as $matchKey => $match) {
                 $parts = explode('\&', $match);
                 // if contains / explode
-                if(str_contains($parts[0], '/')) {
+                if (str_contains($parts[0], '/')) {
                     $parts = explode('/', $parts[0]);
                     $fileHash = $parts[1];
                 } else {

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -259,7 +259,7 @@ class LatexExtension extends ExtensionBase
 
             $postlatex = [
                 '',
-                '\\\\', // "\\\\\n",
+                '\\newline', // "\\\\\n",
                 '\\newline', // "\\\\\n",
                 '\\newline', // "\\\\\n"
             ];

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
@@ -24,6 +24,7 @@
 \usepackage{{ '{' }}tabularx{{ '}' }}
 \usepackage{{ '{' }}makecell{{ '}' }}
 \usepackage{{ '{' }}array{{ '}' }}
+\usepackage{{ '{' }}ragged2e{{ '}' }}
 \usepackage{{ '{' }}xurl{{ '}' }}
 \usepackage{{ '{' }}hyphenat{{ '}' }}
 \usepackage{{ '{' }}enumitem{{ '}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
@@ -22,6 +22,10 @@
 \usepackage{{ '{' }}fancyhdr{{ '}' }}
 \usepackage{{ '{' }}longtable{{ '}' }}
 \usepackage{{ '{' }}tabularx{{ '}' }}
+\usepackage{{ '{' }}makecell{{ '}' }}
+\usepackage{{ '{' }}array{{ '}' }}
+\usepackage{{ '{' }}xurl{{ '}' }}
+\usepackage{{ '{' }}hyphenat{{ '}' }}
 \usepackage{{ '{' }}enumitem{{ '}' }}
 \usepackage{{ '{' }}textcomp{{ '}' }}
 \usepackage{{ '{' }}pifont{{ '}' }}
@@ -33,6 +37,11 @@
 \DeclareUnicodeCharacter{308}{}
 \usepackage[a4paper,inner=15mm,outer=15mm,top=20mm,bottom=10mm,includefoot]{{ '{' }}geometry{{ '}' }}
 \usepackage[normalem]{{ '{' }}ulem{{ '}' }}
+% Patch \newline to force break hyphenated words
+\makeatletter
+\patchcmd{\LT@makecap}{\hb@xt@ \linewidth}{\hb@xt@ \linewidth}{}{}
+\patchcmd{\LT@makehline}{\hb@xt@ \linewidth}{\hb@xt@ \linewidth}{}{}
+\makeatother
 \addtokomafont{{ '{' }}descriptionlabel{{ '}' }}{{ '{' }}\normalfont{{ '}' }}
 \renewcommand{{ '{' }}\familydefault{{ '}' }}{{ '{' }}\sfdefault{{ '}' }}
 \definecolor{{ '{' }}DPlightgrey}{HTML{{ '}' }}{d3d3d3{{ '}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
@@ -25,6 +25,10 @@
 \usepackage{{ '{' }}makecell{{ '}' }}
 \usepackage{{ '{' }}array{{ '}' }}
 \usepackage{{ '{' }}ragged2e{{ '}' }}
+\usepackage{{ '{' }}needspace{{ '}' }}
+\usepackage{{ '{' }}etoolbox{{ '}' }}
+\usepackage{{ '{' }}ifthen{{ '}' }}
+\usepackage{{ '{' }}calc{{ '}' }}
 \usepackage{{ '{' }}xurl{{ '}' }}
 \usepackage{{ '{' }}hyphenat{{ '}' }}
 \usepackage{{ '{' }}enumitem{{ '}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
@@ -39,7 +39,12 @@
             {% endif %}
         {% endfor %}
     {% endfor %}
-    \vspace{0.5cm}
+    \vspace{2cm}
+    \makeatletter % Nötig bei Verwendung von Dimens
+    \ifdim\dimexpr \pagegoal-\pagetotal\relax < 5cm
+    \newpage\vspace*{2cm} % Seitenumbruch und 2cm Abstand
+    \fi
+    \makeatother
     {{ '______________________________'|latex|raw }}\\
     {{ 'city'|trans|latex|raw }}, {{ 'date'|trans|latex|raw }}\\
     \\

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
@@ -1,0 +1,41 @@
+{% set scope = 'external' %}
+{% set count = templateVars|length %}
+{% extends '@DemosPlanCore/DemosPlanCore/pdfexport.tex.twig' %}
+{% block demosplanbundlecontent %}
+    % Überschrift
+    % Anpassen der Caption-Einstellungen
+    \captionsetup[table]{
+    labelformat=empty, % Entfernt "Table 1:"
+    singlelinecheck=false, % Ermöglicht linksbündige Ausrichtung
+    justification=raggedright, % Links ausrichten
+    font=bf, % Fettgedruckter Text für die Caption
+    }
+    \newcolumntype{L}[1]{>{\makecell[\raggedright\hyphenat\arraybackslash]}p{{ '{' }}#1}}
+    \begin{Huge}
+    \section*{{ '{' }}{% if procedure.name is defined %}{{ procedure.name|latex|raw }}{% else %}
+    {{ "Kein Verfahrensname"|latex|raw }}{% endif %}{{ ' - Protokoll'|latex|raw }}{{ '}' }}
+    \end{Huge}
+    {% for category, reportsTitle in templateVars %}
+        {% for title, reports in reportsTitle %}
+            {% if reports is iterable  %}
+                \begin{longtable}{|L{4cm}|L{10cm}|L{3cm}|}
+                \caption{{ '{' }}{{ category|trans|latex|raw }}{{ '}' }}
+                \hline
+                Datum & {{ title|trans|latex|raw }} & Nutzer*in \\
+                \endfirsthead
+                Datum & {{ title|trans|latex|raw }} & Nutzer*in \\
+                \endhead
+                \hline
+                {% for report in reports %}
+                    {{ report.creationDate }} & {{ report.message|trans|latex|raw }} & {{ report.userName }} \\
+                    \hline
+                {% endfor %}
+                \end{longtable}
+                \\
+            {% else %}
+                {{ '\\textbf{' }}{{ category|trans|latex|raw }}{{ '}\\\\' }}
+                {{ 'text.protocol.no.entries'|trans|latex|raw }}\\
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
@@ -10,7 +10,7 @@
     justification=raggedright, % Links ausrichten
     font=bf, % Fettgedruckter Text für die Caption
     }
-    \newcolumntype{L}[1]{>{\makecell[\raggedright\hyphenat\arraybackslash]}p{{ '{' }}#1}}
+    \newcolumntype{L}[1]{>{\RaggedRight\makecell[\hyphenat\arraybackslash]}p{{ '{' }}#1}}
     \begin{Huge}
     \section*{{ '{' }}{% if procedure.name is defined %}{{ procedure.name|latex|raw }}{% else %}
     {{ "Kein Verfahrensname"|latex|raw }}{% endif %}{{ ' - Protokoll'|latex|raw }}{{ '}' }}
@@ -35,7 +35,16 @@
             {% else %}
                 {{ '\\textbf{' }}{{ category|trans|latex|raw }}{{ '}\\\\' }}
                 {{ 'text.protocol.no.entries'|trans|latex|raw }}\\
+                \\
             {% endif %}
         {% endfor %}
     {% endfor %}
+    \vspace{0.5cm}
+    {{ '______________________________'|latex|raw }}\\
+    {{ 'city'|trans|latex|raw }}, {{ 'date'|trans|latex|raw }}\\
+    \\
+    {{ '______________________________'|latex|raw }}\\
+    {{ 'signature'|trans|latex|raw }}\\
+    \\
+    {{ 'exported.on'|trans({'%date%': exportedAt.exportDate, '%time%': exportedAt.exportTime})|latex|raw }}\\
 {% endblock %}


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-11944/HHBOP-Prod-Formatierungsproblematik-in-BOP-Verfahrensprotokollen

phpWord was not able to style the table/page layout for the report-entries export as pdf the desired way. This PR switches to the latex to pdf approach

This does change the default latex filter replacement for newline indicators from ```\\``` to ```\newline``` which behaves differently when used inside tables. This was necessary to prevent signalizing the end of the table-row as done via ```\\``` to allow multi-line columns within individual table-cells.

This is the wrong target-branch - I just need tested it here - the correct one: https://github.com/demos-europe/demosplan-core/pull/3391

### needs to be done
check all other .tex.twig files for broken tables/newlines

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
