### PR TITLE
fix(DPLAN-2252): sorting is lost after form submit

### DIFF
--- a/client/js/components/statement/assessmentTable/DpEditSelectedItemsMenu.vue
+++ b/client/js/components/statement/assessmentTable/DpEditSelectedItemsMenu.vue
@@ -129,8 +129,12 @@ export default {
   },
 
   methods: {
+    capitalizeFirstLetter (str) {
+      return str.charAt(0).toUpperCase() + str.slice(1)
+    },
+
     resetSelection () {
-      this.$store.dispatch(`${this.visibleEntityType}/resetSelection`)
+      this.$store.dispatch(`${this.capitalizeFirstLetter(this.visibleEntityType)}/resetSelection`)
     },
     ...mapMutations('Statement', ['updateStatement'])
   }

--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -311,7 +311,7 @@ export default {
 
     deleteElements (event) {
       sessionStorage.setItem('selectedElements', '{}')
-      window.submitForm(event, 'delete')
+      window.submitForm(event, 'delete', false)
     },
 
     fetchFragmentByStatement (statement) {

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -80,13 +80,11 @@ export default function AssessmentTable () {
   function handleFormSubmission (task) {
     const oldTarget = document.bpform.target
     const oldAction = document.bpform.action
-    let abfrageBox
     let formsend = false
 
     switch (task) {
       case 'delete':
-        abfrageBox = dpconfirm(Translator.trans('check.entries.marked.delete'))
-        if (abfrageBox === true) {
+        if (dpconfirm(Translator.trans('check.entries.marked.delete'))) {
           document.getElementsByName('r_action')[0].value = 'delete'
           document.bpform.submit()
           formsend = true
@@ -97,8 +95,7 @@ export default function AssessmentTable () {
 
       case 'copy':
         // Copying of statements within one procedure is not handled in copyStatementModal yet
-        abfrageBox = dpconfirm(Translator.trans('check.entries.marked.copy'))
-        if (abfrageBox === true) {
+        if (dpconfirm(Translator.trans('check.entries.marked.copy'))) {
           document.getElementsByName('r_action')[0].value = 'copy'
           document.bpform.submit()
           formsend = true


### PR DESCRIPTION
### Ticket
[DPLAN-2252](https://demoseurope.youtrack.cloud/issue/DPLAN-2252/Losch-Aktionen-hebt-Sortierung-anhand-der-Filtern-auf-in-A-Tabelle)

**Description:** This PR provides the option to update the hash or leave it unchanged before submitting the form (the issue with the store name was fixed along this PR)

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
