### PR TITLE
fix(refs DPLAN-12496): reduce margin

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -26,8 +26,8 @@
           @change-fields="updateSearchFields"
           @search="updateSearchQuery"
           @reset="updateSearchQuery" />
-        <div class="bg-color--grey-light-2 rounded-md space-inline-xs ml-2">
-          <span class="color--grey ml-2 line-height--2">
+        <div class="bg-color--grey-light-2 rounded-md ml-2">
+          <span class="color--grey ml-1 align-middle">
             {{ Translator.trans('filter') }}
           </span>
           <filter-flyout


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12496/Filterung-bricht-um-wenn-alle-Filter-gesetzt-sind

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- with reduced margin, all filter flyout triggers still fit in one line if a filter is selected in each of them
- also, the filter label was vertically aligned to align properly with the filter flyout triggers

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- go to segments list
- select a filter in each filter flyout
- make sure all filter flyout triggers are still displayed next to each other:
![filter_flyout_triggers](https://github.com/user-attachments/assets/422f9a14-46ec-4cc0-bb2f-0fd6710b8ccf)


### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
