### PR TITLE
feat (DPLAN-11982) fix recognition of links

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -72,11 +72,15 @@ class HtmlHelper
      */
     public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
-        $pattern = '/(<a\b[^>]*class="[^"]*\b'
-            .preg_quote($className, '/').'\b[^"]*")[^>]*(href="[^"]*")[^>]*(>)(.*?)(<\/a>)/i';
-        $replacement = '$1 href="#'.$prefix.'$4" style="color: blue; text-decoration: underline;"$3'.$prefix.'$4$5';
+        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'.preg_quote($className, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
+        if (preg_match_all($pattern, $htmlText, $matches)) {
+            foreach ($matches[2] as $index => $linkText) {
+                $replacement = '<a class="'.$className.'" href="#'.$prefix.$linkText.'" style="color: blue; text-decoration: underline;">'.$prefix.$linkText.'</a>';
+                $htmlText = str_replace($matches[0][$index], $replacement, $htmlText);
+            }
+        }
 
-        return preg_replace($pattern, $replacement, $htmlText);
+        return $htmlText;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -72,10 +72,13 @@ class HtmlHelper
      */
     public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
-        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'.preg_quote($className, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
+        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'
+            .preg_quote($className, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
         if (preg_match_all($pattern, $htmlText, $matches)) {
             foreach ($matches[2] as $index => $linkText) {
-                $replacement = '<a class="'.$className.'" href="#'.$prefix.$linkText.'" style="color: blue; text-decoration: underline;">'.$prefix.$linkText.'</a>';
+                $replacement = '<a class="'.$className
+                    .'" href="#'.$prefix.$linkText.'" style="color: blue; text-decoration: underline;">'
+                    .$prefix.$linkText.'</a>';
                 $htmlText = str_replace($matches[0][$index], $replacement, $htmlText);
             }
         }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -113,7 +113,7 @@ class HtmlHelperTest extends FunctionalTestCase
         $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '" href="https://www.example3.com">Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a  href="https://www.example5.com" style="color: blue; class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '<a  href="https://www.example5.com" style="color: blue;" class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '">Old Text 5</a>';
         $expectedMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text 3"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 3</a>'.

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -102,8 +102,8 @@ class HtmlHelperTest extends FunctionalTestCase
     public function testUpdateLinkTextWithClass(): void
     {
         // Test 1: <a> tag with class darstellung
-        $htmlWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="https://www.example1.com">Old Text</a>';
+        $htmlWithClass = '<a href="https://www.example1.com" class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '">Old Text</a>';
         $expectedWithClass = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text"'
             .' style="color: blue; text-decoration: underline;">New_Old Text</a>';
         // Test 2: <a> tag without class darstellung
@@ -113,19 +113,18 @@ class HtmlHelperTest extends FunctionalTestCase
         $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '" href="https://www.example3.com">Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
-            '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="https://www.example5.com">Old Text 5</a>';
+            '<a  href="https://www.example5.com" style="color: blue; class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '">Old Text 5</a>';
         $expectedMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text 3"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 3</a>'.
             '<a class="other-class" href="https://www.example4.com">Old Text 4</a>'.
             '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.'" href="#New_Old Text 5"'
             .' style="color: blue; text-decoration: underline;">New_Old Text 5</a>';
         $prefix = 'New_';
-        $href = 'https://www.test.com';
         $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
-        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, $class, $prefix, $href);
-        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, $class, $prefix, $href);
-        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, $class, $prefix, $href);
+        $resultA = $this->sut->updateLinkTextWithClass($htmlWithClass, $class, $prefix);
+        $resultB = $this->sut->updateLinkTextWithClass($htmlWithoutClass, $class, $prefix);
+        $resultC = $this->sut->updateLinkTextWithClass($htmlMixed, $class, $prefix);
         static::assertSame($expectedWithClass, $resultA);
         static::assertSame($expectedWithoutClass, $resultB);
         static::assertSame($expectedMixed, $resultC);
@@ -134,8 +133,8 @@ class HtmlHelperTest extends FunctionalTestCase
     public function testRemoveLinkTagsByClass(): void
     {
         $prefix = 'New_';
-        $htmlMixed = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
-            '" href="https://www.example1.com">Old Text 1</a>'.
+        $htmlMixed = '<a href="https://www.example1.com" class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '">Old Text 1</a>'.
             '<a class="other-class" href="https://www.example2.com">Old Text 2</a>'.
             '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '" href="https://www.example3.com">Old Text 3</a>';


### PR DESCRIPTION
### Ticket
[DPLAN-11982](https://demoseurope.youtrack.cloud/issue/DPLAN-11982/2-2-Als-Bearbeiterin-mochte-ich-Bilder-in-Stellungnahmetexten-und-dem-Export-anzeigen-konnen-um-Einwendungen-korrekt)

This should fix the recognition of links when updating them for export.

### How to review/test
code review, run test


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
