### PR TITLE
fix(DPLAN-11591): layout issue

### DIFF
--- a/client/js/components/faq/DpFaqCategoryItem.vue
+++ b/client/js/components/faq/DpFaqCategoryItem.vue
@@ -13,25 +13,29 @@
       {{ faqCategoryItem.attributes.title }}
     </div><!--
  --><div class="layout__item u-2-of-12 text-center">
-      <a
-        class="btn--blank o-link--default u-mh-0_25"
-        :href="Routing.generate('DemosPlan_faq_administration_category_edit', {categoryId: this.faqCategoryItem.id})"
-        :aria-label="Translator.trans('item.edit')"
-        data-cy="editCategoryItem">
-        <i
-          class="fa fa-pencil"
-          aria-hidden="true" />
-      </a>
-      <a
-        v-if="categoryChildren.length === 0"
-        class="btn--blank o-link--default u-mh-0_25 u-pr"
-        :href="Routing.generate('DemosPlan_faq_administration_category_delete', {categoryId: this.faqCategoryItem.id})"
-        :aria-label="Translator.trans('item.delete')"
-        data-cy="deleteCategoryItem">
-        <i
-          class="fa fa-trash"
-          aria-hidden="true" />
-      </a>
+      <div class="flex flex-col sm:flex-row justify-center">
+        <a
+          class="btn--blank o-link--default"
+          :href="Routing.generate('DemosPlan_faq_administration_category_edit', {categoryId: this.faqCategoryItem.id})"
+          :aria-label="Translator.trans('item.edit')"
+          data-cy="editCategoryItem">
+          <i
+            class="fa fa-pencil"
+            aria-hidden="true" />
+        </a>
+        <div class="sm:ml-2 min-w-1">
+          <a
+            v-if="categoryChildren.length === 0"
+            class="btn--blank o-link--default"
+            :href="Routing.generate('DemosPlan_faq_administration_category_delete', {categoryId: this.faqCategoryItem.id})"
+            :aria-label="Translator.trans('item.delete')"
+            data-cy="deleteCategoryItem">
+            <i
+              class="fa fa-trash"
+              aria-hidden="true" />
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -44,26 +44,28 @@
         class="u-mt-0_125"
         data-cy="enabledFaqItem" />
     </div><!--
- --><div class="layout__item u-2-of-12 text-center u-pv-0_25">
-      <a
-        class="btn--blank o-link--default u-mh-0_25"
-        :href="Routing.generate('DemosPlan_faq_administration_faq_edit', {faqID: this.faqItem.id})"
-        :aria-label="Translator.trans('item.edit')"
-        data-cy="editFaqItem">
-        <i
-          class="fa fa-pencil"
-          aria-hidden="true" />
-      </a>
-      <button
-        type="button"
-        @click="deleteFaqItem"
-        data-cy="deleteFaqItem"
-        :aria-label="Translator.trans('item.delete')"
-        class="btn--blank o-link--default u-mh-0_25">
-        <i
-          class="fa fa-trash"
-          aria-hidden="true" />
-      </button>
+ --><div class="layout__item u-2-of-12 text-center py-1">
+      <div class="flex flex-col sm:flex-row justify-center">
+        <a
+          class="btn--blank o-link--default"
+          :href="Routing.generate('DemosPlan_faq_administration_faq_edit', {faqID: this.faqItem.id})"
+          :aria-label="Translator.trans('item.edit')"
+          data-cy="editFaqItem">
+          <i
+            class="fa fa-pencil"
+            aria-hidden="true" />
+        </a>
+        <button
+          type="button"
+          @click="deleteFaqItem"
+          data-cy="deleteFaqItem"
+          :aria-label="Translator.trans('item.delete')"
+          class="btn--blank o-link--default sm:ml-2">
+          <i
+            class="fa fa-trash"
+            aria-hidden="true" />
+        </button>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Ticket
[DPLAN-11591](https://demoseurope.youtrack.cloud/issue/DPLAN-11591/FAQ-Verwalten-bearbeiten-Icons-sind-nicht-richtig-ausgerichtet)

**Description:**  This PR fixes an issue with the layout by placing the icons in the same position, wrapping them in a Flexbox.

- before:
![image](https://github.com/user-attachments/assets/6e7923e0-8f7f-4a21-83a2-e93ddbcbe574)

- now:
![image](https://github.com/user-attachments/assets/47ed34c4-9375-4add-864f-77358eb52bcc)

- with delete icons:
![image](https://github.com/user-attachments/assets/a5858ea6-08d1-49d8-b388-343731bed8cd)


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
