### PR TITLE
chore refs (DPLAN-12231): allow planners to edit invitation email entirely

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
@@ -110,6 +110,11 @@
                 |json_encode|e('js', 'utf-8') }}')">
         </dp-email-list>
 
+        {% set emailText = templateVars.procedure.settings.emailText|default %}
+        {% if hasPermission('feature_email_invitable_institution_additional_invitation_text') and templateVars.emailTextAdded is defined %}
+            {% set emailText = emailText ~ '<br/><br/>' ~ templateVars.emailTextAdded|wysiwyg|nl2br  %}
+        {% endif %}
+
         <div class="{{ 'u-mb-0_75'|prefixClass }}">
             <dp-label
                 for="r_emailText"
@@ -124,7 +129,7 @@
                     linkButton: true
                 }"
                 required
-                value="{{ templateVars.procedure.settings.emailText|default }}">
+                value="{{ emailText }}">
                 <template v-slot:modal="modalProps">
                     <dp-boiler-plate-modal
                         ref="boilerPlateModal"
@@ -165,17 +170,6 @@
                 {{ "email.send"|trans }}
             </button>
         </div>
-
-        {% if hasPermission('feature_email_invitable_institution_additional_invitation_text') %}
-            <h2 class="u-mt-2">{{ "email.text"|trans }}:</h2>
-            <p>
-                {% if templateVars.emailTextAdded is defined %}
-                    {{ templateVars.emailTextAdded|wysiwyg|nl2br }}
-                {% else %}
-                    Kein Text definiert.
-                {% endif %}
-            </p>
-        {% endif %}
 
     </form>
 


### PR DESCRIPTION
### Ticket
DPLAN-12231

Planners should be able to edit entire invitation email text to be more flexible about the content

### How to review/test
Invite an organisation via email and find the entire text within the textarea, not anymore below

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
