### PR TITLE
fix (refs DPLAN-11968): grant planning_agency invitation permission to fpa-only

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -134,7 +134,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Initialisiere die Permissions.
      */
-    public function initPermissions(UserInterface $user, array $context = null): PermissionsInterface
+    public function initPermissions(UserInterface $user, ?array $context = null): PermissionsInterface
     {
         $this->user = $user;
 
@@ -880,7 +880,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
     /**
      * Setzt das initiale Set von kontxtbezogenen Menue-Highlights.
      */
-    protected function initMenuhightlighting(array $context = null): void
+    protected function initMenuhightlighting(?array $context = null): void
     {
         if (null !== $context) {
             foreach ($context as $permission) {

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -317,10 +317,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 // kann empfehlungen abgeben aber nicht die Bearbeitung abschliessen
                 'field_statement_recommendation',
             ]);
-
-            $this->disablePermissions([
-                'field_procedure_adjustments_planning_agency',  // Planungsbüro einem Verfahren zuordnen
-            ]);
         }
 
         if ($this->user->hasRole(Role::PLANNING_SUPPORTING_DEPARTMENT)) {         // Fachplaner-Fachbehörde GLAUTH Kommune


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-11968/BOB-SH-Bau-Stage-Prod-Ein-Planungsburo-kann-ein-anderes-Planungsburo-einladen

Description.:
grant planning_agency invitation permission to fpa-only...

The permission ```field_procedure_adjustments_planning_agency``` was once enable for all and then disabled for private_planning_agencies exclusively within the core.

Something seems to have gone wrong when refactoring this permission...
The enabling of this permission has been removed, but at least one project did not get adjusted accordingly. It would have relied on the core turning the permission off again after it got activated within the project, which does not work....

removed the disabling of this permission here within the core as it only matters for permissions being enabled inside the core beforehand.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
