### PR TITLE
fix(refs DPLAN-12008): Fix copy of attachments from ostns

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1686,7 +1686,7 @@ class StatementService extends CoreService implements StatementServiceInterface
             return false;
         }
 
-        return $this->statementCopier->copyStatementObjectWithinProcedure($statementObject, $createReport);
+        return $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($statementObject, $createReport);
     }
 
     /**


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12208/Das-Kopieren-einer-original-Stellungnahme-kopiert-die-weiteren-Anhange-nicht-mit.

Description:
Use the correct method to take attachments into account when copying o-stns

### How to review/test
copy ostns with attachments

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
