### PR TITLE
fix(refs DPLAN-1878): prevent resending a post request on page-reload

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2393,6 +2393,12 @@ class DemosPlanProcedureController extends BaseController
         $templateVars['list'] = $procedureService->getBoilerplateList($procedure);
         $templateVars['boilerplateGroups'] = $procedureService->getBoilerplateGroups($procedureId);
 
+        if (!$request->isMethod('GET')) {
+            // prevent sending the same post multiple times when browser reloads the same page (F5)
+            // therefore redirect to self as a get call instead.
+            return $this->redirectBack($request);
+        }
+
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanProcedure/administration_list_boilerplate.html.twig',
             [

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -152,7 +152,7 @@ class DemosPlanProcedureController extends BaseController
         ProcedureService $procedureService,
         ProcedureServiceOutput $procedureServiceOutput,
         private readonly ProcedureTypeResourceType $procedureTypeResourceType,
-        private readonly SortMethodFactory $sortMethodFactory
+        private readonly SortMethodFactory $sortMethodFactory,
     ) {
         $this->procedureServiceOutput = $procedureServiceOutput;
         $this->procedureService = $procedureService;
@@ -229,7 +229,7 @@ class DemosPlanProcedureController extends BaseController
         StatementService $statementService,
         SurveyService $surveyService,
         TranslatorInterface $translator,
-        string $procedure
+        string $procedure,
     ) {
         $templateVars = [];
         $procedureId = $procedure;
@@ -402,7 +402,7 @@ class DemosPlanProcedureController extends BaseController
         array $statementStatuses,
         array $statementPriorities,
         StatementService $statementService,
-        string $procedureId
+        string $procedureId,
     ): ?array {
         $priorityInitialValues = [];
         foreach ($statementPriorities as $key => $label) {
@@ -484,7 +484,7 @@ class DemosPlanProcedureController extends BaseController
     public function generateAssessmentTableFilterLinkFromStatus(
         string $statusLabel,
         string $procedureId,
-        string $type
+        string $type,
     ): string {
         $filterArray = [];
         // First, the status is transformed into the right format for the following method.
@@ -719,7 +719,7 @@ class DemosPlanProcedureController extends BaseController
         MasterTemplateService $masterTemplateService,
         Request $request,
         ServiceStorage $serviceStorage,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         $templateVars = [];
         // Reichere die breadcrumb mit zusätzl. items an
@@ -820,7 +820,7 @@ class DemosPlanProcedureController extends BaseController
         MasterTemplateService $masterTemplateService,
         Request $request,
         ServiceStorage $serviceStorage,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         $templateVars = [];
         // Reichere die breadcrumb mit zusätzl. items an
@@ -923,7 +923,7 @@ class DemosPlanProcedureController extends BaseController
         MasterToebService $masterToebService,
         Request $request,
         ServiceStorage $serviceStorage,
-        $procedure
+        $procedure,
     ) {
         // Storage initialisieren
         $requestPost = $request->request->all();
@@ -984,7 +984,7 @@ class DemosPlanProcedureController extends BaseController
         AddressBookEntryService $addressBookEntryService,
         Request $request,
         TranslatorInterface $translator,
-        $procedureId
+        $procedureId,
     ): Response {
         $procedureService = $this->procedureService;
         $procedure = $procedureService->getProcedure($procedureId);
@@ -1057,7 +1057,7 @@ class DemosPlanProcedureController extends BaseController
         AddressBookEntryService $addressBookEntryService,
         CurrentUserService $currentUserService,
         Request $request,
-        string $procedureId
+        string $procedureId,
     ): Response {
         $orgaId = $currentUserService->getUser()->getOrganisationId() ?? '';
 
@@ -1105,7 +1105,7 @@ class DemosPlanProcedureController extends BaseController
         OrgaService $orgaService,
         Request $request,
         string $procedureId,
-        string $title = 'email.invitation.write'
+        string $title = 'email.invitation.write',
     ): Response {
         $requestPost = $request->request->all();
         $selectedOrganisations = [];
@@ -1225,7 +1225,7 @@ class DemosPlanProcedureController extends BaseController
         StatementService $statementService,
         TranslatorInterface $translator,
         string $procedure,
-        bool $isMaster = false
+        bool $isMaster = false,
     ) {
         try {
             $procedureId = $procedure;
@@ -1469,7 +1469,7 @@ class DemosPlanProcedureController extends BaseController
         FileUploadService $fileUploadService,
         Request $request,
         ServiceStorage $serviceStorage,
-        $procedure
+        $procedure,
     ) {
         $currentProcedure = $currentProcedureService->getProcedureArray();
         $storageResult = [];
@@ -1504,7 +1504,7 @@ class DemosPlanProcedureController extends BaseController
         PermissionsInterface $permissions,
         ProcedureService $procedureService,
         StatementService $statementService,
-        string $procedureId
+        string $procedureId,
     ): Response {
         $currentUserId = $currentUser->getUser()->getId();
         $templateVars = [
@@ -1625,7 +1625,7 @@ class DemosPlanProcedureController extends BaseController
         StatementService $statementService,
         SurveyShowHandler $surveyShowHandler,
         StatementSubmissionNotifier $statementSubmissionNotifier,
-        string $procedure
+        string $procedure,
     ) {
         // @improve T14613
         $procedureId = $procedure;
@@ -2069,7 +2069,7 @@ class DemosPlanProcedureController extends BaseController
         StatementService $statementService,
         ServiceStorage $serviceStorage,
         TranslatorInterface $translator,
-        $procedure
+        $procedure,
     ) {
         // Storage und Output initialisieren
         $serviceOutput = $this->procedureServiceOutput;
@@ -2273,7 +2273,7 @@ class DemosPlanProcedureController extends BaseController
         Request $request,
         ServiceStorage $serviceStorage,
         TranslatorInterface $translator,
-        string $procedure
+        string $procedure,
     ) {
         $templateVars = [];
         $requestPost = $request->request->all();
@@ -2343,7 +2343,7 @@ class DemosPlanProcedureController extends BaseController
     public function boilerplateListAction(
         ProcedureHandler $procedureHandler,
         Request $request,
-        $procedure
+        $procedure,
     ) {
         $procedureId = $procedure;
         $requestPost = $request->request;
@@ -2691,7 +2691,7 @@ class DemosPlanProcedureController extends BaseController
      * @throws MessageBagException
      */
     protected function handleDeleteBoilerplateGroup(
-        string $boilerplateGroupId
+        string $boilerplateGroupId,
     ) {
         $boilerplatesOfGroupToDelete = new ArrayCollection();
         $boilerplateGroupToDelete = $this->procedureService->getBoilerplateGroup($boilerplateGroupId);
@@ -2726,7 +2726,7 @@ class DemosPlanProcedureController extends BaseController
      */
     protected function handleDeleteBoilerplates(
         ProcedureHandler $procedureHandler,
-        array $boilerplateIds
+        array $boilerplateIds,
     ) {
         $storageResult = $procedureHandler->deleteBoilerplates($boilerplateIds);
         if (true === $storageResult) {
@@ -2742,7 +2742,7 @@ class DemosPlanProcedureController extends BaseController
      * @throws MessageBagException
      */
     protected function handleDeleteBoilerplateGroups(
-        array $boilerplateGroupIds
+        array $boilerplateGroupIds,
     ) {
         $boilerplatesOfGroupsToDelete = new ArrayCollection();
         foreach ($boilerplateGroupIds as $boilerplateGroupId) {
@@ -2774,7 +2774,7 @@ class DemosPlanProcedureController extends BaseController
      */
     protected function addProcedureTypesToTemplateVars(
         array $templateVars,
-        bool $isProcedureTemplate
+        bool $isProcedureTemplate,
     ): array {
         // procedure types are completely irrelevant in procedure templates (Blaupausen), so no need
         // to pass the variable if it's a procedure template (Blaupause)


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-1878/Problem-beim-Neu-Laden-der-Textbaustein-Seite

Description:
prevent resending a post request on page-reload by redirecting to self after a post has been processed.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
