### PR TITLE
bug(refs DPLAN-12379): Add z index to draw feature

### DIFF
--- a/client/js/components/map/map/DpOlMapDrawFeature.vue
+++ b/client/js/components/map/map/DpOlMapDrawFeature.vue
@@ -254,7 +254,9 @@ export default {
         name: this.name,
         type: this.type,
         id: `layer${this.featureId}`,
-        style: drawStyle(style)
+        style: drawStyle(style),
+        // make sure drawing layer is always on top
+        zIndex: 1000
       })
 
       this.map.addLayer(layer)


### PR DESCRIPTION
### Ticket
DPLAN-12379

Set z index for drawing layer to 1000 to make sure it is always on top. If other layers are on top of it, we can't edit our drawings.


### How to review/test
Verfahren -> Planungsdokumente und Planzeichnung -> Startkartenausschnitt -> Edit Startkartenausschnitt and/or Kartenbegrenzung and then try to edit a drawing. 

