### PR TITLE
chore: custom fix to set permissions is not needed any more

### DIFF
--- a/tests/backend/bootstrap.php
+++ b/tests/backend/bootstrap.php
@@ -9,18 +9,7 @@
  */
 
 use demosplan\DemosPlanCoreBundle\Application\FrontController;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 
 require dirname(__DIR__, 2).'/vendor/autoload.php';
-
-// set user and group for generated cache and log files to current user
-$userId = 1001;
-$tmpDir = DemosPlanPath::getTemporaryPath('dplan');
-if (!mkdir($tmpDir) && !is_dir($tmpDir)) {
-    throw new \RuntimeException(sprintf('Directory "%s" was not created', $tmpDir));
-}
-chown($tmpDir, $userId);
-posix_setuid($userId);
-posix_setgid($userId);
 
 FrontController::bootstrap();


### PR DESCRIPTION
This PR removes an attempt to fix the file permission during testing that never really worked and with the new cache folder breaks things

### How to review/test
run tests, they should start

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
