### PR TITLE
fix(refs DPLAN-12488): fix pinning statement information

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -488,13 +488,12 @@ export default {
     },
 
     submitterHelpText () {
-      const { gdprConsent, original } = this.localStatement.attributes
+      const { consentRevoked, submitterAndAuthorMetaDataAnonymized } = this.localStatement.attributes
       let helpText = ''
 
-      const isConsentRevoked = gdprConsent?.consentRevoked
-      const isAnonymized = hasPermission('area_statement_anonymize') && original.submitterAndAuthorMetaDataAnonymized
+      const isAnonymized = hasPermission('area_statement_anonymize') && submitterAndAuthorMetaDataAnonymized
 
-      if (isConsentRevoked) {
+      if (consentRevoked) {
         helpText = Translator.trans('personal.data.usage.revoked')
 
         if (isAnonymized) {
@@ -502,7 +501,7 @@ export default {
         }
       }
 
-      if (!isConsentRevoked && isAnonymized) {
+      if (!consentRevoked && isAnonymized) {
         helpText = Translator.trans('statement.anonymized.submitter.data')
       }
 
@@ -553,9 +552,9 @@ export default {
     },
 
     isSubmitterAnonymous () {
-      const { gdprConsent, original } = this.localStatement.attributes
+      const { consentRevoked, submitterAndAuthorMetaDataAnonymized } = this.localStatement.attributes
 
-      return gdprConsent?.consentRevoked || original.submitterAndAuthorMetaDataAnonymized
+      return consentRevoked || submitterAndAuthorMetaDataAnonymized
     },
 
     reset () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -562,6 +562,7 @@ export default {
       const statementFields = [
         'assignee',
         'attachments',
+        'consentRevoked',
         'similarStatementSubmitters',
         'authoredDate',
         'authorName',
@@ -584,6 +585,7 @@ export default {
         'publicParticipationPhase', // TODO: has to be adjusted in the BE
         'recommendation',
         'segmentDraftList',
+        'submitterAndAuthorMetaDataAnonymized',
         'status',
         'submitDate',
         'submitName',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_statement_segments_list.html.twig
@@ -10,6 +10,12 @@
     {% set submitTypeOptions = submitTypeOptions|merge([{ label: label, value: value }]) %}
 {% endfor %}
 
+    {# Available form definitions #}
+    {% set formDefinitions = {} %}
+    {% for definition in templateVars.statementFormDefinition.fieldDefinitions %}
+        {% set formDefinitions = formDefinitions|merge({ (definition.name): { id: definition.id, enabled: definition.enabled, required: definition.required } }) %}
+    {% endfor %}
+
 {% block component_part %}
     <statement-segments-list
         :available-counties="JSON.parse('{{ templateVars.availableCounties|default([])|json_encode|e('js', 'utf-8') }}')"
@@ -24,7 +30,7 @@
         :recommendation-procedure-ids="JSON.parse('{{ recommendationProcedureIds|json_encode|e('js', 'utf-8') }}')"
         statement-id="{{ statementId }}"
         statement-extern-id="{{ statementExternId }}"
-        :statement-form-definitions="JSON.parse('{{ templateVars.statementFormDefinition|json_encode|e('js', 'utf-8') }}')"
+        :statement-form-definitions="JSON.parse('{{ formDefinitions|json_encode|e('js', 'utf-8') }}')"
         :submit-type-options="JSON.parse('{{ submitTypeOptions|json_encode|e('js', 'utf-8') }}')">
     </statement-segments-list>
 {% endblock %}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12488/Klick-auf-Informationen-anheften-funktioniert-noch-nicht

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Pinning statement information in the (new) statement detail view is fixed by making sure all variables are defined: 
- `statementFormDefinitions` need to be prepared in twig to be consumable in vue
- `gdprConsent` and `original` do not exist as statement attributes and were replaced with `consentRevoked` and `submitterAndAuthorMetaDataAnonymized`

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
