### PR TITLE
f (refs DPLAN-12009) picked fix Copy statement with file container 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
@@ -55,7 +55,7 @@ class RpcBulkCopyStatements extends AbstractRpcStatementBulkAction
     {
         try {
             foreach ($statements as $statement) {
-                $copyResult = $this->statementCopier->copyStatementObjectWithinProcedure($statement);
+                $copyResult = $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($statement);
                 if (!$copyResult instanceof Statement) {
                     return false;
                 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ReportService.php
@@ -48,7 +48,8 @@ class ReportService extends CoreService
         private readonly SortMethodFactory $sortMethodFactory,
         private readonly StatementReportEntryFactory $statementReportEntryFactory,
         private readonly TranslatorInterface $translator,
-        private readonly ValidatorInterface $validator
+        private readonly ValidatorInterface $validator,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -60,14 +61,8 @@ class ReportService extends CoreService
     public function persistAndFlushReportEntries(ReportEntry ...$reportEntries): void
     {
         $this->reportRepository->executeAndFlushInTransaction(
-            function (EntityManagerInterface $em) use ($reportEntries) {
-                foreach ($reportEntries as $reportEntry) {
-                    $violations = $this->validator->validate($reportEntry);
-                    if (0 !== $violations->count()) {
-                        throw ViolationsException::fromConstraintViolationList($violations);
-                    }
-                    $em->persist($reportEntry);
-                }
+            function () use ($reportEntries) {
+                $this->persistReportEntries($reportEntries);
 
                 return null;
             }
@@ -335,5 +330,16 @@ class ReportService extends CoreService
         $report = $this->statementReportEntryFactory->createAnonymizationEntry($category, $event);
 
         return $this->reportRepository->addObject($report);
+    }
+
+    public function persistReportEntries(array $reportEntries): void
+    {
+        foreach ($reportEntries as $reportEntry) {
+            $violations = $this->validator->validate($reportEntry);
+            if (0 !== $violations->count()) {
+                throw ViolationsException::fromConstraintViolationList($violations);
+            }
+            $this->entityManager->persist($reportEntry);
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -73,7 +73,7 @@ class StatementCopier extends CoreService
         private readonly StatementReportEntryFactory $statementReportEntryFactory,
         private readonly StatementRepository $statementRepository,
         private readonly StatementService $statementService,
-        private readonly NCNameGenerator $nameGenerator
+        private readonly NCNameGenerator $nameGenerator,
     ) {
         $this->elasticsearchIndexManager = $elasticsearchIndexManager;
         $this->reportService = $reportService;
@@ -430,7 +430,7 @@ class StatementCopier extends CoreService
         Statement $statement,
         Procedure $targetProcedure,
         bool $ignoreReviewer = false,
-        bool $ignoreInternId = false
+        bool $ignoreInternId = false,
     ): bool {
         $sourceProcedure = $statement->getProcedure();
 
@@ -540,7 +540,7 @@ class StatementCopier extends CoreService
         Statement $statement,
         bool $createReport = true,
         bool $copyOnCreateStatement = false,
-        bool $persistAndFlush = true
+        bool $persistAndFlush = true,
     ): Statement|false {
         try {
             $em = $this->getDoctrine()->getManager();
@@ -578,9 +578,9 @@ class StatementCopier extends CoreService
             // T15852 + T14880:
             // in each case reset public verified to ensure FP has to check each new statement
             if (!$newStatement->isManual() && in_array($newStatement->getPublicVerified(), [
-                    Statement::PUBLICATION_APPROVED,
-                    Statement::PUBLICATION_REJECTED,
-                ], true)
+                Statement::PUBLICATION_APPROVED,
+                Statement::PUBLICATION_REJECTED,
+            ], true)
             ) {
                 $newStatement = $this->statementService->setPublicVerified(
                     $newStatement,
@@ -608,7 +608,11 @@ class StatementCopier extends CoreService
             if (true === $createReport) {
                 try {
                     $entry = $this->statementReportEntryFactory->createStatementCopiedEntry($newStatement);
-                    $this->reportService->persistAndFlushReportEntries($entry);
+                    if ($persistAndFlush) {
+                        $this->reportService->persistAndFlushReportEntries($entry);
+                    } else {
+                        $this->reportService->persistReportEntries([$entry]);
+                    }
                     $this->logger->info(
                         'generate report of copyStatement(). ReportID: ',
                         ['identifier' => $entry->getIdentifier()]
@@ -652,7 +656,7 @@ class StatementCopier extends CoreService
     public function isCopyStatementAllowed(
         Statement $statement,
         bool $ignoreCluster = false,
-        bool $ignoreReviewer = false
+        bool $ignoreReviewer = false,
     ): bool {
         // check here for clustermember instead for cluster flag, because on create new cluster a statement will be created, marked as cluster and  have to be copied.
         if (false === $ignoreCluster && $statement->isClusterStatement()) {


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12009/ROBOB-Prod-Bei-verschobenen-STN-wurden-in-der-Ubersicht-die-Links-von-Anhangen-nicht-angepasst

Description:
- use 'copyStatementObjectWithinProcedureWithRelatedFiles' instead of 'copyStatementObjectWithinProcedure' to copy statements with container files.
- refactor 'persistAndFlushReportEntries': this method use transaction and try fo flush report while copying statements which cause an exception and close the EntityManager. To avoid that we have to seprate the persisting part from the transaction, and this is done by refactoring 'persistAndFlushReportEntries'. The method 'persistReportEntry' can be used now in the case when we don't want to flush report entities directly after persisting (which is always the case with statements copying).


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
