### PR TITLE
fix(DPLAN-12411): issue by displaying fragments in the STN list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,9 @@ pipeline {
                     commandDockerRun = 'docker run --cpus=1 -d --name ' + containerName + ' -v ${PWD}:/srv/www -v /var/cache/demosplanCI/:/srv/www/.cache/ --env CURRENT_HOST_USERNAME=$(whoami) --env CURRENT_HOST_USERID=$(id -u $(whoami)) demosdeutschland/demosplan-ci:latest'
                     commandExecYarn =  _dockerExecAsUser('YARN_CACHE_FOLDER=/srv/www/.cache/yarn yarn install --immutable --check-cache', containerName)
                     commandExecComposer = _dockerExecAsRoot('COMPOSER_CACHE_DIR=/srv/www/.cache/composer composer install --classmap-authoritative --no-interaction', containerName)
-                    sh "mkdir -p .cache"
+                    sh "mkdir -p .cache var"
+                    sh "chmod -R 2775 var"
+                    sh "chown -R dplanup:dplanup var"
                     sh "echo ${PWD}"
                     sh "$commandDockerRun"
                     //sh "sleep 10"

--- a/client/js/components/statement/assessmentTable/Fragment.vue
+++ b/client/js/components/statement/assessmentTable/Fragment.vue
@@ -585,7 +585,7 @@ export default {
 
     //  Map store getters to local computed properties with object spread operator
     ...mapGetters(
-      'assessmentTable',
+      'AssessmentTable',
       [
         'adviceValues',
         'agencies',


### PR DESCRIPTION
### Ticket
[DPLAN-12411](https://demoseurope.youtrack.cloud/issue/DPLAN-12411/Datensatze-nicht-sichtbar-via-Abwagungstabelle)

**Description:** This PR fixes the issue by displaying fragments in the STN list: the first letter of the store name should be capitalized.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
