### PR TITLE
chore: sync version of ol used in the masterportal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,12 @@ updates:
       - dependency-name: chalk
         versions:
           - ">= 5"
+
+      # We need to sync the ol version with the one used in the masterportal dependency.
+      # Currently, we are useing masterportal v2.40.0 which depends on ol v9.2.4
+      - dependency-name: ol
+        versions:
+          - "> 9.2.4"
     groups:
       babel:
         patterns:


### PR DESCRIPTION
### Description:
Like mentioned here: https://github.com/demos-europe/demosplan-core/pull/3172#issuecomment-2233597383 the version of ol should be in sync with the one used by the masterportal. The version of masterportal we are currently using is 2.40.0 which uses ol 9.2.4 hence to prevent updates of this dependency which could be potentially incompatible, this version of ol should be set fixed via the dependabot configuration file.

The downside is we need to track masterportal updates and adjust the dependabot.yml accordingly and I am not sure where and if we should document this (further than in a comment)

Masterportal dependencies can be investigated here: https://bitbucket.org/geowerkstatt-hamburg/masterportalapi/src/master/package.json