### PR TITLE
refactor (refs AB#18561): Don't extend xlsExporter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
@@ -13,28 +13,22 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementAttachmentInterface;
-use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Exception\AssessmentTableZipExportException;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceOutput;
-use demosplan\DemosPlanCoreBundle\Logic\EditorService;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
-use demosplan\DemosPlanCoreBundle\Logic\FormOptionsResolver;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
-use demosplan\DemosPlanCoreBundle\Logic\SimpleSpreadsheetService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
-use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
 use Exception;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment;
 
-class AssessmentTableZipExporter extends AssessmentTableXlsExporter
+class AssessmentTableZipExporter extends AssessmentTableFileExporterAbstract
 {
     private const ATTACHMENTS_NOT_ADDABLE = 'error.statements.zip.export.attachments.not.addable';
     private const SHEET_MISSING_IN_XLSX = 'error.statements.zip.export.incomplete.xlsx';
@@ -43,41 +37,35 @@ class AssessmentTableZipExporter extends AssessmentTableXlsExporter
         'An error occurred during the getting of Statement Attachments for Zip export. Zip export was canceled.';
     private const SHEET_MISSING_IN_XLSX_LOG = 'No worksheet in xlsx for zip export!';
     private const SHEET_MISSING_COLUMN_LOG = 'No column for references to attachment in worksheet for zip export!';
-    protected array $supportedTypes = ['zip'];
+    private array $supportedTypes = ['zip'];
 
     public function __construct(
         AssessmentHandler $assessmentHandler,
         AssessmentTableServiceOutput $assessmentTableServiceOutput,
         CurrentProcedureService $currentProcedureService,
-        EditorService $editorService,
-        Environment $twig,
-        FormOptionsResolver $formOptionsResolver,
         LoggerInterface $logger,
-        PermissionsInterface $permissions,
         RequestStack $requestStack,
-        ServiceImporter $serviceImport,
-        SimpleSpreadsheetService $simpleSpreadsheetService,
         StatementHandler $statementHandler,
         TranslatorInterface $translator,
         private readonly AssessmentTablePdfExporter $pdfExporter,
+        private readonly AssessmentTableXlsExporter $xlsExporter,
         private readonly StatementService $statementService,
         private readonly FileService $fileService
     ) {
         parent::__construct(
-            $assessmentHandler,
             $assessmentTableServiceOutput,
             $currentProcedureService,
-            $editorService,
-            $twig,
-            $formOptionsResolver,
+            $assessmentHandler,
+            $translator,
             $logger,
-            $permissions,
             $requestStack,
-            $serviceImport,
-            $simpleSpreadsheetService,
-            $statementHandler,
-            $translator
+            $statementHandler
         );
+    }
+
+    public function supports(string $format): bool
+    {
+        return in_array($format, $this->supportedTypes, true);
     }
 
     /**
@@ -85,7 +73,8 @@ class AssessmentTableZipExporter extends AssessmentTableXlsExporter
      */
     public function __invoke(array $parameters): array
     {
-        $xlsxArray = parent::__invoke($parameters);
+        $xlsExporter = $this->xlsExporter;
+        $xlsxArray = $this->$xlsExporter($parameters);
 
         try {
             $statementAttachments = $this->getAttachmentsOfStatements($xlsxArray['statementIds']);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
@@ -73,8 +73,7 @@ class AssessmentTableZipExporter extends AssessmentTableFileExporterAbstract
      */
     public function __invoke(array $parameters): array
     {
-        $xlsExporter = $this->xlsExporter;
-        $xlsxArray = $xlsExporter($parameters);
+        $xlsxArray = $this->xlsExporter->__invoke($parameters);
 
         try {
             $statementAttachments = $this->getAttachmentsOfStatements($xlsxArray['statementIds']);
@@ -126,8 +125,7 @@ class AssessmentTableZipExporter extends AssessmentTableFileExporterAbstract
                 // if not present yet, invoke the pdfCreator and create an original-stn-pdf to use instead
                 $parameters['statementId'] =
                     $this->statementService->getStatement($statementId)?->getOriginal()->getId();
-                $pdfExporter = $this->pdfExporter;
-                $files[$index]['originalAttachment'] = $pdfExporter(
+                $files[$index]['originalAttachment'] = $this->pdfExporter->__invoke(
                     $parameters
                 );
                 $files[$index]['originalAttachment']['fileHash'] = $this->fileService->createHash();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableZipExporter.php
@@ -74,7 +74,7 @@ class AssessmentTableZipExporter extends AssessmentTableFileExporterAbstract
     public function __invoke(array $parameters): array
     {
         $xlsExporter = $this->xlsExporter;
-        $xlsxArray = $this->$xlsExporter($parameters);
+        $xlsxArray = $xlsExporter($parameters);
 
         try {
             $statementAttachments = $this->getAttachmentsOfStatements($xlsxArray['statementIds']);

--- a/tests/backend/core/Statement/Functional/StatementExportTest.php
+++ b/tests/backend/core/Statement/Functional/StatementExportTest.php
@@ -11,29 +11,24 @@
 namespace Tests\Core\Statement\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementAttachmentInterface;
-use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadFileData;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadStatementData;
 use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceOutput;
-use demosplan\DemosPlanCoreBundle\Logic\EditorService;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
-use demosplan\DemosPlanCoreBundle\Logic\FormOptionsResolver;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
-use demosplan\DemosPlanCoreBundle\Logic\SimpleSpreadsheetService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTablePdfExporter;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableZipExporter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
-use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
-use Twig\Environment;
 
 class StatementExportTest extends FunctionalTestCase
 {
@@ -49,17 +44,12 @@ class StatementExportTest extends FunctionalTestCase
         parent::setUp();
         $assessmentHandler = $this->getContainer()->get(AssessmentHandler::class);
         $assessmentTableServiceOutput = $this->getContainer()->get(AssessmentTableServiceOutput::class);
-        $editorService = $this->getContainer()->get(EditorService::class);
-        $environment = $this->getContainer()->get(Environment::class);
-        $formOptionsResolver = $this->getContainer()->get(FormOptionsResolver::class);
         $loggerInterface = $this->getContainer()->get(LoggerInterface::class);
-        $permissionsInterface = $this->getContainer()->get(PermissionsInterface::class);
-        $serviceImporter = $this->getContainer()->get(ServiceImporter::class);
-        $simpleSpreadsheetService = $this->getContainer()->get(SimpleSpreadsheetService::class);
         $statementHandler = $this->getContainer()->get(StatementHandler::class);
         $translatorInterface = $this->getContainer()->get(TranslatorInterface::class);
         $statementService = $this->getContainer()->get(StatementService::class);
         $assessmentTablePdfExporter = $this->getContainer()->get(AssessmentTablePdfExporter::class);
+        $assessmentTableXlsExporter = $this->getContainer()->get(AssessmentTableXlsExporter::class);
         $fileService = $this->getContainer()->get(FileService::class);
         $requestStack = $this->createMock(RequestStack::class);
         $sessionInterfaceMock = $this->createMock(SessionInterface::class);
@@ -79,17 +69,12 @@ class StatementExportTest extends FunctionalTestCase
             $assessmentHandler,
             $assessmentTableServiceOutput,
             $currentProcedureService,
-            $editorService,
-            $environment,
-            $formOptionsResolver,
             $loggerInterface,
-            $permissionsInterface,
             $requestStack,
-            $serviceImporter,
-            $simpleSpreadsheetService,
             $statementHandler,
             $translatorInterface,
             $assessmentTablePdfExporter,
+            $assessmentTableXlsExporter,
             $statementService,
             $fileService
         );


### PR DESCRIPTION
### Ticket
[ADO-18561](https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/18561)

This PR ensures that the ZipExporter no longer extends the xlsExporter. Instead, the xlsExporter is now injected. The export should work exactly as before.

### How to review/test
Test the zip export in projects where available. / Code Review / run test

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
