### PR TITLE
feature: Add custom drupal condition factory

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -665,6 +665,9 @@ services:
 
     demosplan\DemosPlanCoreBundle\Tools\DocxImporterInterface: '@demosplan\DemosPlanCoreBundle\Tools\DocxImporterRabbitmq'
 
+    demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory:
+        arguments:
+            $conditionFactory: '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
 
     demosplan\DemosPlanCoreBundle\Tools\ServiceImporter:
         arguments:
@@ -1292,11 +1295,7 @@ services:
 
     EDT\Querying\ConditionParsers\Drupal\DrupalConditionParser:
         arguments:
-            $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
-
-    EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory:
-        arguments:
-            $conditionFactory: '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+            $drupalConditionFactory: '@demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory'
 
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser:
         public: true
@@ -1307,7 +1306,7 @@ services:
 
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterValidator:
         arguments:
-            $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
+            $drupalConditionFactory: '@demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory'
 
     EDT\Querying\Utilities\ConditionEvaluator:
         arguments:

--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Factory;
+
+use EDT\Querying\ConditionParsers\Drupal\DrupalConditionFactoryInterface;
+use EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory;
+use EDT\Querying\Conditions\IsNotNull;
+use EDT\Querying\Conditions\IsNull;
+use EDT\Querying\Contracts\PathsBasedInterface;
+
+/**
+ * @template TCondition of PathsBasedInterface
+ * @template-implements DrupalConditionFactoryInterface<TCondition>
+ *
+ * @phpstan-import-type DrupalValue from DrupalConditionFactoryInterface
+ */
+class DemosPlanDrupalConditionFactory extends PredefinedDrupalConditionFactory
+{
+    /**
+     * @return array<non-empty-string, callable(DrupalValue, non-empty-list<non-empty-string>|null): TCondition>
+     */
+    protected function getOperatorFunctionsWithValue(): array
+    {
+        $operators = parent::getOperatorFunctionsWithValue();
+
+        $operators[IsNull::OPERATOR] = fn ($value, ?array $path) => $this->conditionFactory->propertyIsNull($this->assertPath($path));
+        $operators[IsNotNull::OPERATOR] = fn ($value, ?array $path) => $this->conditionFactory->propertyIsNotNull($this->assertPath($path));
+
+        return $operators;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
@@ -20,6 +20,7 @@ use EDT\Querying\Contracts\PathsBasedInterface;
 
 /**
  * @template TCondition of PathsBasedInterface
+ *
  * @template-implements DrupalConditionFactoryInterface<TCondition>
  *
  * @phpstan-import-type DrupalValue from DrupalConditionFactoryInterface


### PR DESCRIPTION
### Ticket
...

This PR extends the PredefinedDrupalConditionFactory of the edt libary. It adds two operators (IsNull and IsNotNull) to the PredefinedDrupalConditionFactory::getOperatorFunctionsWithValue.
Not sure with the name. I called it DemosPlanDrupalConditionFactory.


### How to review/test
code review


### Linked PRs

- https://github.com/demos-europe/demosplan-core/pull/3515
- https://github.com/demos-europe/edt/pull/173


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
