### PR TITLE
fix(refs dplan-12021): Pass Opacity to Segments Map

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -107,6 +107,7 @@
           :key="layer.name"
           :attributions="layer.attribution || ''"
           :order="layer.mapOrder + 1"
+          :opacity="layer.opacity"
           :url="layer.url"
           :layers="layer.layers"
           :projection="layer.projectionValue" />

--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -37,6 +37,12 @@ export default {
       default: 'baselayer_global'
     },
 
+    opacity: {
+      required: false,
+      type: Number,
+      default: 100
+    },
+
     order: {
       required: false,
       type: Number,
@@ -154,11 +160,12 @@ const createSourceTileWMS = (url, layers, projection, attributions, map) => {
  * @return {object} ol/layer/Tile instance
  * @see https://openlayers.org/en/latest/apidoc/module-ol_layer_Tile-TileLayer.html
  */
-const createTileLayer = (title, name, source) => {
+const createTileLayer = (title, name, source, opacity) => {
   return new TileLayer({
     title: title,
     name: name,
     preload: 10,
+    opacity: opacity / 100,
     type: 'base',
     visible: true,
     source: source

--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -107,7 +107,7 @@ export default {
       }
 
       this.source = createSourceTileWMS(this.url, this.layers, this.projection, this.defaultAttributions, this.map)
-      const layer = createTileLayer(this.title, this.name, this.source)
+      const layer = createTileLayer(this.title, this.name, this.source, this.opacity)
 
       //  Insert layer at pos 0, making it the background layer
       this.map.getLayers().insertAt(this.order, layer)

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -27,6 +27,7 @@ export default {
             'url',
             'isEnabled',
             'mapOrder',
+            'opacity',
             'hasDefaultVisibility',
             'layers',
             'projectionValue'


### PR DESCRIPTION
### Ticket
DPLAN-12021

If the Opacity is not 100% but less it should be visible in the segments-map.
