### PR TITLE
fix: Ignore cachesum changes on yarn install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 enableTelemetry: 0
 
 nodeLinker: node-modules
+checksumBehavior: 'ignore'


### PR DESCRIPTION
for some dependencies (vuex-json-api) the cachesum somehow is not stable. It be be related to the fact, that we get the package straight from GH.
