### PR TITLE
feature (ref DPLAN11903): use timezone to export right time

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -75,7 +75,7 @@ class DemosPlanReportController extends BaseController
         $slugify = new Slugify();
         $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);
 
-        $currentTime = Carbon::now();
+        $currentTime = Carbon::now()->timezone('Europe/Berlin');
         $reportMeta = [
             'name'       => $procedure->getName(),
             'exportDate' => $currentTime->format('d.m.Y'),

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -70,7 +70,7 @@ class DemosPlanReportController extends BaseController
         NameGenerator $nameGenerator,
         PermissionsInterface $permissions,
         ProcedureHandler $procedureHandler,
-                              $procedureId
+        $procedureId
     ): Response {
         $slugify = new Slugify();
         $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11903/falsche-Zeitangabe-PDF-Export-Verfahrensprotokoll


Description: set timezone to export right time

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
