### PR TITLE
Add permission to manage Cover page export file

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1513,6 +1513,13 @@ feature_procedure_export_include_assessment_table_original:
     expose: false
     label: 'Procedure export with original statements'
     loginRequired: true
+feature_procedure_export_include_cover_page:
+    description: |-
+        The procedure export generates a ZIP archive. If this permission is enabled
+        a document ("Deckblatt.pdf") will be included in each procedure directory in the export.
+    expose: false
+    label: 'Procedure export with cover page'
+    loginRequired: true
 feature_procedure_export_include_current_news:
     description: |-
         The procedure export generates a ZIP archive. If this permission is enabled

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -217,7 +217,9 @@ class ExportService
                 }
 
                 // Titelblatt
-                $zip = $this->addTitlePageToZip($procedureId, $procedureName, $zip);
+                if ($this->permissions->hasPermission('feature_procedure_export_include_cover_page')) {
+                    $zip = $this->addTitlePageToZip($procedureId, $procedureName, $zip);
+                }
 
                 // Aktuelles
                 if ($this->permissions->hasPermission('feature_procedure_export_include_current_news')) {


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-2155/Export-Planungsburo-noch-enthalten-2


Description: Add Permission to manage who can see cover page (titelblatt) in pricedure zip export file

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
