### PR TITLE
fix (refs DPLAN-12347): Fix tags display for Segment.

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -529,8 +529,8 @@ export default {
     },
 
     tagsAsString () {
-      if (this.segment.hasRelationship('tag')) {
-        return Object.values(this.segment.rel('tag')).map(el => el.attributes.title).join(', ')
+      if (this.segment.hasRelationship('tags')) {
+        return Object.values(this.segment.rel('tags')).map(el => el.attributes.title).join(', ')
       }
 
       return '-'


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12347


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- Fix tags display for Segment.
- segment has relationship `tags` not `tag`

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Go to EWM Lokal, login as `Fachplanung-Admin`, then go to `Verfahren` -> `Stellungnahmen` -> `Stellungnahmen mit Abschnitte -> Details und Erwiderungen`
- in `Abschnitt` List, there `#` Mark, when hover you can see now `Schlagworte`