### PR TITLE
fix(refs DPLAN-12009): Apply fix for regio as well since STNs can be copied/moved here as well

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -66,7 +66,7 @@ class FileController extends BaseController
     {
         $fs = new Filesystem();
         // @improve T14122
-        $file = $fileService->getFileInfo($hash);
+        $file = $fileService->getFileInfo($hash, $procedureId);
 
         // ensure that procedure access check matches file procedure
         if (!$this->isValidProcedure($procedureId, $file, $strictCheck)) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -62,7 +62,7 @@ class FileController extends BaseController
     /**
      * @throws Exception
      */
-    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, ?string $procedureId = null): Response
+    protected function prepareResponseWithHash(FileService $fileService, string $hash, bool $strictCheck = false, string $procedureId = null): Response
     {
         $fs = new Filesystem();
         // @improve T14122

--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -93,9 +93,9 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws Exception
      */
-    public function getFileInfo($hash): FileInfo
+    public function getFileInfo($hash, ?string $procedureId = null): FileInfo
     {
-        $file = $this->fileRepository->getFileInfo($hash);
+        $file = $this->fileRepository->getFileInfo($hash, $procedureId);
 
         if (null !== $file) {
             $path = $file->getPath();
@@ -329,10 +329,10 @@ class FileService extends CoreService implements FileServiceInterface
     public function saveTemporaryFile(
         string $filePath,
         string $fileName,
-        string $userId = null,
-        string $procedureId = null,
+        ?string $userId = null,
+        ?string $procedureId = null,
         ?string $virencheck = FileServiceInterface::VIRUSCHECK_SYNC,
-        string $hash = null
+        ?string $hash = null
     ): File {
         $dplanFile = new File();
         $symfonyFile = new \Symfony\Component\HttpFoundation\File\File($filePath);
@@ -598,7 +598,7 @@ class FileService extends CoreService implements FileServiceInterface
      * @throws InvalidDataException
      * @throws Throwable
      */
-    public function copyByFileString($fileString, string $procedureId = null): ?File
+    public function copyByFileString($fileString, ?string $procedureId = null): ?File
     {
         $file = $this->getFileInfoFromFileString($fileString);
 
@@ -610,7 +610,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws InvalidDataException|Throwable
      */
-    public function copy(?string $hash, string $targetProcedureId = null): ?File
+    public function copy(?string $hash, ?string $targetProcedureId = null): ?File
     {
         $fileToCopy = $this->get($hash);
         if (!$fileToCopy instanceof File) {
@@ -717,7 +717,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @return string
      */
-    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', string $existingHash = null)
+    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', ?string $existingHash = null)
     {
         // Generate a unique name for the file before saving it
         $hash = $existingHash ?? $this->createHash();

--- a/demosplan/DemosPlanCoreBundle/Logic/FileService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileService.php
@@ -93,7 +93,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws Exception
      */
-    public function getFileInfo($hash, ?string $procedureId = null): FileInfo
+    public function getFileInfo($hash, string $procedureId = null): FileInfo
     {
         $file = $this->fileRepository->getFileInfo($hash, $procedureId);
 
@@ -329,10 +329,10 @@ class FileService extends CoreService implements FileServiceInterface
     public function saveTemporaryFile(
         string $filePath,
         string $fileName,
-        ?string $userId = null,
-        ?string $procedureId = null,
+        string $userId = null,
+        string $procedureId = null,
         ?string $virencheck = FileServiceInterface::VIRUSCHECK_SYNC,
-        ?string $hash = null
+        string $hash = null
     ): File {
         $dplanFile = new File();
         $symfonyFile = new \Symfony\Component\HttpFoundation\File\File($filePath);
@@ -598,7 +598,7 @@ class FileService extends CoreService implements FileServiceInterface
      * @throws InvalidDataException
      * @throws Throwable
      */
-    public function copyByFileString($fileString, ?string $procedureId = null): ?File
+    public function copyByFileString($fileString, string $procedureId = null): ?File
     {
         $file = $this->getFileInfoFromFileString($fileString);
 
@@ -610,7 +610,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @throws InvalidDataException|Throwable
      */
-    public function copy(?string $hash, ?string $targetProcedureId = null): ?File
+    public function copy(?string $hash, string $targetProcedureId = null): ?File
     {
         $fileToCopy = $this->get($hash);
         if (!$fileToCopy instanceof File) {
@@ -717,7 +717,7 @@ class FileService extends CoreService implements FileServiceInterface
      *
      * @return string
      */
-    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', ?string $existingHash = null)
+    protected function moveFile(\Symfony\Component\HttpFoundation\File\File $file, $path = '', string $existingHash = null)
     {
         // Generate a unique name for the file before saving it
         $hash = $existingHash ?? $this->createHash();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -18,7 +18,6 @@ use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Doctrine\Generator\NCNameGenerator;
-use demosplan\DemosPlanCoreBundle\Entity\FileContainer;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\County;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Municipality;

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementAttachmentService.php
@@ -14,6 +14,7 @@ use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
 use demosplan\DemosPlanCoreBundle\Repository\StatementAttachmentRepository;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\OptimisticLockException;
@@ -21,8 +22,10 @@ use Doctrine\ORM\ORMException;
 
 class StatementAttachmentService extends CoreService
 {
-    public function __construct(private readonly StatementAttachmentRepository $attachmentRepository)
-    {
+    public function __construct(
+        private readonly StatementAttachmentRepository $attachmentRepository,
+        private readonly StatementRepository $statementRepository
+    ) {
     }
 
     public function createOriginalAttachment(Statement $statement, File $file): StatementAttachment
@@ -65,26 +68,26 @@ class StatementAttachmentService extends CoreService
      *
      * @return Collection<int, StatementAttachment>
      */
-    public function copyAttachmentEntries(Collection $originalAttachments, Statement $targetStatement): Collection
-    {
+    public function copyAttachmentEntries(
+        Collection $originalAttachments,
+        Statement $targetStatement,
+    ): Collection {
         $copiedAttachments = new ArrayCollection();
         foreach ($originalAttachments as $originalAttachment) {
             $copiedAttachments->add($this->copyToStatement(
                 $originalAttachment,
-                $targetStatement
+                $targetStatement,
             ));
         }
 
         return $copiedAttachments;
     }
 
-    private function copyToStatement(StatementAttachment $attachment, Statement $statement): StatementAttachment
-    {
-        return $this->createAttachment(
-            $statement,
-            $attachment->getFile(),
-            $attachment->getType()
-        );
+    private function copyToStatement(
+        StatementAttachment $attachment,
+        Statement $statement,
+    ): StatementAttachment {
+        return $this->statementRepository->copyAttachment($statement, $attachment);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
@@ -30,7 +30,7 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
     /**
      * Hole Infos zum File.
      */
-    public function getFileInfo(string $hash): ?File
+    public function getFileInfo(string $hash, ?string $procedureId = null): ?File
     {
         // Der übergebene Hash ist der Ident der Datenbank
         // Die Spalte Hash bezeichnet den Namen, unter dem die Datei auf dem
@@ -38,14 +38,30 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
 
         /** @var File|null $result */
         $result = $this->findOneBy(['ident' => $hash, 'deleted' => false]);
-
+        if (null !== $result) {
+            return $result;
+        }
         // As ident and hash are historically really strangely used mistakes happened
         // be kind and try to find via hash when nothing was found by ident
-        if (null === $result) {
-            $result = $this->findOneBy(['hash' => $hash, 'deleted' => false]);
+
+        // T36732 In case the same physical file is used for multiple procedures
+        // There will be a fileInfo entity for every reference to a physical file.
+        // They share the same hash - but not necessarily the procedure
+        // - so the findOneBy method for the kindly supported hash is insufficient here.
+        $fileInfos = $this->findBy(['hash' => $hash, 'deleted' => false, 'procedure' => $procedureId]);
+        $fileInfosCount = count($fileInfos);
+        // easy - has to be this one
+        if (0 < $fileInfosCount) {
+            return reset($fileInfos);
+        }
+        $fileInfos = $this->findBy(['hash' => $hash, 'deleted' => false, 'procedure' => null]);
+        $fileInfosCount = count($fileInfos);
+        // tried our best to return the correct fileInfo - but if not successful until here - just return a matching hash
+        if (0 === $fileInfosCount) {
+            return $this->findOneBy(['hash' => $hash, 'deleted' => false]);
         }
 
-        return $result;
+        return reset($fileInfos);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
@@ -30,7 +30,7 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
     /**
      * Hole Infos zum File.
      */
-    public function getFileInfo(string $hash, ?string $procedureId = null): ?File
+    public function getFileInfo(string $hash, string $procedureId = null): ?File
     {
         // Der übergebene Hash ist der Ident der Datenbank
         // Die Spalte Hash bezeichnet den Namen, unter dem die Datei auf dem

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -138,7 +138,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     /**
      * Add new ClusterStatement, what basically is a Statement with a cluster of Statements.
      *
-     * @return statement - headStatement of the created statement-cluster
+     * @return Statement - headStatement of the created statement-cluster
      *
      * @throws Exception
      */
@@ -479,7 +479,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     /**
      * @return array<int, Statement|Segment>
      */
-    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, int $limit = null): array
+    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, ?int $limit = null): array
     {
         return parent::getEntities($conditions, $sortMethods, $offset, $limit);
     }
@@ -991,7 +991,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
      * StatementVotes, which are not contained in $votesToSet, will be deleted.
      * StatementVotes, which are contained in $votesToSet, will be created if not existing, or updated.
      *
-     * @param statement        $statement  - related Statement
+     * @param Statement        $statement  - related Statement
      * @param array|Collection $votesToSet - StatementVotes to set on the given Statement
      *
      * @return Collection<int, StatementVote>
@@ -1763,7 +1763,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     public function copyOriginalStatement(
         Statement $originalToCopy,
         Procedure $targetProcedure,
-        GdprConsent $gdprConsentToSet = null,
+        ?GdprConsent $gdprConsentToSet = null,
         $internIdToSet = null
     ): Statement {
         if (!$originalToCopy->isOriginal()) {
@@ -1800,7 +1800,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         $newOriginalStatement->setSubmit($originalToCopy->getSubmitObject()->add(new DateInterval('PT1S')));
         $newStatementMeta = clone $originalToCopy->getMeta();
         $newOriginalStatement->setMeta($newStatementMeta);
-
+        $newOriginalStatement->setProcedure($targetProcedure);
         $newOriginalStatement->setChildren(null);
 
         /**
@@ -1849,7 +1849,6 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         }
 
         $newOriginalStatement->setExternId($newExternId);
-        $newOriginalStatement->setProcedure($targetProcedure);
 
         if ($originalToCopy->getProcedureId() !== $targetProcedure->getId()) {
             // remove all tags, because procedure specific -> impossible to keep:
@@ -2037,7 +2036,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
         return $statementFileContainer;
     }
 
-    private function copyFile(File $sourceFile, Statement $targetStatement): File
+    public function copyFile(File $sourceFile, Statement $targetStatement): File
     {
         $fileCopy = $this->getFileRepository()->copyFile($sourceFile);
         $fileCopy->setProcedure($targetStatement->getProcedure());

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -479,7 +479,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     /**
      * @return array<int, Statement|Segment>
      */
-    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, ?int $limit = null): array
+    public function getEntities(array $conditions, array $sortMethods, int $offset = 0, int $limit = null): array
     {
         return parent::getEntities($conditions, $sortMethods, $offset, $limit);
     }
@@ -1763,7 +1763,7 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     public function copyOriginalStatement(
         Statement $originalToCopy,
         Procedure $targetProcedure,
-        ?GdprConsent $gdprConsentToSet = null,
+        GdprConsent $gdprConsentToSet = null,
         $internIdToSet = null
     ): Statement {
         if (!$originalToCopy->isOriginal()) {


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12009/ROBOB-Prod-Bei-verschobenen-STN-wurden-in-der-Ubersicht-die-Links-von-Anhangen-nicht-angepasst

Description:
Merged for project-release here: https://github.com/demos-europe/demosplan-core/pull/3431 https://github.com/demos-europe/demosplan-project-robobsh/pull/85

All original statement creations where handling their file copy tasks correct as far as setting individual file-entries for all of them. The only problem was a procedureId that was set to late on the new statement in order to be used for those files.

on copy there was a method StatementAttachmentService::copyToStatement that made use of a createAttachment
method that did not create a new file-entry for the attachment but set the same file-reference. Changed this method to use the correct one from the statement-repository.

on move it was more tricky.
When creating new statements - after their originals are done we create the (normal) statements by... ```StatementHandler::createNonOriginalStatement::copyStatementObjectWithinProcedureWithRelatedFiles::copyStatementObjectWithinProcedure::copyAttachmentEntries::copyToStatement``` ... in the end calling the same problematic method as described above. Therefore The statement and its original use the same file-reference inside their containers.
This makes it necessary to create new file-entries for all moved files - as otherwise the files would be shared with the original-statement which remains inside the source procedure.
But not that quick - by changing the ```copyToStatement``` method - the from now on newly-created statements wont share their statement-attachment files with its original anymore. So only the weitere-attachments need to get new files created on move. The statement-attachment is fine with just an update of its procedure.

The picked changes from the here linked PR are necessary to access the correct now procedure related file by a given hash.

### Linked PRs (optional)
picked part of the fix from:
https://github.com/demos-europe/demosplan-core/pull/2850


### Tasks (optional)
Fix wrong db-entries of failed copies via migration?

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
