### PR TITLE
feat (DPLAN-11982): images in segments export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -12,42 +12,73 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
 use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Exception;
 
-/**
- * Handles the conversion of image tags in HTML content to clickable links with references.
- *
- * This class `ImageLinkConverter` is designed to process HTML content, specifically focusing on converting `<img>` tags
- * into clickable references. It manages a collection of image references, ensuring each image is uniquely identified
- * and accessible. The conversion process involves parsing the HTML, identifying image tags, and replacing them with
- * standardized clickable links that reference the images' absolute paths or identifiers.
- *
- * Usage involves creating an instance with a dependency on a `FileService` for resolving image paths, and then calling
- * the `convert` method with HTML content and an external identifier to process the content.
- */
 final class ImageLinkConverter
 {
     public const IMAGE_REFERENCE_RECOMMENDATION_SUFFIX = '_Darstellung_Erw_';
     private const IMAGE_REFERENCE_RECOMMENDATION_FORMAT = '%s'.self::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'%03d';
+    public const IMAGES_KEY_RECOMMENDATION = 'recommendation';
+    public const IMAGES_KEY_SEGMENTS = 'segments';
+    /**
+     * @var array<int, array<string, array<int, ImageReference>>>
+     */
+    private array $images = [];
     /**
      * @var array<int, ImageReference>
      */
-    private array $images = [];
+    private array $currentImagesFromRecommendationText = [];
     private int $imageCounter = 1;
 
-    public function __construct(private readonly FileService $fileService)
+    public function __construct(private readonly HtmlHelper $htmlHelper, private readonly FileService $fileService)
     {
     }
 
-    public function convert(string $html5, string $statementExternId, bool $asLinkedReference = true): string
-    {
-        $xml = str_replace('<br>', '<br/>', $html5);
+    public function convert(
+        Segment $segment,
+        string $statementExternId,
+        bool $asLinkedReference = true
+    ): ConvertedSegment {
+        $segmentText = $segment->getText();
+        $recommendationText = $segment->getRecommendation();
+        $xmlSegmentText = str_replace('<br>', '<br/>', $segmentText);
+        $xmlRecommendationText = str_replace('<br>', '<br/>', $recommendationText);
 
+        $xmlSegmentText = $this->htmlHelper->updateLinkTextWithClass(
+            $xmlSegmentText,
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+            $statementExternId.'_'
+        );
+        $imageReferencesFromSegmentText = $this->htmlHelper->extractImageDataByClass(
+            $xmlSegmentText,
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL
+        );
+
+        $this->resetCurrentImagesFromRecommendationText();
+        $xmlRecommendationText = $this->replaceImagesWithTextReferences(
+            $xmlRecommendationText,
+            $statementExternId,
+            $asLinkedReference
+        );
+
+        $this->images[] = [
+            self::IMAGES_KEY_RECOMMENDATION => $this->currentImagesFromRecommendationText,
+            self::IMAGES_KEY_SEGMENTS => $imageReferencesFromSegmentText,
+        ];
+
+        return new ConvertedSegment($xmlSegmentText, $xmlRecommendationText);
+    }
+
+    private function replaceImagesWithTextReferences(string $html, string $statementExternId, bool $asLinkedReference): string
+    {
         return preg_replace_callback(
             '/<img(.*?)(src="(.*?)")(.*?)\/?>/i',
             fn (array $matches) => $this->processImageTag($matches, $statementExternId, $asLinkedReference),
-            $xml
+            $html
         );
     }
 
@@ -66,7 +97,7 @@ final class ImageLinkConverter
         }
 
         $image = new ImageReference($imageReference, $this->getAbsoluteImagePath($hash));
-        $this->images[] = $image;
+        $this->currentImagesFromRecommendationText[] = $image;
         ++$this->imageCounter;
 
         return $imageReferenceLink;
@@ -80,6 +111,11 @@ final class ImageLinkConverter
             // The src attribute probably didn't contain a hash --> assume it is a valid path instead.
             return trim($hash);
         }
+    }
+
+    private function resetCurrentImagesFromRecommendationText(): void
+    {
+        $this->currentImagesFromRecommendationText = [];
     }
 
     public function getImages(): array

--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -67,7 +67,7 @@ final class ImageLinkConverter
 
         $this->images[] = [
             self::IMAGES_KEY_RECOMMENDATION => $this->currentImagesFromRecommendationText,
-            self::IMAGES_KEY_SEGMENTS => $imageReferencesFromSegmentText,
+            self::IMAGES_KEY_SEGMENTS       => $imageReferencesFromSegmentText,
         ];
 
         return new ConvertedSegment($xmlSegmentText, $xmlRecommendationText);

--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -77,15 +77,15 @@ final class ImageLinkConverter
     {
         $asLinkedReference
             ? $text = $this->htmlHelper->updateLinkTextWithClass(
-            $text,
-            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
-            $prefix
-        )
+                $text,
+                HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+                $prefix
+            )
             : $text = $this->htmlHelper->removeLinkTagsByClass(
-            $text,
-            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
-            $prefix
-        );
+                $text,
+                HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+                $prefix
+            );
 
         return $text;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -21,6 +21,7 @@ use Exception;
 final class ImageLinkConverter
 {
     public const IMAGE_REFERENCE_RECOMMENDATION_SUFFIX = '_Darstellung_Erw_';
+    public const IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX = '_Darstellung_Stell_';
     private const IMAGE_REFERENCE_RECOMMENDATION_FORMAT = '%s'.self::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'%03d';
     public const IMAGES_KEY_RECOMMENDATION = 'recommendation';
     public const IMAGES_KEY_SEGMENTS = 'segments';
@@ -48,15 +49,14 @@ final class ImageLinkConverter
         $xmlSegmentText = str_replace('<br>', '<br/>', $segmentText);
         $xmlRecommendationText = str_replace('<br>', '<br/>', $recommendationText);
 
-        $xmlSegmentText = $this->htmlHelper->updateLinkTextWithClass(
-            $xmlSegmentText,
-            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
-            $statementExternId.'_'
-        );
+        $prefix = $statementExternId.'_';
         $imageReferencesFromSegmentText = $this->htmlHelper->extractImageDataByClass(
             $xmlSegmentText,
-            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+            $prefix
         );
+
+        $xmlSegmentText = $this->updateSegmentText($asLinkedReference, $xmlSegmentText, $prefix);
 
         $this->resetCurrentImagesFromRecommendationText();
         $xmlRecommendationText = $this->replaceImagesWithTextReferences(
@@ -71,6 +71,23 @@ final class ImageLinkConverter
         ];
 
         return new ConvertedSegment($xmlSegmentText, $xmlRecommendationText);
+    }
+
+    private function updateSegmentText(bool $asLinkedReference, string $text, string $prefix): string
+    {
+        $asLinkedReference
+            ? $text = $this->htmlHelper->updateLinkTextWithClass(
+            $text,
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+            $prefix
+        )
+            : $text = $this->htmlHelper->removeLinkTagsByClass(
+            $text,
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+            $prefix
+        );
+
+        return $text;
     }
 
     private function replaceImagesWithTextReferences(string $html, string $statementExternId, bool $asLinkedReference): string

--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Exception;
 
 /**
@@ -30,7 +31,7 @@ final class ImageLinkConverter
     public const IMAGE_REFERENCE_RECOMMENDATION_SUFFIX = '_Darstellung_Erw_';
     private const IMAGE_REFERENCE_RECOMMENDATION_FORMAT = '%s'.self::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'%03d';
     /**
-     * @var array<string, string>
+     * @var array<int, ImageReference>
      */
     private array $images = [];
     private int $imageCounter = 1;
@@ -64,7 +65,8 @@ final class ImageLinkConverter
                 .$imageReference.'</a>';
         }
 
-        $this->images[$imageReference] = $this->getAbsoluteImagePath($hash);
+        $image = new ImageReference($imageReference, $this->getAbsoluteImagePath($hash));
+        $this->images[] = $image;
         ++$this->imageCounter;
 
         return $imageReferenceLink;

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
@@ -36,8 +36,8 @@ class ImageManager
         }
         $imageSpaceCurrentlyUsed = 0;
         $section->addPageBreak();
-        foreach ($images as $imageReference => $imagePath) {
-            [$width, $height] = getimagesize($imagePath);
+        foreach ($images as $image) {
+            [$width, $height] = getimagesize($image->getImagePath());
             [$maxWidth, $maxHeight] = $this->getMaxWidthAndHeight();
 
             if ($width > $maxWidth) {
@@ -61,9 +61,9 @@ class ImageManager
                 'align'  => Jc::START,
             ];
 
-            $section->addText($imageReference);
-            $section->addBookmark($imageReference);
-            $section->addImage($imagePath, $imageStyle);
+            $section->addText($image->getImageReference());
+            $section->addBookmark($image->getImageReference());
+            $section->addImage($image->getImagePath(), $imageStyle);
         }
 
         // remove already printed images

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export;
+
+use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
+use PhpOffice\PhpWord\Element\Section;
+use PhpOffice\PhpWord\SimpleType\Jc;
+
+class ImageManager
+{
+    private const STANDARD_DPI = 72;
+    private const STANDARD_PT_TEXT = 10;
+    private const MAX_WIDTH_INCH = 10.69;
+    private const MAX_HEIGHT_INCH = 5.42;
+
+    public function __construct(private readonly ImageLinkConverter $imageLinkConverter)
+    {
+    }
+
+    public function addImages(Section $section): void
+    {
+        // Add images after all segments of one statement.
+        $images = $this->imageLinkConverter->getImages();
+        if ([] === $images) {
+            return;
+        }
+        $imageSpaceCurrentlyUsed = 0;
+        $section->addPageBreak();
+        foreach ($images as $imageReference => $imagePath) {
+            [$width, $height] = getimagesize($imagePath);
+            [$maxWidth, $maxHeight] = $this->getMaxWidthAndHeight();
+
+            if ($width > $maxWidth) {
+                $factor = $maxWidth / $width;
+                $width = $maxWidth;
+                $height *= $factor;
+            }
+            if ($height > $maxHeight) {
+                $factor = $maxHeight / $height;
+                $height = $maxHeight;
+                $width *= $factor;
+            }
+            if ($height > $maxHeight - $imageSpaceCurrentlyUsed) {
+                $section->addPageBreak();
+            }
+            $imageSpaceCurrentlyUsed += $height + self::STANDARD_PT_TEXT * 2;
+
+            $imageStyle = [
+                'width'  => $width,
+                'height' => $height,
+                'align'  => Jc::START,
+            ];
+
+            $section->addText($imageReference);
+            $section->addBookmark($imageReference);
+            $section->addImage($imagePath, $imageStyle);
+        }
+
+        // remove already printed images
+        $this->imageLinkConverter->resetImages();
+    }
+
+    private function getMaxWidthAndHeight(): array
+    {
+        $maxWidth = self::MAX_WIDTH_INCH * self::STANDARD_DPI;
+        $maxHeight = self::MAX_HEIGHT_INCH * self::STANDARD_DPI - self::STANDARD_PT_TEXT;
+
+        return [$maxWidth, $maxHeight];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export;
 
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\SimpleType\Jc;
 
@@ -34,40 +35,53 @@ class ImageManager
         if ([] === $images) {
             return;
         }
-        $imageSpaceCurrentlyUsed = 0;
         $section->addPageBreak();
-        foreach ($images as $image) {
-            [$width, $height] = getimagesize($image->getImagePath());
-            [$maxWidth, $maxHeight] = $this->getMaxWidthAndHeight();
 
-            if ($width > $maxWidth) {
-                $factor = $maxWidth / $width;
-                $width = $maxWidth;
-                $height *= $factor;
+        foreach ($images as $imageReferencsArray) {
+            $imageSpaceCurrentlyUsed = 0;
+            foreach ($imageReferencsArray[ImageLinkConverter::IMAGES_KEY_SEGMENTS] as $imageReference) {
+                $imageSpaceCurrentlyUsed = $this->addImage($section, $imageReference, $imageSpaceCurrentlyUsed);
             }
-            if ($height > $maxHeight) {
-                $factor = $maxHeight / $height;
-                $height = $maxHeight;
-                $width *= $factor;
+            foreach ($imageReferencsArray[ImageLinkConverter::IMAGES_KEY_RECOMMENDATION] as $imageReference) {
+                $imageSpaceCurrentlyUsed = $this->addImage($section, $imageReference, $imageSpaceCurrentlyUsed);
             }
-            if ($height > $maxHeight - $imageSpaceCurrentlyUsed) {
-                $section->addPageBreak();
-            }
-            $imageSpaceCurrentlyUsed += $height + self::STANDARD_PT_TEXT * 2;
-
-            $imageStyle = [
-                'width'  => $width,
-                'height' => $height,
-                'align'  => Jc::START,
-            ];
-
-            $section->addText($image->getImageReference());
-            $section->addBookmark($image->getImageReference());
-            $section->addImage($image->getImagePath(), $imageStyle);
         }
 
         // remove already printed images
         $this->imageLinkConverter->resetImages();
+    }
+
+    private function addImage(Section $section, ImageReference $imageReference, float $imageSpaceCurrentlyUsed): float
+    {
+        [$width, $height] = getimagesize($imageReference->getImagePath());
+        [$maxWidth, $maxHeight] = $this->getMaxWidthAndHeight();
+
+        if ($width > $maxWidth) {
+            $factor = $maxWidth / $width;
+            $width = $maxWidth;
+            $height *= $factor;
+        }
+        if ($height > $maxHeight) {
+            $factor = $maxHeight / $height;
+            $height = $maxHeight;
+            $width *= $factor;
+        }
+        if ($height > $maxHeight - $imageSpaceCurrentlyUsed) {
+            $section->addPageBreak();
+        }
+        $imageSpaceCurrentlyUsed += $height + self::STANDARD_PT_TEXT * 2;
+
+        $imageStyle = [
+            'width'  => $width,
+            'height' => $height,
+            'align'  => Jc::START,
+        ];
+
+        $section->addText($imageReference->getImageReference());
+        $section->addBookmark($imageReference->getImageReference());
+        $section->addImage($imageReference->getImagePath(), $imageStyle);
+
+        return $imageSpaceCurrentlyUsed;
     }
 
     private function getMaxWidthAndHeight(): array

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -81,13 +81,14 @@ class HtmlHelper
 
     /**
      * Removes all <a> tags with the specified class from the given HTML text.
+     * The inner text of the removed tags is replaced with the specified prefix.
      */
-    public function removeLinkTagsByClass(string $htmlText, string $className): string
+    public function removeLinkTagsByClass(string $htmlText, string $className, string $prefix): string
     {
         // Regex pattern to match <a> tags with the specified class and capture their inner text
         $pattern = '/<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>(.*?)<\/a>/i';
         // Replacement string to keep only the inner text
-        $replacement = '$1';
+        $replacement = $prefix.'$1';
 
         return preg_replace($pattern, $replacement, $htmlText);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 class HtmlHelper
 {
     public const LINK_CLASS_FOR_DARSTELLUNG_STELL = 'darstellung';
+
     public function __construct(private readonly HTMLSanitizer $htmlSanitizer)
     {
     }
@@ -39,9 +40,10 @@ class HtmlHelper
      * Extracts URLs from the given HTML text that are contained within <a> tags with the specified class, and
      * creates ImageReference objects from those URLs.
      *
-     * @param string $htmlText The input HTML text.
-     * @param string $class The class name to look for within the <a> tags.
-     * @return array<int, ImageReference> An array containing the extracted ImageReference objects.
+     * @param string $htmlText the input HTML text
+     * @param string $class    the class name to look for within the <a> tags
+     *
+     * @return array<int, ImageReference> an array containing the extracted ImageReference objects
      */
     public function extractImageDataByClass(string $htmlText, string $class): array
     {
@@ -67,15 +69,17 @@ class HtmlHelper
     /**
      * Updates the link text of all links with the specified class by appending a prefix.
      *
-     * @param string $htmlText The input HTML text.
-     * @param string $className The class name to look for.
-     * @param string $prefix The prefix to add to the link texts.
-     * @return string The updated HTML text.
+     * @param string $htmlText  the input HTML text
+     * @param string $className the class name to look for
+     * @param string $prefix    the prefix to add to the link texts
+     *
+     * @return string the updated HTML text
      */
     public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
         $pattern = '/(<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>)(.*?)(<\/a>)/i';
-        $replacement = '$1' . $prefix . '$2' . '$3';
+        $replacement = '$1'.$prefix.'$2$3';
+
         return preg_replace($pattern, $replacement, $htmlText);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -55,4 +55,19 @@ class HtmlHelper
 
         return $urls;
     }
+
+    /**
+     * Updates the link text of all links with the specified class by appending a prefix.
+     *
+     * @param string $htmlText The input HTML text.
+     * @param string $className The class name to look for.
+     * @param string $prefix The prefix to add to the link texts.
+     * @return string The updated HTML text.
+     */
+    public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
+    {
+        $pattern = '/(<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>)(.*?)(<\/a>)/i';
+        $replacement = '$1' . $prefix . '$2' . '$3';
+        return preg_replace($pattern, $replacement, $htmlText);
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -69,18 +69,25 @@ class HtmlHelper
     /**
      * Updates the link text of all links with the specified class by appending a prefix, changing the href value based
      * on the link text, changing the text color to blue and underlining the text.
-     *
-     * @param string $htmlText  the input HTML text
-     * @param string $className the class name to look for
-     * @param string $prefix    the prefix to add to the link texts
-     *
-     * @return string the updated HTML text
      */
     public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
         $pattern = '/(<a\b[^>]*class="[^"]*\b'
             .preg_quote($className, '/').'\b[^"]*")[^>]*(href="[^"]*")[^>]*(>)(.*?)(<\/a>)/i';
         $replacement = '$1 href="#'.$prefix.'$4" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
+
+        return preg_replace($pattern, $replacement, $htmlText);
+    }
+
+    /**
+     * Removes all <a> tags with the specified class from the given HTML text.
+     */
+    public function removeLinkTagsByClass(string $htmlText, string $className): string
+    {
+        // Regex pattern to match <a> tags with the specified class and capture their inner text
+        $pattern = '/<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>(.*?)<\/a>/i';
+        // Replacement string to keep only the inner text
+        $replacement = '$1';
 
         return preg_replace($pattern, $replacement, $htmlText);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 
 class HtmlHelper
 {
-    public const LINK_CLASS_FOR_DARSTELLUNG_STELL = 'darstellung';
+    public const LINK_CLASS_FOR_DARSTELLUNG_STELL = 'pdf_importer_image';
 
     public function __construct(private readonly HTMLSanitizer $htmlSanitizer)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -35,10 +35,9 @@ class HtmlHelper
     }
 
     /**
-     * Extracts URLs of links with the class "darstellung" from a given HTML text.
+     * Extracts URLs from the given HTML text that are contained within <a> tags with the specified class.
      *
-     * @param string $htmlText The input HTML text.
-     * @return array<string> An array containing the extracted URLs.
+     * @return array<int, string> An array containing the extracted URLs.
      */
     public static function extractUrlsByClass(string $htmlText, string $class): array
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -80,7 +80,7 @@ class HtmlHelper
     {
         $pattern = '/(<a\b[^>]*class="[^"]*\b'
             .preg_quote($className, '/').'\b[^"]*")[^>]*(href="[^"]*")[^>]*(>)(.*?)(<\/a>)/i';
-        $replacement = '$1 href="#'.$prefix.'$4'.'" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
+        $replacement = '$1 href="#'.$prefix.'$4" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
 
         return preg_replace($pattern, $replacement, $htmlText);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils;
+
+use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
+
+class HtmlHelper
+{
+    public function __construct(private readonly HTMLSanitizer $htmlSanitizer)
+    {
+    }
+
+    public function getHtmlValidText(string $text): string
+    {
+        /** @var string $text $text */
+        $text = str_replace('<br>', '<br/>', $text);
+
+        // strip all a tags without href
+        $pattern = '/<a(?![^>]*\bhref=)([^>]*)>(.*?)<\/a>/i';
+        $text = preg_replace($pattern, '$2', $text);
+
+        // avoid problems in phpword parser
+        return $this->htmlSanitizer->purify($text);
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -67,18 +67,21 @@ class HtmlHelper
     }
 
     /**
-     * Updates the link text of all links with the specified class by appending a prefix.
+     * Updates the link text of all links with the specified class by appending a prefix, changing the href value,
+     * and adding a style attribute to the <a> tag.
      *
      * @param string $htmlText  the input HTML text
      * @param string $className the class name to look for
      * @param string $prefix    the prefix to add to the link texts
+     * @param string $href      the new href value to set
      *
      * @return string the updated HTML text
      */
-    public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
+    public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix, string $href): string
     {
-        $pattern = '/(<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>)(.*?)(<\/a>)/i';
-        $replacement = '$1'.$prefix.'$2$3';
+        $pattern = '/(<a\b[^>]*class="[^"]*\b'
+            .preg_quote($className, '/').'\b[^"]*")[^>]*(href="[^"]*")[^>]*(>)(.*?)(<\/a>)/i';
+        $replacement = '$1 href="'.$href.'" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
 
         return preg_replace($pattern, $replacement, $htmlText);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -39,7 +39,7 @@ class HtmlHelper
      *
      * @return array<int, string> An array containing the extracted URLs.
      */
-    public static function extractUrlsByClass(string $htmlText, string $class): array
+    public function extractUrlsByClass(string $htmlText, string $class): array
     {
         $urls = [];
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -16,6 +16,7 @@ use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 
 class HtmlHelper
 {
+    public const LINK_CLASS_FOR_DARSTELLUNG_STELL = 'darstellung';
     public function __construct(private readonly HTMLSanitizer $htmlSanitizer)
     {
     }
@@ -31,5 +32,28 @@ class HtmlHelper
 
         // avoid problems in phpword parser
         return $this->htmlSanitizer->purify($text);
+    }
+
+    /**
+     * Extracts URLs of links with the class "darstellung" from a given HTML text.
+     *
+     * @param string $htmlText The input HTML text.
+     * @return array<string> An array containing the extracted URLs.
+     */
+    public static function extractUrlsByClass(string $htmlText, string $class): array
+    {
+        $urls = [];
+
+        // The regex pattern to match <a> tags with class="darstellung" and extract their href attributes
+        // It looks for <a> tags with any attributes, but specifically captures a tag if it has the class 'darstellung'
+        // and then captures the value of the href attribute
+        $pattern = '/<a\b[^>]*class="[^"]*\b'.$class.'\b[^"]*"[^>]*href="([^"]*)"[^>]*>/i';
+
+        // Perform the regex match
+        if (preg_match_all($pattern, $htmlText, $matches)) {
+            $urls = $matches[1];  // Extract the URLs from the matches
+        }
+
+        return $urls;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -43,8 +43,8 @@ class HtmlHelper
     {
         $urls = [];
 
-        // The regex pattern to match <a> tags with class="darstellung" and extract their href attributes
-        // It looks for <a> tags with any attributes, but specifically captures a tag if it has the class 'darstellung'
+        // The regex pattern to match <a> tags with the specified class
+        // It looks for <a> tags with any attributes, but specifically captures a tag if it has the specified class
         // and then captures the value of the href attribute
         $pattern = '/<a\b[^>]*class="[^"]*\b'.$class.'\b[^"]*"[^>]*href="([^"]*)"[^>]*>/i';
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -67,21 +67,20 @@ class HtmlHelper
     }
 
     /**
-     * Updates the link text of all links with the specified class by appending a prefix, changing the href value,
-     * and adding a style attribute to the <a> tag.
+     * Updates the link text of all links with the specified class by appending a prefix, changing the href value based
+     * on the link text, changing the text color to blue and underlining the text.
      *
      * @param string $htmlText  the input HTML text
      * @param string $className the class name to look for
      * @param string $prefix    the prefix to add to the link texts
-     * @param string $href      the new href value to set
      *
      * @return string the updated HTML text
      */
-    public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix, string $href): string
+    public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
         $pattern = '/(<a\b[^>]*class="[^"]*\b'
             .preg_quote($className, '/').'\b[^"]*")[^>]*(href="[^"]*")[^>]*(>)(.*?)(<\/a>)/i';
-        $replacement = '$1 href="'.$href.'" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
+        $replacement = '$1 href="#'.$prefix.'$4'.'" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
 
         return preg_replace($pattern, $replacement, $htmlText);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -38,14 +38,12 @@ class HtmlHelper
 
     /**
      * Extracts URLs from the given HTML text that are contained within <a> tags with the specified class, and
-     * creates ImageReference objects from those URLs.
-     *
-     * @param string $htmlText the input HTML text
-     * @param string $class    the class name to look for within the <a> tags
+     * creates ImageReference objects from those URLs. The link text of the <a> tags is used as the image reference.
+     * The image reference is prefixed with the specified prefix.
      *
      * @return array<int, ImageReference> an array containing the extracted ImageReference objects
      */
-    public function extractImageDataByClass(string $htmlText, string $class): array
+    public function extractImageDataByClass(string $htmlText, string $class, string $prefix): array
     {
         $imageReferences = [];
 
@@ -58,7 +56,7 @@ class HtmlHelper
             foreach ($matches[1] as $index => $url) {
                 $linkText = $matches[2][$index];
                 // Create an ImageReference object with linkText as imageReference and url as imagePath
-                $imageReference = new ImageReference($linkText, $url);
+                $imageReference = new ImageReference($prefix.$linkText, $url);
                 $imageReferences[] = $imageReference;
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -130,7 +130,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     }
 
     /**
-     * @param array<string, mixed> $segmentsOrStatements
+     * @param array<string, mixed>            $segmentsOrStatements
      * @param array<string, ConvertedSegment> $convertedSegments
      *
      * @return array<string, mixed>

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -27,6 +27,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageManager;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use PhpOffice\PhpWord\Element\Footer;
@@ -89,13 +90,13 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     {
         Settings::setOutputEscapingEnabled(true);
         $exportData = [];
-        $adjustedRecommendations = [];
+        $convertedSegments = [];
         // unfortunately for xlsx export data needs to be an array
         foreach ($statements as $statement) {
             $segmentsOrStatements = collect([$statement]);
             if (!$statement->getSegmentsOfStatement()->isEmpty()) {
                 $segmentsOrStatements = $statement->getSegmentsOfStatement();
-                $adjustedRecommendations[] =
+                $convertedSegments[] =
                     $this->convertImagesToReferencesInRecommendations($segmentsOrStatements->toArray());
             }
             foreach ($segmentsOrStatements as $segmentOrStatement) {
@@ -103,8 +104,8 @@ class SegmentsByStatementsExporter extends SegmentsExporter
             }
         }
 
-        foreach ($adjustedRecommendations as $recommendation) {
-            $exportData = $this->updateRecommendationsWithTextReferences($exportData, $recommendation);
+        foreach ($convertedSegments as $convertedSegment) {
+            $exportData = $this->updateRecommendationsWithTextReferences($exportData, $convertedSegment);
         }
 
         $columnsDefinition = $this->assessmentTableXlsExporter->selectFormat('segments');
@@ -116,31 +117,38 @@ class SegmentsByStatementsExporter extends SegmentsExporter
     {
         $sortedSegments = $this->sortSegmentsByOrderInProcedure($segments);
 
-        $recommendationTexts = [];
+        $convertedSegments = [];
         /** @var Segment $segment */
         foreach ($sortedSegments as $segment) {
             $externId = $segment->getExternId();
-            $recommendationTexts[$externId] = $this->imageLinkConverter->convert(
-                $segment->getRecommendation(),
-                $externId,
-                false
-            );
+            $convertedSegment = $this->imageLinkConverter->convert($segment, $externId, false);
+            $convertedSegments[$externId] = $convertedSegment;
         }
         $this->imageLinkConverter->resetImages();
 
-        return $recommendationTexts;
+        return $convertedSegments;
     }
 
-    private function updateRecommendationsWithTextReferences(array $segmentsOrStatements, array $adjustedRecommendations): array
-    {
+    /**
+     * @param array<string, mixed> $segmentsOrStatements
+     * @param array<string, ConvertedSegment> $convertedSegments
+     *
+     * @return array<string, mixed>
+     */
+    private function updateRecommendationsWithTextReferences(
+        array $segmentsOrStatements,
+        array $convertedSegments
+    ): array {
         foreach ($segmentsOrStatements as $key => $segmentOrStatement) {
             $isNotSegment = !array_key_exists('recommendation', $segmentOrStatement);
-            $externIdIsNotOfSegment = !array_key_exists($segmentOrStatement['externId'], $adjustedRecommendations);
+            $externIdIsNotOfSegment = !array_key_exists($segmentOrStatement['externId'], $convertedSegments);
             if ($isNotSegment || $externIdIsNotOfSegment) {
                 continue;
             }
 
-            $segmentOrStatement['recommendation'] = $adjustedRecommendations[$segmentOrStatement['externId']];
+            $segmentOrStatement['text'] = $convertedSegments[$segmentOrStatement['externId']]->getText();
+            $segmentOrStatement['recommendation'] =
+                $convertedSegments[$segmentOrStatement['externId']]->getRecommendationText();
             $segmentsOrStatements[$key] = $segmentOrStatement;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -24,8 +24,9 @@ use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageManager;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
-use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use PhpOffice\PhpWord\Element\Footer;
@@ -44,13 +45,14 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         private readonly AssessmentTableXlsExporter $assessmentTableXlsExporter,
         CurrentUserInterface $currentUser,
         private readonly EntityHelper $entityHelper,
-        HTMLSanitizer $htmlSanitizer,
+        HtmlHelper $htmlHelper,
+        ImageManager $imageManager,
         ImageLinkConverter $imageLinkConverter,
         private readonly SegmentExporterFileNameGenerator $fileNameGenerator,
         Slugify $slugify,
         TranslatorInterface $translator
     ) {
-        parent::__construct($currentUser, $htmlSanitizer, $imageLinkConverter, $slugify, $translator);
+        parent::__construct($currentUser, $htmlHelper, $imageManager, $imageLinkConverter, $slugify, $translator);
     }
 
     public function getSynopseFileName(Procedure $procedure, string $suffix): string

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -21,6 +21,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageManager;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 use demosplan\DemosPlanCoreBundle\ValueObject\CellExportStyle;
 use demosplan\DemosPlanCoreBundle\ValueObject\ExportOrgaInfoHeader;
@@ -50,6 +51,7 @@ class SegmentsExporter
 
     public function __construct(
         private readonly CurrentUserInterface $currentUser,
+        private readonly HtmlHelper $htmlHelper,
         private readonly HTMLSanitizer $htmlSanitizer,
         private readonly ImageManager $imageManager,
         protected readonly ImageLinkConverter $imageLinkConverter,
@@ -117,7 +119,7 @@ class SegmentsExporter
     {
         if (Footer::FIRST === $headerType) {
             $preamble = $this->translator->trans('docx.export.preamble');
-            Html::addHtml($header, $this->getHtmlValidText($preamble), false, false);
+            Html::addHtml($header, $this->htmlHelper->getHtmlValidText($preamble), false, false);
         }
     }
 
@@ -313,20 +315,7 @@ class SegmentsExporter
             $cellExportStyle->getWidth(),
             $cellExportStyle->getCellStyle()
         );
-        Html::addHtml($cell, $this->getHtmlValidText($text), false, false);
-    }
-
-    private function getHtmlValidText(string $text): string
-    {
-        /** @var string $text $text */
-        $text = str_replace('<br>', '<br/>', $text);
-
-        // strip all a tags without href
-        $pattern = '/<a\s+(?!.*?\bhref\s*=\s*([\'"])\S*\1)(.*?)>(.*?)<\/a>/i';
-        $text = preg_replace($pattern, '$3', $text);
-
-        // avoid problems in phpword parser
-        return $this->htmlSanitizer->purify($text);
+        Html::addHtml($cell, $this->htmlHelper->getHtmlValidText($text), false, false);
     }
 
     private function addSegmentCell(Row $row, string $text, CellExportStyle $cellExportStyle): void

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -288,6 +288,8 @@ class SegmentsExporter
     private function addSegmentTableBody(Table $table, Segment $segment, string $statementExternId): void
     {
         $textRow = $table->addRow();
+        // Replace image tags in segment text and in segment recommendation text with text references.
+        $convertedSegment = $this->imageLinkConverter->convert($segment, $statementExternId);
         $this->addSegmentHtmlCell(
             $textRow,
             $segment->getExternId(),
@@ -295,14 +297,12 @@ class SegmentsExporter
         );
         $this->addSegmentHtmlCell(
             $textRow,
-            $segment->getText(),
+            $convertedSegment->getText(),
             $this->styles['segmentsTableBodyCell']
         );
-        // Replace image tags in segment recommendation text with a linked reference to the image.
-        $recommendationText = $this->imageLinkConverter->convert($segment->getRecommendation(), $statementExternId);
         $this->addSegmentHtmlCell(
             $textRow,
-            $recommendationText,
+            $convertedSegment->getRecommendationText(),
             $this->styles['segmentsTableBodyCell']
         );
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -22,7 +22,6 @@ use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageManager;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
-use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 use demosplan\DemosPlanCoreBundle\ValueObject\CellExportStyle;
 use demosplan\DemosPlanCoreBundle\ValueObject\ExportOrgaInfoHeader;
 use PhpOffice\PhpWord\Element\Footer;
@@ -52,7 +51,6 @@ class SegmentsExporter
     public function __construct(
         private readonly CurrentUserInterface $currentUser,
         private readonly HtmlHelper $htmlHelper,
-        private readonly HTMLSanitizer $htmlSanitizer,
         private readonly ImageManager $imageManager,
         protected readonly ImageLinkConverter $imageLinkConverter,
         Slugify $slugify,

--- a/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ConvertedSegment.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ConvertedSegment.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport;
+
+use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
+
+/**
+ * @method string getText()
+ * @method string getRecommendationText()
+ */
+class ConvertedSegment extends ValueObject
+{
+    protected string $text;
+    protected string $recommendationText;
+
+    public function __construct(string $text, string $recommendationText)
+    {
+        $this->text = $text;
+        $this->recommendationText = $recommendationText;
+
+        $this->lock();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ImageReference.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ImageReference.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport;
+
+use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
+
+/**
+ * Class ImageReference
+ *
+ * @method string getImagePath()
+ * @method string getImageReference()
+ */
+class ImageReference extends ValueObject
+{
+    protected string $imagePath;
+    protected string $imageReference;
+
+    public function __construct(string $imageReference, string $imagePath)
+    {
+        $this->imageReference = $imageReference;
+        $this->imagePath = $imagePath;
+
+        $this->lock();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ImageReference.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/SegmentExport/ImageReference.php
@@ -15,7 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport;
 use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
 
 /**
- * Class ImageReference
+ * Class ImageReference.
  *
  * @method string getImagePath()
  * @method string getImageReference()

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -97,7 +97,7 @@ class HtmlHelperTest extends FunctionalTestCase
     {
         // Test 1: <a> tag with class darstellung
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Old Text</a>';
-        $expectedWithClass = '<a class="darstellung" href="https://www.test.com"'
+        $expectedWithClass = '<a class="darstellung" href="#New_Old Text"'
             .' style="color: blue; text-decoration: underline;">New_Old Text</a>';
         // Test 2: <a> tag without class darstellung
         $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
@@ -106,10 +106,10 @@ class HtmlHelperTest extends FunctionalTestCase
         $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
-        $expectedMixed = '<a class="darstellung" href="https://www.test.com"'
+        $expectedMixed = '<a class="darstellung" href="#New_Old Text 3"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a class="darstellung" href="https://www.test.com"'
+            '<a class="darstellung" href="#New_Old Text 5"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 5</a>';
         $prefix = 'New_';
         $href = 'https://www.test.com';

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -56,7 +56,7 @@ class HtmlHelperTest extends FunctionalTestCase
         // Test 1: <a> tag with class darstellung and href attribute
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Example 1</a>';
         $expectedWithClass = [
-            new ImageReference($prefix.'Example 1', 'https://www.example1.com')
+            new ImageReference($prefix.'Example 1', 'https://www.example1.com'),
         ];
 
         // Test 2: <a> tag without class darstellung but with href attribute

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -61,12 +61,12 @@ class HtmlHelperTest extends FunctionalTestCase
         $expectedWithoutClass = [];
 
         // Test 3: Multiple <a> tags with and without class darstellung
-        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Example 3</a>' .
-            '<a class="other-class" href="https://www.example4.com">Example 4</a>' .
+        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Example 3</a>'.
+            '<a class="other-class" href="https://www.example4.com">Example 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Example 5</a>';
         $expectedMixed = [
             new ImageReference('Example 3', 'https://www.example3.com'),
-            new ImageReference('Example 5', 'https://www.example5.com')
+            new ImageReference('Example 5', 'https://www.example5.com'),
         ];
 
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
@@ -102,11 +102,11 @@ class HtmlHelperTest extends FunctionalTestCase
         $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         $expectedWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         // Test 3: Multiple <a> tags, some with class darstellung and some without
-        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>' .
-            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>' .
+        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>'.
+            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
-        $expectedMixed = '<a class="darstellung" href="https://www.example3.com">New_Old Text 3</a>' .
-            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>' .
+        $expectedMixed = '<a class="darstellung" href="https://www.example3.com">New_Old Text 3</a>'.
+            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">New_Old Text 5</a>';
         $prefix = 'New_';
         $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix);

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -66,9 +66,9 @@ class HtmlHelperTest extends FunctionalTestCase
         $expectedUrlsMixed = ['https://www.example3.com', 'https://www.example5.com'];
 
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
-        $resultA = HtmlHelper::extractUrlsByClass($htmlWithClass, $class);
-        $resultB = HtmlHelper::extractUrlsByClass($htmlWithoutClass, $class);
-        $resultC = HtmlHelper::extractUrlsByClass($htmlMixed, $class);
+        $resultA = $this->sut->extractUrlsByClass($htmlWithClass, $class);
+        $resultB = $this->sut->extractUrlsByClass($htmlWithoutClass, $class);
+        $resultC = $this->sut->extractUrlsByClass($htmlMixed, $class);
 
         static::assertSame($expectedUrlsWithClass, $resultA);
         static::assertSame($expectedUrlsWithoutClass, $resultB);

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\SegmentExport;
+
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
+use Tests\Base\FunctionalTestCase;
+
+class HtmlHelperTest extends FunctionalTestCase
+{
+    /** @var HtmlHelper */
+    protected $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = $this->getContainer()->get(HtmlHelper::class);
+    }
+
+    public function testGetHtmlValidText(): void
+    {
+        // Test 1: <a> tag with href attribute
+        $textWithHref = '<a href="https://www.example.com">Example</a><br>Hallo Test';
+        $expectedWithATags = '<a href="https://www.example.com">Example</a><br />Hallo Test';
+
+        // Test 2: <a> tag without href attribute
+        $textWithoutHref = '<a>Example</a><br>Hallo Test';
+        $expectedWithoutATags = 'Example<br />Hallo Test';
+
+        // Test 3: <a> tag without href but with other attributes
+        $textWithOtherAttributes = '<a id="example" class="example-class">Example</a><br>Hallo Test';
+        $expectedOtherAttributesRemoved = 'Example<br />Hallo Test';
+
+        $resultA = $this->sut->getHtmlValidText($textWithHref);
+        $resultB = $this->sut->getHtmlValidText($textWithoutHref);
+        $resultC = $this->sut->getHtmlValidText($textWithOtherAttributes);
+
+        static::assertSame($expectedWithATags, $resultA);
+        static::assertSame($expectedWithoutATags, $resultB);
+        static::assertSame($expectedOtherAttributesRemoved, $resultC);
+    }
+}

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -74,4 +74,28 @@ class HtmlHelperTest extends FunctionalTestCase
         static::assertSame($expectedUrlsWithoutClass, $resultB);
         static::assertSame($expectedUrlsMixed, $resultC);
     }
+
+    public function testUpdateLinkTextWithClass(): void
+    {
+        // Test 1: <a> tag with class darstellung
+        $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Old Text</a>';
+        $expectedWithClass = '<a class="darstellung" href="https://www.example1.com">New_Old Text</a>';
+        // Test 2: <a> tag without class darstellung
+        $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
+        $expectedWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
+        // Test 3: Multiple <a> tags, some with class darstellung and some without
+        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>' .
+            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>' .
+            '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
+        $expectedMixed = '<a class="darstellung" href="https://www.example3.com">New_Old Text 3</a>' .
+            '<a class="other-class" href="https://www.example4.com">Old Text 4</a>' .
+            '<a class="darstellung" href="https://www.example5.com">New_Old Text 5</a>';
+        $prefix = 'New_';
+        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix);
+        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, 'darstellung', $prefix);
+        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, 'darstellung', $prefix);
+        static::assertSame($expectedWithClass, $resultA);
+        static::assertSame($expectedWithoutClass, $resultB);
+        static::assertSame($expectedMixed, $resultC);
+    }
 }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -98,7 +98,7 @@ class HtmlHelperTest extends FunctionalTestCase
         // Test 1: <a> tag with class darstellung
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Old Text</a>';
         $expectedWithClass = '<a class="darstellung" href="https://www.test.com"'
-            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text</a>';
+            .' style="color: blue; text-decoration: underline;">New_Old Text</a>';
         // Test 2: <a> tag without class darstellung
         $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         $expectedWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
@@ -107,10 +107,10 @@ class HtmlHelperTest extends FunctionalTestCase
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
         $expectedMixed = '<a class="darstellung" href="https://www.test.com"'
-            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text 3</a>'.
+            .' style="color: blue; text-decoration: underline;">New_Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.test.com"'
-            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text 5</a>';
+            .' style="color: blue; text-decoration: underline;">New_Old Text 5</a>';
         $prefix = 'New_';
         $href = 'https://www.test.com';
         $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix, $href);

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -54,7 +54,8 @@ class HtmlHelperTest extends FunctionalTestCase
     {
         $prefix = 'New_';
         // Test 1: <a> tag with class darstellung and href attribute
-        $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Example 1</a>';
+        $htmlWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example1.com">Example 1</a>';
         $expectedWithClass = [
             new ImageReference($prefix.'Example 1', 'https://www.example1.com'),
         ];
@@ -64,9 +65,10 @@ class HtmlHelperTest extends FunctionalTestCase
         $expectedWithoutClass = [];
 
         // Test 3: Multiple <a> tags with and without class darstellung
-        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Example 3</a>'.
+        $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example3.com">Example 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Example 4</a>'.
-            '<a class="darstellung" href="https://www.example5.com">Example 5</a>';
+            '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="https://www.example5.com">Example 5</a>';
         $expectedMixed = [
             new ImageReference($prefix.'Example 3', 'https://www.example3.com'),
             new ImageReference($prefix.'Example 5', 'https://www.example5.com'),
@@ -100,20 +102,23 @@ class HtmlHelperTest extends FunctionalTestCase
     public function testUpdateLinkTextWithClass(): void
     {
         // Test 1: <a> tag with class darstellung
-        $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Old Text</a>';
-        $expectedWithClass = '<a class="darstellung" href="#New_Old Text"'
+        $htmlWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example1.com">Old Text</a>';
+        $expectedWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text"'
             .' style="color: blue; text-decoration: underline;">New_Old Text</a>';
         // Test 2: <a> tag without class darstellung
         $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         $expectedWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         // Test 3: Multiple <a> tags, some with class darstellung and some without
-        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>'.
+        $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example3.com">Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
-        $expectedMixed = '<a class="darstellung" href="#New_Old Text 3"'
+            '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example5.com">Old Text 5</a>';
+        $expectedMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text 3"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a class="darstellung" href="#New_Old Text 5"'
+            '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text 5"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 5</a>';
         $prefix = 'New_';
         $href = 'https://www.test.com';
@@ -129,9 +134,11 @@ class HtmlHelperTest extends FunctionalTestCase
     public function testRemoveLinkTagsByClass(): void
     {
         $prefix = 'New_';
-        $htmlMixed = '<a class="darstellung" href="https://www.example1.com">Old Text 1</a>'.
+        $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example1.com">Old Text 1</a>'.
             '<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.
-            '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>';
+            '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="https://www.example3.com">Old Text 3</a>';
         $expectedMixed = $prefix
             .'Old Text 1<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.$prefix.'Old Text 3';
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -48,4 +48,30 @@ class HtmlHelperTest extends FunctionalTestCase
         static::assertSame($expectedWithoutATags, $resultB);
         static::assertSame($expectedOtherAttributesRemoved, $resultC);
     }
+
+    public function testExtractUrlsByClass(): void
+    {
+        // Test 1: <a> tag with class darstellung and href attribute
+        $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Example 1</a>';
+        $expectedUrlsWithClass = ['https://www.example1.com'];
+
+        // Test 2: <a> tag without class darstellung but with href attribute
+        $htmlWithoutClass = '<a href="https://www.example2.com">Example 2</a>';
+        $expectedUrlsWithoutClass = [];
+
+        // Test 3: Multiple <a> tags with and without class darstellung
+        $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Example 3</a>' .
+            '<a class="other-class" href="https://www.example4.com">Example 4</a>' .
+            '<a class="darstellung" href="https://www.example5.com">Example 5</a>';
+        $expectedUrlsMixed = ['https://www.example3.com', 'https://www.example5.com'];
+
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+        $resultA = HtmlHelper::extractUrlsByClass($htmlWithClass, $class);
+        $resultB = HtmlHelper::extractUrlsByClass($htmlWithoutClass, $class);
+        $resultC = HtmlHelper::extractUrlsByClass($htmlMixed, $class);
+
+        static::assertSame($expectedUrlsWithClass, $resultA);
+        static::assertSame($expectedUrlsWithoutClass, $resultB);
+        static::assertSame($expectedUrlsMixed, $resultC);
+    }
 }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -124,12 +124,15 @@ class HtmlHelperTest extends FunctionalTestCase
 
     public function testRemoveLinkTagsByClass(): void
     {
+        $prefix = 'New_';
         $htmlMixed = '<a class="darstellung" href="https://www.example1.com">Old Text 1</a>'.
             '<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.
             '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>';
-        $expectedMixed = 'Old Text 1<a class="other-class" href="https://www.example2.com">Old Text 2</a>Old Text 3';
+        $expectedMixed = $prefix
+            .'Old Text 1<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.$prefix.'Old Text 3';
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
-        $result = $this->sut->removeLinkTagsByClass($htmlMixed, $class);
+
+        $result = $this->sut->removeLinkTagsByClass($htmlMixed, $class, $prefix);
         static::assertSame($expectedMixed, $result);
     }
 }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -97,7 +97,8 @@ class HtmlHelperTest extends FunctionalTestCase
     {
         // Test 1: <a> tag with class darstellung
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Old Text</a>';
-        $expectedWithClass = '<a class="darstellung" href="https://www.example1.com">New_Old Text</a>';
+        $expectedWithClass = '<a class="darstellung" href="https://www.test.com"'
+            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text</a>';
         // Test 2: <a> tag without class darstellung
         $htmlWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
         $expectedWithoutClass = '<a href="https://www.example2.com">Old Text</a>';
@@ -105,13 +106,16 @@ class HtmlHelperTest extends FunctionalTestCase
         $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Old Text 5</a>';
-        $expectedMixed = '<a class="darstellung" href="https://www.example3.com">New_Old Text 3</a>'.
+        $expectedMixed = '<a class="darstellung" href="https://www.test.com"'
+            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a class="darstellung" href="https://www.example5.com">New_Old Text 5</a>';
+            '<a class="darstellung" href="https://www.test.com"'
+            .' style="color: blue; text-decoration: underline;"'.'>New_Old Text 5</a>';
         $prefix = 'New_';
-        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix);
-        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, 'darstellung', $prefix);
-        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, 'darstellung', $prefix);
+        $href = 'https://www.test.com';
+        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix, $href);
+        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, 'darstellung', $prefix, $href);
+        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, 'darstellung', $prefix, $href);
         static::assertSame($expectedWithClass, $resultA);
         static::assertSame($expectedWithoutClass, $resultB);
         static::assertSame($expectedMixed, $resultC);

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -113,11 +113,23 @@ class HtmlHelperTest extends FunctionalTestCase
             .' style="color: blue; text-decoration: underline;">New_Old Text 5</a>';
         $prefix = 'New_';
         $href = 'https://www.test.com';
-        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, 'darstellung', $prefix, $href);
-        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, 'darstellung', $prefix, $href);
-        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, 'darstellung', $prefix, $href);
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, $class, $prefix, $href);
+        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, $class, $prefix, $href);
+        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, $class, $prefix, $href);
         static::assertSame($expectedWithClass, $resultA);
         static::assertSame($expectedWithoutClass, $resultB);
         static::assertSame($expectedMixed, $resultC);
+    }
+
+    public function testRemoveLinkTagsByClass(): void
+    {
+        $htmlMixed = '<a class="darstellung" href="https://www.example1.com">Old Text 1</a>'.
+            '<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.
+            '<a class="darstellung" href="https://www.example3.com">Old Text 3</a>';
+        $expectedMixed = 'Old Text 1<a class="other-class" href="https://www.example2.com">Old Text 2</a>Old Text 3';
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+        $result = $this->sut->removeLinkTagsByClass($htmlMixed, $class);
+        static::assertSame($expectedMixed, $result);
     }
 }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -52,9 +52,12 @@ class HtmlHelperTest extends FunctionalTestCase
 
     public function testExtractUrlsByClass(): void
     {
+        $prefix = 'New_';
         // Test 1: <a> tag with class darstellung and href attribute
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Example 1</a>';
-        $expectedWithClass = [new ImageReference('Example 1', 'https://www.example1.com')];
+        $expectedWithClass = [
+            new ImageReference($prefix.'Example 1', 'https://www.example1.com')
+        ];
 
         // Test 2: <a> tag without class darstellung but with href attribute
         $htmlWithoutClass = '<a href="https://www.example2.com">Example 2</a>';
@@ -65,14 +68,15 @@ class HtmlHelperTest extends FunctionalTestCase
             '<a class="other-class" href="https://www.example4.com">Example 4</a>'.
             '<a class="darstellung" href="https://www.example5.com">Example 5</a>';
         $expectedMixed = [
-            new ImageReference('Example 3', 'https://www.example3.com'),
-            new ImageReference('Example 5', 'https://www.example5.com'),
+            new ImageReference($prefix.'Example 3', 'https://www.example3.com'),
+            new ImageReference($prefix.'Example 5', 'https://www.example5.com'),
         ];
 
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
-        $resultA = $this->sut->extractImageDataByClass($htmlWithClass, $class);
-        $resultB = $this->sut->extractImageDataByClass($htmlWithoutClass, $class);
-        $resultC = $this->sut->extractImageDataByClass($htmlMixed, $class);
+
+        $resultA = $this->sut->extractImageDataByClass($htmlWithClass, $class, $prefix);
+        $resultB = $this->sut->extractImageDataByClass($htmlWithoutClass, $class, $prefix);
+        $resultC = $this->sut->extractImageDataByClass($htmlMixed, $class, $prefix);
 
         static::assertIsArray($resultA);
         static::assertCount(1, $resultA);
@@ -81,7 +85,7 @@ class HtmlHelperTest extends FunctionalTestCase
         static::assertSame($expectedWithClass[0]->getImagePath(), $resultA[0]->getImagePath());
 
         static::assertIsArray($resultB);
-        static::assertCount(0, $resultB);
+        static::assertSame($expectedWithoutClass, $resultB);
 
         static::assertIsArray($resultC);
         static::assertCount(2, $resultC);

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\Core\SegmentExport;
 
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Tests\Base\FunctionalTestCase;
 
 class HtmlHelperTest extends FunctionalTestCase
@@ -53,26 +54,43 @@ class HtmlHelperTest extends FunctionalTestCase
     {
         // Test 1: <a> tag with class darstellung and href attribute
         $htmlWithClass = '<a class="darstellung" href="https://www.example1.com">Example 1</a>';
-        $expectedUrlsWithClass = ['https://www.example1.com'];
+        $expectedWithClass = [new ImageReference('Example 1', 'https://www.example1.com')];
 
         // Test 2: <a> tag without class darstellung but with href attribute
         $htmlWithoutClass = '<a href="https://www.example2.com">Example 2</a>';
-        $expectedUrlsWithoutClass = [];
+        $expectedWithoutClass = [];
 
         // Test 3: Multiple <a> tags with and without class darstellung
         $htmlMixed = '<a class="darstellung" href="https://www.example3.com">Example 3</a>' .
             '<a class="other-class" href="https://www.example4.com">Example 4</a>' .
             '<a class="darstellung" href="https://www.example5.com">Example 5</a>';
-        $expectedUrlsMixed = ['https://www.example3.com', 'https://www.example5.com'];
+        $expectedMixed = [
+            new ImageReference('Example 3', 'https://www.example3.com'),
+            new ImageReference('Example 5', 'https://www.example5.com')
+        ];
 
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
-        $resultA = $this->sut->extractUrlsByClass($htmlWithClass, $class);
-        $resultB = $this->sut->extractUrlsByClass($htmlWithoutClass, $class);
-        $resultC = $this->sut->extractUrlsByClass($htmlMixed, $class);
+        $resultA = $this->sut->extractImageDataByClass($htmlWithClass, $class);
+        $resultB = $this->sut->extractImageDataByClass($htmlWithoutClass, $class);
+        $resultC = $this->sut->extractImageDataByClass($htmlMixed, $class);
 
-        static::assertSame($expectedUrlsWithClass, $resultA);
-        static::assertSame($expectedUrlsWithoutClass, $resultB);
-        static::assertSame($expectedUrlsMixed, $resultC);
+        static::assertIsArray($resultA);
+        static::assertCount(1, $resultA);
+        static::assertInstanceOf(ImageReference::class, $resultA[0]);
+        static::assertSame($expectedWithClass[0]->getImageReference(), $resultA[0]->getImageReference());
+        static::assertSame($expectedWithClass[0]->getImagePath(), $resultA[0]->getImagePath());
+
+        static::assertIsArray($resultB);
+        static::assertCount(0, $resultB);
+
+        static::assertIsArray($resultC);
+        static::assertCount(2, $resultC);
+        static::assertInstanceOf(ImageReference::class, $resultC[0]);
+        static::assertInstanceOf(ImageReference::class, $resultC[1]);
+        static::assertSame($expectedMixed[0]->getImageReference(), $resultC[0]->getImageReference());
+        static::assertSame($expectedMixed[0]->getImagePath(), $resultC[0]->getImagePath());
+        static::assertSame($expectedMixed[1]->getImageReference(), $resultC[1]->getImageReference());
+        static::assertSame($expectedMixed[1]->getImagePath(), $resultC[1]->getImagePath());
     }
 
     public function testUpdateLinkTextWithClass(): void

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 
 namespace Tests\Core\Statement\Functional;
 
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
 use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Tests\Base\FunctionalTestCase;
 
@@ -41,14 +45,19 @@ class ImageLinkConverterTest extends FunctionalTestCase
                 $this->createMock(Procedure::class)
             )
         );
-        $this->sut = new ImageLinkConverter($fileService);
+        /** @var HtmlHelper $htmlHelper */
+        $htmlHelper = $this->getContainer()->get(HtmlHelper::class);
+        $this->sut = new ImageLinkConverter($htmlHelper, $fileService);
     }
 
     public function testConvertWithLinkedReference(): void
     {
-        $html = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
-        $statementExternId = 'statement123';
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
+        $segment->setRecommendation($recommendation);
 
+        $statementExternId = 'statement123';
         $linkStyle = 'style="color: blue; text-decoration: underline;"';
         $linkStart = '<a href="#statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX;
         $linkEnd = '" '.$linkStyle.'>';
@@ -57,29 +66,35 @@ class ImageLinkConverterTest extends FunctionalTestCase
             'statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.$linkClose.
             ' more text '.$linkStart.'002'.$linkEnd.
             'statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002'.$linkClose.'</p>';
-        $result = $this->sut->convert($html, $statementExternId);
+        $result = $this->sut->convert($segment, $statementExternId);
 
-        static::assertSame($expected, $result);
+        static::assertSame($expected, $result->getRecommendationText());
     }
 
     public function testConvertWithoutLinkedReference(): void
     {
-        $html = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
+        $segment->setRecommendation($recommendation);
+
         $statementExternId = 'statement123';
-
-        $expected = '<p>Some text statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.
+        $expected = '<p>Some text '.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.
             ' more text statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002</p>';
-        $result = $this->sut->convert($html, $statementExternId, false);
+        $result = $this->sut->convert($segment, $statementExternId, false);
 
-        static::assertSame($expected, $result);
+        static::assertSame($expected, $result->getRecommendationText());
     }
 
     public function testGetImages(): void
     {
-        $html = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
+        $segment->setRecommendation($recommendation);
         $statementExternId = 'statement123';
 
-        $this->sut->convert($html, $statementExternId);
+        $this->sut->convert($segment, $statementExternId);
 
         $keyImage1 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001';
         $keyImage2 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002';
@@ -88,21 +103,42 @@ class ImageLinkConverterTest extends FunctionalTestCase
 
         $result = $this->sut->getImages();
 
-        static::assertCount(2, $result);
-        static::assertInstanceOf(ImageReference::class, $result[0]);
-        static::assertInstanceOf(ImageReference::class, $result[1]);
-        static::assertSame($expectedImage1->getImageReference(), $result[0]->getImageReference());
-        static::assertSame($expectedImage1->getImagePath(), $result[0]->getImagePath());
-        static::assertSame($expectedImage2->getImageReference(), $result[1]->getImageReference());
-        static::assertSame($expectedImage2->getImagePath(), $result[1]->getImagePath());
+        static::assertCount(1, $result);
+        static::assertInstanceOf(
+            ImageReference::class,
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][0]
+        );
+        static::assertInstanceOf(
+            ImageReference::class,
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]
+        );
+        static::assertSame(
+            $expectedImage1->getImageReference(),
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][0]->getImageReference()
+        );
+        static::assertSame(
+            $expectedImage1->getImagePath(),
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][0]->getImagePath()
+        );
+        static::assertSame(
+            $expectedImage2->getImageReference(),
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]->getImageReference()
+        );
+        static::assertSame(
+            $expectedImage2->getImagePath(),
+            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]->getImagePath()
+        );
     }
 
     public function testResetImages(): void
     {
-        $html = '<p>Some text <img src="path/to/image1.jpg" /></p>';
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /></p>';
+        $segment->setRecommendation($recommendation);
         $statementExternId = 'statement123';
 
-        $this->sut->convert($html, $statementExternId);
+        $this->sut->convert($segment, $statementExternId);
         $this->sut->resetImages();
 
         static::assertEmpty($this->sut->getImages());

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -51,54 +51,67 @@ class ImageLinkConverterTest extends FunctionalTestCase
 
     public function testConvertWithLinkedReference(): void
     {
-        /** @var Segment $segment */
-        $segment = SegmentFactory::createOne()->_real();
-        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
-        $segment->setRecommendation($recommendation);
+        $segment = $this->createTestSegment();
 
         $statementExternId = 'statement123';
         $linkStyle = 'style="color: blue; text-decoration: underline;"';
-        $linkStart = '<a href="#statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX;
+        $linkStartRecommendation = '<a href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX;
+        $linkStartSegmentText = '<a class="darstellung" href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX;
         $linkEnd = '" '.$linkStyle.'>';
         $linkClose = '</a>';
-        $expected = '<p>Some text '.$linkStart.'001'.$linkEnd.
-            'statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.$linkClose.
-            ' more text '.$linkStart.'002'.$linkEnd.
-            'statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002'.$linkClose.'</p>';
+
+        $expectedSegmentText = '<p>Some text '.$linkStartSegmentText.'001'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001'.$linkClose.
+            ' more text <a href="path/to/image2.jpg">image2</a>'.
+            ' and '.$linkStartSegmentText.'002'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002'.$linkClose.'</p>';
+
+        $expectedRecommendation = '<p>Some text '.$linkStartRecommendation.'001'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.$linkClose.
+            ' more text '.$linkStartRecommendation.'002'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002'.$linkClose.'</p>';
+
         $result = $this->sut->convert($segment, $statementExternId);
 
-        static::assertSame($expected, $result->getRecommendationText());
+        static::assertSame($expectedSegmentText, $result->getText());
+        static::assertSame($expectedRecommendation, $result->getRecommendationText());
     }
 
     public function testConvertWithoutLinkedReference(): void
     {
-        /** @var Segment $segment */
-        $segment = SegmentFactory::createOne()->_real();
-        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
-        $segment->setRecommendation($recommendation);
+        $segment = $this->createTestSegment();
 
         $statementExternId = 'statement123';
-        $expected = '<p>Some text '.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.
-            ' more text statement123'.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002</p>';
+        $expectedSegmentText = '<p>Some text '.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001'.
+            ' more text <a href="path/to/image2.jpg">image2</a> and '.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002</p>';
+        $expectedRecommendation = '<p>Some text '.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001'.
+            ' more text '.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002</p>';
         $result = $this->sut->convert($segment, $statementExternId, false);
 
-        static::assertSame($expected, $result->getRecommendationText());
+        static::assertSame($expectedSegmentText, $result->getText());
+        static::assertSame($expectedRecommendation, $result->getRecommendationText());
     }
 
     public function testGetImages(): void
     {
-        /** @var Segment $segment */
-        $segment = SegmentFactory::createOne()->_real();
-        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /> more text <img src="path/to/image2.jpg" /></p>';
-        $segment->setRecommendation($recommendation);
+        $segment = $this->createTestSegment();
         $statementExternId = 'statement123';
 
         $this->sut->convert($segment, $statementExternId);
 
-        $keyImage1 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001';
-        $keyImage2 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002';
-        $expectedImage1 = new ImageReference($keyImage1, '/absolute/path/to/image1.jpg');
-        $expectedImage2 = new ImageReference($keyImage2, '/absolute/path/to/image2.jpg');
+        $keyImage1 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001';
+        $keyImage3 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002';
+        $keyImage4 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001';
+        $keyImage5 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002';
+        $imagePath1 = 'path/to/image1.jpg';
+        $imagePath3 = 'path/to/image3.jpg';
+        $imagePath4 = '/absolute/path/to/image4.jpg';
+        $imagePath5 = '/absolute/path/to/image5.jpg';
+        $expectedImage1 = new ImageReference($keyImage1, $imagePath1);
+        $expectedImage3 = new ImageReference($keyImage3, $imagePath3);
+        $expectedImage4 = new ImageReference($keyImage4, $imagePath4);
+        $expectedImage5 = new ImageReference($keyImage5, $imagePath5);
 
         $result = $this->sut->getImages();
 
@@ -111,35 +124,41 @@ class ImageLinkConverterTest extends FunctionalTestCase
             ImageReference::class,
             $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]
         );
-        static::assertSame(
-            $expectedImage1->getImageReference(),
-            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][0]->getImageReference()
-        );
-        static::assertSame(
-            $expectedImage1->getImagePath(),
-            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][0]->getImagePath()
-        );
-        static::assertSame(
-            $expectedImage2->getImageReference(),
-            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]->getImageReference()
-        );
-        static::assertSame(
-            $expectedImage2->getImagePath(),
-            $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION][1]->getImagePath()
-        );
+        [$result1, $result2] = $result[0][ImageLinkConverter::IMAGES_KEY_SEGMENTS];
+        [$result3, $result4] = $result[0][ImageLinkConverter::IMAGES_KEY_RECOMMENDATION];
+        static::assertSame($expectedImage1->getImageReference(), $result1->getImageReference());
+        static::assertSame($expectedImage1->getImagePath(), $result1->getImagePath());
+        static::assertSame($expectedImage3->getImageReference(), $result2->getImageReference());
+        static::assertSame($expectedImage3->getImagePath(), $result2->getImagePath());
+        static::assertSame($expectedImage4->getImageReference(), $result3->getImageReference());
+        static::assertSame($expectedImage4->getImagePath(), $result3->getImagePath());
+        static::assertSame($expectedImage5->getImageReference(), $result4->getImageReference());
+        static::assertSame($expectedImage5->getImagePath(), $result4->getImagePath());
     }
 
     public function testResetImages(): void
     {
-        /** @var Segment $segment */
-        $segment = SegmentFactory::createOne()->_real();
-        $recommendation = '<p>Some text <img src="path/to/image1.jpg" /></p>';
-        $segment->setRecommendation($recommendation);
+        $segment = $this->createTestSegment();
         $statementExternId = 'statement123';
 
         $this->sut->convert($segment, $statementExternId);
         $this->sut->resetImages();
 
         static::assertEmpty($this->sut->getImages());
+    }
+
+    private function createTestSegment(): Segment
+    {
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $link1 = '<a class="darstellung" href="path/to/image1.jpg">Darstellung_Stell_001</a>';
+        $link2 = '<a href="path/to/image2.jpg">image2</a>';
+        $link3 = '<a class="darstellung" href="path/to/image3.jpg">Darstellung_Stell_002</a>';
+        $text = '<p>Some text '.$link1.' more text '.$link2.' and '.$link3.'</p>';
+        $recommendation = '<p>Some text <img src="path/to/image4.jpg" /> more text <img src="path/to/image5.jpg" /></p>';
+        $segment->setRecommendation($recommendation);
+        $segment->setText($text);
+
+        return $segment;
     }
 }

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -20,7 +20,6 @@ use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
-use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
 use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Tests\Base\FunctionalTestCase;
 

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -56,7 +56,8 @@ class ImageLinkConverterTest extends FunctionalTestCase
         $statementExternId = 'statement123';
         $linkStyle = 'style="color: blue; text-decoration: underline;"';
         $linkStartRecommendation = '<a href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX;
-        $linkStartSegmentText = '<a class="darstellung" href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX;
+        $linkStartSegmentText = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX;
         $linkEnd = '" '.$linkStyle.'>';
         $linkClose = '</a>';
 
@@ -151,9 +152,11 @@ class ImageLinkConverterTest extends FunctionalTestCase
     {
         /** @var Segment $segment */
         $segment = SegmentFactory::createOne()->_real();
-        $link1 = '<a class="darstellung" href="path/to/image1.jpg">Darstellung_Stell_001</a>';
+        $link1 = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="path/to/image1.jpg">Darstellung_Stell_001</a>';
         $link2 = '<a href="path/to/image2.jpg">image2</a>';
-        $link3 = '<a class="darstellung" href="path/to/image3.jpg">Darstellung_Stell_002</a>';
+        $link3 = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="path/to/image3.jpg">Darstellung_Stell_002</a>';
         $text = '<p>Some text '.$link1.' more text '.$link2.' and '.$link3.'</p>';
         $recommendation = '<p>Some text <img src="path/to/image4.jpg" /> more text <img src="path/to/image5.jpg" /></p>';
         $segment->setRecommendation($recommendation);

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ImageReference;
 use Tests\Base\FunctionalTestCase;
 
 class ImageLinkConverterTest extends FunctionalTestCase
@@ -82,12 +83,18 @@ class ImageLinkConverterTest extends FunctionalTestCase
 
         $keyImage1 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001';
         $keyImage2 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002';
-        $expectedImages = [
-            $keyImage1 => '/absolute/path/to/image1.jpg',
-            $keyImage2 => '/absolute/path/to/image2.jpg',
-        ];
+        $expectedImage1 = new ImageReference($keyImage1, '/absolute/path/to/image1.jpg');
+        $expectedImage2 = new ImageReference($keyImage2, '/absolute/path/to/image2.jpg');
 
-        static::assertSame($expectedImages, $this->sut->getImages());
+        $result = $this->sut->getImages();
+
+        static::assertCount(2, $result);
+        static::assertInstanceOf(ImageReference::class, $result[0]);
+        static::assertInstanceOf(ImageReference::class, $result[1]);
+        static::assertSame($expectedImage1->getImageReference(), $result[0]->getImageReference());
+        static::assertSame($expectedImage1->getImagePath(), $result[0]->getImagePath());
+        static::assertSame($expectedImage2->getImageReference(), $result[1]->getImageReference());
+        static::assertSame($expectedImage2->getImagePath(), $result[1]->getImagePath());
     }
 
     public function testResetImages(): void

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -907,10 +907,14 @@ docx.export.landscape: "Docx Exp. (Querformat)"
 docx.export.preamble: |
     <p>Bitte beachten Sie, dass Darstellungen im Text referenziert und unter der jeweiligen Stellungnahme oder Einwendung angezeigt werden.</p>
     <p>Die Verweise auf Darstellungen sind wie folgt strukturiert:</p>
+    <p>- In Erwiderungstexten:</p>
     <p>    &lt;ID der Stellungnahme/Einwendung&gt;_Darstellung_Erw_&lt;laufende Nummer&gt;</p>
+    <p>- In Stellungnahme-/Einwendungstexten:</p>
+    <p>    &lt;ID der Stellungnahme/Einwendung&gt;_Darstellung_Stell_&lt;laufende Nummer&gt;</p>
 
     <p>Beispiel:</p>
-    <p>- Für eine Abbildung in einem Erwiderungstext: M12_Darstellung_Erw_001</p>
+    <p>- Für eine Abbildung in einem Erwiderungstext: &lt;M12_Darstellung_Erw_001&gt;</p>
+    <p>- Für eine Abbildung in einem Stellungnahmetext: &lt;M12_Darstellung_Stell_001&gt;</p>
 docx: "DOCX"
 done: "erledigt"
 done.capital: "Erledigt"


### PR DESCRIPTION
### Ticket
[DPLAN-11982](https://demoseurope.youtrack.cloud/issue/DPLAN-11982/2-2-Als-Bearbeiterin-mochte-ich-Bilder-in-Stellungnahmetexten-und-dem-Export-anzeigen-konnen-um-Einwendungen-korrekt)

Referenced images in segment text are added to docx export. (segment export)
DATA generates links to images in statement texts in the format "Darstellung_Stell_XXX". DATA adds a class to the link tags so we can filter for the right links in a text. This pr adds logic to adjust these new links to match the format "statementExternId_Darstellung_Stell_XXX", and adds the linked images to the docx exports. The adjusted format is only relvant in the exported file. So in the interface the format that comes from DATA will be used.


### How to review/test
code review, For local testing you need "Stellungnahme aufteilen", Images in recommendations should work as before,
execute tests.

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
