### PR TITLE
bug(refs DPLAN-12537): Add fallback text for no plandocuments

### DIFF
--- a/client/js/components/document/ElementsAdminList.vue
+++ b/client/js/components/document/ElementsAdminList.vue
@@ -46,6 +46,9 @@
       </template>
     </dp-bulk-edit-header>
     <dp-loading v-if="isLoading" />
+    <p
+      v-else-if="treeData.length < 1"
+      v-text="Translator.trans('plandocuments.no_elements')"/>
     <dp-tree-list
       v-else
       :branch-identifier="isBranch"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2506,6 +2506,7 @@ plandocuments.category.type.paragraph: "Kapitelbezogen (Dokument kann direkt imp
 plandocuments.category.type.set: "Kategorietyp festlegen"
 plandocuments.delete: "Planungsdokumente löschen"
 plandocuments.menu: "Planungs&shy;dokumente"
+plandocuments.no_elements: "Es sind derzeit keine Planungsdokumente hinterlegt."
 plandocuments.uploaded: "Hochgeladene Planungsdokumente"
 planningagency: "Planungsbüro"
 planningagency.participating: "beteiligtes Planungsbüro"


### PR DESCRIPTION
### Ticket
DPLAN-12537

Show text when there no plandocuments.

### How to review/test
Verfahren -> Planungsdokumente und Planzeichnung -> Text should be shown if there are no plandocuments