### PR TITLE
F dplan 12208 fix attachment copy on ostn copy

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1679,7 +1679,7 @@ class StatementService extends CoreService implements StatementServiceInterface
             return false;
         }
 
-        return $this->statementCopier->copyStatementObjectWithinProcedure($statementObject, $createReport);
+        return $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($statementObject, $createReport);
     }
 
     /**


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12208/Das-Kopieren-einer-original-Stellungnahme-kopiert-die-weiteren-Anhange-nicht-mit.


Description:
Use the correct method to take attachments into account when copying o-stns ( already reviewed in https://github.com/demos-europe/demosplan-core/pull/3519 )

### How to review/test
copy stns with attachments


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly


