### PR TITLE
fix(refs DPLAN-11803): properly calculate inParticipation phase

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -210,6 +210,7 @@ export default {
 
     showAutoSwitchToAnalysisHint () {
       const isInParticipation = this.phaseOptions.find(option => option.value === this.selectedPhase)?.permission === 'write'
+
       return hasPermission('feature_auto_switch_to_procedure_end_phase') && this.autoSwitchPhase && isInParticipation
     },
 

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -209,7 +209,8 @@ export default {
     },
 
     showAutoSwitchToAnalysisHint () {
-      return hasPermission('feature_auto_switch_to_procedure_end_phase') && this.autoSwitchPhase && ['participation', 'earlyparticipation', 'anotherparticipation'].includes(this.selectedPhase)
+      const isInParticipation = this.phaseOptions.find(option => option.value === this.selectedPhase)?.permission === 'write'
+      return hasPermission('feature_auto_switch_to_procedure_end_phase') && this.autoSwitchPhase && isInParticipation
     },
 
     startDateId () {


### PR DESCRIPTION
all phases with a "write" permission are participation phases. So we don't have to rely of the string spelling.

### Ticket
DPLAN-11803
