### PR TITLE
fix: DPLAN-12009 copy statement with file container

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
@@ -55,7 +55,7 @@ class RpcBulkCopyStatements extends AbstractRpcStatementBulkAction
     {
         try {
             foreach ($statements as $statement) {
-                $copyResult = $this->statementCopier->copyStatementObjectWithinProcedure($statement);
+                $copyResult = $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($statement);
                 if (!$copyResult instanceof Statement) {
                     return false;
                 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
@@ -49,8 +49,7 @@ class ReportService extends CoreService
         private readonly StatementReportEntryFactory $statementReportEntryFactory,
         private readonly TranslatorInterface $translator,
         private readonly ValidatorInterface $validator,
-        private readonly EntityManagerInterface $entityManager
-
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -344,7 +343,7 @@ class ReportService extends CoreService
         return $this->reportRepository->addObject($report);
     }
 
-    function persistReportEntries(array $reportEntries): void
+    public function persistReportEntries(array $reportEntries): void
     {
         foreach ($reportEntries as $reportEntry) {
             $violations = $this->validator->validate($reportEntry);

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
@@ -61,13 +61,7 @@ class ReportService extends CoreService
     {
         $this->reportRepository->executeAndFlushInTransaction(
             function (EntityManagerInterface $em) use ($reportEntries) {
-                foreach ($reportEntries as $reportEntry) {
-                    $violations = $this->validator->validate($reportEntry);
-                    if (0 !== $violations->count()) {
-                        throw ViolationsException::fromConstraintViolationList($violations);
-                    }
-                    $em->persist($reportEntry);
-                }
+                $this->persistReportEntry($reportEntries, $em);
 
                 return null;
             }
@@ -346,5 +340,16 @@ class ReportService extends CoreService
         $report = $this->statementReportEntryFactory->createAnonymizationEntry($category, $event);
 
         return $this->reportRepository->addObject($report);
+    }
+
+    function persistReportEntry(array $reportEntries, EntityManagerInterface $em): void
+    {
+        foreach ($reportEntries as $reportEntry) {
+            $violations = $this->validator->validate($reportEntry);
+            if (0 !== $violations->count()) {
+                throw ViolationsException::fromConstraintViolationList($violations);
+            }
+            $em->persist($reportEntry);
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -430,7 +430,7 @@ class StatementCopier extends CoreService
         Statement $statement,
         Procedure $targetProcedure,
         bool $ignoreReviewer = false,
-        bool $ignoreInternId = false
+        bool $ignoreInternId = false,
     ): bool {
         $sourceProcedure = $statement->getProcedure();
 
@@ -540,7 +540,7 @@ class StatementCopier extends CoreService
         Statement $statement,
         bool $createReport = true,
         bool $copyOnCreateStatement = false,
-        bool $persistAndFlush = true
+        bool $persistAndFlush = true,
     ): Statement|false {
         try {
             $em = $this->getDoctrine()->getManager();
@@ -578,9 +578,9 @@ class StatementCopier extends CoreService
             // T15852 + T14880:
             // in each case reset public verified to ensure FP has to check each new statement
             if (!$newStatement->isManual() && in_array($newStatement->getPublicVerified(), [
-                    Statement::PUBLICATION_APPROVED,
-                    Statement::PUBLICATION_REJECTED,
-                ], true)
+                Statement::PUBLICATION_APPROVED,
+                Statement::PUBLICATION_REJECTED,
+            ], true)
             ) {
                 $newStatement = $this->statementService->setPublicVerified(
                     $newStatement,
@@ -656,7 +656,7 @@ class StatementCopier extends CoreService
     public function isCopyStatementAllowed(
         Statement $statement,
         bool $ignoreCluster = false,
-        bool $ignoreReviewer = false
+        bool $ignoreReviewer = false,
     ): bool {
         // check here for clustermember instead for cluster flag, because on create new cluster a statement will be created, marked as cluster and  have to be copied.
         if (false === $ignoreCluster && $statement->isClusterStatement()) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -41,7 +41,6 @@ use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
 use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use demosplan\DemosPlanCoreBundle\Traits\DI\RefreshElasticsearchIndexTrait;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
@@ -75,7 +74,6 @@ class StatementCopier extends CoreService
         private readonly StatementRepository $statementRepository,
         private readonly StatementService $statementService,
         private readonly NCNameGenerator $nameGenerator,
-        private readonly EntityManagerInterface $entityManager
     ) {
         $this->elasticsearchIndexManager = $elasticsearchIndexManager;
         $this->reportService = $reportService;
@@ -613,7 +611,7 @@ class StatementCopier extends CoreService
                     if ($persistAndFlush) {
                         $this->reportService->persistAndFlushReportEntries($entry);
                     } else {
-                        $this->reportService->persistReportEntry([$entry], $this->entityManager);
+                        $this->reportService->persistReportEntries([$entry]);
                     }
                     $this->logger->info(
                         'generate report of copyStatement(). ReportID: ',

--- a/docker/demosplan-production/Dockerfile
+++ b/docker/demosplan-production/Dockerfile
@@ -6,6 +6,9 @@ ENV PROJECT_PREFIX=$PROJECT_NAME \
     EXTERNAL_LINK_DIPLAN_COCKPIT=http://temporary.de \
     EXTERNAL_LINK_DIPLAN_PORTAL=http://temporary.de
 
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && echo "$TZ"> /etc/timezone
+
 # install default-mysql-client to be able to dump database
 RUN apt update -y && apt --no-install-recommends install default-mysql-client php8.2-fpm -y \
     && apt-get clean \
@@ -81,6 +84,9 @@ FROM nginxinc/nginx-unprivileged:latest AS nginx
 
 ARG PROJECT_NAME
 ENV PHP_FPM_BETEILIGUNG_SERVICE=beteiligung
+
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && echo "$TZ"> /etc/timezone
 
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12009/ROBOB-Prod-Bei-verschobenen-STN-wurden-in-der-Ubersicht-die-Links-von-Anhangen-nicht-angepasst

Description:
- use 'copyStatementObjectWithinProcedureWithRelatedFiles' instead of 'copyStatementObjectWithinProcedure' to copy statements with container files.
- refactor 'persistAndFlushReportEntries': this method use transaction and try fo flush report while copying statements which cause an exception and close the EntityManager. To avoid that we have to seprate the persisting part from the transaction, and this is done by refactoring 'persistAndFlushReportEntries'. The method 'persistReportEntry' can be used now in the case when we don't want to flush report entities directly after persisting (which is always the case with statements copying).


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
