### PR TITLE
fix(refs DPLAN-11379) the customer got added to the globalContent (news) and is expected to be present when fetching entities within the tests.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ContentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ContentService.php
@@ -127,6 +127,10 @@ class ContentService extends CoreService
     {
         try {
             $singleGlobalContent = $this->contentRepository->get($ident);
+            if (!$singleGlobalContent instanceof GlobalContent) {
+                $message = 'No Content could be fetched for id: '.$ident;
+                throw new InvalidArgumentException($message);
+            }
             if ($this->customerService->getCurrentCustomer()->getId() !== $singleGlobalContent->getCustomer()->getId()) {
                 throw new CustomerNotFoundException('Content does not belong to current customer');
             }

--- a/tests/backend/core/News/Functional/GlobalNewsHandlerTest.php
+++ b/tests/backend/core/News/Functional/GlobalNewsHandlerTest.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Logic\News\GlobalNewsHandler;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
+use InvalidArgumentException;
 use Tests\Base\FunctionalTestCase;
 
 class GlobalNewsHandlerTest extends FunctionalTestCase
@@ -45,7 +46,7 @@ class GlobalNewsHandlerTest extends FunctionalTestCase
         $newsList = $this->sut->getNewsList($user);
         static::assertCount(2, $newsList);
         $this->checkSingleGlobalContentVariables($newsList[0]);
-        static::assertCount(17, $newsList[0]);
+        static::assertCount(18, $newsList[0]);
         static::assertCount(2, $newsList[0]['roles']);
         static::assertCount(1, $newsList[0]['categories']);
         static::assertEquals('GlobalNews2 Title', $newsList[0]['title']);
@@ -58,7 +59,7 @@ class GlobalNewsHandlerTest extends FunctionalTestCase
         static::assertTrue(is_array($newsList));
         static::assertCount(1, $newsList);
         $this->checkSingleGlobalContentVariables($newsList[0]);
-        static::assertCount(17, $newsList[0]);
+        static::assertCount(18, $newsList[0]);
         static::assertCount(2, $newsList[0]['roles']);
     }
 
@@ -66,7 +67,7 @@ class GlobalNewsHandlerTest extends FunctionalTestCase
     {
         $newsList = $this->sut->getGlobalNewsAdminList();
         static::assertCount(2, $newsList);
-        static::assertCount(17, $newsList[0]);
+        static::assertCount(18, $newsList[0]);
         $this->checkSingleGlobalContentVariables($newsList[0]);
         static::assertCount(3, $newsList[1]['roles']);
         static::assertCount(6, $newsList[0]['roles'][1]);
@@ -81,7 +82,7 @@ class GlobalNewsHandlerTest extends FunctionalTestCase
 
         $singleNews = $this->sut->getSingleNews($singleNewsId);
         static::assertTrue(is_array($singleNews));
-        static::assertCount(17, $singleNews);
+        static::assertCount(18, $singleNews);
         $this->checkSingleGlobalContentVariables($singleNews);
         static::assertCount(3, $singleNews['roles']);
         static::assertCount(1, $singleNews['categories']
@@ -92,9 +93,8 @@ class GlobalNewsHandlerTest extends FunctionalTestCase
     {
         $singleNewsId = '';
 
+        $this->expectException(InvalidArgumentException::class);
         $singleNews = $this->sut->getSingleNews($singleNewsId);
-        static::assertTrue(is_array($singleNews));
-        static::assertCount(0, $singleNews);
     }
 
     public function testAddGlobalNews()


### PR DESCRIPTION
Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-11379/ADO-Issue-15401-Portal-Mitteilungen-nur-im-Mandanten-sichtbar-in-dem-sie-erstellt-wurden

Description:
the customer got added to the globalContent (news) and is expected to be present when fetching entities within the tests.
throw an invalid argument exception when trying to fetch a global Content by an invalid id.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
