### PR TITLE
fix(DPLAN-12567): issue by saving department in fragment

### DIFF
--- a/client/js/store/statement/Fragment.js
+++ b/client/js/store/statement/Fragment.js
@@ -482,11 +482,11 @@ export default {
 
           // If the reviewer has been set, update fragment assignment
           if (hasOwnProp(data, 'departmentId')) {
-            if (hasOwnProp(data, 'lastClaimed') && hasOwnProp(responseRelationships, 'lastClaimedUser')) {
+            if (hasOwnProp(data, 'lastClaimed') && responseRelationships.lastClaimedUser?.data) {
               dataToUpdate.lastClaimedUserId = responseRelationships.lastClaimedUser.data.id
             }
 
-            dataToUpdate.departmentId = hasOwnProp(responseRelationships, 'department') ? responseRelationships.department.data.id : ''
+            dataToUpdate.departmentId = responseRelationships.department?.data ? responseRelationships.department.data.id : ''
 
             if (dataToUpdate.departmentId) { // If departmentId is in response and is not null
               // we reset the assignee with the values from BE


### PR DESCRIPTION
### Ticket
[DPLAN-12567](https://demoseurope.youtrack.cloud/issue/DPLAN-12567/Fehler-beim-abwahlen-von-Orga-fur-Datensatz)
`
Description: This PR fixes an issue where NO one department was saved in the fragment. The error was caused by the department field being present in the response, but `data` field was epmty

- [ ] Tests updated/created
- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
