### PR TITLE
fix (DPLAN-12156): Add no page break if no images are present.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/ImageManager.php
@@ -32,11 +32,11 @@ class ImageManager
     {
         // Add images after all segments of one statement.
         $images = $this->imageLinkConverter->getImages();
-        $noImagesPresent = [] === $images[ImageLinkConverter::IMAGES_KEY_RECOMMENDATION]
-            && [] === $images[ImageLinkConverter::IMAGES_KEY_SEGMENTS];
-        if ([] === $images || $noImagesPresent) {
+
+        if (!$this->imagesArePresent($images)) {
             return;
         }
+
         $section->addPageBreak();
 
         foreach ($images as $imageReferencsArray) {
@@ -51,6 +51,20 @@ class ImageManager
 
         // remove already printed images
         $this->imageLinkConverter->resetImages();
+    }
+
+    private function imagesArePresent(array $images): bool
+    {
+        $imagesArePresent = false;
+        foreach ($images as $imageReferencsArray) {
+            if ([] !== $imageReferencsArray[ImageLinkConverter::IMAGES_KEY_SEGMENTS]
+                || [] !== $imageReferencsArray[ImageLinkConverter::IMAGES_KEY_RECOMMENDATION]) {
+                $imagesArePresent = true;
+                break;
+            }
+        }
+
+        return $imagesArePresent;
     }
 
     private function addImage(Section $section, ImageReference $imageReference, float $imageSpaceCurrentlyUsed): float


### PR DESCRIPTION
### Ticket
[DPLAN-12156](https://demoseurope.youtrack.cloud/issue/DPLAN-12166/Beim-Export-von-STN-als-einzelne-DOCX-Dateien-wird-bei-jeder-Datei-am-Ende-eine-leere-Seite-hinzugefugt)

This added check should avoid a page break when no images are present for adding in export.

### How to review/test
code review

second try
old pr: https://github.com/demos-europe/demosplan-core/pull/3501

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
