### PR TITLE
fix (DPLAN-12156): Add no page break if no images are present.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
@@ -32,7 +32,9 @@ class ImageManager
     {
         // Add images after all segments of one statement.
         $images = $this->imageLinkConverter->getImages();
-        if ([] === $images) {
+        $noImagesPresent = $images[ImageLinkConverter::IMAGES_KEY_RECOMMENDATION] === []
+            && $images[ImageLinkConverter::IMAGES_KEY_SEGMENTS] === [];
+        if ([] === $images || $noImagesPresent) {
             return;
         }
         $section->addPageBreak();


### PR DESCRIPTION
### Ticket
[DPLAN-12156](https://demoseurope.youtrack.cloud/issue/DPLAN-12166/Beim-Export-von-STN-als-einzelne-DOCX-Dateien-wird-bei-jeder-Datei-am-Ende-eine-leere-Seite-hinzugefugt)

This added check should avoid a page break when no images are present for adding in export.

### How to review/test
code review

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
