### PR TITLE
F dplan 12495 adjust create statement

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -176,6 +176,12 @@
               {{ Translator.trans('statement.details_and_recommendation') }}
             </a>
             <a
+              data-cy="detailView"
+              :href="Routing.generate('dm_plan_assessment_single_view', { statement: id, procedureId: procedureId })"
+              rel="noopener">
+              {{ Translator.trans('detail.view') }}
+            </a>
+            <a
               v-if="hasPermission('feature_read_source_statement_via_api')"
               data-cy="listStatements:originalPDF"
               :class="{'is-disabled': originalPdf === null}"

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -176,7 +176,7 @@
               {{ Translator.trans('statement.details_and_recommendation') }}
             </a>
             <a
-              data-cy="detailView"
+              data-cy="listStatements:statementDetailView"
               :href="Routing.generate('dm_plan_assessment_single_view', { statement: id, procedureId: procedureId })"
               rel="noopener">
               {{ Translator.trans('detail.view') }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -1,32 +1,21 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
 {% block component_part %}
 
-    {% if
-        hasPermission('feature_statements_import_excel') or
+    {% set path = hasPermission('feature_statements_import_excel') or
         hasPermission('feature_import_statement_pdf') or
         hasPermission('feature_segments_import_excel') or
-        hasPermission('feature_simplified_new_statement_create') %}
+        hasPermission('feature_simplified_new_statement_create') ? 'DemosPlan_procedure_import' : 'DemosPlan_statement_new_submitted' %}
+
         {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
             heading: 'statements'|trans,
             subnav: [ {
-                href: path('DemosPlan_procedure_import', { procedureId: procedure }),
+                href: path(path, { procedureId: procedure }),
                 label:  'statement.new'|trans,
                 datacy: 'listStatements:statementNew',
                 icon: 'fa-plus'
             }],
             flush: true
         } %}
-    {% else %}
-        {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
-            heading: 'statements'|trans,
-            subnav: [ {
-                href: path('DemosPlan_statement_new_submitted', { procedureId: procedure }),
-                label:  'statement.new'|trans,
-                icon: 'fa-plus'
-            }],
-            flush: true
-        } %}
-    {% endif %}
 
     {% set submitTypesOptions = [] %}
     {% for key, translated in getFormOption('statement_submit_types.values', true)|filter(key => key != 'system') %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -1,16 +1,32 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
 {% block component_part %}
 
-    {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
-        heading: 'statements'|trans,
-        subnav: [ {
-            href: path('DemosPlan_procedure_import', { procedureId: procedure }),
-            label:  'statement.new'|trans,
-            datacy: 'createStatement',
-            icon: 'fa-plus'
-        }],
-        flush: true
-    } %}
+    {% if
+        hasPermission('feature_statements_import_excel') or
+        hasPermission('feature_import_statement_pdf') or
+        hasPermission('feature_segments_import_excel') or
+        hasPermission('feature_simplified_new_statement_create') %}
+        {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
+            heading: 'statements'|trans,
+            subnav: [ {
+                href: path('DemosPlan_procedure_import', { procedureId: procedure }),
+                label:  'statement.new'|trans,
+                datacy: 'listStatements:statementNew',
+                icon: 'fa-plus'
+            }],
+            flush: true
+        } %}
+    {% else %}
+        {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
+            heading: 'statements'|trans,
+            subnav: [ {
+                href: path('DemosPlan_statement_new_submitted', { procedureId: procedure }),
+                label:  'statement.new'|trans,
+                icon: 'fa-plus'
+            }],
+            flush: true
+        } %}
+    {% endif %}
 
     {% set submitTypesOptions = [] %}
     {% for key, translated in getFormOption('statement_submit_types.values', true)|filter(key => key != 'system') %}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12495/Klick-auf-Neue-Stellungnahme-funktioniert-nicht


Description:
- Display new stn button on stn list based on permissions:
- In ewm it goes to .../import 
- for other projects like diplanrog it should go to ../manual

### How to review/test
- Go to diplanrog, the stn should to to create manual stn 
- in EWM it should go as usual
- It is a general template, so it is good to check these 2 projects


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
