### PR TITLE
fix(refs DPLAN-12410): add link to public detail

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -3,6 +3,9 @@
     {% set td_width_2 = 80 %}
     {% set td_width_3 = 20 %}
 
+{# Needed to display link to public detail in base.html.twig #}
+{% set procedure = templateVars.procedure.id %}
+
 {% block demosplanbundlecontent %}
 
     {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {


### PR DESCRIPTION
### Ticket
[DPLAN-12410](https://demoseurope.youtrack.cloud/issue/DPLAN-12410/Keine-Verlinkung-zu-Offentlichkeitsansicht-bei-Planungsdokumente-und-Planzeichnung)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- as in other pages in the admin area, a link to the public participation area should be displayed at the top in the planning documents page
- the `procedure` variable was missing for this to work

![planning_documents_link](https://github.com/user-attachments/assets/0c8bf53c-2dde-4b35-8c39-61a62bcb1fe4)

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
