### PR TITLE
fix (refs DPLAN-11944): Change ProcedureReportExport to use rabbitmq rather than phpword

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ExportReportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ExportReportService.php
@@ -13,12 +13,8 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Report;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
-use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Repository\ReportRepository;
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\Writer\WriterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -69,117 +65,34 @@ class ExportReportService extends CoreService
     }
 
     /**
-     * Generates the report with the received info in the given document format.
+     * Generates the report with the received info in pdf format.
      *
-     * @param string $format - 'ODText', 'RTF', 'Word2007', 'HTML', 'PDF'
      *
      * @return WriterInterface
      *
      * @throws Exception
      */
-    public function generateProcedureReport(array $reportInfo, array $reportMeta, string $format = 'PDF')
+    public function generateProcedureReport(array $reportInfo): array
     {
-        $phpWord = PhpWordConfigurator::getPreConfiguredPhpWord();
-        $section = $phpWord->addSection();
-
-        $docTitle = $reportMeta['name'].' - '.$this->translator->trans('protocol');
-        $section->addText($docTitle, $this->styles['docTitleFont']);
-
-        $dateText = $this->translator->trans('exported.on', ['date' => $reportMeta['exportDate'], 'time' => $reportMeta['exportTime']]);
-        $section->addText($dateText, $this->styles['baseFont']);
-        $section->addTextBreak(2);
-
-        foreach ($reportInfo as $reportBlock) {
-            $this->writeReportBlockTitle($section, $reportBlock['titleMessage']);
-            if (empty($reportBlock['reportEntries'])) {
-                $noEntriesMessage = $this->translator->trans('text.protocol.no.entries');
-                $noInfoText = $section->addText($noEntriesMessage, $this->styles['noInfoMessage']);
-                $noInfoText->setParagraphStyle($this->styles['paragraph']);
-            } else {
-                $table = $section->addTable();
-                $blockTitleMsg = $reportBlock['headerMessage'] ?? $reportBlock['titleMessage'];
-                $this->writeReportBlockHeader($blockTitleMsg, $table);
-                $this->writeReportBlockBody($reportBlock['reportEntries'], $table);
+        $reportMessages = [];
+        foreach ($reportInfo as $reportCategory) {
+            $reportHeader = $reportCategory['headerMessage'] ?? $reportCategory['titleMessage'];
+            $reportCategoryTitle = $reportCategory['titleMessage'];
+            $reportMessages[$reportCategoryTitle] = [$reportHeader => []];
+            /** @var ReportEntry $reportEntry */
+            foreach ($reportCategory['reportEntries'] as $reportEntry) {
+                $reportMessages[$reportCategoryTitle][$reportHeader][] = [
+                    'creationDate' => $reportEntry->getCreated()->format('d.m.Y H:i:s'),
+                    'userName'     => u($reportEntry->getUserName()),
+                    'message'      => $this->messageConverter->convertMessage($reportEntry),
+                ];
+            }
+            if ([] === $reportMessages[$reportCategoryTitle][$reportHeader]) {
+                $reportMessages[$reportCategoryTitle][$reportHeader] = $this->translator->trans('text.protocol.no.entries');
             }
         }
 
-        $this->writeSignatureField($section, $dateText);
-
-        return IOFactory::createWriter($phpWord, $format);
-    }
-
-    /** Adds a field for signatures at the end of $section.
-     */
-    private function writeSignatureField(Section $section, string $exportedOn = '')
-    {
-        $font = $this->styles['baseFont'];
-        $section->addTextBreak(2);
-
-        $placeAndDateText = $this->translator->trans('city').', '.$this->translator->trans('date');
-        $signatureText = $this->translator->trans('signature');
-        $placeholder = '______________________________';
-
-        $section->addText($placeholder, $font);
-        $section->addText($placeAndDateText, $font);
-        $section->addTextBreak(1);
-        $section->addText($placeholder, $font);
-        $section->addText($signatureText, $font);
-        $section->addTextBreak(1);
-        $section->addText($exportedOn, $font);
-    }
-
-    private function writeReportBlockTitle(Section $section, string $blockTitleMsg)
-    {
-        $titleMessage = htmlspecialchars($this->translator->trans($blockTitleMsg));
-        $tableTitle = $section->addText($titleMessage, $this->styles['titleFont']);
-        $tableTitle->setParagraphStyle($this->styles['paragraph']);
-    }
-
-    private function writeReportBlockHeader(string $blockTitleMsg, Table $table)
-    {
-        $table->addRow($this->styles['rowHeight'], $this->styles['tableHeader']);
-
-        $dateHeaderLabel = htmlspecialchars($this->translator->trans('date'));
-        $dateHeaderCell = $table->addCell($this->styles['dateCellWidth'], $this->styles['tableHeader']);
-        $dateHeaderText = $dateHeaderCell->addText($dateHeaderLabel, $this->styles['tableHeaderFont']);
-        $dateHeaderText->setParagraphStyle($this->styles['paragraph']);
-
-        $messageHeaderLabel = htmlspecialchars($this->translator->trans($blockTitleMsg));
-        $headerCell = $table->addCell($this->styles['descriptionCellWidth'], $this->styles['tableHeader']);
-        $headerCell->addText($messageHeaderLabel, $this->styles['tableHeaderFont']);
-
-        $userHeaderLabel = htmlspecialchars($this->translator->trans('user'));
-        $userHeaderCell = $table->addCell($this->styles['userCellWidth'], $this->styles['tableHeader']);
-        $userHeaderCell->addText($userHeaderLabel, $this->styles['tableHeaderFont']);
-    }
-
-    private function writeReportBlockBody(array $reportEntries, Table $table)
-    {
-        /** @var ReportEntry $reportEntry */
-        foreach ($reportEntries as $reportEntry) {
-            $this->writeReportEntry($reportEntry, $table);
-        }
-    }
-
-    private function writeReportEntry(ReportEntry $reportEntry, Table $table)
-    {
-        $table->addRow($this->styles['rowHeight'], $this->styles['tableRow']);
-
-        $creationDate = $reportEntry->getCreated()->format('d.m.Y H:i:s');
-        $dateEntryCell = $table->addCell($this->styles['dateCellWidth']);
-        $dateEntryCell->addText($creationDate, $this->styles['baseFont']);
-
-        $messageParts = $this->getMessageParts($reportEntry);
-        $cell = $table->addCell($this->styles['descriptionCellWidth']);
-        foreach ($messageParts as $messagePart) {
-            $message = strip_tags((string) $messagePart);
-            $cellText = $cell->addText($message, $this->styles['baseFont']);
-            $cellText->setParagraphStyle($this->styles['paragraph']);
-        }
-
-        $userName = $reportEntry->getUserName();
-        $userCell = $table->addCell($this->styles['userCellWidth']);
-        $userCell->addText(u($userName)->normalize()->toString(), $this->styles['baseFont']);
+        return $reportMessages;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/LatexExtension.php
@@ -243,9 +243,9 @@ class LatexExtension extends ExtensionBase
 
             $postlatex = [
                 '',
-                '\\\\', // "\\\\\n",
-                '\\\\', // "\\\\\n",
-                '\\\\', // "\\\\\n"
+                '\\newline', // "\n",
+                '\\newline', // "\n",
+                '\\newline', // "\n"
             ];
 
             // Kill situations in which a end{itemize} is directly followed by a latex paragraph feed

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
@@ -22,6 +22,15 @@
 \usepackage{{ '{' }}fancyhdr{{ '}' }}
 \usepackage{{ '{' }}longtable{{ '}' }}
 \usepackage{{ '{' }}tabularx{{ '}' }}
+\usepackage{{ '{' }}makecell{{ '}' }}
+\usepackage{{ '{' }}array{{ '}' }}
+\usepackage{{ '{' }}ragged2e{{ '}' }}
+\usepackage{{ '{' }}needspace{{ '}' }}
+\usepackage{{ '{' }}etoolbox{{ '}' }}
+\usepackage{{ '{' }}ifthen{{ '}' }}
+\usepackage{{ '{' }}calc{{ '}' }}
+\usepackage{{ '{' }}xurl{{ '}' }}
+\usepackage{{ '{' }}hyphenat{{ '}' }}
 \usepackage{{ '{' }}enumitem{{ '}' }}
 \usepackage{{ '{' }}textcomp{{ '}' }}
 \usepackage{{ '{' }}pifont{{ '}' }}
@@ -33,6 +42,11 @@
 \DeclareUnicodeCharacter{308}{}
 \usepackage[a4paper,inner=15mm,outer=15mm,top=20mm,bottom=10mm,includefoot]{{ '{' }}geometry{{ '}' }}
 \usepackage[normalem]{{ '{' }}ulem{{ '}' }}
+% Patch \newline to force break hyphenated words
+\makeatletter
+\patchcmd{\LT@makecap}{\hb@xt@ \linewidth}{\hb@xt@ \linewidth}{}{}
+\patchcmd{\LT@makehline}{\hb@xt@ \linewidth}{\hb@xt@ \linewidth}{}{}
+\makeatother
 \addtokomafont{{ '{' }}descriptionlabel{{ '}' }}{{ '{' }}\normalfont{{ '}' }}
 \renewcommand{{ '{' }}\familydefault{{ '}' }}{{ '{' }}\sfdefault{{ '}' }}
 \definecolor{{ '{' }}DPlightgrey}{HTML{{ '}' }}{d3d3d3{{ '}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanReport/list.procedure.report.tex.twig
@@ -1,0 +1,55 @@
+{% set scope = 'external' %}
+{% set count = templateVars|length %}
+{% extends '@DemosPlanCore/DemosPlanCore/pdfexport.tex.twig' %}
+{% block demosplanbundlecontent %}
+    % Überschrift
+    % Anpassen der Caption-Einstellungen
+    \captionsetup[table]{
+    labelformat=empty, % Entfernt "Table 1:"
+    singlelinecheck=false, % Ermöglicht linksbündige Ausrichtung
+    justification=raggedright, % Links ausrichten
+    font=bf, % Fettgedruckter Text für die Caption
+    }
+    \newcolumntype{L}[1]{>{\RaggedRight\makecell[\hyphenat\arraybackslash]}p{{ '{' }}#1}}
+    \begin{Huge}
+    \section*{{ '{' }}{% if procedure.name is defined %}{{ procedure.name|latex|raw }}{% else %}
+    {{ "Kein Verfahrensname"|latex|raw }}{% endif %}{{ ' - Protokoll'|latex|raw }}{{ '}' }}
+    \end{Huge}
+    {% for category, reportsTitle in templateVars %}
+        {% for title, reports in reportsTitle %}
+            {% if reports is iterable  %}
+                \begin{longtable}{|L{4cm}|L{10cm}|L{3cm}|}
+                \caption{{ '{' }}{{ category|trans|latex|raw }}{{ '}' }}
+                \hline
+                Datum & {{ title|trans|latex|raw }} & Nutzer*in \\
+                \endfirsthead
+                Datum & {{ title|trans|latex|raw }} & Nutzer*in \\
+                \endhead
+                \hline
+                {% for report in reports %}
+                    {{ report.creationDate }} & {{ report.message|trans|latex|raw }} & {{ report.userName }} \\
+                    \hline
+                {% endfor %}
+                \end{longtable}
+                \\
+            {% else %}
+                {{ '\\textbf{' }}{{ category|trans|latex|raw }}{{ '}\\\\' }}
+                {{ 'text.protocol.no.entries'|trans|latex|raw }}\\
+                \\
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+    \vspace{2cm}
+    \makeatletter % Nötig bei Verwendung von Dimens
+    \ifdim\dimexpr \pagegoal-\pagetotal\relax < 5cm
+    \newpage\vspace*{2cm} % Seitenumbruch und 2cm Abstand
+    \fi
+    \makeatother
+    {{ '______________________________'|latex|raw }}\\
+    {{ 'city'|trans|latex|raw }}, {{ 'date'|trans|latex|raw }}\\
+    \\
+    {{ '______________________________'|latex|raw }}\\
+    {{ 'signature'|trans|latex|raw }}\\
+    \\
+    {{ 'exported.on'|trans({'%date%': exportedAt.exportDate, '%time%': exportedAt.exportTime})|latex|raw }}\\
+{% endblock %}


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-11944/HHBOP-Prod-Formatierungsproblematik-in-BOP-Verfahrensprotokollen

phpWord was not able to style the table/page layout for the report-entries export as pdf the desired way. This PR switches to the latex to pdf approach

This does change the default latex filter replacement for newline indicators from ```\\``` to ```\newline``` which behaves differently when used inside tables. This was necessary to prevent signalizing the end of the table-row as done via ```\\``` to allow multi-line columns within individual table-cells.

### needs to be done
check all other .tex.twig files for broken tables/newlines

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))