### PR TITLE
fix(DPLAN-12522): range input position by different browsers

### DIFF
--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerListLayer.vue
@@ -12,7 +12,7 @@
     v-if="layer.attributes.isEnabled && !layer.attributes.isScope &&  !layer.attributes.isBplan"
     :id="id"
     :title="layerTitle"
-    :class="[(isVisible && layer.attributes.canUserToggleVisibility) ? prefixClass('is-active') : '', prefixClass('c-map__group-item c-map__layer')]"
+    :class="[(isVisible && layer.attributes.canUserToggleVisibility) ? prefixClass('is-active') : '', prefixClass('c-map__group-item c-map__layer flex items-center space-x-1')]"
     @click="toggleFromSelf(false)">
     <span
       :class="prefixClass('c-map__group-item-controls')"

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -333,13 +333,14 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
             left: 10px;
             position: absolute;
             right: 30px;
-            top: 10px;
+            top: 9px;
 
             display: inline-block;
             padding-left: 10px;
 
             input[type='range'] {
                 width: 100%;
+                height: 15px;
 
                 &:focus {
                     @include keyboard-focus;
@@ -381,6 +382,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
         &__layer {
             padding: 4px 8px;
             line-height: 20px;
+            min-height: 33px;
 
             img {
                 max-width: none;


### PR DESCRIPTION
### Ticket
[DPLAN-12522](https://demoseurope.youtrack.cloud/issue/DPLAN-12522/Transparenzeinstellung-ist-verschoben)

**Description:** This PR fixes an issue with the positioning of the range input, which has different styling across browsers. To adjust it, add a height to the range input, add height to the `li` element and place buttons inside a flex container.

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
