### PR TITLE
chore: initially fpa should be able to create procedures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -16,6 +16,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
@@ -30,6 +31,7 @@ class LoadUserData extends ProdFixture implements DependentFixtureInterface
 {
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly AccessControlService $accessControlPermissionService,
         private readonly OrgaService $orgaService,
         private readonly UserHandler $userHandler,
         private readonly UserService $userService
@@ -55,6 +57,12 @@ class LoadUserData extends ProdFixture implements DependentFixtureInterface
 
         // Citizen pseudo user suboptimal, but isso
         $this->createAnonymousCitizenUser($manager, $orgaTypeOlauth, $customer);
+
+        $this->accessControlPermissionService->enablePermissionCustomerOrgaRole(
+            AccessControlService::CREATE_PROCEDURES_PERMISSION,
+            $customer,
+            $this->getReference('role_RMOPSA')
+        );
     }
 
     public function getDependencies()


### PR DESCRIPTION
Prod Fixtures should allow planner admins to create procedures by default

### How to review/test
create a new database instance with prod fixtures. You should be able to create new procedures

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
