### PR TITLE
fix (DPLAN-12568) Remove paramaters of initializable as id should not…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
@@ -108,7 +108,7 @@ final class PlaceResourceType extends DplanResourceType
             ->filterable();
 
         if ($this->currentUser->hasPermission('area_manage_segment_places')) {
-            $configBuilder->id->initializable(false, true);
+            $configBuilder->id->initializable();
             $configBuilder->name->updatable()->initializable(false, null, true);
             $configBuilder->solved->updatable()->initializable(true);
             $configBuilder->description->updatable()->initializable(true);

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlaceResourceType.php
@@ -36,7 +36,7 @@ use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
 final class PlaceResourceType extends DplanResourceType
 {
     public function __construct(
-        private readonly PlaceRepository $placeRepository
+        private readonly PlaceRepository $placeRepository,
     ) {
     }
 


### PR DESCRIPTION
Same as this PR just to be able to merge in main:
https://github.com/demos-europe/demosplan-core/pull/3735

### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12568/Hinzufugte-Bearbeitungsschritt-ist-weg-nach-Seite-refresh

- Make constructorArgument as false as ID is not needed when the resource type is created

### How to review/test
- Go to Steps in Verfahren page
- Create new step. Also edit it
- REfresh page
- It should work

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
