### PR TITLE
fix(DPLAN-12326): image overlaps text

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/newsdetail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/newsdetail.html.twig
@@ -11,7 +11,7 @@
 
         {% block aside %}
             {% if news.picture is defined and news.picture != "" %}
-                <img class="c-image c-image--detail max-w-full" src="{{ path("core_logo", { 'hash': news.picture|getFile('hash') }) }}">
+                <img class="c-image max-w-full" src="{{ path("core_logo", { 'hash': news.picture|getFile('hash') }) }}">
                 <p class="font-size-smaller">{{ news.pictitle }}</p>
             {% endif %}
         {% endblock aside %}


### PR DESCRIPTION
### Ticket
[DPLAN-12326](https://demoseurope.youtrack.cloud/issue/DPLAN-12326/Bild-uberdeckt-Mitteilungstext-Portal-Mitteilungen)

Description: This PR fixes an issue with overlapping images. The `c-image--detail` class adds a `max-width: 530px`, which conflicts with the `max-w-full `class from Tailwind. To resolve this, the `c-image--detail `class has been removed from the Twig template.


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
