### PR TITLE
fix(refs DPLAN-12577): determine if node is a folder or a file correctly

### DIFF
--- a/client/js/components/document/ElementsList.vue
+++ b/client/js/components/document/ElementsList.vue
@@ -164,7 +164,7 @@ export default {
      */
     isBranch () {
       return function ({ node }) {
-        return node.type === 'elements'
+        return node.type !== 'SingleDocument' && node.type === 'Elements'
       }
     },
 


### PR DESCRIPTION
### Ticket
[DPLAN-XXXXX
or
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/XXXXX](https://demoseurope.youtrack.cloud/issue/DPLAN-12577/Offentlichkeitsansicht-hinzufugte-Ordner-sind-mit-NaN-undefined-angezeigt)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR fixes the document tree of the public detail view. There was a problem to correctly determine if an element is a file or a folder/subfolder. Basically any type of folder which can contain files is never of the type `SingleDocument`. So to resolve this issue, an additional check has been added to the `isBranch` function. Even though I think this may not be the cleanest possible solution I couldn't find a more efficient way to solve this issue without largely refactoring this component (which i prefer not to do while there are still many bugs in this project but look forward to do so later).

Also I was a little bit surprised that the fix was a one-liner in the end since this was really research heavy so far. Nevertheless, this small diff also fixes another bug https://demoseurope.youtrack.cloud/issue/DPLAN-12581/Selektierte-Planungsdokumente-herunterladen-wirft-500-Internal-Server-Error which prevented a user to download a sub selection of planning documents, which is now also possible.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- checkout branch
- select a procedure
- go to public detail and watch the document section
- make sure everything works as intended


### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
