### PR TITLE
bug(refs DPLAN-12484): Fix target name for ol map draw point

### DIFF
--- a/client/js/components/procedure/basicSettings/DpProcedureCoordinate.vue
+++ b/client/js/components/procedure/basicSettings/DpProcedureCoordinate.vue
@@ -40,7 +40,7 @@
         <div :class="prefixClass('inline-block')">
           <dp-ol-map-draw-point
             :class="prefixClass('u-mb-0_5')"
-            target="procedureCoordinateDrawer"
+            target="layer:procedureCoordinateDrawer"
             :active="isDrawingActive"
             @tool:setPoint="checkProcedureValidation"
             @tool:activated="setDrawingActive" />


### PR DESCRIPTION
### Ticket
DPLAN-12484

The layer name was changed [here](https://github.com/demos-europe/demosplan-core/pull/3688), so we need to also change the target name for DpOlMapDrawPoint. 

### How to review/test
Verfahren -> Grundeinstellungen -> Verortung des Verfahrens -> You should be able to draw a point. 

