### PR TITLE
fix(refs DPLAN-1917): bump demosplan-addon version to v0.40

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "cebe/php-openapi": "^1.5",
         "cocur/slugify": "^4.0",
         "composer/package-versions-deprecated": "1.11.99.5",
-        "demos-europe/demosplan-addon": "0.39",
+        "demos-europe/demosplan-addon": "0.40",
         "doctrine/annotations": "^2.0",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5dea4ebd8b6b971118551e50cad1e382",
+    "content-hash": "19d68f1ac375684561f32d0ec1030c47",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1548,16 +1548,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.39",
+            "version": "v0.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "90091ab6718d02074e6d4da320bd38516973cb51"
+                "reference": "af2ed7947edec356993e4bbe01e521c3c912f6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/90091ab6718d02074e6d4da320bd38516973cb51",
-                "reference": "90091ab6718d02074e6d4da320bd38516973cb51",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/af2ed7947edec356993e4bbe01e521c3c912f6ce",
+                "reference": "af2ed7947edec356993e4bbe01e521c3c912f6ce",
                 "shasum": ""
             },
             "require": {
@@ -1622,9 +1622,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.39"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.40"
             },
-            "time": "2024-08-06T10:14:40+00:00"
+            "time": "2024-09-23T09:17:26+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-1917/Basemap-wird-nicht-per-Default-auf-Startseitenkarte-bei-neuem-Mandanten-eingetragen

Description:
Introduces new constants for use in https://github.com/demos-europe/demosplan-core/pull/3680
Implemented in https://github.com/demos-europe/demosplan-addon/pull/124


- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
