### PR TITLE
f DPLAN-12231 remove doubled note

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2162,8 +2162,7 @@ class DemosPlanProcedureController extends BaseController
                 try {
                     $storageResult = $this->procedureHandler->sendInvitationEmails(
                         $procedureAsArray,
-                        $this->prepareIncomingData($request, 'emailEdit'),
-                        $emailTextAdded
+                        $this->prepareIncomingData($request, 'emailEdit')
                     );
 
                     // generiere eine Erfolgsmeldung für die eingeladenen TöB

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -398,13 +398,25 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
 
         foreach ($recipientsWithEmail as $recipientData) {
             // Send invitation mail for each selected public agency organisation:
-            $this->sendPublicAgencyInvitationMail(
-                $recipientData['email2'],
-                $agencyMainEmailAddress,
-                $providedEmailTitle,
-                $providedEmailText,
-                $emailTextAdded
-            );
+
+            if (strpos($providedEmailText, "HINWEIS") !== false) {
+                $this->sendPublicAgencyInvitationMail(
+                    $recipientData['email2'],
+                    $agencyMainEmailAddress,
+                    $providedEmailTitle,
+                    $providedEmailText,
+                    ''
+                );
+            } else {
+                $this->sendPublicAgencyInvitationMail(
+                    $recipientData['email2'],
+                    $agencyMainEmailAddress,
+                    $providedEmailTitle,
+                    $providedEmailText,
+                    $emailTextAdded
+                );
+            }
+
 
             // Send invitation mail for each cc-email-addresses
             if (isset($recipientData['ccEmails']) && is_array($recipientData['ccEmails'])) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -355,7 +355,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
      * @throws NoRecipientsWithEmailException
      * @throws MissingDataException           Thrown if email title or email text is empty
      */
-    public function sendInvitationEmails(array $procedure, array $request, string $emailTextAdded): InvitationEmailResult
+    public function sendInvitationEmails(array $procedure, array $request): InvitationEmailResult
     {
         $helperServices = $this->getHelperServices();
         if (!array_key_exists('serviceMail', $helperServices)
@@ -399,23 +399,13 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         foreach ($recipientsWithEmail as $recipientData) {
             // Send invitation mail for each selected public agency organisation:
 
-            if (strpos($providedEmailText, "HINWEIS") !== false) {
-                $this->sendPublicAgencyInvitationMail(
-                    $recipientData['email2'],
-                    $agencyMainEmailAddress,
-                    $providedEmailTitle,
-                    $providedEmailText,
-                    ''
+            $this->sendPublicAgencyInvitationMail(
+                $recipientData['email2'],
+                $agencyMainEmailAddress,
+                $providedEmailTitle,
+                $providedEmailText,
                 );
-            } else {
-                $this->sendPublicAgencyInvitationMail(
-                    $recipientData['email2'],
-                    $agencyMainEmailAddress,
-                    $providedEmailTitle,
-                    $providedEmailText,
-                    $emailTextAdded
-                );
-            }
+
 
 
             // Send invitation mail for each cc-email-addresses
@@ -426,7 +416,6 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
                         $agencyMainEmailAddress,
                         $providedEmailTitle,
                         $providedEmailText,
-                        $emailTextAdded
                     );
                 }
             }
@@ -443,7 +432,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         // send planning agency emails
         $ccMailAddresses = $this->getPlaningAgencyCCEmailRecipients($procedure, $ccEmailAddresses);
         foreach ($ccMailAddresses as $singleCC) {
-            $this->sendPublicAgencyInvitationMail($singleCC, $agencyMainEmailAddress, $providedEmailTitle, $providedEmailText, $emailTextAdded);
+            $this->sendPublicAgencyInvitationMail($singleCC, $agencyMainEmailAddress, $providedEmailTitle, $providedEmailText);
         }
 
         try {
@@ -995,14 +984,11 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         string $from,
         string $emailTitle,
         string $emailText,
-        string $emailTextAdded
     ): void {
         $vars = [];
         try {
             $vars['mailsubject'] = $emailTitle;
-            $vars['mailbody'] =
-                $emailText
-                .html_entity_decode(nl2br($emailTextAdded), ENT_QUOTES, 'UTF-8');
+            $vars['mailbody'] = $emailText;
 
             $this->mailService->sendMail(
                 'dm_toebeinladung',

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -404,7 +404,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
                 $agencyMainEmailAddress,
                 $providedEmailTitle,
                 $providedEmailText,
-                );
+            );
 
 
             // Send invitation mail for each cc-email-addresses
@@ -431,7 +431,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         // send planning agency emails
         $ccMailAddresses = $this->getPlaningAgencyCCEmailRecipients($procedure, $ccEmailAddresses);
         foreach ($ccMailAddresses as $singleCC) {
-            $this->sendPublicAgencyInvitationMail($singleCC, $agencyMainEmailAddress, $providedEmailTitle);
+            $this->sendPublicAgencyInvitationMail($singleCC, $agencyMainEmailAddress, $providedEmailTitle, $providedEmailText);
         }
 
         try {

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -406,7 +406,6 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
                 $providedEmailText,
             );
 
-
             // Send invitation mail for each cc-email-addresses
             if (isset($recipientData['ccEmails']) && is_array($recipientData['ccEmails'])) {
                 foreach ($recipientData['ccEmails'] as $ccEmailAddress) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
@@ -112,7 +112,7 @@
 
         {% set emailText = templateVars.procedure.settings.emailText|default %}
         {% if hasPermission('feature_email_invitable_institution_additional_invitation_text') and templateVars.emailTextAdded is defined %}
-            {% set emailText = emailText ~ '<br/><br/>' %}
+            {% set emailText = emailText ~ '<br/><br/>' ~ templateVars.emailTextAdded|wysiwyg|nl2br %}
         {% endif %}
 
         <div class="{{ 'u-mb-0_75'|prefixClass }}">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
@@ -112,7 +112,7 @@
 
         {% set emailText = templateVars.procedure.settings.emailText|default %}
         {% if hasPermission('feature_email_invitable_institution_additional_invitation_text') and templateVars.emailTextAdded is defined %}
-            {% set emailText = emailText ~ '<br/><br/>' ~ templateVars.emailTextAdded|wysiwyg|nl2br  %}
+            {% set emailText = emailText ~ '<br/><br/>' %}
         {% endif %}
 
         <div class="{{ 'u-mb-0_75'|prefixClass }}">


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12231/BLP-Munchen-Automatisch-Angehangten-E-Mail-Text-bei-E-Mail-Einladung-zu-Verfahren-bearbeitbar-machen.


Description: remove doubled note

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

