### PR TITLE
bug(refs DPLAN-2128): persist checkbox selection of search modal in local storage

### DIFF
--- a/client/js/components/statement/assessmentTable/SearchModal/SearchModal.vue
+++ b/client/js/components/statement/assessmentTable/SearchModal/SearchModal.vue
@@ -316,6 +316,20 @@ export default {
   methods: {
     ...mapMutations('Filter', ['setCurrentSearch']),
 
+    loadSelectedCheckboxes () {
+      const savedCheckboxes = JSON.parse(localStorage.getItem('selectedCheckboxes'))
+
+      if (savedCheckboxes) {
+        this.availableFilterFields.forEach(checkbox => {
+          const savedCheckbox = savedCheckboxes.find(savedCheckbox => savedCheckbox.id === checkbox.id)
+
+          if (savedCheckbox) {
+            checkbox.checked = savedCheckbox.checked
+          }
+        })
+      }
+    },
+
     toggleModal () {
       this.$refs.searchModal.toggle()
     },
@@ -335,6 +349,15 @@ export default {
       })
     },
 
+    saveSelectedCheckboxes () {
+      const selectedCheckboxes = this.filterCheckBoxesItems.map(checkbox => ({
+        id: checkbox.id,
+        checked: checkbox.checked
+      }))
+
+      localStorage.setItem('selectedCheckboxes', JSON.stringify(selectedCheckboxes))
+    },
+
     submit (event) {
       if (this.isForm) {
         const searchWordInput = document.querySelector('input[name="search_word2"]')
@@ -346,6 +369,8 @@ export default {
           this.toggleModal()
         }
       }
+
+      this.saveSelectedCheckboxes()
     }
   },
 
@@ -359,6 +384,8 @@ export default {
     this.availableFilterFields.forEach(checkbox => {
       Vue.set(checkbox, 'checked', this.preselectedFields.includes(checkbox.id))
     })
+
+    this.loadSelectedCheckboxes()
   }
 }
 </script>

--- a/client/js/components/statement/assessmentTable/SearchModal/SearchModal.vue
+++ b/client/js/components/statement/assessmentTable/SearchModal/SearchModal.vue
@@ -347,6 +347,7 @@ export default {
       this.availableFilterFields.forEach(checkbox => {
         checkbox.checked = false
       })
+      localStorage.removeItem('selectedCheckboxes')
     },
 
     saveSelectedCheckboxes () {


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-2128/SUCHE-erweiterte-Suche-wird-nach-einmaliger-Suche-geloscht

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR solves that a selection of checkboxes will be lost after submitting an expanded search via the `SearchModal.vue` component. To tackle this issue, the `SearchModal.vue` component can now persist the selection of those checkboxes via the local storage of the browser and load the selection on mounted from there. Also the selection must be resetable hence the local storage including the selected checkboxes will be removed when clicking the reset button.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- checkout branch
- login as FPA (e.g. Tyrion Lannister)
- navigate to assessment table
- click the `Erweiterte Suche`-button and select any checkboxes
- submit -> after the page reload, the selection should be saved
- reset -> the selection should be cleared

![grafik](https://github.com/user-attachments/assets/fcd2ef54-6d0d-4121-98f7-9ab73641a4b3)


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
