### PR TITLE
bug(refs DPLAN-1953): Set full width to true

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/list_subscriptions.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/list_subscriptions.html.twig
@@ -3,7 +3,8 @@
 {% block component_part %}
     {% embed '@DemosPlanCore/DemosPlanCore/includes/participation_area_skeleton.html.twig' with {
         'content_heading': "notifications"|trans,
-        'content_subheading': "text.notifications.new.procedures"|trans({ link: path("DemosPlan_user_portal") })|wysiwyg
+        'content_subheading': "text.notifications.new.procedures"|trans({ link: path("DemosPlan_user_portal") })|wysiwyg,
+        'full_width': true
     }%}
 
         {% block content %}


### PR DESCRIPTION
### Ticket
DPLAN-1953

We don't have an aside block here, so we can show the content over the whole width.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Login as Privatperson -> Profil icon -> Benachrichtigungen: The table should use the whole width of the page