### PR TITLE
chore (refs DPLAN-564): allow upload of huge files

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/FileExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/FileExtension.php
@@ -150,7 +150,7 @@ class FileExtension extends ExtensionBase
         $fieldHint = '',
         $required = false,
         $callback = '',
-        $chunksize = '0',
+        $chunksize = 'Infinity',
         $maxFileSize = 0,
         $omitCssClassPrefix = true
     ) {

--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/FileExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/FileExtension.php
@@ -152,7 +152,7 @@ class FileExtension extends ExtensionBase
         $callback = '',
         $chunksize = 'Infinity',
         $maxFileSize = 0,
-        $omitCssClassPrefix = true
+        $omitCssClassPrefix = true,
     ) {
         $elementId = $fieldName.'-'.str_replace('.', '', uniqid('', true));
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -80,13 +80,7 @@
                     "r_zipImport",
                     "hide",
                     "zip",
-                    "form.button.upload.zip",
-                    1,
-                    false,
-                    '',
-                    false,
-                    '',
-                    20000000
+                    "form.button.upload.zip"
                 )
             }}
 


### PR DESCRIPTION
### Ticket
DPLAN-564

Default value to use automatic chunk size is 'Infinity', not '0'

### How to review/test
Upload huge files e.g. in document section

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
