### PR TITLE
F dplan 12579 adjust text width in pdf export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/Enum/ListLineWidth.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/Enum/ListLineWidth.php
@@ -15,7 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\
 enum ListLineWidth: int
 {
     case VERTICAL_SPLIT_VIEW = 7;
-    case VERTICAL_NOT_SPLIT_VIEW = 17;
+    case VERTICAL_NOT_SPLIT_VIEW = 18;
     case HORIZONTAL_SPLIT_VIEW = 12;
-    case HORIZONTAL_NOT_SPLIT_VIEW = 24;
+    case HORIZONTAL_NOT_SPLIT_VIEW = 27;
 }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_condensed.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry_condensed.tex.twig
@@ -83,11 +83,15 @@
   {% else %}
     {% if isOriginal is defined and isOriginal == true %}
 
+        {# the list width is already adjusted for every export to take up all the whitespace, the text should
+        actually have the same width as the lists and that's why we can use 'listwidth' as reference here. #}
+        {% set textWidth = templateVars.listwidth|default('24.5cm') %}
+
         \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}24.5cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
         \ParallelLText{{ '{' }} \textbf{{ '{' }}{{ "statement"|trans|latex|raw }}{{ '}' }}{{ '}' }}
         \ParallelRText{{ '{' }}{{ '}' }}
         \end{Parallel}
-        \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}24.5cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
+        \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}{{ textWidth ~ 'cm' }}{{ '}' }}{{ '{' }}0cm{{ '}' }}
         \ParallelLText{{ '{' }}{{ statement.text|default("notspecified"|trans)|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
         \ParallelRText{{ '{' }}{{ '}' }}
         \end{Parallel}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
@@ -54,12 +54,17 @@
     {% block priority %} {% endblock %}
   		\hline
 	\end{longtable}
+
+    {# the list width is already adjusted for every export to take up all the whitespace, the text should
+        actually have the same width as the lists and that's why we can use 'listwidth' as reference here. #}
+    {% set textWidth = templateVars.listwidth|default('18cm') %}
+
     {% if statement.movedToProcedureName is defined and statement.movedToProcedureName is not null %}
         \verb|{{ "statement.moved"|trans({ name: statement.movedToProcedureName })|latex }}|
     {% else %}
     \begin{{ '{' }}longtable{{ '}' }}{{ '{' }}p{{ '{' }}17cm{{ '}' }}p{{ '{' }}0cm{{ '}' }}{{ '}' }}\centering \textbf{{ '{' }}{{ "statement"|trans|latex|raw }}{{ '}' }} & \\
     \end{{ '{' }}longtable{{ '}' }}
-    \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}17cm{{ '}' }}{{ '{' }}0cm{{ '}' }}
+    \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}{{ textWidth ~ 'cm' }}{{ '}' }}{{ '{' }}0cm{{ '}' }}
     \ParallelLText{{ '{' }}{{ statement.text|default('')|latex(listwidth=templateVars.listwidth)|raw }}{{ '}' }}
     \ParallelRText{{ '{' }}{{ '}' }}
     \end{Parallel}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12579/Pdf-Formatierung-Querformat-Stellungnahme-Text-nimmt-nicht-den-gesamten-Whitespace


Description: 
use list width as reference to adjust text width :  the list width is already adjusted for every export to take up all the whitespaces, the text should actually have the same width and take up all the whitespaces too.



Delete the checkbox if it doesn't apply/isn't necessary.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
