### PR TITLE
Update latex to adjustment data 

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
@@ -20,7 +20,7 @@
                 {% if statement.isSubmittedByCitizen %} {{ "liked.by"|trans|latex|raw }}: & {% if statement.likesNum is defined and statement.likesNum  == 1 %}{{ statement.likesNum }}{{ "person"|trans|latex|raw }}{% else %}{{ statement.likesNum|default() }} {{ "persons"|trans|latex|raw }}{% endif %}\\{% endif %}
             {% endif %}
             {% if hasPermission('feature_documents_category_use_paragraph') %}
-            {{ "paragraph"|trans|latex|raw }}: & {% if statement.paragraph  is defined and statement.paragraph.title  != '' %}{{ statement.paragraph.title|latex|raw }}{% else %} {{ "notspecified"|trans|latex|raw }} {% endif %}
+            {{ "paragraph"|trans|latex|raw }}: & {% if statement.paragraph  is defined and statement.paragraph.title  != '' %}{{ statement.paragraph.title|latex|raw }}{% else %} {{ "notspecified"|trans|latex|raw }} {% endif %} \\
             {% endif %}
   			{{ "file"|trans|latex|raw }}: & {% if statement.files|default([])|length > 0 %}{% for file in statement.files %}{{ file|getFile('name')|latex|raw }} {% endfor %}{% else %} {{ "notspecified"|trans|latex|raw }} {% endif %}\\
             {% if hasPermission('field_statement_public_allowed') %}{{ "publish.on.platform"|trans|latex|raw }}:& {% if statement.publicAllowed %}{{ "yes"|trans }}{% else %}{{ "no"|trans }}{% endif %} \\{% endif %}


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12329/Dateiname-in-PDF-verschoben-meine-Entwurfe


Description: refactor latex file and add next line  to adjustment data in pdf export file

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
