### PR TITLE
feat (DPLAN-12497): remove assessmenttable in specific projects

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -530,7 +530,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
 
             $this->enablePermissions([
                 'area_admin',  // Verwalten
-                'area_admin_assessmenttable',  // Verwalten Abwaegungstabelle
                 'area_admin_dashboard',  // Übersichtsseite
                 'area_admin_map',  // Verwalten Planzeichnung
                 'area_admin_map_description',  // Verwalten Planzeichenerklärung

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -124,7 +124,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         ProcedureAccessEvaluator $procedureAccessEvaluator,
         private ProcedureRepository $procedureRepository,
         private readonly ValidatorInterface $validator,
-        private readonly AccessControlService $accessControlPermission
+        private readonly AccessControlService $accessControlPermission,
     ) {
         $this->addonPermissionInitializers = $addonRegistry->getPermissionInitializers();
         $this->globalConfig = $globalConfig;

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -2387,7 +2387,6 @@ class PermissionsTest extends FunctionalTestCase
                     'area_accessibility_explanation',
                     'area_admin',
                     'area_admin_analysis',
-                    'area_admin_assessmenttable',
                     'area_admin_consultations',
                     'area_admin_faq',
                     'area_admin_preferences',
@@ -2750,7 +2749,6 @@ class PermissionsTest extends FunctionalTestCase
                 'isMember'                          => true,
                 'featuresAllowed'                   => [
                     'area_admin',
-                    'area_admin_assessmenttable',
                     'area_admin_dashboard',
                     'area_data_protection_text',
                     'area_demosplan',
@@ -2834,7 +2832,6 @@ class PermissionsTest extends FunctionalTestCase
                 ],
                 'featuresDenied'                    => [
                     'area_admin',
-                    'area_admin_assessmenttable',
                     'area_admin_faq',
                     'area_admin_procedures',
                     'area_admin_statement_list',
@@ -2907,7 +2904,6 @@ class PermissionsTest extends FunctionalTestCase
                 ],
                 'featuresDenied'                    => [
                     'area_admin',
-                    'area_admin_assessmenttable',
                     'area_admin_faq',
                     'area_admin_procedures',
                     'area_admin_statement_list',

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -3078,7 +3078,7 @@ class PermissionsTest extends FunctionalTestCase
         bool $ownsProcedure,
         bool $isMember,
         array $allowedPermissions,
-        array $disallowedPermissions
+        array $disallowedPermissions,
     ): void {
         // do debug a specific permission enable debugging and paste dataset name
         $debugPermission = false;


### PR DESCRIPTION
### Ticket
[DPLAN-12497](https://demoseurope.youtrack.cloud/issue/DPLAN-12497/Abwagungstabelle-in-der-Ansicht-entfernen)

To remove the assessment table for specific projects I removed the activation of the permission "area_admin_assessmenttable" in the core. Then I enabled the permission only in the projects where needed. 

### How to review/test
code review, check different project configuration in interface

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
