### PR TITLE
fix(refs dplan 12265): Pass Procedure ID properly to documents editor…

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_edit.html.twig
@@ -73,10 +73,9 @@
             :basic-auth="dplan.settings.basicAuth"
             class="u-mb"
             hidden-input="r_text"
-            procedure-id="{{ procedure }}"
             :required="true"
             :routes="{
-             getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
+             getFileByHash: (hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: '{{ procedure }}' })
             }"
             :toolbar-items="{
                 imageButton: true,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/paragraph_admin_new.html.twig
@@ -64,10 +64,9 @@
             :basic-auth="dplan.settings.basicAuth"
             class="u-mb"
             hidden-input="r_text"
-            procedure-id="{{ procedure }}"
             :required="true"
             :routes="{
-               getFileByHash: (hash, procedure) => Routing.generate('core_file_procedure', { hash: hash, procedureId: procedure })
+               getFileByHash: (hash) => Routing.generate('core_file_procedure', { hash: hash, procedureId: '{{ procedure }}' }),
             }"
             :toolbar-items="{
                 imageButton: true,


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12105/BOB-SH-BLP-Prod-und-Stage-Andern-oder-hinzufugen-von-Bildern-in-Kapiteln-nicht-moglich

Description : The ProcedureId is static in this place and has to be used via twig. (picked fix from https://github.com/demos-europe/demosplan-core/pull/3287