### PR TITLE
F dplan 12400 adjust pdf url

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/public_newsdetail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/public_newsdetail.html.twig
@@ -41,7 +41,7 @@
                     <a
                         target="_blank"
                         rel="noopener"
-                        href="{{ path("core_file", { 'hash': news.pdf|getFile('hash') }) }}">
+                        href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) }}">
                         {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                         {% if(news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}
                             ({{ news.pdf|getFile('size') }} {{ news.pdf|getFile('mimeType') }})


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12400/PDF-in-Aktuelle-Meldung-kann-nicht-heruntergeladen-werden

Adjust how the URL of pdf is gotten in template

### How to review/test
1. First login as admin and go to /verfahren/PROCEDURE_ID/verwalten/aktuelles
2. Click on any news and upload a PDF
3. Then logout and check the Verfahren like this:
4. Go to verfahren/PROCEDURE_ID/public/detail and check in the section Aktuelle Mitteiligung if the PDF is clickable
5. Click on Weiter lesen (to go to the details news) and also check that the PDF is clickable and you can see the PDF

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
