### PR TITLE
bug(refs DPLAN-12380): Correct typo in Vuex mutation subscription

### DIFF
--- a/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
+++ b/client/js/components/statement/assessmentTable/DpAssessmentTableCard.vue
@@ -1293,7 +1293,7 @@ export default {
 
     // Update card view if table view has been change (per Ansicht Button)
     this.$store.subscribe(mutation => {
-      if (mutation.type === 'assessmentTable/setProperty' && mutation.payload.prop === 'currentTableView') {
+      if (mutation.type === 'AssessmentTable/setProperty' && mutation.payload.prop === 'currentTableView') {
         this.toggleView(mutation.payload.val)
       }
     })


### PR DESCRIPTION
### Ticket
DPLAN-12380

Changed 'assessmentTable' to 'AssessmentTable' in the Vuex mutation subscription to ensure the toggleView method is called correctly.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Abwägungstabelle -> Change "Ansicht" -> view should change accordingly
<!-- 
