### PR TITLE
bug(refs DPLAN-12484): Features should be an array, not an object

### DIFF
--- a/client/js/components/map/map/DpOlMapLayerVector.vue
+++ b/client/js/components/map/map/DpOlMapLayerVector.vue
@@ -65,7 +65,7 @@ export default {
 
     geoJsonFeatures () {
       // Validate geojson? https://github.com/craveprogramminginc/GeoJSON-Validation
-      return this.isFeatureGeoJSON ? new GeoJSON().readFeatures({ properties: { id: `feature:${this.name}` }, ...this.features }) : {}
+      return this.isFeatureGeoJSON ? new GeoJSON().readFeatures({ properties: { id: `feature:${this.name}` }, ...this.features }) : []
     }
   },
 


### PR DESCRIPTION
### Ticket
DPLAN-12484

OL expects features as an array instead of an object. 

### How to review/test
This bug only appears with ne procedures. 

New procedure -> Grundeinstellungen -> There should be no errors in console and you should be able to draw a point for Ortsbezug