### PR TITLE
Provide command to install automatically all defined project addons

### DIFF
--- a/config/addons.yml
+++ b/config/addons.yml
@@ -1,8 +1,8 @@
 # example usage
 #dplan_addons:
 #    -
-#      name: "mygithuborga/myaddon"
-#      version: "0.6.1"
+#      name: "Name like in composer.json"
+#      version: "v0.6.1"
 #    -
 #      name: "mygithuborga/myaddon2"
-#      version: "0.31.1"
+#      version: "v0.31.1"

--- a/config/addons.yml
+++ b/config/addons.yml
@@ -1,0 +1,8 @@
+# example usage
+#dplan_addons:
+#    -
+#      name: "mygithuborga/myaddon"
+#      version: "0.6.1"
+#    -
+#      name: "mygithuborga/myaddon2"
+#      version: "0.31.1"

--- a/demosplan/DemosPlanCoreBundle/Addon/AddonInfo.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonInfo.php
@@ -12,7 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Addon;
 
 use DemosEurope\DemosplanAddon\Permission\PermissionInitializerInterface;
 
-final class AddonInfo
+class AddonInfo
 {
     public const DEFAULT_CONTROLLER_PATH = '/src/Controller';
 
@@ -56,5 +56,10 @@ final class AddonInfo
     public function getUIHooks(): array
     {
         return $this->config['manifest']['ui'];
+    }
+
+    public function getVersion(): string
+    {
+        return $this->config['version'];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
-
 class AddonAutoinstallCommand extends CoreCommand
 {
     protected static $defaultName = 'dplan:addon:autoinstall';
@@ -34,7 +33,7 @@ class AddonAutoinstallCommand extends CoreCommand
         private readonly AddonRegistry $registry,
         private readonly CacheClearCommand $cacheClearCommand,
         ParameterBagInterface $parameterBag,
-        string $name = null
+        ?string $name = null,
     ) {
         parent::__construct($parameterBag, $name);
     }
@@ -54,7 +53,7 @@ class AddonAutoinstallCommand extends CoreCommand
         // remove already installed addons with the correct versions from the list
         foreach ($addons as $key => $addonConfig) {
             $name = $addonConfig['name'];
-            $repo = 'demos-europe/' . $name;
+            $repo = 'demos-europe/'.$name;
             if (array_key_exists($repo, $enabledAddons)) {
                 if ($addonConfig['version'] === $enabledAddons[$repo]->getVersion()) {
                     $output->note("Addon {$name} is already installed in Version {$addonConfig['version']}");
@@ -68,7 +67,7 @@ class AddonAutoinstallCommand extends CoreCommand
             }
         }
 
-        //uninstall addons that are enabled but not in the config
+        // uninstall addons that are enabled but not in the config
         $this->uninstallUnneededAddons($enabledAddons, $output);
 
         // iterate over addons and install them if they are not already installed
@@ -79,7 +78,6 @@ class AddonAutoinstallCommand extends CoreCommand
         }
 
         return Command::SUCCESS;
-
     }
 
     private function runCommand(Command $command, array $arguments, SymfonyStyle $output): int
@@ -99,8 +97,8 @@ class AddonAutoinstallCommand extends CoreCommand
                 $this->runCommand($this->cacheClearCommand, ['--force' => true], $output);
 
                 $arguments = [
-                    '--name' => $name,
-                    '--tag' => $addonConfig['version'],
+                    '--name'   => $name,
+                    '--tag'    => $addonConfig['version'],
                     '--github' => true,
                 ];
                 $this->runCommand($this->addonInstallCommand, $arguments, $output);
@@ -127,5 +125,4 @@ class AddonAutoinstallCommand extends CoreCommand
         ];
         $this->runCommand($this->addonUninstallCommand, $arguments, $output);
     }
-
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Addon;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+
+class AddonAutoinstallCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:addon:autoinstall';
+    protected static $defaultDescription = 'Installs any addons defined in project configuration addons.yaml';
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+
+        $addons = $this->parameterBag->get('dplan_addons');
+        // return if no addons are defined
+        if (null === $addons) {
+            return Command::SUCCESS;
+        }
+        return Command::SUCCESS;
+
+    }
+
+
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
@@ -12,10 +12,14 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
+use demosplan\DemosPlanCoreBundle\Command\CacheClearCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 
@@ -24,17 +28,104 @@ class AddonAutoinstallCommand extends CoreCommand
     protected static $defaultName = 'dplan:addon:autoinstall';
     protected static $defaultDescription = 'Installs any addons defined in project configuration addons.yaml';
 
+    public function __construct(
+        private readonly AddonInstallFromZipCommand $addonInstallCommand,
+        private readonly AddonUninstallCommand $addonUninstallCommand,
+        private readonly AddonRegistry $registry,
+        private readonly CacheClearCommand $cacheClearCommand,
+        ParameterBagInterface $parameterBag,
+        string $name = null
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $output = new SymfonyStyle($input, $output);
 
         $addons = $this->parameterBag->get('dplan_addons');
         // return if no addons are defined
         if (null === $addons) {
             return Command::SUCCESS;
         }
+
+        $enabledAddons = $this->registry->getEnabledAddons();
+
+        // remove already installed addons with the correct versions from the list
+        foreach ($addons as $key => $addonConfig) {
+            $name = $addonConfig['name'];
+            $repo = 'demos-europe/' . $name;
+            if (array_key_exists($repo, $enabledAddons)) {
+                if ($addonConfig['version'] === $enabledAddons[$repo]->getVersion()) {
+                    $output->note("Addon {$name} is already installed in Version {$addonConfig['version']}");
+                    unset($addons[$key]);
+                } else {
+                    // uninstall addon if it is installed but in the wrong version
+                    $this->uninstallOutdatedAddon($output, $name, $enabledAddons[$repo], $addonConfig['version']);
+                }
+                // unset from enabled addons to find addons that are enabled but not in the config and thus need to be uninstalled
+                unset($enabledAddons[$repo]);
+            }
+        }
+
+        //uninstall addons that are enabled but not in the config
+        $this->uninstallUnneededAddons($enabledAddons, $output);
+
+        // iterate over addons and install them if they are not already installed
+        $this->installAddons($addons, $enabledAddons, $output);
+
+        if (!empty($addons)) {
+            $output->note('This command will end with an error because during the installation of the addons the cache is cleared. There seems to be no way to avoid this. When it states that some cache file was not found, everything is fine.');
+        }
+
         return Command::SUCCESS;
 
     }
 
+    private function runCommand(Command $command, array $arguments, SymfonyStyle $output): int
+    {
+        $arrayInput = new ArrayInput($arguments);
+        $command->setApplication($this->getApplication());
+
+        return $command->run($arrayInput, $output);
+    }
+
+    private function installAddons(mixed $addons, array $enabledAddons, SymfonyStyle $output): void
+    {
+        foreach ($addons as $addonConfig) {
+            $name = $addonConfig['name'];
+            if (!in_array($name, $enabledAddons, true)) {
+                $output->note("Installing addon {$name} in Version {$addonConfig['version']}");
+                $this->runCommand($this->cacheClearCommand, ['--force' => true], $output);
+
+                $arguments = [
+                    '--name' => $name,
+                    '--tag' => $addonConfig['version'],
+                    '--github' => true,
+                ];
+                $this->runCommand($this->addonInstallCommand, $arguments, $output);
+            }
+        }
+    }
+
+    private function uninstallUnneededAddons(array $enabledAddons, SymfonyStyle $output): void
+    {
+        foreach ($enabledAddons as $repo => $addon) {
+            $output->note("Addon {$addon->getName()} is enabled but not in the config and will be uninstalled");
+            $arguments = [
+                'name' => $repo,
+            ];
+            $this->runCommand($this->addonUninstallCommand, $arguments, $output);
+        }
+    }
+
+    private function uninstallOutdatedAddon(SymfonyStyle $output, mixed $name, $enabledAddons, $version): void
+    {
+        $output->note("Addon {$name} is already installed in Version {$enabledAddons->getVersion()}, but should be in Version {$version}");
+        $arguments = [
+            'name' => sprintf('demos-europe/%s', $name),
+        ];
+        $this->runCommand($this->addonUninstallCommand, $arguments, $output);
+    }
 
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -72,7 +72,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         private readonly HttpClientInterface $httpClient,
         private readonly Registrator $installer,
         ParameterBagInterface $parameterBag,
-        ?string $name = null
+        ?string $name = null,
     ) {
         parent::__construct($parameterBag, $name);
     }
@@ -471,7 +471,7 @@ class AddonInstallFromZipCommand extends CoreCommand
             // which makes it harder to recognize the installed addon version
             $zipResponse = $this->httpClient->request('GET', $zipUrl, $ghOptions);
             if (404 === $zipResponse->getStatusCode()) {
-                throw new RuntimeException('Could not access repository '. $zipUrl);
+                throw new RuntimeException('Could not access repository '.$zipUrl);
             }
 
             $zipContent = $zipResponse->getContent(false);
@@ -572,7 +572,6 @@ class AddonInstallFromZipCommand extends CoreCommand
     private function getRepo(array $ghOptions, InputInterface $input, SymfonyStyle $output): string
     {
         if ($this->name) {
-
             return $this->name;
         }
 
@@ -582,17 +581,14 @@ class AddonInstallFromZipCommand extends CoreCommand
             $ghReposUrl
         );
         $availableAddons = collect($availableRepositories)->filter(
-            function ($repo)
-            {
+            function ($repo) {
                 return str_contains($repo['name'], 'demosplan-addon-');
             }
         )
-            ->map(function ($repo)
-            {
+            ->map(function ($repo) {
                 return $repo['name'];
             })
-            ->sortBy(function ($repo)
-            {
+            ->sortBy(function ($repo) {
                 return $repo;
             })
             ->values()
@@ -603,14 +599,16 @@ class AddonInstallFromZipCommand extends CoreCommand
         );
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
+
         return $questionHelper->ask($input, $output, $question);
     }
 
     private function getTag(string $ghUrl, array $ghOptions, InputInterface $input, SymfonyStyle $output): mixed
     {
-        if($this->tag) {
+        if ($this->tag) {
             return $this->tag;
         }
+
         return $this->getGithubItem($ghUrl, $ghOptions, $input, $output);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -63,6 +63,10 @@ class AddonInstallFromZipCommand extends CoreCommand
     private string $zipCachePath;
     private string $addonsDirectory;
     private string $addonsCacheDirectory;
+    private ?string $folder;
+    private ?string $branch;
+    private ?string $tag;
+    private ?string $name;
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -90,6 +94,8 @@ class AddonInstallFromZipCommand extends CoreCommand
         $this->addOption('force-download', '', InputOption::VALUE_NONE, 'Force download repository from GitHub');
         $this->addOption('folder', '', InputOption::VALUE_REQUIRED, 'Folder to read addon zips from', 'addonZips');
         $this->addOption('develop', 'd', InputOption::VALUE_NONE, 'Install local addon repository');
+        $this->addOption('name', '', InputOption::VALUE_OPTIONAL, 'Install specific addon by repository name');
+        $this->addOption('tag', '', InputOption::VALUE_OPTIONAL, 'Install specific addon tag');
     }
 
     /**
@@ -103,29 +109,31 @@ class AddonInstallFromZipCommand extends CoreCommand
         $reinstall = $input->getOption('reinstall');
         $enable = !$input->getOption('no-enable');
         $path = $input->getArgument('path');
-        $folder = $input->getOption('folder');
-        $branch = $input->getOption('branch');
+        $this->folder = $input->getOption('folder');
+        $this->branch = $input->getOption('branch');
+        $this->name = $input->getOption('name');
+        $this->tag = $input->getOption('tag') ?: null;
 
-        $this->createDirectoryIfNecessary(DemosPlanPath::getRootPath($folder));
+        $this->createDirectoryIfNecessary(DemosPlanPath::getRootPath($this->folder));
 
         $this->setGlobalPaths();
 
         if (null === $path) {
             try {
                 if ($input->getOption('local')) {
-                    $path = $this->getPathFromZip($input, $output, $folder);
+                    $path = $this->getPathFromZip($input, $output);
                     $this->setZipPaths($path);
                 } elseif ($input->getOption('github')) {
-                    $path = $this->loadFromGithub($input, $output, $folder, $branch);
+                    $path = $this->loadFromGithub($input, $output);
                     $this->setZipPaths($path);
                 } elseif ($input->getOption('repos')) {
-                    $path = $this->loadFromApiRepository($input, $output, $folder);
+                    $path = $this->loadFromApiRepository($input, $output);
                     $this->setZipPaths($path);
                 } elseif ($input->getOption('develop')) {
-                    $path = $this->getPathFromLocalDevelopment($input, $output, $folder);
+                    $path = $this->getPathFromLocalDevelopment($input, $output);
                     $this->setDevelopPaths($path);
                 } else {
-                    $path = $this->getPathFromZip($input, $output, $folder);
+                    $path = $this->getPathFromZip($input, $output);
                     $this->setZipPaths($path);
                 }
             } catch (Exception $e) {
@@ -358,12 +366,12 @@ class AddonInstallFromZipCommand extends CoreCommand
         }
     }
 
-    private function getPathFromZip(InputInterface $input, OutputInterface $output, string $folder): string
+    private function getPathFromZip(InputInterface $input, OutputInterface $output): string
     {
-        $zips = glob(DemosPlanPath::getRootPath($folder).'/*.zip');
+        $zips = glob(DemosPlanPath::getRootPath($this->folder).'/*.zip');
 
         if (!is_array($zips) || 0 === count($zips)) {
-            throw new RuntimeException("No Addon zips found in Folder {$folder}");
+            throw new RuntimeException("No Addon zips found in Folder {$this->folder}");
         }
 
         $question = new ChoiceQuestion('Which addon do you want to install? When you want to install the addon directly via GitHub use --github ', $zips);
@@ -373,7 +381,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         return $questionHelper->ask($input, $output, $question);
     }
 
-    private function loadFromApiRepository(InputInterface $input, SymfonyStyle $output, mixed $folder): string
+    private function loadFromApiRepository(InputInterface $input, SymfonyStyle $output): string
     {
         $addonRepositoryUrl = $this->parameterBag->get('addon_repository_url');
         try {
@@ -411,7 +419,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         $tag = $this->askItem($existingTagsContent, $input, $output);
 
         // tags are prefixed with v, but the zip file is not
-        $path = DemosPlanPath::getRootPath($folder).'/'.$repo.'-'.str_replace('v', '', $tag).'.zip';
+        $path = DemosPlanPath::getRootPath($this->folder).'/'.$repo.'-'.str_replace('v', '', $tag).'.zip';
         if (file_exists($path) && !$input->getOption('force-download')) {
             $output->info('File '.$path.' already exists, skipping download. You may use the --force-download option to force a download.');
         } else {
@@ -425,7 +433,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         return $path;
     }
 
-    private function loadFromGithub(InputInterface $input, SymfonyStyle $output, mixed $folder, ?string $branch): string
+    private function loadFromGithub(InputInterface $input, SymfonyStyle $output): string
     {
         try {
             $ghToken = $this->parameterBag->get('github_token');
@@ -440,35 +448,19 @@ class AddonInstallFromZipCommand extends CoreCommand
             ],
         ];
 
-        $ghReposUrl = 'https://api.github.com/orgs/demos-europe/repos?per_page=100';
-        $availableRepositories = $this->fetchRepositories($ghOptions, $ghReposUrl);
-        $availableAddons = collect($availableRepositories)->filter(function ($repo) {
-            return str_contains($repo['name'], 'demosplan-addon-');
-        })
-            ->map(function ($repo) {
-                return $repo['name'];
-            })
-            ->sortBy(function ($repo) {
-                return $repo;
-            })
-            ->values()
-            ->toArray();
-        $question = new ChoiceQuestion('Which addon do you want to install? ', $availableAddons);
-        /** @var QuestionHelper $questionHelper */
-        $questionHelper = $this->getHelper('question');
-        $repo = $questionHelper->ask($input, $output, $question);
+        $repo = $this->getRepo($ghOptions, $input, $output);
 
         // default: show tags
-        if (null === $branch) {
+        if (null === $this->branch) {
             // fetch a list of available tags
             $ghUrl = 'https://api.github.com/repos/demos-europe/'.$repo.'/tags';
-            $tag = $this->getGithubItem($ghUrl, $ghOptions, $input, $output);
+            $tag = $this->getTag($ghUrl, $ghOptions, $input, $output);
             $zipUrl = sprintf('https://github.com/demos-europe/%s/archive/refs/tags/%s.zip', $repo, $tag);
             // tags are prefixed with v, but the zip file in GitHub is not
-            $path = DemosPlanPath::getRootPath($folder).'/'.$repo.'-'.str_replace('v', '', $tag).'.zip';
+            $path = DemosPlanPath::getRootPath($this->folder).'/'.$repo.'-'.str_replace('v', '', $tag).'.zip';
         } else {
-            $zipUrl = sprintf('https://github.com/demos-europe/%s/archive/refs/heads/%s.zip', $repo, $branch);
-            $path = DemosPlanPath::getRootPath($folder).'/'.$repo.'-'.$branch.'.zip';
+            $zipUrl = sprintf('https://github.com/demos-europe/%s/archive/refs/heads/%s.zip', $repo, $this->branch);
+            $path = DemosPlanPath::getRootPath($this->folder).'/'.$repo.'-'.$this->branch.'.zip';
         }
 
         // branches should always be downloaded
@@ -478,6 +470,9 @@ class AddonInstallFromZipCommand extends CoreCommand
             // $zipUrl url is hardcoded by purpose as the zip otherwise extracts to a folder containing the hash, not the tag
             // which makes it harder to recognize the installed addon version
             $zipResponse = $this->httpClient->request('GET', $zipUrl, $ghOptions);
+            if (404 === $zipResponse->getStatusCode()) {
+                throw new RuntimeException('Could not access repository '. $zipUrl);
+            }
 
             $zipContent = $zipResponse->getContent(false);
             file_put_contents($path, $zipContent);
@@ -546,7 +541,7 @@ class AddonInstallFromZipCommand extends CoreCommand
         return $this->askItem($existingItemsContent, $input, $output);
     }
 
-    private function getPathFromLocalDevelopment(InputInterface $input, SymfonyStyle $output, mixed $folder): string
+    private function getPathFromLocalDevelopment(InputInterface $input, SymfonyStyle $output): string
     {
         $fs = new Filesystem();
         $addonDevFolder = DemosPlanPath::getRootPath('addonDev');
@@ -572,5 +567,50 @@ class AddonInstallFromZipCommand extends CoreCommand
     {
         $this->addonsDirectory = DemosPlanPath::getRootPath(Registrator::ADDON_DIRECTORY);
         $this->addonsCacheDirectory = DemosPlanPath::getRootPath(Registrator::ADDON_CACHE_DIRECTORY);
+    }
+
+    private function getRepo(array $ghOptions, InputInterface $input, SymfonyStyle $output): string
+    {
+        if ($this->name) {
+
+            return $this->name;
+        }
+
+        $ghReposUrl = 'https://api.github.com/orgs/demos-europe/repos?per_page=100';
+        $availableRepositories = $this->fetchRepositories(
+            $ghOptions,
+            $ghReposUrl
+        );
+        $availableAddons = collect($availableRepositories)->filter(
+            function ($repo)
+            {
+                return str_contains($repo['name'], 'demosplan-addon-');
+            }
+        )
+            ->map(function ($repo)
+            {
+                return $repo['name'];
+            })
+            ->sortBy(function ($repo)
+            {
+                return $repo;
+            })
+            ->values()
+            ->toArray();
+        $question = new ChoiceQuestion(
+            'Which addon do you want to install? ',
+            $availableAddons
+        );
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+        return $questionHelper->ask($input, $output, $question);
+    }
+
+    private function getTag(string $ghUrl, array $ghOptions, InputInterface $input, SymfonyStyle $output): mixed
+    {
+        if($this->tag) {
+            return $this->tag;
+        }
+        return $this->getGithubItem($ghUrl, $ghOptions, $input, $output);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * dplan:update.
@@ -41,6 +42,7 @@ class CacheClearCommand extends CoreCommand
             InputOption::VALUE_NONE,
             'If this is set, only apcu and opcache will be cleared, otherwise cache:clear will be called too'
         );
+        $this->addOption('force', '', InputOption::VALUE_NONE, 'Delete cache directory directly');
     }
 
     /**
@@ -52,6 +54,14 @@ class CacheClearCommand extends CoreCommand
     {
         $output = new SymfonyStyle($input, $output);
 
+        $force = $input->getOption('force');
+        if ($force) {
+            $output->warning('Force option set. Clearing cache directory directly');
+            $this->forceClear($output);
+
+            return Command::SUCCESS;
+        }
+
         $output->comment('Clearing CLI APCu and OpCache and any app cache');
         try {
             // clear any app cache
@@ -60,10 +70,13 @@ class CacheClearCommand extends CoreCommand
 
             DemosPlanTools::cacheClear();
             $output->success('Cleared CLI APCu and OpCache');
-        } catch (Exception) {
-            $output->error('Failed to clear CLI APCu and OpCache, aborting');
+        } catch (Exception $e) {
+            $output->error('Failed to clear CLI APCu and OpCache, force delete it');
+            $output->error($e->getMessage());
 
-            return (int) Command::FAILURE;
+            $this->forceClear($output);
+
+            return Command::FAILURE;
         }
 
         if ('test' !== $this->getApplication()->getKernel()->getEnvironment()) {
@@ -105,5 +118,12 @@ class CacheClearCommand extends CoreCommand
         }
 
         $cacheClearCommand->run(new StringInput($commandWithSignature), $output);
+    }
+
+    private function forceClear(SymfonyStyle $output)
+    {
+        $output->warning('Removing cache directory directly as a fallback');
+        $fs = new FileSystem();
+        $fs->remove($this->getApplication()->getKernel()->getCacheDir());
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
@@ -123,7 +123,7 @@ class CacheClearCommand extends CoreCommand
     private function forceClear(SymfonyStyle $output)
     {
         $output->warning('Removing cache directory directly as a fallback');
-        $fs = new FileSystem();
+        $fs = new Filesystem();
         $fs->remove($this->getApplication()->getKernel()->getCacheDir());
     }
 }

--- a/demosplan/DemosPlanCoreBundle/DependencyInjection/Compiler/OptionsLoaderPass.php
+++ b/demosplan/DemosPlanCoreBundle/DependencyInjection/Compiler/OptionsLoaderPass.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\DependencyInjection\Compiler;
 
+use demosplan\DemosPlanCoreBundle\DependencyInjection\Configuration\AddonTreeBuilder;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Configuration\FormOptionsTreeBuilder;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Configuration\ProcedurePhasesTreeBuilder;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -26,6 +27,7 @@ class OptionsLoaderPass implements CompilerPassInterface
     final public const OVERRIDABLE_CONFIGS = [
         'form_options.yml'      => FormOptionsTreeBuilder::class,
         'procedurephases.yml'   => ProcedurePhasesTreeBuilder::class,
+        'addons.yml'   => AddonTreeBuilder::class,
     ];
 
     public function process(ContainerBuilder $container): void
@@ -35,6 +37,7 @@ class OptionsLoaderPass implements CompilerPassInterface
             DemosPlanPath::getProjectPath('app/Resources/DemosPlanCoreBundle/config'),
             DemosPlanPath::getConfigPath('procedure'),
             DemosPlanPath::getProjectPath('app/Resources/DemosPlanCoreBundle/config/procedure'),
+            DemosPlanPath::getProjectPath('app/config'),
         ]);
 
         foreach (self::OVERRIDABLE_CONFIGS as $overridableConfig => $configClassName) {

--- a/demosplan/DemosPlanCoreBundle/DependencyInjection/Compiler/OptionsLoaderPass.php
+++ b/demosplan/DemosPlanCoreBundle/DependencyInjection/Compiler/OptionsLoaderPass.php
@@ -27,7 +27,7 @@ class OptionsLoaderPass implements CompilerPassInterface
     final public const OVERRIDABLE_CONFIGS = [
         'form_options.yml'      => FormOptionsTreeBuilder::class,
         'procedurephases.yml'   => ProcedurePhasesTreeBuilder::class,
-        'addons.yml'   => AddonTreeBuilder::class,
+        'addons.yml'            => AddonTreeBuilder::class,
     ];
 
     public function process(ContainerBuilder $container): void

--- a/demosplan/DemosPlanCoreBundle/DependencyInjection/Configuration/AddonTreeBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/DependencyInjection/Configuration/AddonTreeBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class AddonTreeBuilder implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('dplan_addons');
+
+        $treeBuilder->getRootNode()
+            ->children()
+            ->arrayNode('dplan_addons')
+            ->arrayPrototype()
+            ->children()
+            ->scalarNode('name')->isRequired()->end()
+            ->scalarNode('version')->isRequired()->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/tests/backend/core/Core/Functional/Command/AddonAutoinstallCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/AddonAutoinstallCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace backend\core\Core\Functional\Command;
+
+use demosplan\DemosPlanCoreBundle\Addon\AddonInfo;
+use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Addon\AddonAutoinstallCommand;
+use demosplan\DemosPlanCoreBundle\Command\Addon\AddonInstallFromZipCommand;
+use demosplan\DemosPlanCoreBundle\Command\Addon\AddonUninstallCommand;
+use demosplan\DemosPlanCoreBundle\Command\CacheClearCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+
+class AddonAutoinstallCommandTest extends FunctionalTestCase
+{
+    private ?AddonInstallFromZipCommand $addonInstallCommand;
+    private ?AddonUninstallCommand $addonUninstallCommand;
+    private ?AddonRegistry $registry;
+    private ?CacheClearCommand $cacheClearCommand;
+    private ?ParameterBagInterface $parameterBag;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->addonInstallCommand = $this->createMock(AddonInstallFromZipCommand::class);
+        $this->addonUninstallCommand = $this->createMock(AddonUninstallCommand::class);
+        $this->registry = $this->createMock(AddonRegistry::class);
+        $this->cacheClearCommand = $this->createMock(CacheClearCommand::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
+    }
+
+    public function testInstallsAddonsDefinedInConfiguration(): void
+    {
+        $addons = [
+            ['name' => 'addon1', 'version' => '1.0.0'],
+            ['name' => 'addon2', 'version' => '2.0.0'],
+        ];
+
+        $this->parameterBag->method('get')->with('dplan_addons')->willReturn($addons);
+        $this->registry->method('getEnabledAddons')->willReturn([]);
+
+        $this->cacheClearCommand->expects($this->exactly(2))->method('run')->willReturn(Command::SUCCESS);
+        $this->addonInstallCommand->expects($this->exactly(2))->method('run')->willReturn(Command::SUCCESS);
+
+        $this->executeCommand();
+    }
+
+    public function testSkipsInstallationIfAddonAlreadyInstalled(): void
+    {
+        $addons = [
+            ['name' => 'addon1', 'version' => '1.0.0'],
+        ];
+
+        $enabledAddons = [
+            'demos-europe/addon1' => $this->createMock(AddonInfo::class),
+        ];
+
+        $enabledAddons['demos-europe/addon1']->method('getVersion')->willReturn('1.0.0');
+
+        $this->parameterBag->method('get')->with('dplan_addons')->willReturn($addons);
+        $this->registry->method('getEnabledAddons')->willReturn($enabledAddons);
+
+        $this->cacheClearCommand->expects($this->never())->method('run');
+        $this->addonInstallCommand->expects($this->never())->method('run');
+
+        $this->executeCommand();
+    }
+
+    public function testUninstallsOutdatedAddonAndInstallsNewVersion(): void
+    {
+        $addons = [
+            ['name' => 'addon1', 'version' => '2.0.0'],
+        ];
+
+        $enabledAddons = [
+            'demos-europe/addon1' => $this->createMock(AddonInfo::class),
+        ];
+
+        $enabledAddons['demos-europe/addon1']->method('getVersion')->willReturn('1.0.0');
+
+        $this->parameterBag->method('get')->with('dplan_addons')->willReturn($addons);
+        $this->registry->method('getEnabledAddons')->willReturn($enabledAddons);
+
+        $this->cacheClearCommand->expects($this->once())->method('run')->willReturn(Command::SUCCESS);
+        $this->addonUninstallCommand->expects($this->once())->method('run')->willReturn(Command::SUCCESS);
+        $this->addonInstallCommand->expects($this->once())->method('run')->willReturn(Command::SUCCESS);
+
+        $this->executeCommand();
+    }
+
+    public function testUninstallsAddonsNotInConfiguration(): void
+    {
+        $addons = [];
+
+        $enabledAddons = [
+            'demos-europe/addon1' => $this->createMock(AddonInfo::class),
+        ];
+
+        $this->parameterBag->method('get')->with('dplan_addons')->willReturn($addons);
+        $this->registry->method('getEnabledAddons')->willReturn($enabledAddons);
+
+        $this->addonUninstallCommand->expects($this->once())->method('run')->willReturn(Command::SUCCESS);
+
+        $this->executeCommand();
+    }
+
+    public function testReturnsSuccessIfNoAddonsDefined(): void
+    {
+        $this->parameterBag->method('get')->with('dplan_addons')->willReturn(null);
+
+        $commandTester = $this->executeCommand();
+
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+    }
+
+    private function executeCommand(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+
+        $application->add(new AddonAutoinstallCommand(
+            $this->addonInstallCommand,
+            $this->addonUninstallCommand,
+            $this->registry,
+            $this->cacheClearCommand,
+            $this->parameterBag
+        ));
+
+        $command = $application->find(AddonAutoinstallCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        return $commandTester;
+    }
+}

--- a/tests/backend/core/Core/Functional/Command/AddonAutoinstallCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/AddonAutoinstallCommandTest.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace backend\core\Core\Functional\Command;
 
 use demosplan\DemosPlanCoreBundle\Addon\AddonInfo;


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/5706

To ease deployment this PR allows to define all addons with their Versions that should be installed and provides a new command to install them e.g. during update or container build


### How to review/test
define addons in projects config/addons.yml and call bin/project dplan:addon:autoinstall

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
