### PR TITLE
feat (refs DPLAN-12536): remove duplicated success message

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -84,7 +84,6 @@ use demosplan\DemosPlanCoreBundle\Logic\Grouping\EntityGrouper;
 use demosplan\DemosPlanCoreBundle\Logic\Grouping\StatementEntityGroup;
 use demosplan\DemosPlanCoreBundle\Logic\Grouping\StatementEntityGrouper;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiPaginationParser;
-use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\StatementReportEntryFactory;
@@ -418,17 +417,6 @@ class StatementService extends CoreService implements StatementServiceInterface
 
         /** @var StatementCreatedEvent $statementCreatedEvent */
         $statementCreatedEvent = $this->eventDispatcher->dispatch(new ManualOriginalStatementCreatedEvent($statement));
-
-        if ($this->permissions->hasPermission('area_admin_statement_list')) {
-            $this->messageBag->addObject(LinkMessageSerializable::createLinkMessage(
-                'confirm',
-                'confirm.statement.new',
-                ['externId' => $statementCreatedEvent->getStatement()->getExternId()],
-                'dplan_procedure_statement_list',
-                ['procedureId' => $statementCreatedEvent->getStatement()->getProcedure()->getId()],
-                $statementCreatedEvent->getStatement()->getExternId()
-            ));
-        }
 
         // statement similarities are calculated?
         $statementSimilarities = $statementCreatedEvent->getStatementSimilarities();


### PR DESCRIPTION
### Ticket
[DPLAN-12536](https://demoseurope.youtrack.cloud/issue/DPLAN-12536/Doppelte-Notifications-fur-erstellen-von-eine-Stellungnahme)

A while ago, no success message was displayed at all. As a fix, a message was added (here: [DPLAN-1995](https://demoseurope.youtrack.cloud/issue/DPLAN-1995/Confirm-Message-fehlt-nach-Speichern-einer-Direkteingabe)) where I would now remove it. After removing it, one message should displayed again.

### How to review/test
test in interface

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
