### PR TITLE
bug(refs DPLAN-12552): Distinguish between master and procedure

### DIFF
--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -300,7 +300,7 @@ export default {
   },
 
   async mounted () {
-    const settings = await this.fetchProcedureMapSettings(this.procedureId, this.isMaster)
+    const settings = await this.fetchProcedureMapSettings({ procedureId: this.procedureId, isMaster: this.isMaster })
     this.procedureMapSettings = JSON.parse(JSON.stringify(settings))
   }
 }

--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -50,7 +50,7 @@
         @suitableScalesChange="value => areScalesSuitable = value" />
 
       <dp-input
-        v-if="!procedureMapSettings.attributes.featureInfoUrl.global && hasPermission('feature_map_feature_info')"
+        v-if="!procedureMapSettings.attributes.useGlobalInformationUrl && hasPermission('feature_map_feature_info')"
         v-model="procedureMapSettings.attributes.informationUrl"
         id="informationURL"
         class="u-mb"
@@ -135,6 +135,12 @@ export default {
   },
 
   props: {
+    isMaster: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     procedureId: {
       type: String,
       required: true
@@ -155,13 +161,13 @@ export default {
       },
       procedureMapSettings: {
         id: '',
-        type: 'ProcecdureMapSetting',
+        type: 'ProcedureMapSetting',
         attributes: {
           coordinate: [],
           copyright: '',
           defaultMapExtent: [],
           defaultBoundingBox: [],
-          featureInfoUrl: { global: false },
+          useGlobalInformationUrl: false,
           informationUrl: '',
           showOnlyOverlayCategory: false,
           mapExtent: [],
@@ -294,7 +300,7 @@ export default {
   },
 
   async mounted () {
-    const settings = await this.fetchProcedureMapSettings(this.procedureId)
+    const settings = await this.fetchProcedureMapSettings(this.procedureId, this.isMaster)
     this.procedureMapSettings = JSON.parse(JSON.stringify(settings))
   }
 }

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -729,7 +729,7 @@ export default {
       }
     })
     this.setContent({ prop: 'commentsList', val: { ...this.commentsList, procedureId: this.procedureId, statementId: this.statementId } })
-    this.fetchProcedureMapSettings(this.procedureId)
+    this.fetchProcedureMapSettings({ procedureId: this.procedureId })
       .then(response => {
         this.procedureMapSettings = { ...this.procedureMapSettings, ...response.attributes }
       })

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -39,10 +39,10 @@ export default {
         .then(response => checkResponse(response))
     },
 
-    fetchProcedureMapSettings ({ commit }, args = { procedureId, isMaster: false }) {
+    fetchProcedureMapSettings ({ commit }, { procedureId, isMaster = false }) {
       try {
-        const resourceType = args.isMaster ? 'ProcedureTemplate' : 'Procedure'
-        const url = Routing.generate('api_resource_get', { resourceId: args.procedureId, resourceType: resourceType })
+        const resourceType = isMaster ? 'ProcedureTemplate' : 'Procedure'
+        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: resourceType })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
           'defaultBoundingBox',

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -41,7 +41,7 @@ export default {
 
     fetchProcedureMapSettings ({ commit }, procedureId) {
       try {
-        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'Procedure' })
+        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'ProcedureTemplateResourceType' })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
           'defaultBoundingBox',
@@ -75,7 +75,7 @@ export default {
 
         const params = {
           fields: {
-            Procedure: [
+            ProcedureTemplate: [
               'mapSetting'
             ].join(),
             ProcedureMapSetting: procedureMapSettingFields.join()

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -39,9 +39,10 @@ export default {
         .then(response => checkResponse(response))
     },
 
-    fetchProcedureMapSettings ({ commit }, procedureId) {
+    fetchProcedureMapSettings ({ commit }, procedureId, isMaster) {
       try {
-        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'ProcedureTemplate' })
+        const resourceType = isMaster ? 'ProcedureTemplate' : 'Procedure'
+        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: resourceType })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
           'defaultBoundingBox',
@@ -58,7 +59,7 @@ export default {
 
         if (hasPermission('feature_map_feature_info')) {
           procedureMapSettingFields.push('informationUrl')
-          procedureMapSettingFields.push('featureInfoUrl')
+          procedureMapSettingFields.push('useGlobalInformationUrl')
         }
 
         if (hasPermission('feature_map_attribution')) {
@@ -75,7 +76,7 @@ export default {
 
         const params = {
           fields: {
-            ProcedureTemplate: [
+            Procedure: [
               'mapSetting'
             ].join(),
             ProcedureMapSetting: procedureMapSettingFields.join()
@@ -97,7 +98,7 @@ export default {
                 copyright: data.copyright ?? '',
                 defaultBoundingBox: defaultBoundingBox,
                 defaultMapExtent: defaultMapExtent,
-                featureInfoUrl: data.featureInfoUrl ?? { global: false },
+                useGlobalInformationUrl: data.useGlobalInformationUrl ?? false,
                 informationUrl: data.informationUrl ?? '',
                 showOnlyOverlayCategory: data.showOnlyOverlayCategory ?? false,
                 mapExtent: convertExtentToFlatArray(data.mapExtent) ?? defaultMapExtent, // Maximum extent of the map

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -41,7 +41,7 @@ export default {
 
     fetchProcedureMapSettings ({ commit }, procedureId) {
       try {
-        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'ProcedureTemplateResourceType' })
+        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: 'ProcedureTemplate' })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
           'defaultBoundingBox',

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -39,10 +39,10 @@ export default {
         .then(response => checkResponse(response))
     },
 
-    fetchProcedureMapSettings ({ commit }, procedureId, isMaster) {
+    fetchProcedureMapSettings ({ commit }, args= { procedureId, isMaster }) {
       try {
-        const resourceType = isMaster ? 'ProcedureTemplate' : 'Procedure'
-        const url = Routing.generate('api_resource_get', { resourceId: procedureId, resourceType: resourceType })
+        const resourceType = args.isMaster ? 'ProcedureTemplate' : 'Procedure'
+        const url = Routing.generate('api_resource_get', { resourceId: args.procedureId, resourceType: resourceType })
         const procedureMapSettingFields = ['availableScales',
           'boundingBox',
           'defaultBoundingBox',
@@ -76,7 +76,7 @@ export default {
 
         const params = {
           fields: {
-            Procedure: [
+            [resourceType]: [
               'mapSetting'
             ].join(),
             ProcedureMapSetting: procedureMapSettingFields.join()

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -39,7 +39,7 @@ export default {
         .then(response => checkResponse(response))
     },
 
-    fetchProcedureMapSettings ({ commit }, args= { procedureId, isMaster }) {
+    fetchProcedureMapSettings ({ commit }, args= { procedureId, isMaster: false }) {
       try {
         const resourceType = args.isMaster ? 'ProcedureTemplate' : 'Procedure'
         const url = Routing.generate('api_resource_get', { resourceId: args.procedureId, resourceType: resourceType })

--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -39,7 +39,7 @@ export default {
         .then(response => checkResponse(response))
     },
 
-    fetchProcedureMapSettings ({ commit }, args= { procedureId, isMaster: false }) {
+    fetchProcedureMapSettings ({ commit }, args = { procedureId, isMaster: false }) {
       try {
         const resourceType = args.isMaster ? 'ProcedureTemplate' : 'Procedure'
         const url = Routing.generate('api_resource_get', { resourceId: args.procedureId, resourceType: resourceType })

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -62,7 +62,7 @@ class DemosPlanMapController extends BaseController
         Breadcrumb $breadcrumb,
         TranslatorInterface $translator,
         ProcedureService $procedureService,
-        $procedureId
+        $procedureId,
     ) {
         // reichere die breadcrumb mit extraItem an
         $breadcrumb->addItem(
@@ -104,7 +104,7 @@ class DemosPlanMapController extends BaseController
         Request $request,
         ServiceStorage $serviceStorage,
         TranslatorInterface $translator,
-        $procedure
+        $procedure,
     ) {
         $templateVars = [];
         try {
@@ -187,7 +187,7 @@ class DemosPlanMapController extends BaseController
         ServiceStorage $serviceStorage,
         TranslatorInterface $translator,
         $procedure,
-        $gislayerID
+        $gislayerID,
     ) {
         try {
             // Storage und Output initialisieren
@@ -404,7 +404,7 @@ class DemosPlanMapController extends BaseController
         ProcedureService $procedureService,
         ProcedureServiceStorage $procedureServiceStorage,
         Request $request,
-        $procedureId
+        $procedureId,
     ) {
         $mapOfProcedure = $elementHandler->mapHandler($procedureId);
         $requestPost = $request->request->all();
@@ -520,7 +520,7 @@ class DemosPlanMapController extends BaseController
         Request $request,
         ServiceStorage $serviceStorage,
         MapService $mapService,
-        MapHandler $mapHandler
+        MapHandler $mapHandler,
     ) {
         $requestPost = $request->request;
         if ($requestPost->has('gislayerdelete')) {
@@ -586,7 +586,7 @@ class DemosPlanMapController extends BaseController
         MasterTemplateService $masterTemplateService,
         ServiceStorage $serviceStorage,
         $type = 'edit',
-        $gislayerID = null
+        $gislayerID = null,
     ) {
         $templateVars = [];
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -61,6 +61,7 @@ class DemosPlanMapController extends BaseController
     public function mapAdminAction(
         Breadcrumb $breadcrumb,
         TranslatorInterface $translator,
+        ProcedureService $procedureService,
         $procedureId
     ) {
         // reichere die breadcrumb mit extraItem an
@@ -74,9 +75,11 @@ class DemosPlanMapController extends BaseController
             ]
         );
 
+        $procedure = $procedureService->getProcedure($procedureId);
+
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanMap/map_admin.html.twig',
-            ['procedure' => $procedureId, 'title' => 'drawing.admin.adjustments.gis']
+            ['procedure' => $procedureId, 'master' => $procedure?->getMaster(), 'title' => 'drawing.admin.adjustments.gis']
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -79,7 +79,7 @@ class DemosPlanMapController extends BaseController
 
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanMap/map_admin.html.twig',
-            ['procedure' => $procedureId, 'master' => $procedure?->getMaster(), 'title' => 'drawing.admin.adjustments.gis']
+            ['procedure' => $procedureId, 'isMaster' => $procedure?->getMaster(), 'title' => 'drawing.admin.adjustments.gis']
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
@@ -41,7 +41,6 @@ final class ProcedureTemplateResourceType extends DplanResourceType
     protected function getProperties(): array
     {
         if ($this->currentUser->hasAnyPermissions('area_public_participation', 'area_admin_map')) {
-            $properties[] = $this->createAttribute($this->coordinate)->readable()->aliasedPath(Paths::procedure()->settings->coordinate);
             $properties[] = $this->createToOneRelationship($this->mapSetting)->aliasedPath(Paths::procedure()->settings)->readable();
         }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureTemplateResourceType.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\EntityPath\Paths;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use EDT\PathBuilding\End;
+use EDT\Querying\Contracts\PathException;
 
 /**
  * @template-extends DplanResourceType<Procedure>
@@ -25,21 +27,31 @@ use EDT\PathBuilding\End;
  * @property-read End $description
  * @property-read End $agencyMainEmailAddress
  * @property-read End $masterTemplate
+ * @property-read End $coordinate
+ * @property-read ProcedureMapSettingResourceType $mapSetting
  * @property-read AgencyEmailAddressResourceType $agencyExtraEmailAddresses
  * @property-read OrgaResourceType $orga               Do not expose! Alias usage only.
  * @property-read OrgaResourceType $owningOrganisation
  */
 final class ProcedureTemplateResourceType extends DplanResourceType
 {
+    /**
+     * @throws PathException
+     */
     protected function getProperties(): array
     {
-        return [
-            $this->createIdentifier()->readable()->sortable()->filterable(),
-            $this->createAttribute($this->agencyMainEmailAddress)->readable(true)->sortable()->filterable(),
-            $this->createAttribute($this->description)->readable()->aliasedPath($this->desc),
-            $this->createToManyRelationship($this->agencyExtraEmailAddresses)->readable()->filterable(),
-            $this->createToOneRelationship($this->owningOrganisation)->readable()->aliasedPath($this->orga)->sortable()->filterable(),
-        ];
+        if ($this->currentUser->hasAnyPermissions('area_public_participation', 'area_admin_map')) {
+            $properties[] = $this->createAttribute($this->coordinate)->readable()->aliasedPath(Paths::procedure()->settings->coordinate);
+            $properties[] = $this->createToOneRelationship($this->mapSetting)->aliasedPath(Paths::procedure()->settings)->readable();
+        }
+
+        $properties[] = $this->createIdentifier()->readable()->sortable()->filterable();
+        $properties[] = $this->createAttribute($this->agencyMainEmailAddress)->readable(true)->sortable()->filterable();
+        $properties[] = $this->createAttribute($this->description)->readable()->aliasedPath($this->desc);
+        $properties[] = $this->createToManyRelationship($this->agencyExtraEmailAddresses)->readable()->filterable();
+        $properties[] = $this->createToOneRelationship($this->owningOrganisation)->readable()->aliasedPath($this->orga)->sortable()->filterable();
+
+        return $properties;
     }
 
     protected function getAccessConditions(): array

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -7,7 +7,7 @@
     } %}
 
     <map-admin
-        :is-master="{{ isMaster|json_encode }}"
+        :is-master="Boolean({{ isMaster }})"
         procedure-id="{{ procedure }}">
     </map-admin>
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -6,7 +6,9 @@
         heading: 'drawing.mapsection.define'|trans
     } %}
 
-    <map-admin procedure-id="{{ procedure }}">
+    <map-admin
+        :is-master="{{ master }}"
+        procedure-id="{{ procedure }}">
     </map-admin>
 
 {% endblock %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -7,7 +7,7 @@
     } %}
 
     <map-admin
-        :is-master="{{ master | json_encode() }}"
+        :is-master="{{ master|json_encode }}"
         procedure-id="{{ procedure }}">
     </map-admin>
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -7,7 +7,7 @@
     } %}
 
     <map-admin
-        :is-master="{{ master|json_encode }}"
+        :is-master="{{ isMaster|json_encode }}"
         procedure-id="{{ procedure }}">
     </map-admin>
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin.html.twig
@@ -7,7 +7,7 @@
     } %}
 
     <map-admin
-        :is-master="{{ master }}"
+        :is-master="{{ master | json_encode() }}"
         procedure-id="{{ procedure }}">
     </map-admin>
 


### PR DESCRIPTION
### Ticket
DPLAN-12552

- Use `useGlobalInformationUrl` instead of `featureInfoUrl.global`. It seems like this was renamed. `featureInfoUrl` is not available anymore. 
- Add prop `isMaster` to check if we are in procedure or in master
- Make resource type dynamically depending on procedure or master

### How to review/test
Blaupausen -> Planungsdokumente und Planzeichnung -> Startkartenausschnitte -> Everything should be working as expected

