### PR TITLE
fix(refs AB#18954): send correct relationship to BE

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -531,7 +531,7 @@
               :editable="isClaimed"
               ref="tags"
               @field:update="updateStatement"
-              @field:save="data => saveStatement(data, 'relationship', 'tag')" />
+              @field:save="data => saveStatement(data, 'relationship', 'tags')" />
           </dp-item-row>
 
           <!-- Statement / Recommendation Text -->


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/18954

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The relationship has to be `tags`, not `tag`.
(See DemosPlanStatementAPIController, where the supported relationships are listed (among them `tags`)). I guess this was changed accidentally in the FE.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Go to the assessment table, add a tag to a statement and save it. There should be no error.

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
