### PR TITLE
fix(refs DPLAN-11964): Set empty array as empty Object for Territory

### DIFF
--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -37,7 +37,7 @@
       :max-extent="procedureMapSettings.attributes.defaultMapExtent"
       :procedure-id="procedureId"
       :procedure-coordinates="procedureMapSettings.attributes.coordinate"
-      :procedure-init-territory="procedureMapSettings.attributes.territory.length > 0 ? procedureMapSettings.attributes.territory : {}"
+      :procedure-init-territory="Array.isArray(procedureMapSettings.attributes.territory) ? {} : procedureMapSettings.attributes.territory"
       :scales="procedureMapSettings.attributes.availableScales"
       @field:update="setField" />
 

--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -37,7 +37,7 @@
       :max-extent="procedureMapSettings.attributes.defaultMapExtent"
       :procedure-id="procedureId"
       :procedure-coordinates="procedureMapSettings.attributes.coordinate"
-      :procedure-init-territory="procedureMapSettings.attributes.territory"
+      :procedure-init-territory="procedureMapSettings.attributes.territory.length > 0 ? procedureMapSettings.attributes.territory : {}"
       :scales="procedureMapSettings.attributes.availableScales"
       @field:update="setField" />
 


### PR DESCRIPTION
The Components expects an Object and can't handle (empty) Arrays. Maybe the fix should be done where ever the Array is set. But I couldn't find out where that happens (in acceptable time)

### Ticket
DPLAN-11964
