### PR TITLE
fix (DPLAN-12164 & DPLAN-12165): fix image links in export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -48,8 +48,8 @@ class HtmlHelper
         $imageReferences = [];
 
         // The regex pattern to match <a> tags with the specified class and extract their href attributes and link text
-        $pattern =
-            '/<a\b[^>]*class="[^"]*\b'.preg_quote($class, '/').'\b[^"]*"[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/i';
+        // irrespective of the order of class and href attributes
+        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'.preg_quote($class, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
 
         // Perform the regex match
         if (preg_match_all($pattern, $htmlText, $matches)) {

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -54,8 +54,8 @@ class HtmlHelperTest extends FunctionalTestCase
     {
         $prefix = 'New_';
         // Test 1: <a> tag with class darstellung and href attribute
-        $htmlWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="https://www.example1.com">Example 1</a>';
+        $htmlWithClass = '<a href="https://www.example1.com" class="'.
+            HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'">Example 1</a>';
         $expectedWithClass = [
             new ImageReference($prefix.'Example 1', 'https://www.example1.com'),
         ];


### PR DESCRIPTION
### Tickets
[DPLAN-12164](https://demoseurope.youtrack.cloud/issue/DPLAN-12164/ID-fehlt-in-der-Abbildung-US)
[DPLAN-12165](https://demoseurope.youtrack.cloud/issue/DPLAN-12165/Referenz-nicht-als-Hyperlink-markiert-US)

the placement of the class attribut in the a tags should be irrelevant.

### How to review/test
code review + run test

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
