### PR TITLE
bug(refs DPLAN-12600): Remove link to old details page

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -176,12 +176,6 @@
               {{ Translator.trans('statement.details_and_recommendation') }}
             </a>
             <a
-              data-cy="listStatements:statementDetailView"
-              :href="Routing.generate('dm_plan_assessment_single_view', { statement: id, procedureId: procedureId })"
-              rel="noopener">
-              {{ Translator.trans('detail.view') }}
-            </a>
-            <a
               v-if="hasPermission('feature_read_source_statement_via_api')"
               data-cy="listStatements:originalPDF"
               :class="{'is-disabled': originalPdf === null}"


### PR DESCRIPTION
### Ticket
DPLAN-12600

The link was only added to compare old and new details page and should be removed now.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Stellungnahmen -> Click on three dots -> There should be only a link to "Details und Erwiderungen" and no link to "Detailansicht"

