### PR TITLE
fix(refs DPLAN-12267): add consideration as BoilerplateCategory permi…

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -796,6 +796,12 @@ feature_data_protection_text_customized_view:
     label: 'View customized data protection text'
     parent: area_data_protection_text
     loginRequired: false
+feature_enable_default_consideration_BoilerplateCategory:
+    description: |-
+        Adds new Boilerplate(s) to the category consideration by default.
+        The checkbox - show within consideration - is checked by default.
+    label: show Boilerplate within considerations
+    loginRequired: true
 feature_department_add:
     description: 'allows the user to create a new department'
     label: 'create department'

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -244,7 +244,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         UserService $userService,
         private readonly StatementCopier $statementCopier,
         private readonly ValidatorInterface $validator,
-        private readonly StatementDeleter $statementDeleter
+        private readonly StatementDeleter $statementDeleter,
     ) {
         parent::__construct($messageBag);
         $this->assignService = $assignService;
@@ -1122,7 +1122,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         $draftStatementIds,
         $notificationReceiverId = '',
         $public = false,
-        bool $gdprConsentReceived = false
+        bool $gdprConsentReceived = false,
     ): array {
         if (!is_array($draftStatementIds)) {
             $draftStatementIds = [$draftStatementIds];
@@ -1148,7 +1148,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         array $draftStatementIds,
         $notificationReceiverId = '',
         $public = false,
-        bool $gdprConsentReceived = false
+        bool $gdprConsentReceived = false,
     ): array {
         $permissions = $this->permissions;
         // throw exception if GDPR consent is required, but was not given
@@ -2318,7 +2318,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
             $newTagData = [
                 'topic'          => $dataset[0] ?? '',
                 'tag'            => $dataset[1] ?? '',
-                'useBoilerplate' => isset($dataset[2]) ? 'ja' === $dataset[2] : 'nein',
+                'useBoilerplate' => isset($dataset[2]) ? 'ja' === $dataset[2] : false,
                 'boilerplate'    => $dataset[3] ?? '',
             ];
             $newTags[] = $newTagData;
@@ -3533,7 +3533,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
         Statement $headStatement,
         Statement $statementToAdd,
         $ignoreAssignmentOfStatement = false,
-        $ignoreAssignmentOfHeadStatement = false
+        $ignoreAssignmentOfHeadStatement = false,
     ) {
         try {
             if (!$headStatement->isClusterStatement()) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -105,6 +105,7 @@ use Doctrine\ORM\Query\QueryException;
 use Exception;
 use Goodby\CSV\Import\Standard\Interpreter;
 use Goodby\CSV\Import\Standard\Lexer;
+use Illuminate\Support\Collection;
 use ReflectionException;
 use Symfony\Component\Finder\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraints\Email;
@@ -114,7 +115,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
-use Illuminate\Support\Collection;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -3526,7 +3526,7 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
      * @param bool $ignoreAssignmentOfStatement     - Determines if a assignment statement will be updated regardless
      * @param bool $ignoreAssignmentOfHeadStatement - Determines if a assignment headStatement will be updated regardless
      *
-     * @return statement|bool - false the given statementToAdd was not added to the given headStatement,
+     * @return Statement|bool - false the given statementToAdd was not added to the given headStatement,
      *                        otherwise the headStatement
      */
     public function addStatementToCluster(

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
@@ -10,6 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\BoilerplateCategoryInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory;
@@ -43,7 +45,7 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
         $procedureId,
         $includeNewsCategory = true,
         $includeEmailCategory = true,
-        $includeConsiderationCategory = true
+        $includeConsiderationCategory = true,
     ): array {
         // short + performant way in case of all types are included:
         if ($includeNewsCategory && $includeEmailCategory && $includeConsiderationCategory) {
@@ -84,19 +86,13 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
     }
 
     /**
-     * Fetch all info about certain boilerplate.
-     *
-     * @param string $boilerplateCategoryTitle
-     *
-     * @return BoilerplateCategory|null
+     * Fetch all info about certain boilerplateCategory by title and procedure.
      */
-    public function getByTitle($boilerplateCategoryTitle)
-    {
-        try {
-            return $this->findOneBy(['title' => $boilerplateCategoryTitle]);
-        } catch (Exception) {
-            return null;
-        }
+    public function getByTitle(
+        string $boilerplateCategoryTitle,
+        ProcedureInterface $procedure,
+    ): ?BoilerplateCategoryInterface {
+        return $this->findOneBy(['title' => $boilerplateCategoryTitle, 'procedure' => $procedure]);
     }
 
     /**
@@ -128,7 +124,7 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
      * @param array $data         - holds the content of the boilerplate, which is about to post
      * @param bool  $returnEntity
      *
-     * @return boilerplateCategory|bool - true if the object could be mapped to the DB, otherwise false
+     * @return BoilerplateCategory|bool - true if the object could be mapped to the DB, otherwise false
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
@@ -180,17 +181,19 @@ class BoilerplateRepository extends FluentRepository implements ArrayInterface, 
      * Add an entry to the DB if the related procedure are exsisting
      * and the given array has the keys 'title' and 'text'.
      *
-     * @param array $data - holds the content of the boilerplate, which is about to post
+     * @param array              $data       - holds the content of the boilerplate, which is about to post
+     * @param array<int, string> $categories - holds a list of BoilerplateCategory titles
      *
      * @return Boilerplate
      *
      * @throws Exception
      */
-    public function add(array $data)
+    public function add(array $data, array $categories = [])
     {
         if (!$data['procedure'] instanceof Procedure) {
             $data['procedure'] = $this->getEntityManager()->getReference(Procedure::class, $data['procedure']);
         }
+        $procedure = $data['procedure'];
 
         if (!array_key_exists('title', $data) || !array_key_exists('text', $data)) {
             throw new InvalidArgumentException('Title and Text needed for creating Boilerplate');
@@ -200,25 +203,46 @@ class BoilerplateRepository extends FluentRepository implements ArrayInterface, 
 
         $boilerplate->setText($data['text']);
         $boilerplate->setTitle($data['title']);
-        $boilerplate->setProcedure($data['procedure']);
+        $boilerplate->setProcedure($procedure);
 
-        $categories = [];
-        if (array_key_exists('categories', $data)) {
-            $em = $this->getEntityManager();
-            foreach ($data['categories'] as $category) {
-                $categories[] = $em->getReference(BoilerplateCategory::class, $category);
-            }
-            $boilerplate->setCategories($categories);
-        }
-
-        foreach ($categories as $category) {
-            $this->getEntityManager()->persist($category);
+        $boilerplateCategories = $this->getOrCreateRelevantCategories($categories, $procedure);
+        if (0 < count($boilerplateCategories)) {
+            $boilerplate->setCategories($boilerplateCategories);
         }
 
         $this->getEntityManager()->persist($boilerplate);
         $this->getEntityManager()->flush();
 
         return $boilerplate;
+    }
+
+    /**
+     * fetches the boilerplateCategories for a specific procedure by given titles
+     * or otherwise creates new boilerplateCategory(ies) for that procedure with the given title(s).
+     *
+     * @param array<int, string> $categories - holds a list of BoilerplateCategory titles
+     *
+     * @throws Exception
+     */
+    private function getOrCreateRelevantCategories(array $categories, ProcedureInterface $procedure): array
+    {
+        $boilerplateCategoryRepository = $this->getEntityManager()->getRepository(BoilerplateCategory::class);
+        $resultingCategories = [];
+        foreach ($categories as $category) {
+            $boilerplateCategory = $boilerplateCategoryRepository->getByTitle($category, $procedure);
+            if (null !== $boilerplateCategory) {
+                $resultingCategories[] = $boilerplateCategory;
+            } else {
+                $boilerplateCategory = new BoilerplateCategory();
+                $boilerplateCategory->setProcedure($procedure);
+                $boilerplateCategory->setTitle($category);
+                $boilerplateCategory->setDescription('');
+                $boilerplateCategoryRepository->addObject($boilerplateCategory);
+                $resultingCategories[] = $boilerplateCategory;
+            }
+        }
+
+        return $resultingCategories;
     }
 
     /**


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12267/Beim-CSV-Import-von-Schlagworten-und-Textbausteinen-werden-Textbausteine-nicht-automatisch-im-Bereich-Erwiderung-angezeigt

Description:
add consideration as BoilerplateCategory permission based by default

```
Adjust BoilerplateCategoryRepository ->
refactor method getByTitle to actually work
- it was not used nor working before;
Adjust BoilerplateRepository ->
refactor the add method to handle categories
in a working way. The key categories was
never set before so no old behavior got
compromised.
added private helper method to make adding
categories work;
ProcedureService -> alter logic to add
the category consideration to all boilerplate
if permission is active;
StatementHandler -> fix buggy code to
return a bool all the time and not a
string in some cases before used inside an
if condition!
```

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))

