### PR TITLE
F dplan 12254 add custom drupal condition factory

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1292,13 +1292,13 @@ services:
 
     EDT\JsonApi\Validation\FieldsValidator: ~
 
-    EDT\Querying\ConditionParsers\Drupal\DrupalConditionParser:
-        arguments:
-            $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
-
-    EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory:
+    demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory:
         arguments:
             $conditionFactory: '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+
+    EDT\Querying\ConditionParsers\Drupal\DrupalConditionParser:
+        arguments:
+            $drupalConditionFactory: '@demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory'
 
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser:
         public: true
@@ -1309,7 +1309,7 @@ services:
 
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterValidator:
         arguments:
-            $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
+            $drupalConditionFactory: '@demosplan\DemosPlanCoreBundle\Logic\Factory\DemosPlanDrupalConditionFactory'
 
     EDT\Querying\Utilities\ConditionEvaluator:
         arguments:

--- a/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Factory/DemosPlanDrupalConditionFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Factory;
+
+use EDT\Querying\ConditionParsers\Drupal\DrupalConditionFactoryInterface;
+use EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory;
+use EDT\Querying\Contracts\PathsBasedInterface;
+use EDT\Querying\Drupal\StandardOperator;
+
+/**
+ * @template TCondition of PathsBasedInterface
+ *
+ * @template-implements DrupalConditionFactoryInterface<TCondition>
+ *
+ * @phpstan-import-type DrupalValue from DrupalConditionFactoryInterface
+ */
+class DemosPlanDrupalConditionFactory extends PredefinedDrupalConditionFactory
+{
+    /**
+     * @return array<non-empty-string, callable(DrupalValue, non-empty-list<non-empty-string>|null): TCondition>
+     */
+    protected function getOperatorFunctionsWithValue(): array
+    {
+        $operators = parent::getOperatorFunctionsWithValue();
+
+        $operators[StandardOperator::IS_NULL] = fn ($value, ?array $path): PathsBasedInterface => $this->conditionFactory->propertyIsNull($path);
+        $operators[StandardOperator::IS_NOT_NULL] = fn ($value, ?array $path): PathsBasedInterface => $this->conditionFactory->propertyIsNotNull($path);
+
+        return $operators;
+    }
+}


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12254/Filter-Bearbeiter-Nicht-zugewiesen-funktioniert-nicht

Description:  add DemosPlanDrupalConditionFactory: in some cases however conditions do have values, we do need the OPERATORS 'IS NULL' and 'IS NOT NULL' and since they are only available in the condition without values, some filters are not working anymore. The DemosPlanDrupalConditionFactory extends the PredefinedDrupalConditionFactory and adds two operators (IsNull and IsNotNull) to the operators with value

Not sure with the name. I am open to any suggestion.

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
