### PR TITLE
B ado18953 success notification

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -193,7 +193,7 @@ class DemosPlanAssessmentController extends BaseController
                     $statementHandler->addStatementToCluster($headStatement, $newStatement->getChildren()[0], true, true);
                 }
                 $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId);
-                $routeName = $currentUser->getUser()->hasRole(Role::PROCEDURE_DATA_INPUT) ?
+                $routeName = $isDataInput ?
                     'DemosPlan_statement_orga_list' : 'dplan_assessmenttable_view_table';
                 $routeParameters = 'DemosPlan_statement_orga_list' === $routeName ?
                     [

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -22,7 +22,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\FileUploadService;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ServiceOutput;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -192,28 +192,7 @@ class DemosPlanAssessmentController extends BaseController
                 if (null !== $headStatement) {
                     $statementHandler->addStatementToCluster($headStatement, $newStatement->getChildren()[0], true, true);
                 }
-                $filterSet = $assessmentHandler->handleFilterHash($request, $procedureId);
-                $routeName = $isDataInput ?
-                    'DemosPlan_statement_orga_list' : 'dplan_assessmenttable_view_table';
-                $routeParameters = 'DemosPlan_statement_orga_list' === $routeName ?
-                    [
-                        'procedureId' => $procedureId,
-                    ] :
-                    [
-                        'procedureId' => $procedureId,
-                        'filterHash'  => $filterSet->getHash(),
-                        '_fragment'   => $request->query->get('fragment', ''),
-                    ];
                 if ($newStatement instanceof Statement) {
-                    $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
-                        'confirm',
-                        'confirm.statement.new',
-                        ['externId' => $newStatement->getExternId()],
-                        $routeName,
-                        $routeParameters,
-                        $newStatement->getExternId()
-                    ));
-
                     return $this->redirectToRoute(
                         'DemosPlan_statement_new_submitted',
                         ['procedureId' => $procedureId]

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -2888,52 +2888,10 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
                 }
 
                 /** @var ManualStatementCreatedEvent $assessableStatementEvent */
-                $assessableStatementEvent = $this->eventDispatcher->dispatch(
+                $this->eventDispatcher->dispatch(
                     new ManualStatementCreatedEvent($assessableStatement),
                     ManualStatementCreatedEventInterface::class
                 );
-                $assessableStatement = $assessableStatementEvent->getStatement();
-
-                $routeName = 'dm_plan_assessment_single_view';
-                $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statement' => $assessableStatement->getId()];
-
-                if ('' != ($originalStatement['headStatementId'] ?? '')) {
-                    $routeName = 'DemosPlan_cluster_single_statement_view';
-                    $routeParameters = ['procedure' => $newOriginalStatement->getProcedureId(), 'statementId' => $assessableStatement->getId()];
-                }
-
-                if ($isDataInput) {
-                    $routeName = 'DemosPlan_statement_single_view';
-                    $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statementId' => $newOriginalStatement->getId()];
-                }
-
-                if ($this->permissions->hasPermission('feature_segments_of_statement_list')) {
-                    $routeName = 'dplan_statement_segments_list';
-                    $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statementId' => $assessableStatement->getId(), 'action' => 'editText'];
-                }
-
-                // check for permission to avoid link to an unreachable area
-                if ($this->permissions->hasPermission('area_admin_assessmenttable')
-                    || $this->permissions->hasPermission('feature_segments_of_statement_list')
-                    || $this->permissions->hasPermission('feature_statement_data_input_orga')) {
-                    // success messages with link to created statement
-                    $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
-                        'confirm',
-                        'confirm.statement.new',
-                        ['externId' => $assessableStatement->getExternId()],
-                        $routeName,
-                        $routeParameters,
-                        $assessableStatement->getExternId())
-                    );
-                } else {
-                    $this->messageBag->add(
-                        'confirm',
-                        'confirm.statement.new',
-                        ['externId' => $assessableStatement->getExternId()]
-                    );
-                }
-            } else {
-                $this->getMessageBag()->add('error', 'error.save');
             }
         } catch (Exception $e) {
             $this->getMessageBag()->add('error', 'error.save');

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -2888,10 +2888,52 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
                 }
 
                 /** @var ManualStatementCreatedEvent $assessableStatementEvent */
-                $this->eventDispatcher->dispatch(
+                $assessableStatementEvent = $this->eventDispatcher->dispatch(
                     new ManualStatementCreatedEvent($assessableStatement),
                     ManualStatementCreatedEventInterface::class
                 );
+                $assessableStatement = $assessableStatementEvent->getStatement();
+
+                $routeName = 'dm_plan_assessment_single_view';
+                $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statement' => $assessableStatement->getId()];
+
+                if ('' != ($originalStatement['headStatementId'] ?? '')) {
+                    $routeName = 'DemosPlan_cluster_single_statement_view';
+                    $routeParameters = ['procedure' => $newOriginalStatement->getProcedureId(), 'statementId' => $assessableStatement->getId()];
+                }
+
+                if ($isDataInput) {
+                    $routeName = 'DemosPlan_statement_single_view';
+                    $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statementId' => $newOriginalStatement->getId()];
+                }
+
+                if ($this->permissions->hasPermission('feature_segments_of_statement_list')) {
+                    $routeName = 'dplan_statement_segments_list';
+                    $routeParameters = ['procedureId' => $newOriginalStatement->getProcedureId(), 'statementId' => $assessableStatement->getId(), 'action' => 'editText'];
+                }
+
+                // check for permission to avoid link to an unreachable area
+                if ($this->permissions->hasPermission('area_admin_assessmenttable')
+                    || $this->permissions->hasPermission('feature_segments_of_statement_list')
+                    || $this->permissions->hasPermission('feature_statement_data_input_orga')) {
+                    // success messages with link to created statement
+                    $this->getMessageBag()->addObject(LinkMessageSerializable::createLinkMessage(
+                        'confirm',
+                        'confirm.statement.new',
+                        ['externId' => $assessableStatement->getExternId()],
+                        $routeName,
+                        $routeParameters,
+                        $assessableStatement->getExternId())
+                    );
+                } else {
+                    $this->messageBag->add(
+                        'confirm',
+                        'confirm.statement.new',
+                        ['externId' => $assessableStatement->getExternId()]
+                    );
+                }
+            } else {
+                $this->getMessageBag()->add('error', 'error.save');
             }
         } catch (Exception $e) {
             $this->getMessageBag()->add('error', 'error.save');

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -426,17 +426,15 @@ class StatementService extends CoreService implements StatementServiceInterface
         /** @var StatementCreatedEvent $statementCreatedEvent */
         $statementCreatedEvent = $this->eventDispatcher->dispatch(new ManualOriginalStatementCreatedEvent($statement));
 
-        if (null !== $statementCreatedEvent) {
-            if ($this->permissions->hasPermission('area_admin_statement_list')) {
-                $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
-                    'confirm',
-                    'confirm.statement.new',
-                    ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
-                    'dplan_procedure_statement_list',
-                    ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
-                    $statementCreatedEvent->getStatement()->getExternId()
-                ));
-            }
+        if ($this->permissions->hasPermission('area_admin_statement_list')) {
+            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
+                'confirm',
+                'confirm.statement.new',
+                ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
+                'dplan_procedure_statement_list',
+                ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
+                $statementCreatedEvent->getStatement()->getExternId()
+            ));
         }
 
         // statement similarities are calculated?

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -427,14 +427,16 @@ class StatementService extends CoreService implements StatementServiceInterface
         $statementCreatedEvent = $this->eventDispatcher->dispatch(new ManualOriginalStatementCreatedEvent($statement));
 
         if (null !== $statementCreatedEvent) {
-            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
-                'confirm',
-                'confirm.statement.new',
-                ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
-                'dplan_procedure_statement_list',
-                ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
-                $statementCreatedEvent->getStatement()->getExternId()
-            ));
+            if ($this->permissions->hasPermission('area_admin_statement_list')) {
+                $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
+                    'confirm',
+                    'confirm.statement.new',
+                    ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
+                    'dplan_procedure_statement_list',
+                    ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
+                    $statementCreatedEvent->getStatement()->getExternId()
+                ));
+            }
         }
 
         // statement similarities are calculated?


### PR DESCRIPTION
### Ticket: https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/18953


Description: Success notification dependent on Role of user and one of them is about data collector role (Datenerfassung), use a permission to clear when it should be appeared.

### How to review/test
create a statement and test the link in success notification.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
