### PR TITLE
Fix(DPLAN-12449): dp-obscure tag not being applied

### DIFF
--- a/client/js/components/statement/assessmentTable/EditableText.vue
+++ b/client/js/components/statement/assessmentTable/EditableText.vue
@@ -38,7 +38,8 @@
           mark: mark,
           obscure: obscure,
           strikethrough: strikethrough
-        }">
+        }"
+        @transformObscureTag="transformObscureTag">
         <template v-slot:modal="modalProps">
           <dp-boiler-plate-modal
             v-if="boilerPlate"
@@ -249,6 +250,7 @@ export default {
       isShortened: false,
       loading: false,
       shortText: '',
+      transformedText: '',
       uneditedFullText: ''
     }
   },
@@ -267,6 +269,13 @@ export default {
     },
 
     save () {
+      /** transformedText contains the text with the obscure tag applied.
+       * To avoid the cursor jumping to the end, we update the fullText with transformedText only when the save action is triggered.
+       * */
+      if (this.transformedText && this.transformedText !== this.fullText) {
+        this.fullText = this.transformedText
+      }
+
       // If there are no changes, no need to save something.
       if (this.uneditedFullText === this.fullText) {
         this.isEditing = false
@@ -287,6 +296,10 @@ export default {
       this.$emit('field:save', emitData)
 
       this.fullTextLoaded = false
+    },
+
+    transformObscureTag (value) {
+      this.transformedText = value
     },
 
     toggleEditMode () {


### PR DESCRIPTION
**Ticket:** [DPLAN-12449](https://demoseurope.youtrack.cloud/issue/DPLAN-12449/Geschwarzte-Stellungnahme-Text-ist-sichtbar-in-Offentlichkeit-Ansicht)

**Description:** This PR fixes an issue where the `<dp-obscure>` tag was not being applied because the `transformObscureTag` function was not triggered. This function should be executed with every update action, otherwise, the `<dp-obscure>` tag will not be transformed as expected.

However, executing it with every update action causes another bug, [DPLAN-12305 Prevent Cursor from Jumping to End of File](https://github.com/demos-europe/demosplan-ui/pull/995). To resolve this, the transformed text should be processed outside the input event to avoid updating the full text directly.

I think it's because `fullText` is a `v-model` of the editor, and if its value is different from the HTML, it updates the field and causes the cursor to jump. So, we shouldn't update `fullText` directly but store it in a different variable. I haven't found a better solution, I tried different approaches... If you have a better idea, feel free to share :)

### Linked PRs (optional)
- https://github.com/demos-europe/demosplan-ui/pull/1027

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
