### PR TITLE
F dplan 12514 add berlin time to filenames

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
@@ -265,7 +265,7 @@ class AssessmentHandler extends CoreHandler
         return new DocxExportResult(
             sprintf(
                 $this->translator->trans('considerationtable').'-%s.docx',
-                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
+                Carbon::now('Europe/Berlin')->format('d-m-Y-H:i')
             ),
             $objWriter
         );

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
@@ -265,8 +265,9 @@ class AssessmentHandler extends CoreHandler
         return new DocxExportResult(
             sprintf(
                 $this->translator->trans('considerationtable').'-%s.docx',
-                Carbon::now()->format('d-m-Y-H:i')
-            ), $objWriter
+                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
+            ),
+            $objWriter
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableDocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableDocxExporter.php
@@ -58,7 +58,7 @@ class AssessmentTableDocxExporter extends AssessmentTableFileExporterAbstract
 
             $fileName = sprintf(
                 $this->translator->trans('considerationtable').'-%s.docx',
-                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
+                Carbon::now('Europe/Berlin')->format('d-m-Y-H:i')
             );
 
             $file = [

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableDocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableDocxExporter.php
@@ -58,7 +58,7 @@ class AssessmentTableDocxExporter extends AssessmentTableFileExporterAbstract
 
             $fileName = sprintf(
                 $this->translator->trans('considerationtable').'-%s.docx',
-                Carbon::now()->format('d-m-Y-H:i')
+                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
             );
 
             $file = [

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -57,7 +57,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
         ServiceImporter $serviceImport,
         SimpleSpreadsheetService $simpleSpreadsheetService,
         StatementHandler $statementHandler,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         parent::__construct(
             $assessmentTableServiceOutput,
@@ -373,7 +373,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
         string $key,
         string $permission,
         string $columnTitle,
-        int $width = 20
+        int $width = 20,
     ): void {
         if ($this->permissions->hasPermission($permission)) {
             $columnsDefinition[] = $this->createColumnDefinition($key, $columnTitle, $width);
@@ -388,7 +388,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
     protected function prepareDataForExcelExport(
         array $statements,
         bool $anonymous,
-        array $keysOfAttributesToExport
+        array $keysOfAttributesToExport,
     ): array {
         $attributeKeysWhichCauseNewLine = collect(['priorityAreaKeys', 'tagNames']);
         $formattedStatements = collect([]);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -106,7 +106,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
         return [
             'filename' => sprintf(
                 $this->translator->trans('considerationtable').'-%s.xlsx',
-                Carbon::now()->format('d-m-Y-H:i')
+                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
             ),
             'writer'       => $objWriter,
             'statementIds' => $statementIds,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -106,7 +106,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
         return [
             'filename' => sprintf(
                 $this->translator->trans('considerationtable').'-%s.xlsx',
-                Carbon::now('Europe/Berlin')->format('d-m-Y H:i')
+                Carbon::now('Europe/Berlin')->format('d-m-Y-H:i')
             ),
             'writer'       => $objWriter,
             'statementIds' => $statementIds,


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12514

Description:
Use the correct time zone when embedding the current time within file names.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
