### PR TITLE
bug(refs DPLAN-1967): Add min height

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -106,7 +106,7 @@
           data-cy="segment:imgModal"/>
         <dp-data-table
           ref="dataTable"
-          class="overflow-x-auto pb-3"
+          class="overflow-x-auto pb-3 min-h-12"
           :class="{ 'px-2 overflow-y-scroll grow': isFullscreen, 'scrollbar-none': !isFullscreen }"
           data-cy="segmentsList"
           has-flyout


### PR DESCRIPTION
### Ticket
DPLAN-1967

The overflow-x: auto on the container sets overflow-y to hidden. To solve this, min height is added to the container so flyout has always enough space.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
You need a procedure with only one small segment. 
Verfahren -> Abschnitte -> Check fly out 