### PR TITLE
fix (refs DPLAN-12068): add interface to event dispatcher.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Segment;
 
+use DemosEurope\DemosplanAddon\Contracts\Events\AfterSegmentationEventInterface;
 use DemosEurope\DemosplanAddon\Controller\APIController;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
@@ -149,7 +150,7 @@ class DraftsInfoApiController extends APIController
             $segmentHandler->addSegments($segments);
 
             // request additional statement processing (asynchronous)
-            $eventDispatcher->dispatch(new AfterSegmentationEvent($statementHandler->getStatementWithCertainty($statementId)));
+            $eventDispatcher->dispatch(new AfterSegmentationEvent($statementHandler->getStatementWithCertainty($statementId)),AfterSegmentationEventInterface::class);
 
             $currentUser = $currentUserProvider->getUser();
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
@@ -150,7 +150,7 @@ class DraftsInfoApiController extends APIController
             $segmentHandler->addSegments($segments);
 
             // request additional statement processing (asynchronous)
-            $eventDispatcher->dispatch(new AfterSegmentationEvent($statementHandler->getStatementWithCertainty($statementId)),AfterSegmentationEventInterface::class);
+            $eventDispatcher->dispatch(new AfterSegmentationEvent($statementHandler->getStatementWithCertainty($statementId)), AfterSegmentationEventInterface::class);
 
             $currentUser = $currentUserProvider->getUser();
 


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12068#focus=Comments-4-51132.0-0

Description:
Add interface to event dispatcher.
This way the event can be caught inside addons.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
