### PR TITLE
fix(refs DPLAN-12407): fix spacings and alignments

### DIFF
--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -142,7 +142,7 @@
           <div class="c-at-item__row-icon u-pl-0">
             <!-- DragHandler -->
           </div>
-          <div class="flex c-at-item__row">
+          <div class="flex">
               <div class="flex-1 u-pl-0_5">
                 {{ Translator.trans('description') }}
               </div>

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -27,9 +27,9 @@
 <template>
   <fieldset id="gisLayers">
     <div class="flex">
-      <legend class="w-1/4">
+      <h2 class="w-1/4">
         {{ Translator.trans('gislayer') }}
-      </legend>
+      </h2>
       <div class="w-3/4 text-right">
         <dp-split-button>
           <a

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -25,7 +25,9 @@
 </documentation>
 
 <template>
-  <fieldset id="gisLayers">
+  <fieldset
+    id="gisLayers"
+    class="pb-0">
     <div class="flex">
       <h2 class="w-1/4">
         {{ Translator.trans('gislayer') }}
@@ -173,13 +175,16 @@
             data-cy="baseMapLayerListItem"
             :index="idx" />
         </dp-draggable>
-        <div class="flex u-mt u-mb">
-          <h3 class="w-1/3">
+        <div class="u-mt u-mb">
+          <h3>
             {{ Translator.trans('map.base.minimap') }}
           </h3>
-          <div class="w-2/3">
+          <div>
+            <p class="font-size-small">
+              {{ Translator.trans('map.base.minimap.hint') }}
+            </p>
             <select
-              class="o-form__control-select"
+              class="o-form__control-select w-1/2"
               data-cy="adminLayerList:currentMinimapLayer"
               v-model="currentMinimapLayer">
               <option :value="{id: '', attributes: { name: 'default' }}">
@@ -193,13 +198,10 @@
               </option>
             </select>
           </div>
-          <p class="font-size-small">
-            {{ Translator.trans('map.base.minimap.hint') }}
-          </p>
         </div>
       </template>
       <div
-        class="text-right u-mv space-inline-s"
+        class="text-right u-mt-1_5 space-inline-s"
         v-if="!isLoading">
         <dp-button
           data-cy="adminLayerList:save"

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -25,9 +25,7 @@
 </documentation>
 
 <template>
-  <fieldset
-    id="gisLayers"
-    class="pb-0">
+  <div id="gisLayers">
     <div class="flex">
       <h2 class="w-1/4">
         {{ Translator.trans('gislayer') }}
@@ -222,7 +220,7 @@
         </button>
       </div>
     </div>
-  </fieldset>
+  </div>
 </template>
 
 <script>

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -53,7 +53,7 @@
     <div
       class="relative"
       :class="{'pointer-events-none': false === isEditable}">
-      <div class="u-mt flex">
+      <div class="mt-4 flex">
         <h3
           v-if="hasPermission('feature_map_baselayer')"
           class="flex-1 w-1/3">
@@ -70,7 +70,7 @@
           </button>
           <button
             @click.prevent="setActiveTab('mapOrder')"
-            class="btn--blank o-link--default u-ml"
+            class="btn--blank o-link--default ml-4"
             :class="{'o-link--active':currentTab === 'mapOrder'}">
             {{ Translator.trans('map.set.order.map') }}
           </button>
@@ -78,11 +78,11 @@
       </div>
 
       <!-- List-Head -->
-      <div class="color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5">
-        <div class="c-at-item__row-icon u-pl-0">
+      <div class="color--grey mb-1 mt-2 mr-2">
+        <div class="c-at-item__row-icon pl-0">
           <!-- DragHandler -->
         </div>
-        <div class="flex u-pl-0_5">
+        <div class="flex pl-2">
           <div class="flex-1">
             {{ Translator.trans('description') }}
           </div>
@@ -90,14 +90,14 @@
             v-if="hasPermission('feature_map_layer_visibility')"
             class="w-1/12 text-right">
               <i
-                class="fa fa-link u-mr-0_5"
+                class="fa fa-link mr-2"
                 v-tooltip="{ content: Translator.trans('explanation.gislayer.visibilitygroup'), classes: 'max-w-none' }" />
           </div>
           <div
             v-if="hasPermission('feature_map_layer_visibility')"
             class="w-1/12 text-right">
               <i
-                class="fa fa-eye u-mr-0_5"
+                class="fa fa-eye mr-2"
                 v-tooltip="Translator.trans('explanation.gislayer.visibility')" />
           </div>
 
@@ -125,32 +125,32 @@
 
       <dp-loading
         v-if="isLoading"
-        class="list__item u-pv-0_5 border--top" />
+        class="list__item py-2 border--top" />
 
       <div
         v-if="(0 === currentList.length ) && false === isLoading"
-        class="list__item u-pv-0_5 border--top color--grey">
+        class="list__item py-2 border--top color--grey">
         {{ Translator.trans('no.data') }}
       </div>
 
       <template v-if="hasPermission('feature_map_baselayer')">
-        <h3 class="u-mt">
+        <h3 class="mt-4">
           {{ Translator.trans('map.bases') }}
         </h3>
         <!-- List-Head -->
-        <div class="color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5">
-          <div class="c-at-item__row-icon u-pl-0">
+        <div class="color--grey mb-1 mt-2 mr-2">
+          <div class="c-at-item__row-icon pl-0">
             <!-- DragHandler -->
           </div>
           <div class="flex">
-              <div class="flex-1 u-pl-0_5">
+              <div class="flex-1 pl-2">
                 {{ Translator.trans('description') }}
               </div>
               <div
                 v-if="hasPermission('feature_map_layer_visibility')"
                 class="w-1/12 text-right">
                 <i
-                  class="fa fa-eye u-mr-0_5"
+                  class="fa fa-eye mr-2"
                   v-tooltip="Translator.trans('explanation.gislayer.visibility')" />
               </div>
               <div class="w-1/12 text-right">
@@ -173,7 +173,7 @@
             data-cy="baseMapLayerListItem"
             :index="idx" />
         </dp-draggable>
-        <div class="u-mt u-mb">
+        <div class="my-4">
           <h3>
             {{ Translator.trans('map.base.minimap') }}
           </h3>
@@ -199,7 +199,7 @@
         </div>
       </template>
       <div
-        class="text-right u-mt-1_5 space-inline-s"
+        class="text-right mt-5 space-x-2"
         v-if="!isLoading">
         <dp-button
           data-cy="adminLayerList:save"

--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -27,7 +27,7 @@
     @click="setActiveState"
     @mouseover="mouseOverElement"
     @mouseout="mouseOutElement">
-    <div class="c-at-item__row-icon layout__item u-pl-0">
+    <div class="c-at-item__row-icon layout__item pl-0">
       <i
         class="fa fa-bars handle w-[20px] cursor-grab"
         aria-hidden="true"
@@ -109,7 +109,7 @@
           :disabled="'' !== layer.attributes.visibilityGroupId || (true === isChildOfCategoryThatAppearsAsLayer)"
           @change.prevent="toggleHasDefaultVisibility"
           :checked="hasDefaultVisibility"
-          :class="iconClass">
+          :class="[iconClass, 'o-sortablelist__checkbox']">
       </div><!--
   --></template><!--
           Show this Stuff for 'special category that looks like an Layer and hides all his children'
@@ -119,7 +119,7 @@
           type="checkbox"
           data-cy="adminLayerListItem:toggleDefaultVisibility"
           :checked="hasDefaultVisibility"
-          :class="iconClass"
+          :class="[iconClass, 'o-sortablelist__checkbox']"
           @change.prevent="toggleHasDefaultVisibility">
       </div><!--
      -->
@@ -140,7 +140,7 @@
       </a>
       <button
         v-if="childElements.length <= 0"
-        class="btn--blank o-link--default u-mr-0_5"
+        class="btn--blank o-link--default u-mr-0_5 align-bottom"
         data-cy="adminLayerListItem:deleteElement"
         :title="Translator.trans('delete')"
         @click.prevent="deleteElement">
@@ -248,7 +248,7 @@ export default {
     return {
       drag: false,
       preventActiveFromToggeling: false,
-      iconClass: 'fa with--40 u-ml u-mr',
+      iconClass: 'mb-0 u-ml',
       showChildren: true
     }
   },

--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -18,7 +18,7 @@
 <template>
   <div
     :id="layer.id"
-    class="o-sortablelist__item u-pv-0_5 u-pl-0_5 border--top"
+    class="o-sortablelist__item py-2 pl-2 border--top"
     :class="{
       'is-active' : isActive,
       'cursor-pointer' : (false === layer.attributes.isBaseLayer && 'GisLayerCategory' !== layer.type && false === isChildOfCategoryThatAppearsAsLayer),
@@ -49,7 +49,7 @@
       {{ layer.attributes.name }}
       <span
         v-if="isChildOfCategoryThatAppearsAsLayer && 'mapOrder' === sortingType"
-        class="font-size-smaller u-mr-0_5">
+        class="font-size-smaller mr-2">
           <!-- children of categories that should appear as Layer
                     only in map-list (where no categories are shown)
                     -->
@@ -57,23 +57,23 @@
       </span>
       <span
         v-if="layer.attributes.layerWithChildrenHidden"
-        class="font-size-smaller u-mr-0_5">
+        class="font-size-smaller mr-2">
           <!-- categories that should appear as Layer -->
         <br>{{ Translator.trans('maplayer.category.with.hidden.children') }}
       </span>
       <span
         v-if="layer.attributes.description"
-        class="font-size-smaller u-mr-0_5">
+        class="font-size-smaller mr-2">
         <br>{{ layer.attributes.description }}
       </span>
       <span
         v-if="layer.attributes.isBplan"
-        class="font-size-smaller u-mr-0_5">
+        class="font-size-smaller mr-2">
         <br>{{ Translator.trans('explanation.gislayer.useas.bplan') }}
       </span>
       <span
         v-if="layer.attributes.isScope"
-        class="font-size-smaller u-mr-0_5">
+        class="font-size-smaller mr-2">
         <br>{{ Translator.trans('explanation.gislayer.useas.scope') }}
       </span>
       <span
@@ -134,13 +134,13 @@
         :href="editLink"
         data-cy="editLink">
         <i
-          class="fa fa-pencil u-mr-0_5"
+          class="fa fa-pencil mr-2"
           aria-hidden="true"
           :title="Translator.trans('edit')" /><span class="sr-only">{{ Translator.trans('edit') }}</span>
       </a>
       <button
         v-if="childElements.length <= 0"
-        class="btn--blank o-link--default u-mr-0_5 align-bottom"
+        class="btn--blank o-link--default mr-2 align-bottom"
         data-cy="adminLayerListItem:deleteElement"
         :title="Translator.trans('delete')"
         @click.prevent="deleteElement">
@@ -154,7 +154,7 @@
     <!-- recursive nesting inside -->
     <dp-draggable
       v-if="(layer.type === 'GisLayerCategory' && false === layer.attributes.layerWithChildrenHidden) && showChildren"
-      class="layout u-ml u-mt-0_25"
+      class="layout ml-4 mt-1"
       :class="[childElements.length <= 0 ? 'o-sortablelist__empty' :'']"
       :opts="draggableOptions"
       v-model="childElements">
@@ -174,7 +174,7 @@
     <!-- if special category that looks like an Layer and hides all his children -->
     <dp-draggable
       v-if="(layer.type === 'GisLayerCategory' && layer.attributes.layerWithChildrenHidden) && showChildren"
-      class="layout u-ml u-mt-0_25"
+      class="layout ml-4 mt-1"
       :class="[childElements.length <= 0 ? 'o-sortablelist__empty' :'']"
       :opts="draggableOptions"
       v-model="childElements"
@@ -248,7 +248,7 @@ export default {
     return {
       drag: false,
       preventActiveFromToggeling: false,
-      iconClass: 'mb-0 u-ml',
+      iconClass: 'mb-0 ml-4',
       showChildren: true
     }
   },

--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -27,7 +27,7 @@
     @click="setActiveState"
     @mouseover="mouseOverElement"
     @mouseout="mouseOutElement">
-    <div class="c-at-item__row-icon layout__item pl-0">
+    <div class="c-at-item__row-icon inline-block">
       <i
         class="fa fa-bars handle w-[20px] cursor-grab"
         aria-hidden="true"

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_sortablelist.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_sortablelist.scss
@@ -60,4 +60,8 @@
             background: $dp-color-neutral-light-3;
         }
     }
+
+    &__checkbox {
+        margin-right: 27px !important;
+    }
 }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
@@ -10,7 +10,7 @@
 
     {% if hasPermission('feature_map_use_plan_draw_pdf') or hasPermission('feature_map_use_plan_pdf') or canEditMapHint %}
         <form
-            class="flow-root border--bottom u-pb-0_5 u-mb"
+            class="flow-root border--bottom u-pb u-mb"
             name="planform"
             action="{{ path('DemosPlan_map_administration_gislayer',{'procedureId':procedure}) }}"
             method="post"
@@ -58,7 +58,7 @@
                         {{ fileupload( "r_planPDF", "drawing.explanation"|trans, null, null, null, true ) }}
 
                         {% if templateVars.procedure.settings.planDrawPDF is defined and templateVars.procedure.settings.planPDF != '' %}
-                            <div class="u-mb break-words">
+                            <div class="u-mb-0_5 u-mt break-words">
                                 <a
                                     class="o-hellip"
                                     target="_blank"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
@@ -10,7 +10,7 @@
 
     {% if hasPermission('feature_map_use_plan_draw_pdf') or hasPermission('feature_map_use_plan_pdf') or canEditMapHint %}
         <form
-            class="flow-root border--bottom u-pb u-mb"
+            class="flow-root border--bottom pb-4 mb-4"
             name="planform"
             action="{{ path('DemosPlan_map_administration_gislayer',{'procedureId':procedure}) }}"
             method="post"
@@ -27,15 +27,15 @@
             {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
 
             {% if hasPermission('feature_map_use_plan_draw_pdf') or hasPermission('feature_map_use_plan_pdf') %}
-                <fieldset class="u-pb layout layout--flush" id="drawingData">
+                <fieldset class="pb-4 layout layout--flush" id="drawingData">
                     {% if hasPermission('feature_map_use_plan_draw_pdf') %}
                         {# upload pdf #}
-                        <div class="u-mb">
+                        <div class="mb-4">
                             {{ fileupload( "r_planDrawPDF", "drawing"|trans, null, null, null, true) }}
                         </div>
 
                         {% if templateVars.procedure.settings.planDrawPDF is defined and templateVars.procedure.settings.planDrawPDF != '' %}
-                            <div class="u-mb break-words">
+                            <div class="mb-4 break-words">
                                 <a
                                     class="o-hellip"
                                     target="_blank"
@@ -58,7 +58,7 @@
                         {{ fileupload( "r_planPDF", "drawing.explanation"|trans, null, null, null, true ) }}
 
                         {% if templateVars.procedure.settings.planDrawPDF is defined and templateVars.procedure.settings.planPDF != '' %}
-                            <div class="u-mb-0_5 u-mt break-words">
+                            <div class="mb-3 mt-4 break-words">
                                 <a
                                     class="o-hellip"
                                     target="_blank"
@@ -85,7 +85,7 @@
                     </h3>
                     {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
                         helpText: 'map.hint.edit.contextual.help'|trans,
-                        cssClasses:'float-right u-mt-0_5'
+                        cssClasses:'float-right mt-3'
                     } %}
                     <p class="lbl__hint">
                         {{ 'map.hint.edit.explanation'|trans }}
@@ -105,7 +105,7 @@
                 </fieldset>
             {% endif %}
 
-            <div class="text-right space-inline-s">
+            <div class="text-right space-x-2">
                 <input
                     class="btn btn--primary"
                     type="submit"

--- a/tests/frontend/unit/__snapshots__/DpAdminLayerList.spec.js.snap
+++ b/tests/frontend/unit/__snapshots__/DpAdminLayerList.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AdminLayerList should render a empty admin layer list 1`] = `
-"<fieldset id=\\"gisLayers\\">
+"<div id=\\"gisLayers\\">
   <div class=\\"flex\\">
-    <legend class=\\"w-1/4\\">
+    <h2 class=\\"w-1/4\\">
       gislayer
-    </legend>
+    </h2>
     <div class=\\"w-3/4 text-right\\">
       <dp-split-button-stub><a data-cy=\\"createNewGisLayer\\" href=\\"DemosPlan_map_administration_gislayer_new\\" class=\\"btn btn--primary has-dropdown\\">
           gislayer.create
@@ -13,62 +13,63 @@ exports[`AdminLayerList should render a empty admin layer list 1`] = `
     </div>
   </div>
   <div class=\\"relative\\">
-    <div class=\\"u-mt flex\\">
+    <div class=\\"mt-4 flex\\">
       <h3 class=\\"flex-1 w-1/3\\">
         map.overlays
       </h3>
       <div class=\\"flex-1 w-2/3 text-right\\"><button class=\\"btn--blank o-link--default\\">
           map.set.order.tree
-        </button> <button class=\\"btn--blank o-link--default u-ml\\">
+        </button> <button class=\\"btn--blank o-link--default ml-4\\">
           map.set.order.map
         </button></div>
     </div>
-    <div class=\\"color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5\\">
-      <div class=\\"c-at-item__row-icon u-pl-0\\"></div>
-      <div class=\\"flex u-pl-0_5\\">
+    <div class=\\"color--grey mb-1 mt-2 mr-2\\">
+      <div class=\\"c-at-item__row-icon pl-0\\"></div>
+      <div class=\\"flex pl-2\\">
         <div class=\\"flex-1\\">
           description
         </div>
-        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-link u-mr-0_5 has-tooltip\\" data-original-title=\\"null\\"></i></div>
-        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-eye u-mr-0_5 has-tooltip\\" data-original-title=\\"null\\"></i></div>
+        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-link mr-2 has-tooltip\\" data-original-title=\\"null\\"></i></div>
+        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-eye mr-2 has-tooltip\\" data-original-title=\\"null\\"></i></div>
         <div class=\\"w-1/12 text-right\\">
           edit
         </div>
       </div>
     </div>
     <!---->
-    <dp-loading-stub class=\\"list__item u-pv-0_5 border--top\\"></dp-loading-stub>
+    <dp-loading-stub class=\\"list__item py-2 border--top\\"></dp-loading-stub>
     <!---->
-    <h3 class=\\"u-mt\\">
+    <h3 class=\\"mt-4\\">
       map.bases
     </h3>
-    <div class=\\"color--grey u-mb-0_25 u-mt-0_5 u-mr-0_5\\">
-      <div class=\\"c-at-item__row-icon u-pl-0\\"></div>
-      <div class=\\"flex c-at-item__row\\">
-        <div class=\\"flex-1 u-pl-0_5\\">
+    <div class=\\"color--grey mb-1 mt-2 mr-2\\">
+      <div class=\\"c-at-item__row-icon pl-0\\"></div>
+      <div class=\\"flex\\">
+        <div class=\\"flex-1 pl-2\\">
           description
         </div>
-        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-eye u-mr-0_5 has-tooltip\\" data-original-title=\\"null\\"></i></div>
+        <div class=\\"w-1/12 text-right\\"><i class=\\"fa fa-eye mr-2 has-tooltip\\" data-original-title=\\"null\\"></i></div>
         <div class=\\"w-1/12 text-right\\">
           edit
         </div>
       </div>
     </div>
     <!---->
-    <div class=\\"flex u-mt u-mb\\">
-      <h3 class=\\"w-1/3\\">
+    <div class=\\"my-4\\">
+      <h3>
         map.base.minimap
       </h3>
-      <div class=\\"w-2/3\\"><select data-cy=\\"adminLayerList:currentMinimapLayer\\" class=\\"o-form__control-select\\">
+      <div>
+        <p class=\\"font-size-small\\">
+          map.base.minimap.hint
+        </p> <select data-cy=\\"adminLayerList:currentMinimapLayer\\" class=\\"o-form__control-select w-1/2\\">
           <option value=\\"[object Object]\\">
             selection.no
           </option>
-        </select></div>
-      <p class=\\"font-size-small\\">
-        map.base.minimap.hint
-      </p>
+        </select>
+      </div>
     </div>
     <!---->
   </div>
-</fieldset>"
+</div>"
 `;


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12407/Grundkarten-Auge-Icon-und-Bearbeiten-sind-verrutscht-und-da-gibt-keine-Padding-fur-Ubersichtskarte

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Lots of spacings and alignments are fixed in the planning documents view:
- table header items are aligned properly
- icons in the table are aligned properly
- spacing above and below items is consistent
- the "Übersichtskarte" heading and the hint are displayed above the select
- the "Kartenebenen" legend is changed to an h2 to better match (and visualize) the logical hierarchy

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->


### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
