### PR TITLE
chore: add subdomain to oauth_keycloak_logout_route

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -15,6 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -66,12 +67,11 @@ class LogoutSubscriber implements EventSubscriberInterface
                 $currentCustomer = $this->customerService->getCurrentCustomer();
                 $logoutRoute = str_replace(
                     'post_logout_redirect_uri=https://',
-                    'post_logout_redirect_uri=https://'. $currentCustomer->getSubdomain() . '.',
+                    'post_logout_redirect_uri=https://'.$currentCustomer->getSubdomain().'.',
                     $logoutRoute
                 );
                 $this->logger->info('Redirecting to Keycloak for logout adjusted', [$logoutRoute]);
-
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->logger->error('Could not get current customer', [$e->getMessage()]);
             }
             $response = $this->redirect($logoutRoute);

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Cookie\PreviousRouteCookie;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -26,6 +27,7 @@ class LogoutSubscriber implements EventSubscriberInterface
     private array $allowedCookieNames = [PreviousRouteCookie::NAME];
 
     public function __construct(
+        private readonly CustomerService $customerService,
         private readonly LoggerInterface $logger,
         private readonly ParameterBagInterface $parameterBag,
         private readonly PermissionsInterface $permissions,
@@ -57,8 +59,22 @@ class LogoutSubscriber implements EventSubscriberInterface
 
         // let oauth identity provider handle logout when defined
         if ('' !== $this->parameterBag->get('oauth_keycloak_logout_route')) {
-            $this->logger->info('Redirecting to Keycloak for logout', [$this->parameterBag->get('oauth_keycloak_logout_route')]);
-            $response = $this->redirect($this->parameterBag->get('oauth_keycloak_logout_route'));
+            $logoutRoute = $this->parameterBag->get('oauth_keycloak_logout_route');
+            $this->logger->info('Redirecting to Keycloak for logout initial', [$logoutRoute]);
+            // add subdomain for redirect
+            try {
+                $currentCustomer = $this->customerService->getCurrentCustomer();
+                $logoutRoute = str_replace(
+                    'post_logout_redirect_uri=https://',
+                    'post_logout_redirect_uri=https://'. $currentCustomer->getSubdomain() . '.',
+                    $logoutRoute
+                );
+                $this->logger->info('Redirecting to Keycloak for logout adjusted', [$logoutRoute]);
+
+            } catch (\Exception $e) {
+                $this->logger->error('Could not get current customer', [$e->getMessage()]);
+            }
+            $response = $this->redirect($logoutRoute);
         }
 
         if ($this->permissions->hasPermission('feature_has_logout_landing_page')) {


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/18403

when redirecting back to beteiligung from keycloak the subdomain needs to be included into the redirect url. This needs to be done dynamically as customer differs

### How to review/test
You could set `oauth_keycloak_logout_route: 'http://diplanbau.dplan.local/app_dev.php/?post_logout_redirect_uri=https://something.dplan.local/app_dev.php/impressum'` or something the like in parameters and review URL on logout

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
