### PR TITLE
chore: use MessageBagInterface in DI to show all messages

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/DocumentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/DocumentHandler.php
@@ -288,21 +288,21 @@ class DocumentHandler extends CoreHandler
 
             if ($fileInfo->isDir()) {
                 $result[] = [
-                  'isDir'   => true,
-                  'title'   => $fileInfo->getFilename(),
-                  'path'    => $fileInfo->getPathname(),
-                  'entries' => $this->elementImportDirToArray(
-                      $fileInfo->getPathname()
-                  ),
+                    'isDir'   => true,
+                    'title'   => $fileInfo->getFilename(),
+                    'path'    => $fileInfo->getPathname(),
+                    'entries' => $this->elementImportDirToArray(
+                        $fileInfo->getPathname()
+                    ),
                 ];
             } else {
                 // utf8_decode filename, weil Zip Umlaute kaputt macht
                 $filename = utf8_decode($fileInfo->getFilename());
 
                 $result[] = [
-                  'isDir'  => false,
-                  'title'  => $filename,
-                    'path' => $fileInfo->getPathname(),
+                    'isDir'  => false,
+                    'title'  => $filename,
+                    'path'   => $fileInfo->getPathname(),
                 ];
 
                 // Speichere die Anzahl der Dateien in die Session

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/DocumentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/DocumentHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\Document;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\ElementsInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
@@ -19,7 +20,6 @@ use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use demosplan\DemosPlanCoreBundle\Exception\VirusFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\ResourceTypeService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
@@ -57,7 +57,7 @@ class DocumentHandler extends CoreHandler
         private readonly ElementHandler $elementHandler,
         ElementsService $elementsService,
         private readonly FileService $fileService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly ParagraphService $paragraphService,
         private readonly ProcedureService $procedureService,
         SingleDocumentHandler $singleDocumentHandler,

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementHandler.php
@@ -303,8 +303,6 @@ class ElementHandler extends CoreHandler
      * Kategorie löschen.
      *
      * @param array|string $idents
-     *
-     * @return mixed
      */
     public function administrationElementDeleteHandler($idents)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementHandler.php
@@ -11,12 +11,12 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\Document;
 
 use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Logic\ArrayHelper;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Exception;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -31,7 +31,7 @@ class ElementHandler extends CoreHandler
      */
     protected $elementsWitchChildrenFlat;
 
-    public function __construct(private readonly ArrayHelper $arrayHelper, private readonly ElementsService $elementService, private readonly FlashMessageHandler $flashMessageHandler, MessageBag $messageBag, private readonly PermissionsInterface $permissions, private readonly TranslatorInterface $translator)
+    public function __construct(private readonly ArrayHelper $arrayHelper, private readonly ElementsService $elementService, private readonly FlashMessageHandler $flashMessageHandler, MessageBagInterface $messageBag, private readonly PermissionsInterface $permissions, private readonly TranslatorInterface $translator)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphHandler.php
@@ -200,10 +200,10 @@ class ParagraphHandler extends CoreHandler
             return $document;
         } elseif (isset($documentId)
             && (
-                $this->service->isDirectParentOf($parentParagraphId, $documentId) ||
-                (
-                    null === $parentParagraphId &&
-                    !$this->service->hasParent($document['ident'])
+                $this->service->isDirectParentOf($parentParagraphId, $documentId)
+                || (
+                    null === $parentParagraphId
+                    && !$this->service->hasParent($document['ident'])
                 )
             )
         ) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphHandler.php
@@ -10,9 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Document;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ParagraphHandler extends CoreHandler
@@ -20,7 +20,7 @@ class ParagraphHandler extends CoreHandler
     /** @var ParagraphService */
     protected $service;
 
-    public function __construct(ParagraphService $paragraphService, private readonly FlashMessageHandler $flashMessageHandler, MessageBag $messageBag, private readonly TranslatorInterface $translator)
+    public function __construct(ParagraphService $paragraphService, private readonly FlashMessageHandler $flashMessageHandler, MessageBagInterface $messageBag, private readonly TranslatorInterface $translator)
     {
         parent::__construct($messageBag);
         $this->service = $paragraphService;

--- a/demosplan/DemosPlanCoreBundle/Logic/Faq/FaqHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Faq/FaqHandler.php
@@ -34,9 +34,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
+use Illuminate\Support\Collection;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Illuminate\Support\Collection;
 use UnexpectedValueException;
 
 class FaqHandler extends CoreHandler implements FaqHandlerInterface
@@ -181,7 +181,7 @@ class FaqHandler extends CoreHandler implements FaqHandlerInterface
      * @throws CustomerNotFoundException
      * @throws MessageBagException
      */
-    public function addOrUpdateFaq($data, Faq $faq = null): ?Faq
+    public function addOrUpdateFaq($data, ?Faq $faq = null): ?Faq
     {
         // improve:
         // Sanitize and validate fields

--- a/demosplan/DemosPlanCoreBundle/Logic/Faq/FaqHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Faq/FaqHandler.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Faq;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FaqCategoryInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FaqInterface;
 use DemosEurope\DemosplanAddon\Contracts\Handler\FaqHandlerInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Category;
 use demosplan\DemosPlanCoreBundle\Entity\Faq;
 use demosplan\DemosPlanCoreBundle\Entity\FaqCategory;
@@ -25,7 +26,6 @@ use demosplan\DemosPlanCoreBundle\Exception\FaqNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Repository\RoleRepository;
@@ -47,7 +47,7 @@ class FaqHandler extends CoreHandler implements FaqHandlerInterface
     protected $contentService;
 
     public function __construct(
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly TranslatorInterface $translator,
         private readonly EntityManagerInterface $entityManager,
         private readonly FaqResourceType $faqResourceType,

--- a/demosplan/DemosPlanCoreBundle/Logic/Forum/ForumHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Forum/ForumHandler.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Forum;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
@@ -17,7 +18,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use Exception;
@@ -51,7 +51,7 @@ class ForumHandler extends CoreHandler
         private readonly FlashMessageHandler $flashMessageHandler,
         ForumService $forumService,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly OrgaService $orgaService,
         private readonly TranslatorInterface $translator,
         UserService $userService

--- a/demosplan/DemosPlanCoreBundle/Logic/Forum/ForumHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Forum/ForumHandler.php
@@ -215,6 +215,7 @@ class ForumHandler extends CoreHandler
             // ansonsten  Platzhaltertext für Moderation
             $data['text'] = 'Moderator';
         }
+
         // die Beiträge  werden mit leeren Variablen überschrieben um einen Platzhalter zu generieren
         return $this->forumService->updateThreadEntry($threadEntry['ident'], $data);
     }
@@ -382,8 +383,6 @@ class ForumHandler extends CoreHandler
      * @param string $releaseId
      * @param array  $data
      * @param int    $limitForVotes
-     *
-     * @return mixed
      */
     public function saveOnlineVotesOfUserStories($releaseId, $data, $limitForVotes)
     {
@@ -443,8 +442,6 @@ class ForumHandler extends CoreHandler
 
     /**
      * Get a list of all releases.
-     *
-     * @return mixed
      */
     public function getReleases()
     {
@@ -455,8 +452,6 @@ class ForumHandler extends CoreHandler
      * Get all info of one release.
      *
      * @param string $releaseId
-     *
-     * @return mixed
      */
     public function getSingleRelease($releaseId)
     {
@@ -563,8 +558,6 @@ class ForumHandler extends CoreHandler
      * Get all info and user stories of one release.
      *
      * @param string $releaseId
-     *
-     * @return mixed
      */
     public function getUserStoriesForRelease($releaseId)
     {
@@ -575,8 +568,6 @@ class ForumHandler extends CoreHandler
      * Get all info about one user story.
      *
      * @param string $storyId
-     *
-     * @return mixed
      */
     public function getUserStory($storyId)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Help/HelpHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Help/HelpHandler.php
@@ -10,16 +10,16 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Help;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Help\ContextualHelp;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\MissingPostParameterException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Exception;
 
 class HelpHandler extends CoreHandler
 {
-    public function __construct(MessageBag $messageBag, private readonly HelpService $helpService)
+    public function __construct(MessageBagInterface $messageBag, private readonly HelpService $helpService)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/News/GlobalNewsHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/News/GlobalNewsHandler.php
@@ -11,12 +11,12 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\News;
 
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
-use Doctrine\ORM\ORMException;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\TransactionRequiredException;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\TransactionRequiredException;
 use Exception;
 use ReflectionException;
 

--- a/demosplan/DemosPlanCoreBundle/Logic/News/GlobalNewsHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/News/GlobalNewsHandler.php
@@ -10,13 +10,13 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\News;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\TransactionRequiredException;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Exception;
 use ReflectionException;
 
@@ -27,7 +27,7 @@ class GlobalNewsHandler extends CoreHandler
      */
     protected $contentService;
 
-    public function __construct(ContentService $contentService, MessageBag $messageBag)
+    public function __construct(ContentService $contentService, MessageBagInterface $messageBag)
     {
         parent::__construct($messageBag);
         $this->contentService = $contentService;

--- a/demosplan/DemosPlanCoreBundle/Logic/News/NewsHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/News/NewsHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\News;
 
 use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\GlobalContent;
 use demosplan\DemosPlanCoreBundle\Entity\News\News;
@@ -20,7 +21,6 @@ use demosplan\DemosPlanCoreBundle\Logic\ArrayHelper;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use demosplan\DemosPlanCoreBundle\Repository\ContentRepository;
 use demosplan\DemosPlanCoreBundle\Repository\NewsRepository;
@@ -55,7 +55,7 @@ class NewsHandler extends CoreHandler
         private readonly FlashMessageHandler $flashMessageHandler,
         GlobalNewsHandler $globalNewsHandler,
         ManagerRegistry $doctrine,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         PermissionsInterface $permissions,
         ProcedureNewsService $procedureNewsService,
         private readonly TranslatorInterface $translator

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\Procedure;
 
 use DemosEurope\DemosplanAddon\Contracts\Handler\ProcedureHandlerInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\NotificationReceiver;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
@@ -27,7 +28,6 @@ use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\PublicAffairsAgentHandler;
@@ -88,7 +88,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         private readonly EntityManagerInterface $entityManager,
         Environment $twig,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly OrgaService $orgaService,
         private readonly PermissionsInterface $permissions,
         private readonly PrepareReportFromProcedureService $prepareReportFromProcedureService,

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -38,9 +38,9 @@ use demosplan\DemosPlanCoreBundle\ValueObject\Procedure\InvitationEmailResult;
 use demosplan\DemosPlanCoreBundle\ValueObject\SettingsFilter;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use Illuminate\Support\Collection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
-use Illuminate\Support\Collection;
 use Twig\Environment;
 
 use function array_key_exists;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureProposalHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureProposalHandler.php
@@ -10,19 +10,19 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Procedure;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureProposal;
 use demosplan\DemosPlanCoreBundle\Logic\ArrayHelper;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Map\MapService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Services\ApiResourceService;
 use demosplan\DemosPlanCoreBundle\Transformers\Map\MapOptionsTransformer;
 use Exception;
 
 class ProcedureProposalHandler extends CoreHandler
 {
-    public function __construct(private readonly ArrayHelper $arrayHelper, MessageBag $messageBag, private readonly ProcedureProposalService $procedureProposalService, private readonly ApiResourceService $resourceService, private readonly MapService $mapService)
+    public function __construct(private readonly ArrayHelper $arrayHelper, MessageBagInterface $messageBag, private readonly ProcedureProposalService $procedureProposalService, private readonly ApiResourceService $resourceService, private readonly MapService $mapService)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -15,6 +15,7 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PreNewProcedureCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Form\Procedure\AbstractProcedureFormTypeInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Contracts\Services\ProcedureServiceStorageInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
@@ -32,7 +33,6 @@ use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\ArrayHelper;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\LegacyFlashMessageCreator;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ProcedureReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
@@ -95,7 +95,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         private readonly LoggerInterface $logger,
         private readonly LegacyFlashMessageCreator $legacyFlashMessageCreator,
         private readonly MasterTemplateService $masterTemplateService,
-        private readonly MessageBag $messageBag,
+        private readonly MessageBagInterface $messageBag,
         private readonly NotificationReceiverRepository $notificationReceiverRepository,
         private readonly OrgaService $orgaService,
         private readonly PermissionsInterface $permissions,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
 use Carbon\Carbon;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\HashedQuery;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementFragment;
@@ -23,7 +24,6 @@ use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceOu
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\HashedQueryService;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\ViewOrientation;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\UserFilterSetService;
 use demosplan\DemosPlanCoreBundle\Logic\SimpleSpreadsheetService;
@@ -68,7 +68,7 @@ class AssessmentHandler extends CoreHandler
         private readonly CurrentUserInterface $currentUser,
         private readonly GlobalConfig $globalConfig,
         HashedQueryService $filterSetService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly PresentableOriginalStatementFactory $presentableOriginalStatementFactory,
         private readonly ProcedureService $procedureService,
         private readonly RouterInterface $router,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementHandler.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\NotificationReceiver;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatement;
@@ -22,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\Repository\NotificationReceiverRepository;
@@ -90,7 +90,7 @@ class DraftStatementHandler extends CoreHandler
         FileService $fileService,
         private readonly GlobalConfigInterface $globalConfig,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         ProcedureHandler $procedureHandler,
         RouterInterface $router,
         TranslatorInterface $translator,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeHandler.php
@@ -11,12 +11,12 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 
@@ -50,7 +50,7 @@ class StatementAnonymizeHandler extends CoreHandler
     public function __construct(
         CurrentUserInterface $currentUserInterface,
         private readonly ManagerRegistry $doctrine,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly PermissionsInterface $permissions,
         private readonly StatementAnonymizeService $statementAnonymizeService
     ) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeHandler.php
@@ -133,8 +133,8 @@ class StatementAnonymizeHandler extends CoreHandler
     private function deleteHistory(array $actions, Statement $statement): void
     {
         if (array_key_exists(self::DELETE_STATEMENT_TEXT_HISTORY, $actions)
-            && true === $actions[self::DELETE_STATEMENT_TEXT_HISTORY] &&
-            $this->permissions->hasPermission('feature_statement_text_history_delete')
+            && true === $actions[self::DELETE_STATEMENT_TEXT_HISTORY]
+            && $this->permissions->hasPermission('feature_statement_text_history_delete')
         ) {
             $this->statementAnonymizeService->deleteHistoryOfTextsRecursively($statement, true);
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
@@ -444,7 +444,7 @@ class StatementFilterHandler extends CoreHandler
                 // FB or FPA
                 'hasPermission' => $this->permissions->hasPermissions(
                     [
-                    'area_admin_assessmenttable',
+                        'area_admin_assessmenttable',
                         'feature_documents_category_use_paragraph',
                     ]),
                 'type'          => 'statement',

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
@@ -10,9 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use Exception;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -22,7 +22,7 @@ class StatementFilterHandler extends CoreHandler
     /** @var Permissions */
     protected $permissions;
 
-    public function __construct(MessageBag $messageBag, PermissionsInterface $permissions, private readonly TranslatorInterface $translator)
+    public function __construct(MessageBagInterface $messageBag, PermissionsInterface $permissions, private readonly TranslatorInterface $translator)
     {
         parent::__construct($messageBag);
         $this->permissions = $permissions;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -105,6 +105,7 @@ use Doctrine\ORM\Query\QueryException;
 use Exception;
 use Goodby\CSV\Import\Standard\Interpreter;
 use Goodby\CSV\Import\Standard\Lexer;
+use Illuminate\Support\Collection;
 use ReflectionException;
 use Symfony\Component\Finder\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraints\Email;
@@ -114,7 +115,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
-use Illuminate\Support\Collection;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -3526,7 +3526,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
      * @param bool $ignoreAssignmentOfStatement     - Determines if a assignment statement will be updated regardless
      * @param bool $ignoreAssignmentOfHeadStatement - Determines if a assignment headStatement will be updated regardless
      *
-     * @return statement|bool - false the given statementToAdd was not added to the given headStatement,
+     * @return Statement|bool - false the given statementToAdd was not added to the given headStatement,
      *                        otherwise the headStatement
      */
     public function addStatementToCluster(

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -14,6 +14,7 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\ManualStatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Handler\StatementHandlerInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\ResourceObject;
 use DemosEurope\DemosplanAddon\Utilities\Json;
@@ -76,7 +77,6 @@ use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiActionService;
 use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
@@ -222,7 +222,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         private readonly GlobalConfigInterface $globalConfig,
         private readonly JsonApiActionService $jsonApiActionService,
         MailService $mailService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         MunicipalityService $municipalityService,
         private readonly OrgaService $orgaService,
         ParagraphService $paragraphService,

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CustomerHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CustomerHandler.php
@@ -10,13 +10,13 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Branding;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\CustomerResourceInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
@@ -33,7 +33,7 @@ class CustomerHandler extends CoreHandler
 
     public function __construct(
         CustomerService $customerService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         private readonly PermissionsInterface $permissions,
         private readonly ValidatorInterface $validator)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/User/CustomerHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/CustomerHandler.php
@@ -21,8 +21,8 @@ use demosplan\DemosPlanCoreBundle\ValueObject\User\CustomerResourceInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use function array_key_exists;
 
+use function array_key_exists;
 
 class CustomerHandler extends CoreHandler
 {

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OrgaHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OrgaHandler.php
@@ -11,13 +11,13 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\DataProtectionOrganisation;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\ImprintOrganisation;
 use Exception;
@@ -25,7 +25,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OrgaHandler extends CoreHandler
 {
-    public function __construct(private readonly OrgaService $orgaService, MessageBag $messageBag, private readonly TranslatorInterface $translator, private readonly CurrentUserInterface $currentUser)
+    public function __construct(private readonly OrgaService $orgaService, MessageBagInterface $messageBag, private readonly TranslatorInterface $translator, private readonly CurrentUserInterface $currentUser)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/PublicAffairsAgentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/PublicAffairsAgentHandler.php
@@ -10,12 +10,12 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Exception\PublicAffairsAgentNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Exception;
 
 class PublicAffairsAgentHandler extends CoreHandler
@@ -25,7 +25,7 @@ class PublicAffairsAgentHandler extends CoreHandler
         return $this->orgaHandler;
     }
 
-    public function __construct(private readonly OrgaHandler $orgaHandler, MessageBag $messageBag)
+    public function __construct(private readonly OrgaHandler $orgaHandler, MessageBagInterface $messageBag)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/RoleHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/RoleHandler.php
@@ -11,15 +11,15 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use Webmozart\Assert\Assert;
 
 class RoleHandler extends CoreHandler
 {
-    public function __construct(private readonly RoleService $roleService, MessageBag $messageBag)
+    public function __construct(private readonly RoleService $roleService, MessageBagInterface $messageBag)
     {
         parent::__construct($messageBag);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\User;
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Contracts\UserHandlerInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\ResourceObject;
@@ -50,7 +51,6 @@ use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\FlashMessageHandler;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftStatementService;
 use demosplan\DemosPlanCoreBundle\Types\UserFlagKey;
@@ -141,7 +141,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
         private readonly GlobalConfigInterface $globalConfig,
         MailService $mailService,
         private readonly MasterToebService $masterToebService,
-        MessageBag $messageBag,
+        MessageBagInterface $messageBag,
         OrgaHandler $orgaHandler,
         OrgaService $orgaService,
         private readonly PasswordValidator $passwordValidator,

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -62,6 +62,7 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
+use Illuminate\Support\Collection;
 use LogicException;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -74,7 +75,6 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Illuminate\Support\Collection;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -359,7 +359,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
     /**
      * @throws Exception
      */
-    protected function validateUserData(array $data, string $userId = null): array
+    protected function validateUserData(array $data, ?string $userId = null): array
     {
         $mandatoryErrors = [];
         $new = null === $userId;
@@ -370,11 +370,11 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
                 || (array_key_exists('lastname', $data) && '' === trim((string) $data['lastname']))
             ) {
                 $mandatoryErrors[] = [
-                'type'    => 'error',
-                'message' => $this->flashMessageHandler->createFlashMessage(
-                    'mandatoryError', ['fieldLabel' => $this->translator->trans('name.last')]
-                ),
-            ];
+                    'type'    => 'error',
+                    'message' => $this->flashMessageHandler->createFlashMessage(
+                        'mandatoryError', ['fieldLabel' => $this->translator->trans('name.last')]
+                    ),
+                ];
             }
         }
         if (!array_key_exists('organisationId', $data) || '' === trim((string) $data['organisationId'])) {
@@ -520,7 +520,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
                     'userName' => $user->getFullname(),
                     'token'    => $hash,
                     'uId'      => $user->getId(),
-                    ],
+                ],
                     'projectName' => $this->demosplanConfig->getProjectName(),
                 ]
             );
@@ -843,7 +843,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
      *
      * @param string $userId indicates the user whose data will be wiped
      *
-     * @return user|bool - The wiped User if all operations are successful, otherwise false
+     * @return User|bool - The wiped User if all operations are successful, otherwise false
      */
     public function wipeUserData($userId)
     {
@@ -1752,7 +1752,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
      *
      * @param string $organisationId Indicates the organisation whose data will be wiped
      *
-     * @return orga|array The wiped organisation if all operations are successful, otherwise errors
+     * @return Orga|array The wiped organisation if all operations are successful, otherwise errors
      *
      * @throws MessageBagException
      */

--- a/tests/backend/core/Core/Functional/MessageBagTest.php
+++ b/tests/backend/core/Core/Functional/MessageBagTest.php
@@ -10,7 +10,7 @@
 
 namespace Tests\Core\Core\Functional;
 
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use Tests\Base\FunctionalTestCase;
 use Illuminate\Support\Collection;
 
@@ -22,14 +22,14 @@ use Illuminate\Support\Collection;
 class MessageBagTest extends FunctionalTestCase
 {
     /**
-     * @var MessageBag
+     * @var MessageBagInterface
      */
     protected $sut;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->sut = self::$container->get(MessageBag::class);
+        $this->sut = self::$container->get(MessageBagInterface::class);
     }
 
     public function testSetStringMessages()

--- a/tests/backend/core/Core/Functional/MessageBagTest.php
+++ b/tests/backend/core/Core/Functional/MessageBagTest.php
@@ -11,8 +11,8 @@
 namespace Tests\Core\Core\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
-use Tests\Base\FunctionalTestCase;
 use Illuminate\Support\Collection;
+use Tests\Base\FunctionalTestCase;
 
 /**
  * Teste MessageBag.

--- a/tests/backend/core/Core/Unit/Handler/CoreHandlerTest.php
+++ b/tests/backend/core/Core/Unit/Handler/CoreHandlerTest.php
@@ -25,7 +25,7 @@ use Tests\Base\UnitTestCase;
 class CoreHandlerTest extends UnitTestCase
 {
     /**
-     * @var \demosplan\DemosPlanCoreBundle\Logic\CoreHandler
+     * @var CoreHandler
      */
     protected $coreHandler;
 

--- a/tests/backend/core/Core/Unit/Handler/CoreHandlerTest.php
+++ b/tests/backend/core/Core/Unit/Handler/CoreHandlerTest.php
@@ -10,8 +10,8 @@
 
 namespace Tests\Core\Core\Unit\Handler;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Logic\CoreHandler;
-use demosplan\DemosPlanCoreBundle\Logic\MessageBag;
 use stdClass;
 use Symfony\Component\HttpFoundation\FileBag;
 use Tests\Base\UnitTestCase;
@@ -34,7 +34,7 @@ class CoreHandlerTest extends UnitTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->coreHandler = new CoreHandler(self::$container->get(MessageBag::class));
+        $this->coreHandler = new CoreHandler(self::$container->get(MessageBagInterface::class));
 
         if (is_dir($this->getUploadDir().'/coreHandlerUpload_test/')) {
             $this->deleteTestDir();


### PR DESCRIPTION
MessageBagInterface should be used in DI everywhere, as otherwise another instance of the MessageBag is instantiated and the collected messages are never shown in the interface

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
