### PR TITLE
fix(DPLAN-12564): empty detail page of STN

### DIFF
--- a/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
+++ b/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
@@ -141,7 +141,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('AssessmentTable', ['counties', 'municipalities', 'priorityAreas', 'tag'])
+    ...mapGetters('AssessmentTable', ['counties', 'municipalities', 'priorityAreas', 'tags'])
   },
 
   methods: {


### PR DESCRIPTION
### Ticket
[DPLAN-12564](https://demoseurope.youtrack.cloud/issue/DPLAN-12564)

**Description:** This PR fixes an issue where the details page of STN was empty. The issue was caused by an incorrect reference to the store, it should be `tags` instead of `tag`, as `tag` does not exist.

### How to review/test
EIne Stellungnahme erstellen -> zur Detailansicht navigieren -> Seite ist komlett leer
