### PR TITLE
bug(refs DPLAN-12154): Fix segmentation buttons

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -673,7 +673,9 @@ export default {
 
           this.toggleAssignableUsersSelect()
           this.$nextTick(() => {
-            this.$refs.imageModal.addClickListener(this.$refs.recommendationContainer.querySelectorAll('img'))
+            if (this.$refs.recommendationContainer) {
+              this.$refs.imageModal.addClickListener(this.$refs.recommendationContainer.querySelectorAll('img'))
+            }
           })
         })
         .catch(() => {

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -58,13 +58,12 @@
       :text="Translator.trans('segment.edit')"
       @click="$emit('edit-segment', segment.id)" />
     <addon-wrapper
-      :addon-props="{
-        segmentStatus: segment.status
-      }"
+      v-if="segment.status !== 'confirmed'"
+      class="inline-block mr-1"
       hook-name="split.statement.buttons"
       @segment:confirm="$emit('segment:confirm', segment.id)" />
     <dp-button-icon
-      class="u-ml-0_25"
+      class="ml-1"
       icon="fa-trash"
       :text="Translator.trans('selection.tags.discard')"
       @click="$emit('delete-segment', segment.id)" />

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -58,12 +58,14 @@
       :text="Translator.trans('segment.edit')"
       @click="$emit('edit-segment', segment.id)" />
     <addon-wrapper
-      v-if="segment.status !== 'confirmed'"
-      class="inline-block mr-1"
+      :addon-props="{
+        class: 'mt-1',
+        segmentStatus: segment.status
+      }"
+      class="inline-block"
       hook-name="split.statement.buttons"
       @segment:confirm="$emit('segment:confirm', segment.id)" />
     <dp-button-icon
-      class="ml-1"
       icon="fa-trash"
       :text="Translator.trans('selection.tags.discard')"
       @click="$emit('delete-segment', segment.id)" />


### PR DESCRIPTION
### Ticket
DPLAN-12154

- Fix segmentation buttons: We need `inline-block` here for the `div` in the addonWrapper and some margin for the icon in the addon
- Fix another bug where we get a console error when recommendationContainer does not exist

~~Move condition for rendering addon component from inside the addon to here, so we don't have an empty div lingering around.
I'm not sure about this approach. We don't have the empty div and therefor no styling issues, but does it make sense to have this condition in core? Or should this logic remain in the addon?~~
<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

