### PR TITLE
fix(refs DPLAN-11812): add to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,5 +186,6 @@
   ],
   "resolutions": {
     "@mapbox/mapbox-gl-style-spec": "13.14.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12105/BOB-SH-BLP-Prod-und-Stage-Andern-oder-hinzufugen-von-Bildern-in-Kapiteln-nicht-moglich

https://demoseurope.youtrack.cloud/issue/DPLAN-11812/Installation-BOBSH-2024.3.4

Description:
add to package.json

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
