### PR TITLE
I t35963 adjust procedure details page

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -794,7 +794,7 @@ export default {
       }
     })
     this.setContent({ prop: 'commentsList', val: { ...this.commentsList, procedureId: this.procedure.id, statementId: this.statementId } })
-    this.fetchProcedureMapSettings(this.procedureId)
+    this.fetchProcedureMapSettings(this.procedure.id)
       .then(response => {
         this.procedureMapSettings = { ...this.procedureMapSettings, ...response.attributes }
       })

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
@@ -90,6 +90,7 @@ class SegmentController extends BaseController
 
         $recommendationProcedureIds = $procedureService->getRecommendationProcedureIds($currentUser->getUser(), $procedureId);
         $isSourceAndCoupledProcedure = $tokenFetcher->isSourceAndCoupledProcedure($procedure);
+        $statementFormDefinition = $procedure->getStatementFormDefinition();
 
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanProcedure/administration_statement_segments_list.html.twig',
@@ -105,6 +106,7 @@ class SegmentController extends BaseController
                 'title'                      => 'segments.recommendations.create',
                 'templateVars'               => [
                     'isSourceAndCoupledProcedure' => $isSourceAndCoupledProcedure,
+                    'statementFormDefinition' => $statementFormDefinition
                 ],
             ]
         );

--- a/demosplan/DemosPlanCoreBundle/Logic/Router.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Router.php
@@ -132,6 +132,7 @@ class Router implements RouterInterface, WarmableInterface
     {
         if (array_key_exists('procedure', $parameters) && is_array($parameters['procedure']) && array_key_exists('id', $parameters['procedure']) && null !== $parameters['procedure']['id']) {
             $parameters['procedure'] = $this->slugifyProcedureIdParam($parameters['procedure']['id']);
+
             return $parameters;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Router.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Router.php
@@ -130,6 +130,11 @@ class Router implements RouterInterface, WarmableInterface
      */
     private function convertProcedureIdParameter(array $parameters): array
     {
+        if (array_key_exists('procedure', $parameters) && is_array($parameters['procedure']) && array_key_exists('id', $parameters['procedure']) && null !== $parameters['procedure']['id']) {
+            $parameters['procedure'] = $this->slugifyProcedureIdParam($parameters['procedure']['id']);
+            return $parameters;
+        }
+
         if (array_key_exists('procedure', $parameters) && null !== $parameters['procedure']) {
             $parameters['procedure'] = $this->slugifyProcedureIdParam($parameters['procedure']);
         }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
@@ -11,7 +11,6 @@
 {% endfor %}
 
 {% block component_part %}
-{#    TP DO: Fill statementFormDefinitions #}
     <statement-segments-list
         :available-counties="JSON.parse('{{ templateVars.availableCounties|default([])|json_encode|e('js', 'utf-8') }}')"
         :available-external-phases="JSON.parse('{{ templateVars.externalPhases|default([])|json_encode|e('js', 'utf-8') }}')"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
@@ -25,7 +25,7 @@
         :recommendation-procedure-ids="JSON.parse('{{ recommendationProcedureIds|json_encode|e('js', 'utf-8') }}')"
         statement-id="{{ statementId }}"
         statement-extern-id="{{ statementExternId }}"
-        statement-form-definitions="{}"
+        statement-form-definitions="JSON.parse('{{ templateVars.statementFormDefinition|json_encode|e('js', 'utf-8') }}')"
         :submit-type-options="JSON.parse('{{ submitTypeOptions|json_encode|e('js', 'utf-8') }}')">
     </statement-segments-list>
 {% endblock %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
@@ -25,7 +25,7 @@
         :recommendation-procedure-ids="JSON.parse('{{ recommendationProcedureIds|json_encode|e('js', 'utf-8') }}')"
         statement-id="{{ statementId }}"
         statement-extern-id="{{ statementExternId }}"
-        statement-form-definitions="JSON.parse('{{ templateVars.statementFormDefinition|json_encode|e('js', 'utf-8') }}')"
+        :statement-form-definitions="JSON.parse('{{ templateVars.statementFormDefinition|json_encode|e('js', 'utf-8') }}')"
         :submit-type-options="JSON.parse('{{ submitTypeOptions|json_encode|e('js', 'utf-8') }}')">
     </statement-segments-list>
 {% endblock %}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-3304/ADO-Issue-14299-Integration-EWM-Part-1-Aktivierung-der-Aufteilung-Verschlagwortung-und-STN-und-Abschnittsliste-zur-Erwiderung

- Enable going to the details page
- Display meta data

### How to review/test
- Go to a detail page of stn
- the details page should be displayed (before this PR it was throwing an error)


Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
