### PR TITLE
chore: reorganize cache & log folders

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -181,7 +181,7 @@ class DemosPlanKernel extends Kernel
         // use distinct logfiles for parallel tests if needed
         if ('test' === $this->getEnvironment()) {
             return DemosPlanPath::getRootPath(
-                sprintf('var/logs/%s/%s/%s',  $this->environment, $this->activeProject, $_SERVER['APP_TEST_SHARD'] ?? '')
+                sprintf('var/logs/%s/%s/%s', $this->environment, $this->activeProject, $_SERVER['APP_TEST_SHARD'] ?? '')
             );
         }
 

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -153,14 +153,14 @@ class DemosPlanKernel extends Kernel
     {
         if ($this->isLocalContainer()) {
             return DemosPlanPath::getRootPath(
-                sprintf('var/%s/cache/%s', $this->activeProject, $this->environment)
+                sprintf('var/cache/%s/%s', $this->environment, $this->activeProject)
             );
         }
 
         // use distinct caches for parallel tests if needed
         if ('test' === $this->getEnvironment()) {
             return DemosPlanPath::getRootPath(
-                sprintf('var/%s/cache/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
+                sprintf('var/cache/%s/%s/%s', $this->environment, $this->activeProject, $_SERVER['APP_TEST_SHARD'] ?? '')
             );
         }
 
@@ -174,14 +174,14 @@ class DemosPlanKernel extends Kernel
     {
         if ($this->isLocalContainer()) {
             return DemosPlanPath::getRootPath(
-                sprintf('var/%s/log/%s', $this->activeProject, $this->environment)
+                sprintf('var/log/%s/%s', $this->environment, $this->activeProject)
             );
         }
 
         // use distinct logfiles for parallel tests if needed
         if ('test' === $this->getEnvironment()) {
             return DemosPlanPath::getRootPath(
-                sprintf('var/%s/logs/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
+                sprintf('var/logs/%s/%s/%s',  $this->environment, $this->activeProject, $_SERVER['APP_TEST_SHARD'] ?? '')
             );
         }
 

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -151,23 +151,20 @@ class DemosPlanKernel extends Kernel
      */
     public function getCacheDir(): string
     {
-        // override default symfony4 cache dir
-        $dir = DemosPlanPath::getProjectPath('app/cache/'.$this->environment);
-
         if ($this->isLocalContainer()) {
-            $dir = DemosPlanPath::getTemporaryPath(
-                sprintf('dplan/%s/cache/%s', $this->activeProject, $this->environment)
+            return DemosPlanPath::getRootPath(
+                sprintf('var/%s/cache/%s', $this->activeProject, $this->environment)
             );
         }
 
         // use distinct caches for parallel tests if needed
         if ('test' === $this->getEnvironment()) {
-            $dir = DemosPlanPath::getTemporaryPath(
-                sprintf('dplan/%s/cache/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
+            return DemosPlanPath::getRootPath(
+                sprintf('var/%s/cache/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
             );
         }
 
-        return $dir;
+        return parent::getCacheDir();
     }
 
     /**
@@ -175,23 +172,20 @@ class DemosPlanKernel extends Kernel
      */
     public function getLogDir(): string
     {
-        // override default symfony4 cache dir
-        $dir = DemosPlanPath::getProjectPath('app/logs');
-
         if ($this->isLocalContainer()) {
-            $dir = DemosPlanPath::getTemporaryPath(
-                sprintf('dplan/%s/logs/%s', $this->activeProject, $this->environment)
+            return DemosPlanPath::getRootPath(
+                sprintf('var/%s/log/%s', $this->activeProject, $this->environment)
             );
         }
 
         // use distinct logfiles for parallel tests if needed
         if ('test' === $this->getEnvironment()) {
-            $dir = DemosPlanPath::getTemporaryPath(
-                sprintf('dplan/%s/logs/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
+            return DemosPlanPath::getRootPath(
+                sprintf('var/%s/logs/%s/%s', $this->activeProject, $this->environment, $_SERVER['APP_TEST_SHARD'] ?? '')
             );
         }
 
-        return $dir;
+        return parent::getLogDir();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -78,7 +78,7 @@ class DemosPlanKernel extends Kernel
     public function __construct(
         private readonly string $activeProject,
         string $environment,
-        bool $debug
+        bool $debug,
     ) {
         parent::__construct($environment, $debug);
 
@@ -298,7 +298,7 @@ class DemosPlanKernel extends Kernel
      */
     private function determineParameterGlobs(
         string $coreConfigPath,
-        string $projectConfigPath
+        string $projectConfigPath,
     ): array {
         $parameterGlobs = [
             // global defaults
@@ -332,7 +332,7 @@ class DemosPlanKernel extends Kernel
      */
     private function determineServiceGlobs(
         string $coreConfigPath,
-        string $projectConfigPath
+        string $projectConfigPath,
     ): array {
         $bundleGlobs = [
             // default bundle configurations

--- a/docker/demosplan-production/Dockerfile
+++ b/docker/demosplan-production/Dockerfile
@@ -46,11 +46,11 @@ RUN mkdir -p /srv/www/projects/$PROJECT_NAME/web/js && \
     mkdir -p /srv/www/projects/$PROJECT_NAME/web/fonts && \
     mkdir -p /srv/www/projects/$PROJECT_NAME/web/images && \
     mkdir -p /srv/www/projects/$PROJECT_NAME/web/video && \
-    mkdir -p /srv/www/projects/$PROJECT_NAME/app/cache && \
-    mkdir -p /srv/www/projects/$PROJECT_NAME/app/logs && \
+    mkdir -p /srv/www/var/cache && \
+    mkdir -p /srv/www/var/logs && \
     chown -R www-data /srv/www/projects/$PROJECT_NAME/web && \
-    chown -R www-data /srv/www/projects/$PROJECT_NAME/app/cache && \
-    chown -R www-data /srv/www/projects/$PROJECT_NAME/app/logs
+    chown -R www-data /srv/www/var/cache && \
+    chown -R www-data /srv/www/var/logs
 
 USER www-data
 RUN DEVELOPMENT_CONTAINER=1 ./fe build $PROJECT_NAME && rm -rf /srv/www/node_modules && rm -rf /srv/www/.cache

--- a/docker/demosplan-production/nginx.conf.template
+++ b/docker/demosplan-production/nginx.conf.template
@@ -49,7 +49,6 @@ server
         # Mitigate https://httpoxy.org/ vulnerabilities
         fastcgi_param HTTP_PROXY "";
         fastcgi_param HTTPS off;
-        fastcgi_param DEVELOPMENT_CONTAINER 1;
 
         fastcgi_pass $PHP_FPM_BETEILIGUNG_SERVICE:9000;
 

--- a/docker/demosplan-production/zzz-dplan.ini
+++ b/docker/demosplan-production/zzz-dplan.ini
@@ -13,6 +13,9 @@ opcache.memory_consumption=256
 opcache.max_accelerated_files=100000
 opcache.interned_strings_buffer=32
 opcache.fast_shutdown=1
+opcache.preload=/srv/www/config/preload.php
+; required for opcache.preload:
+opcache.preload_user=www-data
 ; maximum memory allocated to store the results
 realpath_cache_size=4096K
 


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/17734

To move towards the default symfony 6 directory structure log and cache folders are moved to their default position under var/log and var/cache. During local development a special folder is used to keep the files projectwise separated like var/<project>/log|cache
The usage of the standard structure allows to have a stable path e.g. for log extraction. During local development debugging is easier, as the whole stack is available in the IDE and caches may be deleted there. Moreover the Logfiles are directly available.

The downside to use the default structure was once that docker was quite slow with file synchronization on huge IO (which may be the case for the logfiles). As symfony uses the default path even in docker setups this might not be a problem any more, I could not experience any difference.

As a bonus of the predictable paths we are now able to use the opcache preloading in production.

### How to review/test
run the project and find the logs and caches in the project roots var folder. 

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
