### PR TITLE
Fix(dplan 12522): position of the opacity control slider

### DIFF
--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
@@ -19,7 +19,7 @@
       @mouseover="toggleOpacityControl(true)"
       @mouseout="toggleOpacityControl(false)">
       <button
-        :class="prefixClass('btn--blank btn--focus w-3 text-left')"
+        :class="prefixClass('btn--blank btn--focus w-3 text-left py-0.5')"
         :aria-label="layer.attributes.name + ' ' + statusAriaText"
         :data-cy="dataCy"
         @focus="toggleOpacityControl(true)"

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -333,7 +333,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
             left: 10px;
             position: absolute;
             right: 30px;
-            top: 6px;
+            top: 10px;
 
             display: inline-block;
             padding-left: 10px;

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -333,7 +333,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
             left: 10px;
             position: absolute;
             right: 30px;
-            top: 10px;
+            top: 6px;
 
             display: inline-block;
             padding-left: 10px;


### PR DESCRIPTION
### Ticket
[DPLAN-12522](https://demoseurope.youtrack.cloud/issue/DPLAN-12522/Transparenzeinstellung-ist-verschoben)

**Description:** This PR fixes an issue with the position of the opacity control slider (in the Robobsh, bobsh projects) by adding padding to the toggle opacity control button. In the Robobsh project the button is somehow smaller than in Diplanbau (did not find why..), so adding padding makes it same across these projects. The original PR where the top position was changed is [here](https://github.com/demos-europe/demosplan-core/pull/3663).

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
