### PR TITLE
fix(refs DPLAN-12009): Fix file copies on STN copy to different procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -66,7 +66,7 @@ class FileController extends BaseController
     {
         $fs = new Filesystem();
         // @improve T14122
-        $file = $fileService->getFileInfo($hash);
+        $file = $fileService->getFileInfo($hash, $procedureId);
 
         // ensure that procedure access check matches file procedure
         if (!$this->isValidProcedure($procedureId, $file, $strictCheck)) {

--- a/demosplan/DemosPlanCoreBundle/Entity/File.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/File.php
@@ -382,7 +382,7 @@ class File extends CoreEntity implements UuidEntityInterface, FileInterface
         return $this->procedure;
     }
 
-    public function setProcedure(?ProcedureInterface $procedure): void
+    public function setProcedure(ProcedureInterface $procedure): void
     {
         $this->procedure = $procedure;
     }

--- a/demosplan/DemosPlanCoreBundle/Entity/File.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/File.php
@@ -382,7 +382,7 @@ class File extends CoreEntity implements UuidEntityInterface, FileInterface
         return $this->procedure;
     }
 
-    public function setProcedure(ProcedureInterface $procedure): void
+    public function setProcedure(?ProcedureInterface $procedure): void
     {
         $this->procedure = $procedure;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -104,9 +104,9 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws Exception
      */
-    public function getFileInfo($hash): FileInfo
+    public function getFileInfo($hash, string $procedureId = null): FileInfo
     {
-        $file = $this->fileRepository->getFileInfo($hash);
+        $file = $this->fileRepository->getFileInfo($hash, $procedureId);
 
         if (null !== $file) {
             $path = $file->getPath();

--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -104,7 +104,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws Exception
      */
-    public function getFileInfo($hash, string $procedureId = null): FileInfo
+    public function getFileInfo($hash, ?string $procedureId = null): FileInfo
     {
         $file = $this->fileRepository->getFileInfo($hash, $procedureId);
 
@@ -340,10 +340,10 @@ class FileService extends CoreService implements FileServiceInterface
     public function saveTemporaryFile(
         string $filePath,
         string $fileName,
-        string $userId = null,
-        string $procedureId = null,
+        ?string $userId = null,
+        ?string $procedureId = null,
         ?string $virencheck = FileServiceInterface::VIRUSCHECK_SYNC,
-        string $hash = null
+        ?string $hash = null
     ): File {
         $dplanFile = new File();
         $symfonyFile = new \Symfony\Component\HttpFoundation\File\File($filePath);
@@ -605,7 +605,7 @@ class FileService extends CoreService implements FileServiceInterface
      * @throws InvalidDataException
      * @throws Throwable
      */
-    public function copyByFileString($fileString, string $procedureId = null): ?File
+    public function copyByFileString($fileString, ?string $procedureId = null): ?File
     {
         $file = $this->getFileInfoFromFileString($fileString);
 
@@ -617,7 +617,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws InvalidDataException|Throwable
      */
-    public function copy(?string $hash, string $targetProcedureId = null): ?File
+    public function copy(?string $hash, ?string $targetProcedureId = null): ?File
     {
         $fileToCopy = $this->get($hash);
         if (!$fileToCopy instanceof File) {
@@ -724,7 +724,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @return string
      */
-    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', string $existingHash = null)
+    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', ?string $existingHash = null)
     {
         // Generate a unique name for the file before saving it
         $hash = $existingHash ?? $this->createHash();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -224,8 +224,7 @@ class StatementCopier extends CoreService
         $originalAttachments = $sourceStatement->getAttachments();
         $copiedAttachments = $this->statementAttachmentService->copyAttachmentEntries(
             $originalAttachments,
-            $copiedStatement,
-            $targetProcedure
+            $copiedStatement
         );
         $copiedStatement->setAttachments($copiedAttachments);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -18,7 +18,6 @@ use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Doctrine\Generator\NCNameGenerator;
-use demosplan\DemosPlanCoreBundle\Entity\FileContainer;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\County;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Municipality;
@@ -39,6 +38,7 @@ use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\StatementReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
+use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
 use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use demosplan\DemosPlanCoreBundle\Traits\DI\RefreshElasticsearchIndexTrait;
 use Doctrine\ORM\EntityNotFoundException;
@@ -61,6 +61,7 @@ class StatementCopier extends CoreService
         private readonly CurrentUserInterface $currentUser,
         private readonly ElementsService $elementService,
         private readonly FileService $fileService,
+        private readonly FileContainerRepository $fileContainerRepository,
         IndexManager $elasticsearchIndexManager,
         private readonly MessageBagInterface $messageBag,
         private readonly PermissionsInterface $permissions,
@@ -223,7 +224,8 @@ class StatementCopier extends CoreService
         $originalAttachments = $sourceStatement->getAttachments();
         $copiedAttachments = $this->statementAttachmentService->copyAttachmentEntries(
             $originalAttachments,
-            $copiedStatement
+            $copiedStatement,
+            $targetProcedure
         );
         $copiedStatement->setAttachments($copiedAttachments);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
@@ -197,8 +197,6 @@ class StatementMover extends CoreService
                 $statementFileContainers = $this->fileContainerRepository->getStatementFileContainers($statementToMove->getId());
                 foreach ($statementFileContainers as $fileContainer) {
                     $file = $this->statementRepository->copyFile($fileContainer->getFile(), $statementToMove);
-                    //$file = $fileContainer->getFile();
-                    //$file->setProcedure($statementToMove->getProcedure());
                     $fileContainer->setFile($file);
                     $this->fileContainerRepository->updateObject($fileContainer);
                 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
@@ -28,6 +28,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use demosplan\DemosPlanCoreBundle\Logic\EntityContentChangeService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\StatementReportEntryFactory;
+use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
 use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Exception;
@@ -45,6 +46,7 @@ class StatementMover extends CoreService
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly ElementsService $elementsService,
+        private readonly FileContainerRepository $fileContainerRepository,
         private readonly PermissionsInterface $permissions,
         private readonly MessageBagInterface $messageBag,
         private readonly StatementService $statementService,
@@ -186,11 +188,35 @@ class StatementMover extends CoreService
             $lockedByAssignment = $this->statementService->isStatementObjectLockedByAssignment($statementToMove);
             if (!$lockedByAssignment) {
                 $statementToMove->setAssignee(null);
+                foreach ($statementToMove->getAttachments() as $attachment) {
+                    $file = $attachment->getFile();
+                    $file->setProcedure($targetProcedure);
+                    $attachment->setFile($file);
+                }
+                $statementFileContainers = $this->fileContainerRepository->getStatementFileContainers($statementToMove->getId());
+                foreach ($statementFileContainers as $fileContainer) {
+                    $file = $fileContainer->getFile();
+                    $file->setProcedure($statementToMove->getProcedure());
+                    $fileContainer->setFile($file);
+                    $this->fileContainerRepository->updateObject($fileContainer);
+                }
                 $updatedStatementToMove = $this->statementService->updateStatementFromObject(
                     $statementToMove,
                     true
                 );
                 // update $originalStatement to persist changes:
+                foreach ($copyOfOriginalStatementToMove->getAttachments() as $attachment) {
+                    $file = $attachment->getFile();
+                    $file->setProcedure($targetProcedure);
+                    $attachment->setFile($file);
+                }
+                $originalStatementFileContainers = $this->fileContainerRepository->getStatementFileContainers($copyOfOriginalStatementToMove->getId());
+                foreach ($originalStatementFileContainers as $originalFileContainer) {
+                    $file = $originalFileContainer->getFile();
+                    $file->setProcedure($statementToMove->getProcedure());
+                    $originalFileContainer->setFile($file);
+                    $this->fileContainerRepository->updateObject($originalFileContainer);
+                }
                 $updatedOriginalStatementToMove = $this->statementService->updateStatementFromObject(
                     $copyOfOriginalStatementToMove,
                     true,

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
 use demosplan\DemosPlanCoreBundle\Entity\File;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
 use demosplan\DemosPlanCoreBundle\Repository\StatementAttachmentRepository;
@@ -65,25 +66,38 @@ class StatementAttachmentService extends CoreService
      *
      * @return Collection<int, StatementAttachment>
      */
-    public function copyAttachmentEntries(Collection $originalAttachments, Statement $targetStatement): Collection
-    {
+    public function copyAttachmentEntries(
+        Collection $originalAttachments,
+        Statement $targetStatement,
+        ?Procedure $targetProcedure = null
+    ): Collection {
         $copiedAttachments = new ArrayCollection();
         foreach ($originalAttachments as $originalAttachment) {
             $copiedAttachments->add($this->copyToStatement(
                 $originalAttachment,
-                $targetStatement
+                $targetStatement,
+                $targetProcedure
             ));
         }
 
         return $copiedAttachments;
     }
 
-    private function copyToStatement(StatementAttachment $attachment, Statement $statement): StatementAttachment
-    {
+    private function copyToStatement(
+        StatementAttachment $attachment,
+        Statement $statement,
+        ?Procedure $targetProcedure
+    ): StatementAttachment {
+        $type = $attachment->getType();
+        $file = $attachment->getFile();
+        if (null !== $targetProcedure) {
+            $file->setProcedure($targetProcedure);
+        }
+
         return $this->createAttachment(
             $statement,
-            $attachment->getFile(),
-            $attachment->getType()
+            $file,
+            $type
         );
     }
 
@@ -101,7 +115,6 @@ class StatementAttachmentService extends CoreService
     public function createAttachment(Statement $statement, File $file, string $type): StatementAttachment
     {
         $attachment = new StatementAttachment();
-        $file->setProcedure($statement->getProcedure());
         $attachment->setFile($file);
         $attachment->setType($type);
         $attachment->setStatement($statement);

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
@@ -101,6 +101,7 @@ class StatementAttachmentService extends CoreService
     public function createAttachment(Statement $statement, File $file, string $type): StatementAttachment
     {
         $attachment = new StatementAttachment();
+        $file->setProcedure($statement->getProcedure());
         $attachment->setFile($file);
         $attachment->setType($type);
         $attachment->setStatement($statement);

--- a/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
@@ -30,7 +30,7 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
     /**
      * Hole Infos zum File.
      */
-    public function getFileInfo(string $hash): ?File
+    public function getFileInfo(string $hash, string $procedureId = null): ?File
     {
         // Der übergebene Hash ist der Ident der Datenbank
         // Die Spalte Hash bezeichnet den Namen, unter dem die Datei auf dem
@@ -38,14 +38,30 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
 
         /** @var File|null $result */
         $result = $this->findOneBy(['ident' => $hash, 'deleted' => false]);
-
+        if (null !== $result) {
+            return $result;
+        }
         // As ident and hash are historically really strangely used mistakes happened
         // be kind and try to find via hash when nothing was found by ident
-        if (null === $result) {
-            $result = $this->findOneBy(['hash' => $hash, 'deleted' => false]);
+
+        // T36732 In case the same physical file is used for multiple procedures
+        // There will be a fileInfo entity for every reference to a physical file.
+        // They share the same hash - but not necessarily the procedure
+        // - so the findOneBy method for the kindly supported hash is insufficient here.
+        $fileInfos = $this->findBy(['hash' => $hash, 'deleted' => false, 'procedure' => $procedureId]);
+        $fileInfosCount = count($fileInfos);
+        // easy - has to be this one
+        if (0 < $fileInfosCount) {
+            return reset($fileInfos);
+        }
+        $fileInfos = $this->findBy(['hash' => $hash, 'deleted' => false, 'procedure' => null]);
+        $fileInfosCount = count($fileInfos);
+        // tried our best to return the correct fileInfo - but if not successful until here - just return a matching hash
+        if (0 === $fileInfosCount) {
+            return $this->findOneBy(['hash' => $hash, 'deleted' => false]);
         }
 
-        return $result;
+        return reset($fileInfos);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
@@ -30,7 +30,7 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
     /**
      * Hole Infos zum File.
      */
-    public function getFileInfo(string $hash, string $procedureId = null): ?File
+    public function getFileInfo(string $hash, ?string $procedureId = null): ?File
     {
         // Der übergebene Hash ist der Ident der Datenbank
         // Die Spalte Hash bezeichnet den Namen, unter dem die Datei auf dem

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -138,7 +138,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     /**
      * Add new ClusterStatement, what basically is a Statement with a cluster of Statements.
      *
-     * @return statement - headStatement of the created statement-cluster
+     * @return Statement - headStatement of the created statement-cluster
      *
      * @throws Exception
      */
@@ -479,7 +479,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     /**
      * @return array<int, Statement|Segment>
      */
-    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, int $limit = null): array
+    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, ?int $limit = null): array
     {
         return parent::getEntities($conditions, $sortMethods, $offset, $limit);
     }
@@ -1011,7 +1011,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
      * StatementVotes, which are not contained in $votesToSet, will be deleted.
      * StatementVotes, which are contained in $votesToSet, will be created if not existing, or updated.
      *
-     * @param statement        $statement  - related Statement
+     * @param Statement        $statement  - related Statement
      * @param array|Collection $votesToSet - StatementVotes to set on the given Statement
      *
      * @return Collection<int, StatementVote>
@@ -1783,7 +1783,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     public function copyOriginalStatement(
         Statement $originalToCopy,
         Procedure $targetProcedure,
-        GdprConsent $gdprConsentToSet = null,
+        ?GdprConsent $gdprConsentToSet = null,
         $internIdToSet = null
     ): Statement {
         if (!$originalToCopy->isOriginal()) {

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -2031,11 +2031,9 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
             ->getStatementFileContainers($originalToCopy->getId());
 
         $fileStrings = [];
-        $copiedFileContainers = [];
         foreach ($fileContainers as $fileContainer) {
             $statementFileContainer = $this->copyFileContainer($fileContainer, $newOriginalStatement);
             $fileStrings[] = $statementFileContainer->getFileString();
-            $copiedFileContainers[] = $statementFileContainer;
         }
 
         $newOriginalStatement->setFiles($fileStrings);

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -2058,7 +2058,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         return $statementFileContainer;
     }
 
-    private function copyFile(File $sourceFile, Statement $targetStatement): File
+    public function copyFile(File $sourceFile, Statement $targetStatement): File
     {
         $fileCopy = $this->getFileRepository()->copyFile($sourceFile);
         $fileCopy->setProcedure($targetStatement->getProcedure());

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -1820,7 +1820,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         $newOriginalStatement->setSubmit($originalToCopy->getSubmitObject()->add(new DateInterval('PT1S')));
         $newStatementMeta = clone $originalToCopy->getMeta();
         $newOriginalStatement->setMeta($newStatementMeta);
-
+        $newOriginalStatement->setProcedure($targetProcedure);
         $newOriginalStatement->setChildren(null);
 
         /**
@@ -1869,7 +1869,6 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         }
 
         $newOriginalStatement->setExternId($newExternId);
-        $newOriginalStatement->setProcedure($targetProcedure);
 
         if ($originalToCopy->getProcedureId() !== $targetProcedure->getId()) {
             // remove all tags, because procedure specific -> impossible to keep:
@@ -2032,9 +2031,11 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
             ->getStatementFileContainers($originalToCopy->getId());
 
         $fileStrings = [];
+        $copiedFileContainers = [];
         foreach ($fileContainers as $fileContainer) {
             $statementFileContainer = $this->copyFileContainer($fileContainer, $newOriginalStatement);
             $fileStrings[] = $statementFileContainer->getFileString();
+            $copiedFileContainers[] = $statementFileContainer;
         }
 
         $newOriginalStatement->setFiles($fileStrings);


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12009/ROBOB-Prod-Bei-verschobenen-STN-wurden-in-der-Ubersicht-die-Links-von-Anhangen-nicht-angepasst

Description:
All original statement creations where handling their file copy tasks correct as far as setting individual file-entries for all of them. The only problem was a procedureId that was set to late on the new statement in order to be used for those files.

on copy there was a method StatementAttachmentService::copyToStatement that made use of a createAttachment
method that did not create a new file-entry for the attachment but set the same file-reference. Changed this method to use the correct one from the statement-repository.

on move it was more tricky.
When creating new statements - after their originals are done we create the (normal) statements by... ```StatementHandler::createNonOriginalStatement::copyStatementObjectWithinProcedureWithRelatedFiles::copyStatementObjectWithinProcedure::copyAttachmentEntries::copyToStatement``` ... in the end calling the same problematic method as described above. Therefore The statement and its original use the same file-reference inside their containers.
This makes it necessary to create new file-entries for all moved files - as otherwise the files would be shared with the original-statement which remains inside the source procedure.
But not that quick - by changing the ```copyToStatement``` method - the from now on newly-created statements wont share their statement-attachment files with its original anymore. So only the weitere-attachments need to get new files created on move. The statement-attachment is fine with just an update of its procedure.

The picked changes from the here linked PR are necessary to access the correct now procedure related file by a given hash.

### Linked PRs (optional)
picked part of the fix from:
https://github.com/demos-europe/demosplan-core/pull/2850


### Tasks (optional)
Fix wrong db-entries of failed copies via migration?

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
