### PR TITLE
fix(DPLAN-12306): drawing interactions issue

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -394,7 +394,7 @@ export default {
 
     addTerritoryLayer () {
       //  If there is no territory wms layer defined but a "hand-drawn" territory, craft a vector layer from it
-      if (!this.hasTerritoryWMS && this.procedureSettings.territory.length > 0 && this.procedureSettings.territory !== '{}') {
+      if (!this.hasTerritoryWMS && this.procedureSettings.territory.length > 2) {
         //  Read GeoJson features
         const features = new GeoJSON().readFeatures(this.procedureSettings.territory)
 


### PR DESCRIPTION
### Ticket
[DPLAN-12306](https://demoseurope.youtrack.cloud/issue/DPLAN-12306/Einzeichnen-Tools-funktionieren-nicht-Public-Detail)

**Description:** This PR adjusts the check in FE for procedureSettings.territory when it is empty. Currently, we might receive an empty string, an empty object, or an empty array. To handle all these scenarios, add a check to ensure that the string length is greater than 2.

Since territory is a GeoJSON object, the negative value could be an empty object or an empty string. However, we are currently receiving an empty array. To handle this correctly, someone from the BE should check the procedureSettings entity to determine why we are receiving an array instead of an object.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
