### PR TITLE
chore (refs DPLAN-12460): Fix hidden flyout.

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -107,7 +107,11 @@
         <dp-data-table
           ref="dataTable"
           class="overflow-x-auto pb-3"
-          :class="{ 'px-2 overflow-y-scroll grow': isFullscreen, 'scrollbar-none': !isFullscreen }"
+          :class="{
+            'px-2 overflow-y-scroll grow': isFullscreen,
+            'scrollbar-none': !isFullscreen,
+            'min-h-12': items.length < 3
+          }"
           data-cy="segmentsList"
           has-flyout
           :header-fields="headerFields"


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12460/Bei-Abschnittsliste-mit-wenigen-Eintragen-sind-nach-Klick-auf-drei-Punkte-die-Optionen-abgeschnitten


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- Fix hidden flyout.
- If a section list has only a few entries, then don't full display for flyout menu.