### PR TITLE
fix(refs DPLAN-12401): add missing fields to request

### DIFF
--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
@@ -23,7 +23,7 @@
         :layer-groups-alternate-visibility="layerGroupsAlternateVisibility" />
       <dp-public-layer-list-category
         v-else
-        :key="layer.id"
+        :key="`category:${layer.id}?`"
         :group="layer"
         :layer-type="layerType"
         :visible="true"

--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
@@ -42,6 +42,7 @@ export default {
   name: 'DpPublicLayerList',
 
   components: {
+    DpPublicLayerListCategory,
     DpPublicLayerListLayer
   },
 

--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
@@ -9,11 +9,11 @@
 
 <template>
   <li
+    v-if="layer.attributes.isEnabled && !layer.attributes.isScope &&  !layer.attributes.isBplan"
     :id="id"
     :title="layerTitle"
     :class="[(isVisible && layer.attributes.canUserToggleVisibility) ? prefixClass('is-active') : '', prefixClass('c-map__group-item c-map__layer')]"
-    @click="toggleFromSelf(false)"
-    v-if="layer.attributes.isEnabled && false === layer.attributes.isScope && false === layer.attributes.isBplan">
+    @click="toggleFromSelf(false)">
     <span
       :class="prefixClass('c-map__group-item-controls')"
       @mouseover="toggleOpacityControl(true)"
@@ -66,6 +66,7 @@ import { DpContextualHelp, prefixClass } from '@demos-europe/demosplan-ui'
 
 export default {
   name: 'DpPublicLayerListLayer',
+
   components: { DpContextualHelp },
 
   props: {

--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper.vue
@@ -40,7 +40,6 @@
 <script>
 import DpPublicLayerList from './DpPublicLayerList'
 import { prefixClass } from '@demos-europe/demosplan-ui'
-import proj4 from 'proj4'
 
 export default {
   name: 'DpPublicLayerListWrapper',
@@ -99,36 +98,6 @@ export default {
     this.$root.$on('custom-layer:unfolded map-tools:unfolded layer-legend:unfolded', () => {
       this.unfolded = false
     })
-  },
-
-  mounted () {
-
-    // Register the EPSG:25832 projection
-    proj4.defs("EPSG:25832", "+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs");
-
-    // Define the source CRS (EPSG:25832 for UTM zone 32N)
-    const sourceCRS = 'EPSG:25832';
-// Define the target CRS (WGS 84)
-    const targetCRS = 'EPSG:4326';
-
-    const minX = 1022620.5089412
-    const minY = 7303548.4394861
-    const maxX = 1082434.2285687
-    const maxY = 7336258.1049054
-
-// Define the BBOX coordinates
-//     const minX = 529491.15106134;
-//     const minY = 6072530.23884729;
-//     const maxX = 530143.40083621;
-//     const maxY = 6073456.86514068;
-
-// Transform the coordinates
-    const [minLon, minLat] = proj4(sourceCRS, targetCRS, [minX, minY]);
-    const [maxLon, maxLat] = proj4(sourceCRS, targetCRS, [maxX, maxY]);
-
-// Print the transformed coordinates
-    console.log(`Min coordinates (longitude, latitude): (${minLon}, ${minLat})`);
-    console.log(`Max coordinates (longitude, latitude): (${maxLon}, ${maxLat})`);
   }
 }
 </script>

--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper.vue
@@ -24,7 +24,7 @@
       layer-type="overlay" />
 
     <div
-      v-if="0 < baseLayers.length && unfolded && showBaseLayers"
+      v-if="baseLayers.length > 0 && unfolded && showBaseLayers"
       :class="prefixClass('c-map__group')">
       <div :class="prefixClass('c-map__layer pointer-events-none bg-color--grey-light-1')">
         {{ Translator.trans('map.bases') }}
@@ -40,6 +40,7 @@
 <script>
 import DpPublicLayerList from './DpPublicLayerList'
 import { prefixClass } from '@demos-europe/demosplan-ui'
+import proj4 from 'proj4'
 
 export default {
   name: 'DpPublicLayerListWrapper',
@@ -83,6 +84,7 @@ export default {
   methods: {
     toggle () {
       const unfolded = this.unfolded = !this.unfolded
+
       if (unfolded) {
         this.$root.$emit('layer-list:unfolded')
       }
@@ -97,6 +99,36 @@ export default {
     this.$root.$on('custom-layer:unfolded map-tools:unfolded layer-legend:unfolded', () => {
       this.unfolded = false
     })
+  },
+
+  mounted () {
+
+    // Register the EPSG:25832 projection
+    proj4.defs("EPSG:25832", "+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs");
+
+    // Define the source CRS (EPSG:25832 for UTM zone 32N)
+    const sourceCRS = 'EPSG:25832';
+// Define the target CRS (WGS 84)
+    const targetCRS = 'EPSG:4326';
+
+    const minX = 1022620.5089412
+    const minY = 7303548.4394861
+    const maxX = 1082434.2285687
+    const maxY = 7336258.1049054
+
+// Define the BBOX coordinates
+//     const minX = 529491.15106134;
+//     const minY = 6072530.23884729;
+//     const maxX = 530143.40083621;
+//     const maxY = 6073456.86514068;
+
+// Transform the coordinates
+    const [minLon, minLat] = proj4(sourceCRS, targetCRS, [minX, minY]);
+    const [maxLon, maxLat] = proj4(sourceCRS, targetCRS, [maxX, maxY]);
+
+// Print the transformed coordinates
+    console.log(`Min coordinates (longitude, latitude): (${minLon}, ${minLat})`);
+    console.log(`Max coordinates (longitude, latitude): (${maxLon}, ${maxLat})`);
   }
 }
 </script>

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -207,25 +207,30 @@ const LayersStore = {
           GisLayerCategory: [
             'categories',
             'gisLayers',
+            'hasDefaultVisibility',
+            'isVisible',
             'name',
             'layerWithChildrenHidden',
+            'parentId',
             'treeOrder',
-            'isVisible',
-            'hasDefaultVisibility',
-            'parentId'
           ].join(),
           GisLayer: [
-            'name',
-            'url',
-            'isEnabled',
-            'treeOrder',
-            'mapOrder',
+            'canUserToggleVisibility',
+            'categoryId',
             'hasDefaultVisibility',
+            'isBaseLayer',
+            'isBplan',
+            'isEnabled',
+            'isMinimap',
+            'isScope',
             'layers',
             'layerType',
-            'visibilityGroupId',
-            'isMinimap',
-            'categoryId'
+            'mapOrder',
+            'name',
+            'opacity',
+            'treeOrder',
+            'url',
+            'visibilityGroupId'
           ].join()
         },
         filter: {

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -333,7 +333,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
             left: 10px;
             position: absolute;
             right: 30px;
-            top: 5px;
+            top: 10px;
 
             display: inline-block;
             padding-left: 10px;


### PR DESCRIPTION
### Ticket
DPLAN-12401

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Some fields were missing from the layer request, so the corresponding attributes were `undefined` and some condition checks evaluated to `false`, so elements were not displayed in the interface.
Since for displaying the layers in the navigation, we checked if the attributes `isScope` and `isBplan` were false, the condition evaluated to `false` when the attributes were `undefined`.
I changed the condition to check for falsy to make it slightly more robust.

Apart from the bug fix, this PR also includes a few small improvements.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Go to public detail of a procedure that has overlay layers defined. Make sure they are displayed in the navigation and their opacity can be adjusted. (The opacity slider appears when hovering over the eye icon for toggling layer visibility).

![layer_list](https://github.com/user-attachments/assets/42521b8a-85d2-4699-9334-7d3932b9d39d)


### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
