### PR TITLE
Fix(DPLAN-2252): issue where the 'remove' action was resetting the sorting option

### DIFF
--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -154,8 +154,8 @@ export default {
     ]),
 
     ...mapState('Statement', [
+      'filterHash',
       'statements',
-      'filterHash'
     ]),
 
     ...mapState('Fragment', [

--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -154,7 +154,8 @@ export default {
     ]),
 
     ...mapState('Statement', [
-      'statements'
+      'statements',
+      'filterHash'
     ]),
 
     ...mapState('Fragment', [
@@ -311,7 +312,7 @@ export default {
 
     deleteElements (event) {
       sessionStorage.setItem('selectedElements', '{}')
-      window.submitForm(event, 'delete', false)
+      window.submitForm(event, 'delete', this.filterHash)
     },
 
     fetchFragmentByStatement (statement) {

--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -455,7 +455,6 @@ export default {
       const dropdownOptions = []
       const ascPrefix = Translator.trans('ascending').charAt(0).toUpperCase() + Translator.trans('ascending').substring(1)
       const descPrefix = Translator.trans('descending').charAt(0).toUpperCase() + Translator.trans('descending').substring(1)
-      console.log('sortingOptions', this.sortingOptions)
       this.sortingOptions.forEach(option => {
         const hasSortingDirection = option.value !== 'forPoliticians'
         dropdownOptions.push({

--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -455,6 +455,7 @@ export default {
       const dropdownOptions = []
       const ascPrefix = Translator.trans('ascending').charAt(0).toUpperCase() + Translator.trans('ascending').substring(1)
       const descPrefix = Translator.trans('descending').charAt(0).toUpperCase() + Translator.trans('descending').substring(1)
+
       this.sortingOptions.forEach(option => {
         const hasSortingDirection = option.value !== 'forPoliticians'
         dropdownOptions.push({
@@ -547,8 +548,7 @@ export default {
     handleSortChange (newVal) {
       this.setProperty({
         prop: 'sort',
-        val: newVal,
-        hash: ''
+        val: newVal
       })
       this.triggerApiCallForStatements()
     },

--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -455,7 +455,7 @@ export default {
       const dropdownOptions = []
       const ascPrefix = Translator.trans('ascending').charAt(0).toUpperCase() + Translator.trans('ascending').substring(1)
       const descPrefix = Translator.trans('descending').charAt(0).toUpperCase() + Translator.trans('descending').substring(1)
-
+      console.log('sortingOptions', this.sortingOptions)
       this.sortingOptions.forEach(option => {
         const hasSortingDirection = option.value !== 'forPoliticians'
         dropdownOptions.push({
@@ -548,7 +548,8 @@ export default {
     handleSortChange (newVal) {
       this.setProperty({
         prop: 'sort',
-        val: newVal
+        val: newVal,
+        hash: ''
       })
       this.triggerApiCallForStatements()
     },

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -54,7 +54,7 @@ export default function AssessmentTable () {
       })
   }
 
-  window.submitForm = function (event, task, isHashUpdateNeeded = null) {
+  window.submitForm = function (event, task, filterHash = null) {
     // In case the call originated from a native browser event it needs to be terminated
     if (event) {
       event.stopPropagation()
@@ -65,17 +65,16 @@ export default function AssessmentTable () {
     const filterOptions = inputFields.filter(inputField => inputField.name.includes('filter') && inputField.value !== '')
     const procedureId = $('form[name=bpform]').data('statement-admin-container')
 
-    if (!isHashUpdateNeeded) {
-      console.log('if')
+    if (filterHash) {
+      // there are cases were the filterHash has not to be updated, but take the current one
+      document.bpform.action = Routing.generate('dplan_assessmenttable_view_table', { procedureId, filterHash })
+      handleFormSubmission(task)
+    } else {
       window.updateFilterHash(procedureId, filterOptions)
         .then((filterHash) => {
           document.bpform.action = Routing.generate('dplan_assessmenttable_view_table', { procedureId, filterHash })
           handleFormSubmission(task)
         })
-    } else {
-      console.log('else', isHashUpdateNeeded)
-      document.bpform.action = Routing.generate('dplan_assessmenttable_view_table', { procedureId, isHashUpdateNeeded })
-      handleFormSubmission(task)
     }
   }
 

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -13,7 +13,6 @@
  * their functionality to other components.
  */
 import { checkResponse, dpApi } from '@demos-europe/demosplan-ui'
-
 export default function AssessmentTable () {
   /*
    * Fix for T6396: if scrolled down the select parent has `position:fixed`
@@ -55,7 +54,7 @@ export default function AssessmentTable () {
       })
   }
 
-  window.submitForm = function (event, task, isHashUpdateNeeded = true) {
+  window.submitForm = function (event, task, isHashUpdateNeeded = null) {
     // In case the call originated from a native browser event it needs to be terminated
     if (event) {
       event.stopPropagation()
@@ -66,13 +65,16 @@ export default function AssessmentTable () {
     const filterOptions = inputFields.filter(inputField => inputField.name.includes('filter') && inputField.value !== '')
     const procedureId = $('form[name=bpform]').data('statement-admin-container')
 
-    if (isHashUpdateNeeded) {
+    if (!isHashUpdateNeeded) {
+      console.log('if')
       window.updateFilterHash(procedureId, filterOptions)
         .then((filterHash) => {
           document.bpform.action = Routing.generate('dplan_assessmenttable_view_table', { procedureId, filterHash })
           handleFormSubmission(task)
         })
     } else {
+      console.log('else', isHashUpdateNeeded)
+      document.bpform.action = Routing.generate('dplan_assessmenttable_view_table', { procedureId, isHashUpdateNeeded })
       handleFormSubmission(task)
     }
   }

--- a/client/js/lib/statement/AssessmentTable.js
+++ b/client/js/lib/statement/AssessmentTable.js
@@ -13,6 +13,7 @@
  * their functionality to other components.
  */
 import { checkResponse, dpApi } from '@demos-europe/demosplan-ui'
+
 export default function AssessmentTable () {
   /*
    * Fix for T6396: if scrolled down the select parent has `position:fixed`

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -223,7 +223,7 @@ export default {
     pagination: {},
     persistStatementSelection: true,
     initStatements: [],
-    statementGrouping: {},
+    statementGrouping: {}
   },
 
   mutations: {

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -222,7 +222,8 @@ export default {
     pagination: {},
     persistStatementSelection: true,
     initStatements: [],
-    statementGrouping: {}
+    statementGrouping: {},
+    filterHash: ''
   },
 
   mutations: {
@@ -343,6 +344,10 @@ export default {
      */
     updatePagination (state, value) {
       set(state, 'pagination', Object.assign(state.pagination, value))
+    },
+
+    updateFilterHash (state, value) {
+      set(state, 'filterHash', value)
     },
 
     updatePersistStatementSelection (state, value) {
@@ -616,6 +621,7 @@ export default {
           commit('setFilteredState', response.meta.isFiltered)
           commit('setInitStatements', response.meta.statementAssignments)
           commit('setStatementGrouping', response.meta.grouping)
+          commit('updateFilterHash', response.meta.filterHash)
           const refinedStatements = {}
           const sessionStorageUpdates = {}
 

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -216,6 +216,7 @@ export default {
   name: 'Statement',
 
   state: {
+    filterHash: '',
     statements: {},
     procedureId: '',
     selectedElements: {},
@@ -223,7 +224,6 @@ export default {
     persistStatementSelection: true,
     initStatements: [],
     statementGrouping: {},
-    filterHash: ''
   },
 
   mutations: {
@@ -342,12 +342,13 @@ export default {
     /**
      * @param value
      */
-    updatePagination (state, value) {
-      set(state, 'pagination', Object.assign(state.pagination, value))
-    },
 
     updateFilterHash (state, value) {
       set(state, 'filterHash', value)
+    },
+
+    updatePagination (state, value) {
+      set(state, 'pagination', Object.assign(state.pagination, value))
     },
 
     updatePersistStatementSelection (state, value) {


### PR DESCRIPTION
### Ticket
[DPLAN-2252](https://demoseurope.youtrack.cloud/issue/DPLAN-2252/Losch-Aktionen-hebt-Sortierung-anhand-der-Filtern-auf-in-A-Tabelle)

**Description:** This PR adds the option to pass the current `filterHash` into the `submitForm` method, as there are cases where the `filterHash` should not be updated and should use the current one, especially for the delete action. 

Additionally, the request to route `dplan_assessmenttable_view_table` was missed, even though the tag did not need to be updated, the request should still be made

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
