### PR TITLE
fix (refs DPLAN-12022): use new permission to read technical support entry

### DIFF
--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -15,11 +15,11 @@ All rights reserved
     <p class="u-mt-0_75">
       {{ Translator.trans('support.introduction') }}
     </p>
-    <p>
+    <p v-if="hasPermission()('feature_customer_support_technical_read')">
       {{ Translator.trans('support.contact.advice') }}
     </p>
     <h3
-      v-if="contacts.length > 0"
+      v-if="Object.keys(contacts).length > 0"
       class="u-mt-0_75">
       {{ Translator.trans('support') }}
     </h3>
@@ -38,10 +38,12 @@ All rights reserved
           :reachability="{ officeHours: contact.attributes.text }" />
       </li>
     </ul>
-    <h3>
+    <h3
+      v-if="hasPermission()('feature_customer_support_technical_read')">
       {{ Translator.trans('support.technical') }}
     </h3>
-    <div class="lg:w-8/12">
+    <div class="lg:w-8/12"
+         v-if="hasPermission()('feature_customer_support_technical_read')">
       <dp-support-card
         :phone-number="Translator.trans('support.contact.number')"
         :reachability="{
@@ -56,6 +58,7 @@ All rights reserved
 
 import { mapActions, mapState } from 'vuex'
 import DpSupportCard from './DpSupportCard'
+import {hasPermission} from "@demos-europe/demosplan-ui";
 
 export default {
   name: 'DpSupport',
@@ -79,6 +82,9 @@ export default {
   },
 
   methods: {
+    hasPermission() {
+      return hasPermission
+    },
     ...mapActions('customerContact', {
       fetchContacts: 'list'
     }),

--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -43,7 +43,7 @@ All rights reserved
       {{ Translator.trans('support.technical') }}
     </h3>
     <div class="lg:w-8/12"
-         v-if="hasPermission()('feature_customer_support_technical_read')">
+         v-if="hasPermission('feature_customer_support_technical_read')">
       <dp-support-card
         :phone-number="Translator.trans('support.contact.number')"
         :reachability="{

--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -82,9 +82,6 @@ export default {
   },
 
   methods: {
-    hasPermission() {
-      return hasPermission
-    },
     ...mapActions('customerContact', {
       fetchContacts: 'list'
     }),

--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -15,7 +15,7 @@ All rights reserved
     <p class="u-mt-0_75">
       {{ Translator.trans('support.introduction') }}
     </p>
-    <p v-if="hasPermission()('feature_customer_support_technical_read')">
+    <p v-if="hasPermission('feature_customer_support_technical_read')">
       {{ Translator.trans('support.contact.advice') }}
     </p>
     <h3

--- a/client/js/components/support/DpSupport.vue
+++ b/client/js/components/support/DpSupport.vue
@@ -39,7 +39,7 @@ All rights reserved
       </li>
     </ul>
     <h3
-      v-if="hasPermission()('feature_customer_support_technical_read')">
+      v-if="hasPermission('feature_customer_support_technical_read')">
       {{ Translator.trans('support.technical') }}
     </h3>
     <div class="lg:w-8/12"

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -735,6 +735,12 @@ feature_customer_support_contact_administration:
     label: 'Enables the option to create/edit/delete supportContact entities.'
     expose: true
     loginRequired: true
+feature_customer_support_technical_read:
+    description: |-
+        Enables the technical support tab under /informationen
+    label: 'Enables the technical support tab under /informationen.'
+    expose: true
+    loginRequired: true
 feature_customer_login_support_contact_administration:
     description: |-
         Enables the option to create/edit/delete the customer supportLoginContact entity.


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12022/Als-Technischer-Support-mochte-ich-nur-Anfragen-von-bestimmten-Rollen-annehmen-um-Kosten-zu-senken.

Description:
use new permission to read technical support entry.
Rename translation key for 'Inhaltlicher Support' to 'Support'
move over some fix from main to show the Support headline if list not empty

### How to review/test
GoTo /informationen in diplanbau/fest/rog and check with and without roles.

### Tasks (optional)
- [x] waiting for question regarding another trans key: https://demosdeutschland.slack.com/archives/CAJHZ7FHV/p1720441528809099?thread_ts=1720172173.603069&cid=CAJHZ7FHV


### PR Checklist

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
