### PR TITLE
fix (DPLAN-12156): fix path cannot be empty

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -50,11 +50,7 @@ final class ImageLinkConverter
         $xmlRecommendationText = str_replace('<br>', '<br/>', $recommendationText);
 
         $prefix = $statementExternId.'_';
-        $imageReferencesFromSegmentText = $this->htmlHelper->extractImageDataByClass(
-            $xmlSegmentText,
-            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
-            $prefix
-        );
+        $imageReferencesFromSegmentText = $this->convertImageReferences($xmlSegmentText, $prefix);
 
         $xmlSegmentText = $this->updateSegmentText($asLinkedReference, $xmlSegmentText, $prefix);
 
@@ -71,6 +67,24 @@ final class ImageLinkConverter
         ];
 
         return new ConvertedSegment($xmlSegmentText, $xmlRecommendationText);
+    }
+
+    private function convertImageReferences(string $xmlSegmentText, string $prefix): array
+    {
+        $imageReferencesFromSegmentText = $this->htmlHelper->extractImageDataByClass(
+            $xmlSegmentText,
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL,
+            $prefix
+        );
+
+        foreach ($imageReferencesFromSegmentText as $key => $imageReference) {
+            $imageReferencesFromSegmentText[$key] = new ImageReference(
+                $imageReference->getImageReference(),
+                $this->getAbsoluteImagePath($imageReference->getImagePath())
+            );
+        }
+
+        return $imageReferencesFromSegmentText;
     }
 
     private function updateSegmentText(bool $asLinkedReference, string $text, string $prefix): string

--- a/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ImageLinkConverter.php
@@ -69,6 +69,11 @@ final class ImageLinkConverter
         return new ConvertedSegment($xmlSegmentText, $xmlRecommendationText);
     }
 
+    /**
+     * Extracts image references from the given XML segment text and converts them to ImageReference objects.
+     *
+     * @return array<int, ImageReference> an array containing the extracted ImageReference objects
+     */
     private function convertImageReferences(string $xmlSegmentText, string $prefix): array
     {
         $imageReferencesFromSegmentText = $this->htmlHelper->extractImageDataByClass(

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -105,8 +105,8 @@ class ImageLinkConverterTest extends FunctionalTestCase
         $keyImage3 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002';
         $keyImage4 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'001';
         $keyImage5 = $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_RECOMMENDATION_SUFFIX.'002';
-        $imagePath1 = 'path/to/image1.jpg';
-        $imagePath3 = 'path/to/image3.jpg';
+        $imagePath1 = '/absolute/path/to/image1.jpg';
+        $imagePath3 = '/absolute/path/to/image3.jpg';
         $imagePath4 = '/absolute/path/to/image4.jpg';
         $imagePath5 = '/absolute/path/to/image5.jpg';
         $expectedImage1 = new ImageReference($keyImage1, $imagePath1);
@@ -153,10 +153,10 @@ class ImageLinkConverterTest extends FunctionalTestCase
         /** @var Segment $segment */
         $segment = SegmentFactory::createOne()->_real();
         $link1 = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="path/to/image1.jpg">Darstellung_Stell_001</a>';
+            '" href="image1.jpg">Darstellung_Stell_001</a>';
         $link2 = '<a href="path/to/image2.jpg">image2</a>';
         $link3 = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="path/to/image3.jpg">Darstellung_Stell_002</a>';
+            '" href="image3.jpg">Darstellung_Stell_002</a>';
         $text = '<p>Some text '.$link1.' more text '.$link2.' and '.$link3.'</p>';
         $recommendation = '<p>Some text <img src="path/to/image4.jpg" /> more text <img src="path/to/image5.jpg" /></p>';
         $segment->setRecommendation($recommendation);


### PR DESCRIPTION
### Ticket
[DPLAN-12156](https://demoseurope.youtrack.cloud/issue/DPLAN-12156/Fehler-bei-Export-wenn-Bilder-sowohl-in-STN-Texten-als-auch-in-Erwiderungstexten-existieren)

 I think we have to use the getAbsoluteImagePath() here.

### How to review/test
code review

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
