### PR TITLE
fix(DPLAN-1875):improve error handling

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Form/ProcedureUiDefinitionFormType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/ProcedureUiDefinitionFormType.php
@@ -87,7 +87,7 @@ class ProcedureUiDefinitionFormType extends AbstractBaseResourceFormType
                     'required'   => false,
                     'empty_data' => '',
                     'attr'       => [
-                        'hint'       => $this->translator->trans('edit.statement.confirm.info.explanation').'<br><br>'.$this->translator->trans('error.length.text', ['count' => 500]),
+                        'hint'       => $this->translator->trans('edit.statement.confirm.info.explanation').'<br><br>',
                         'attributes' => [
                             'maxlength=500',
                         ],

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_procedure_type_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_procedure_type_edit.html.twig
@@ -74,6 +74,7 @@
                     type: 'editor',
                     attr: {
                         customAttrs: [
+                            ':maxlength=500',
                             ':fullscreen-button=false',
                             ':link-button=true',
                             ':list-buttons=false',


### PR DESCRIPTION
### Ticket
[DPLAN-1875](https://demoseurope.youtrack.cloud/issue/DPLAN-1875/Fehlerfeld-wird-nicht-gehighlightet-Fehler-Notifcation-gibt-keine-klare-Auskunft)

Description: This PR improves error handling by adding the `maxlength` attribute to the editor, which checks the length, adds a hint for the user and applies an error class `is-invalid` when the conditions are not met.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
