### PR TITLE
build(refs AB#14277): bump dp consent

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@demos-europe/demosplan-ui": "0.3.27",
-    "@demos-europe/dp-consent": "^1.2",
+    "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd",
     "@masterportal/masterportalapi": "2.22.0",
     "@sentry/browser": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@demos-europe/demosplan-ui": "0.3.27",
-    "@demos-europe/dp-consent": "^1.1.2",
+    "@demos-europe/dp-consent": "^1.2",
     "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd",
     "@masterportal/masterportalapi": "2.22.0",
     "@sentry/browser": "^8.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,15 +217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.24.6":
-  version: 7.24.6
-  resolution: "@babel/helper-module-imports@npm:7.24.6"
-  dependencies:
-    "@babel/types": "npm:^7.24.6"
-  checksum: 10c0/e0db3fbfcd963d138f0792ff626f940a576fcf212d02b8fe6478dccf3421bd1c2a76f8e69c7450c049985e7b63b30be309a24eeeb6ad7c2137a31b676a095a84
-  languageName: node
-  linkType: hard
-
 "@babel/helper-module-imports@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-module-imports@npm:7.24.7"
@@ -322,14 +313,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.24.8":
+"@babel/helper-string-parser@npm:^7.24.6, @babel/helper-string-parser@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-string-parser@npm:7.24.8"
   checksum: 10c0/6361f72076c17fabf305e252bf6d580106429014b3ab3c1f5c4eb3e6d465536ea6b670cc0e9a637a77a9ad40454d3e41361a2909e70e305116a23d68ce094c08
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.24.7":
+"@babel/helper-validator-identifier@npm:^7.24.6, @babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 10c0/87ad608694c9477814093ed5b5c080c2e06d44cb1924ae8320474a74415241223cc2a725eea2640dd783ff1e3390e5f95eede978bc540e870053152e58f1d651
@@ -1434,7 +1425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.6, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.24.6
   resolution: "@babel/types@npm:7.24.6"
   dependencies:
@@ -1464,6 +1455,17 @@ __metadata:
     "@babel/helper-validator-identifier": "npm:^7.24.7"
     to-fast-properties: "npm:^2.0.0"
   checksum: 10c0/4970b3481cab39c5c3fdb7c28c834df5c7049f3c7f43baeafe121bb05270ebf0da7c65b097abf314877f213baa591109c82204f30d66cdd46c22ece4a2f32415
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.8.3":
+  version: 7.25.2
+  resolution: "@babel/types@npm:7.25.2"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.24.8"
+    "@babel/helper-validator-identifier": "npm:^7.24.7"
+    to-fast-properties: "npm:^2.0.0"
+  checksum: 10c0/e489435856be239f8cc1120c90a197e4c2865385121908e5edb7223cfdff3768cba18f489adfe0c26955d9e7bbb1fb10625bc2517505908ceb0af848989bd864
   languageName: node
   linkType: hard
 
@@ -2042,10 +2044,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/dp-consent@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@demos-europe/dp-consent@npm:1.1.2"
-  checksum: 10c0/fc4501510a96519c0cb6146934b92f2a078206475a8981fd87d500b2f2459926afa32f147ac21f5e20fd1c9a3f62e25553c19a9a8914f5c1372e9c1086909c68
+"@demos-europe/dp-consent@npm:^1.2":
+  version: 1.2.0
+  resolution: "@demos-europe/dp-consent@npm:1.2.0"
+  checksum: 10c0/b2b39d4432a1f03d1e7ca68e5c9b47e702c52eb1ae2ee87abbde79ac664511cdeeaa28d5ecec162eb9cab1835b0a6cbefeef98628279d7f3acfe6d2e4b9bfa86
   languageName: node
   linkType: hard
 
@@ -11746,7 +11748,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.24.8"
     "@babel/runtime": "npm:^7.24.8"
     "@demos-europe/demosplan-ui": "npm:0.3.27"
-    "@demos-europe/dp-consent": "npm:^1.1.2"
+    "@demos-europe/dp-consent": "npm:^1.2"
     "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"
     "@masterportal/masterportalapi": "npm:2.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,10 +2044,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/dp-consent@npm:^1.2":
-  version: 1.2.0
-  resolution: "@demos-europe/dp-consent@npm:1.2.0"
-  checksum: 10c0/b2b39d4432a1f03d1e7ca68e5c9b47e702c52eb1ae2ee87abbde79ac664511cdeeaa28d5ecec162eb9cab1835b0a6cbefeef98628279d7f3acfe6d2e4b9bfa86
+"@demos-europe/dp-consent@npm:^1.3":
+  version: 1.3.0
+  resolution: "@demos-europe/dp-consent@npm:1.3.0"
+  checksum: 10c0/eb268b83f7953ae9845c1d2bf176d76b88e56d36e4fb497be68496746bfd93dc772771d5d7b34f272038a2825b2fa1fa2af4410b5aa2346605b33595324f00f3
   languageName: node
   linkType: hard
 
@@ -11748,7 +11748,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.24.8"
     "@babel/runtime": "npm:^7.24.8"
     "@demos-europe/demosplan-ui": "npm:0.3.27"
-    "@demos-europe/dp-consent": "npm:^1.2"
+    "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "github:eFrane/vuex-json-api#19c2354ad97c17bdda02358dc9ee4a2ffce181dd"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"
     "@masterportal/masterportalapi": "npm:2.22.0"


### PR DESCRIPTION
### Ticket
DPLAN-DPLAN-12170
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/14277


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Bumps `dp-consent` so the changes made in https://github.com/demos-europe/cookie-consent/pull/3 become available in demosplan-core.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Run `yarn && yarn dev:<project>`
- Delete cookies to make the consent bar appear in the project interface
- It should look like this:
![dp-consent-v1_3](https://github.com/user-attachments/assets/feac87bf-a614-424a-8df7-0115207b3dc2)


### Linked PRs
Text is adjusted in
- https://github.com/demos-europe/demosplan-core/pull/3528


### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
