### PR TITLE
fix(refs DPLAN-12428): cast MaxPerPage Param from string to int

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -880,7 +880,7 @@ class DemosPlanDocumentController extends BaseController
         $currentPage = $request->get('page', 1) > 0 ? $request->get('page', 1) : 1;
 
         try {
-            $documentlistPager->setMaxPerPage($request->get('r_limit', 3));
+            $documentlistPager->setMaxPerPage((int) $request->get('r_limit', 3));
             $documentlistPager->setCurrentPage($currentPage);
         } catch (Exception $e) {
             $this->getLogger()->warning('Could not set paginate: ', [$e]);

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -104,7 +104,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         ServiceImporter $serviceImporter,
         $procedure,
-        $elementId
+        $elementId,
     ) {
         $route = 'DemosPlan_elements_administration_edit';
 
@@ -178,7 +178,7 @@ class DemosPlanDocumentController extends BaseController
         ServiceImporter $serviceImporter,
         ElementHandler $elementHandler,
         string $procedure,
-        array $element
+        array $element,
     ) {
         try {
             $templateVars = [];
@@ -270,7 +270,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         TranslatorInterface $translator,
         $procedure,
-        $documentID
+        $documentID,
     ) {
         // Storage und Output initialisieren
         $paragraphDocument = $paragraphService->getParaDocument($documentID);
@@ -370,7 +370,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         TranslatorInterface $translator,
         $procedure,
-        $elementId
+        $elementId,
     ) {
         // get Element -> get Title
         $elementService = $this->elementsService;
@@ -457,7 +457,7 @@ class DemosPlanDocumentController extends BaseController
         TranslatorInterface $translator,
         $procedure,
         $elementId,
-        $category
+        $category,
     ) {
         $templateVars = [];
         $templateVars['procedure'] = $procedure;
@@ -531,7 +531,7 @@ class DemosPlanDocumentController extends BaseController
         SingleDocumentHandler $singleDocumentHandler,
         TranslatorInterface $translator,
         $procedure,
-        $documentID
+        $documentID,
     ) {
         $templateVars = [];
         $templateVars['procedure'] = $procedure;
@@ -745,7 +745,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         FileUploadService $fileUploadService,
         FileService $fileService,
-        string $procedureId
+        string $procedureId,
     ) {
         $templateVars = [];
         $session = $request->getSession();
@@ -1029,7 +1029,7 @@ class DemosPlanDocumentController extends BaseController
         TranslatorInterface $translator,
         EventDispatcherPostInterface $eventDispatcherPost,
         string $procedure,
-        string $elementId
+        string $elementId,
     ) {
         // Storage und Output initialisieren
         $elementService = $this->elementsService;
@@ -1180,7 +1180,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         ServiceOutput $serviceOutput,
         TranslatorInterface $translator,
-        $procedure
+        $procedure,
     ) {
         $title = 'element.admin.category.new';
         $inData = $this->prepareIncomingData($request, 'elementnew');
@@ -1255,7 +1255,7 @@ class DemosPlanDocumentController extends BaseController
         ElementsService $elementsService,
         Request $request,
         $procedure,
-        $title
+        $title,
     ): Response {
         $elements = $elementsService->getEnabledFileAndParagraphElements(
             $procedure,
@@ -1306,7 +1306,7 @@ class DemosPlanDocumentController extends BaseController
         Request $request,
         $procedure,
         $elementId,
-        $category
+        $category,
     ) {
         // @improve T14613
         $procedureId = $procedure;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -655,7 +655,7 @@ class ElasticsearchResultCreator extends CoreService
                 $limit = $defaultLimits[0];
             }
 
-            $paginator->setMaxPerPage($limit);
+            $paginator->setMaxPerPage((int) $limit);
             // try to paginate Result, check for validity
             try {
                 $paginator->setCurrentPage($page);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -114,7 +114,7 @@ class ElasticsearchResultCreator extends CoreService
         private readonly UserService $userService,
         private readonly ParagraphService $paragraphService,
         private readonly SingleDocumentRepository $singleDocumentRepository,
-        private readonly DepartmentRepository $departmentRepository
+        private readonly DepartmentRepository $departmentRepository,
     ) {
     }
 
@@ -144,7 +144,7 @@ class ElasticsearchResultCreator extends CoreService
         $aggregationsOnly = false,
         $aggregationsMinDocumentCount = 1,
         $addAllAggregations = true,
-        array $customAggregations = []
+        array $customAggregations = [],
     ): ElasticsearchResult {
         $elasticsearchResultStatement = new ElasticsearchResult();
         try {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -1397,7 +1397,7 @@ class StatementFragmentService extends CoreService
                 $limit = 25;
             }
 
-            $paginator->setMaxPerPage($limit);
+            $paginator->setMaxPerPage((int) $limit);
             // try to paginate Result, check for validity
             try {
                 $paginator->setCurrentPage($page);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -139,7 +139,7 @@ class StatementFragmentService extends CoreService
         private readonly StatementService $statementService,
         TranslatorInterface $translator,
         private readonly UserRepository $userRepository,
-        UserService $userService
+        UserService $userService,
     ) {
         $this->assignService = $assignService;
         $this->elementService = $elementService;
@@ -1129,7 +1129,7 @@ class StatementFragmentService extends CoreService
         $limit = 0,
         $page = 1,
         $searchFields = [],
-        $addAllAggregations = true
+        $addAllAggregations = true,
     ): ElasticsearchResult {
         $elasticsearchResultStatement = new ElasticsearchResult();
         $boolQuery = new BoolQuery();
@@ -1740,7 +1740,7 @@ class StatementFragmentService extends CoreService
      */
     public function updateClaimingForStatementFragmentFromStatementFragmentUpdate(
         StatementFragment $statementFragment,
-        StatementFragmentUpdate $statementFragmentUpdate
+        StatementFragmentUpdate $statementFragmentUpdate,
     ) {
         if (in_array('assigneeId', $statementFragmentUpdate->getPropertiesSet(), true)) {
             $newAssigneeId = $statementFragmentUpdate->getAssigneeId();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2390,13 +2390,6 @@ class StatementService extends CoreService implements StatementServiceInterface
             if ('r_view_mode' === $key && '' !== $rParams[$key]) {
                 $resParams['view_mode'] = AssessmentTableViewMode::create($rParams[$key]);
             }
-            if ('r_limit' === $key
-                && is_numeric($value)
-                && array_key_exists('request', $resParams)
-                && array_key_exists('limit', $resParams['request'])
-            ) {
-                $resParams['request']['limit'] = (int) $value;
-            }
         }
 
         return $resParams;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2390,10 +2390,10 @@ class StatementService extends CoreService implements StatementServiceInterface
             if ('r_view_mode' === $key && '' !== $rParams[$key]) {
                 $resParams['view_mode'] = AssessmentTableViewMode::create($rParams[$key]);
             }
-            if ('r_limit' === $key &&
-                is_numeric($value) &&
-                array_key_exists('request', $resParams) &&
-                array_key_exists('limit', $resParams['request'])
+            if ('r_limit' === $key
+                && is_numeric($value)
+                && array_key_exists('request', $resParams)
+                && array_key_exists('limit', $resParams['request'])
             ) {
                 $resParams['request']['limit'] = (int) $value;
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2390,6 +2390,13 @@ class StatementService extends CoreService implements StatementServiceInterface
             if ('r_view_mode' === $key && '' !== $rParams[$key]) {
                 $resParams['view_mode'] = AssessmentTableViewMode::create($rParams[$key]);
             }
+            if ('r_limit' === $key &&
+                is_numeric($value) &&
+                array_key_exists('request', $resParams) &&
+                array_key_exists('limit', $resParams['request'])
+            ) {
+                $resParams['request']['limit'] = (int) $value;
+            }
         }
 
         return $resParams;

--- a/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
+++ b/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
@@ -149,7 +149,7 @@ trait ElasticsearchQueryTrait
                 $limit = 1;
             }
 
-            $paginator->setMaxPerPage($limit);
+            $paginator->setMaxPerPage((int) $limit);
 
             // try to paginate Result, check for validity
             try {

--- a/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
+++ b/demosplan/DemosPlanCoreBundle/Traits/DI/ElasticsearchQueryTrait.php
@@ -89,7 +89,7 @@ trait ElasticsearchQueryTrait
         $esQuery,
         $limit = -1,
         $page = 1,
-        Index $index = null): array
+        ?Index $index = null): array
     {
         $result = [];
 


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12428/Fehlermeldung-beim-Original-STn-List

Description:
The params retrieved from the form are parsed as strings. We need an integer to call the method $paginator->setMaxPerPage().

This change within the PagerFanta library was introduced here: https://github.com/BabDev/Pagerfanta/commit/36ab48a0a25e55186b1f002acf5c0ed655b81dae and we have updated to version >3 since the 06.06.24

Added a simple type cast for uses of PagerFanta::setMaxPerPage

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
