### PR TITLE
fix(refs DPLAN-12020): use adjusted url to create layer

### DIFF
--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -119,7 +119,7 @@ export default {
         url += params
       }
 
-      this.source = createSourceTileWMS(this.url, this.layers, this.projection, this.defaultAttributions, this.map)
+      this.source = createSourceTileWMS(url, this.layers, this.projection, this.defaultAttributions, this.map)
       const layer = createTileLayer(this.title, this.name, this.source, this.opacity)
 
       //  Insert layer at pos 0, making it the background layer


### PR DESCRIPTION
### Ticket
[DPLAN-XXXXX
or
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/XXXXX
](https://demoseurope.youtrack.cloud/issue/DPLAN-12020/Kartenebene-wird-in-EWM-nicht-angezeigt-in-DiPlanBau-schon)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

In the previous fix, the url was adjusted, but not used when creating the layer, so the layer was still not displayed.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Go to the "Karteneinstellungen" view -> Startkartenausschnitt and set it to an area around Coswig, e.g. like this:
![startkartenausschnitt](https://github.com/user-attachments/assets/6ccf64c7-8474-4a46-a7d5-acfa70526128)
- Hit "Speichern und zurück"
- Go to "Kartenebenen definieren" -> Neue Kartenebene and enter the following data:
**Name***   pick whatever
**URL*** https://maps.deges.de/server/services/AWF_EWMS_WMS_WFS/VKE3251_2_S84_Achse_dxf_25833/MapServer/WMSServer?SERVICE=WMS
**Typ***   WMS
**Layer***   0
**Projektion***   EPSG:25833
**Deckkraft in %***   100
**x** Kartenebene veröffentlichen
- Go to the segments list > "Erwiderungen verfassen" and open the "Ortsbezug" map for a segment
- The map should display the layer (inside the red rectangle, but without the red rectangle):
![ortsbezug_layer](https://github.com/user-attachments/assets/50e80840-439b-4def-b0e1-3651d4e24d14)




### Linked PRs (optional)
<!-- 
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
Original fix: https://github.com/demos-europe/demosplan-core/pull/3399

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
