### PR TITLE
fix(refs DPLAN-12372): Fix UserResourceType access conditions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
@@ -98,6 +98,7 @@ final class UserResourceType extends DplanResourceType implements UserResourceTy
                     [RoleInterface::API_AI_COMMUNICATOR, RoleInterface::CITIZEN],
                     $this->roleInCustomers->role->code
                 ),
+                $this->conditionFactory->propertyHasValue(false, $this->deleted),
             ];
         }
         $currentProcedure = $this->currentProcedureService->getProcedure();

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/UserResourceType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use DemosEurope\DemosplanAddon\Contracts\ResourceType\UserResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
@@ -86,10 +87,21 @@ final class UserResourceType extends DplanResourceType implements UserResourceTy
     protected function getAccessConditions(): array
     {
         // Without this permission users can use their own User resource only.
+        $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
         if ($this->currentUser->hasPermission('area_manage_users')) {
-            return [];
+            return [
+                $this->conditionFactory->propertyHasValue(
+                    $currentCustomer->getId(),
+                    $this->roleInCustomers->customer->id
+                ),
+                $this->conditionFactory->propertyHasNotAnyOfValues(
+                    [RoleInterface::API_AI_COMMUNICATOR, RoleInterface::CITIZEN],
+                    $this->roleInCustomers->role->code
+                ),
+            ];
         }
         $currentProcedure = $this->currentProcedureService->getProcedure();
+
         $user = $this->currentUser->getUser();
         $userAuthorized = null === $currentProcedure
             ? false


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12385/Userliste-als-Support-ist-nicht-korrekt-nach-Mandant-gefiltert

related to:
https://demoseurope.youtrack.cloud/issue/DPLAN-12372/EWM-Mandant-fur-NOK-anlegen
https://demoseurope.youtrack.cloud/issue/DPLAN-12373/EWM-Mandant-fur-DB-Systel-erstellen
 
Description:
Fix UserResourceType access conditions for support user to filter available users
- exclude non current customer users as well as citizen and ai-api user

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
