### PR TITLE
fix(refs DPLAN-12516): fix statement modal layout

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -302,8 +302,9 @@
                   </label>
                 </div>
               </div><!--
-           --><div :class="[prefixClass(initialFiles.length === 0 ? 'u-1-of-1' : 'u-1-of-2'), prefixClass('layout__item u-mt u-mb')]">
+           --><div :class="[prefixClass(initialFiles.length === 0 ? 'u-1-of-1' : 'u-1-of-2'), prefixClass('layout__item u-mb')]">
                 <dp-label
+                  :class="prefixClass('mb-2')"
                   :text="Translator.trans('upload.files')"
                   for="r_file" />
 
@@ -318,7 +319,6 @@
                   ref="uploadFiles"
                   :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '2GB' }) }"
                   :tus-endpoint="dplan.paths.tusEndpoint"
-                  :side-by-side="initialFiles.length === 0"
                   :storage-name="fileStorageName"
                   @file-remove="removeUnsavedFile"
                   @upload-success="addUnsavedFile" />
@@ -329,7 +329,7 @@
               :class="prefixClass('layout')">
               <dp-input
                 id="r_represents"
-                :class="prefixClass('layout__item u-1-of-2')"
+                :class="prefixClass('layout__item md:w-1/2')"
                 :label="{
                   text: Translator.trans('statement.representation.creation')
                 }"
@@ -342,7 +342,7 @@
         </template>
         <div
           v-if="loggedIn"
-          :class="prefixClass('text-right u-mv-0_5 flow-root u-mt-0_5 space-inline-s')">
+          :class="prefixClass('text-right sm:text-center md:text-right mb-2 flow-root')">
           <!-- Logged in, existing draft statement -->
           <dp-loading
             v-if="isLoading"
@@ -352,7 +352,7 @@
             v-if="displayEditSubmit"
             type="submit"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--primary u-1-of-1-palm u-mt-0_5-palm')"
+            :class="prefixClass('btn btn--primary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-palm')"
             @click="sendStatement"
             data-cy="saveChangedStatement">
             {{ Translator.trans('save.and.close') }}
@@ -361,7 +361,7 @@
             v-if="displayEditSubmit"
             type="submit"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-mt-0_5-palm')"
+            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-palm u-ml-0_5-desk-up')"
             @click="e => sendStatement(e,false, true)"
             data-cy="saveChangedStatementWothoutClosing">
             {{ Translator.trans('save') }}
@@ -375,7 +375,7 @@
               :disabled="isLoading"
               data-cy="statementModal:statementSaveImmediate"
               @click="e => sendStatement(e,true)"
-              :class="prefixClass('btn btn--primary u-1-of-1-palm u-mt-0_5-palm')">
+              :class="prefixClass('btn btn--primary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-lap-down')">
               {{ Translator.trans('statement.save.immediate') }}
             </button>
             <button
@@ -383,7 +383,7 @@
               :disabled="isLoading"
               :class="[
                 hasPermission('feature_draft_statement_citizen_immediate_submit') ? prefixClass('btn--secondary') : prefixClass('btn--primary'),
-                prefixClass('btn u-1-of-1-palm u-mt-0_5-palm')
+                prefixClass('btn u-1-of-1-palm u-1-of-2-lap u-mt-0_5-lap-down u-ml-0_5-desk-up')
               ]"
               @click="sendStatement"
               data-cy="statementModal:saveAsDraft">
@@ -399,7 +399,7 @@
             type="reset"
             data-cy="statementModal:discardChanges"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-ml-lap-up')"
+            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-lap-down u-ml-0_5-desk-up')"
             @click.prevent="() => reset()">
             {{ Translator.trans('discard.changes') }}
           </button>
@@ -407,7 +407,7 @@
         <!-- for not logged in users -->
         <div
           v-else
-          :class="prefixClass('text-right u-mt-0_5 space-inline-s')">
+          :class="prefixClass('text-right sm:text-center md:text-right mb-2')">
           <dp-loading
             v-if="isLoading"
             :class="prefixClass('align-text-bottom inline-block')"
@@ -415,7 +415,7 @@
           <button
             type="reset"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--secondary u-1-of-1-palm')"
+            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-1-of-2-lap')"
             data-cy="statementModal:discardStatement"
             @click.prevent="() => reset()">
             {{ Translator.trans('discard.statement') }}
@@ -424,7 +424,7 @@
             type="submit"
             data-cy="statementFormSubmit"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--primary u-1-of-1-palm u-mt-0_5-palm')"
+            :class="prefixClass('btn btn--primary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-lap-down u-ml-0_5-desk-up')"
             form-name="statementForm"
             @click="validateStatementStep">
             {{ Translator.trans('continue.personal_data') }}

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -437,24 +437,19 @@
         autocomplete="on"
         v-show="step === 1"
         data-dp-validate="submitterForm">
-        <div :class="prefixClass('c-statement__formhint flash-info u-mb-0_5')">
-          <i
-            :class="prefixClass('c-statement__hint-icon fa fa-lg fa-info-circle')"
-            aria-hidden="true" />
-          <span :class="prefixClass('block u-ml')">
-            <p v-cleanhtml="statementFormHintPersonalData" />
-            {{ Translator.trans('error.mandatoryfields') }}
-          </span>
+      <dp-inline-notification
+        type="info">
+        <p
+          v-if="statementFormHintPersonalData"
+          v-cleanhtml="statementFormHintPersonalData" />
+        <p>
+          {{ Translator.trans('error.mandatoryfields') }}
+        </p>
+        <p v-if="extraPersonalHint !== ''">
+          {{ extraPersonalHint }}
+        </p>
+      </dp-inline-notification>
 
-          <template v-if="extraPersonalHint !== ''">
-            <i
-              :class="prefixClass('c-statement__hint-icon fa fa-lg fa-info-circle')"
-              aria-hidden="true" />
-            <span :class="prefixClass('block u-ml')">
-              {{ extraPersonalHint }}
-            </span>
-          </template>
-        </div>
         <div
           v-show="dpValidate.submitterForm === false"
           id="submitterFormErrors"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -171,36 +171,14 @@
         </div>
 
         <template v-if="hasPermission('field_statement_add_assignment') && hasPlanningDocuments">
-          <p
-            aria-hidden="true"
-            :class="prefixClass('c-statement__formblock-title u-mb-0_25 weight--bold inline-block')">
-            {{ Translator.trans('element.assigned') }}
-          </p>
-          <p
-            aria-hidden="true"
-            :class="prefixClass('c-statement__formblock u-ml u-mb-0_5 u-mt-0_5 inline-block')">
-            <template v-if="formData.r_element_id !== ''">
-              <button
-                @click="gotoTab('procedureDetailsDocumentlist')"
-                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up u-1-of-1-palm')">
-                <i
-                  aria-hidden="true"
-                  :class="prefixClass('fa fa-pencil')" />
-                {{ Translator.trans('document.reference.change') }}
-              </button>
-              <span :class="prefixClass('hide-lap-up')" />
-              <button
-                @click="removeDocumentRelation"
-                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up u-1-of-1-palm')"
-                :href="Routing.generate( 'DemosPlan_procedure_public_detail', { procedure: procedureId }) + '#procedureDetailsDocumentlist'">
-                <i
-                  aria-hidden="true"
-                  :class="prefixClass('fa fa-trash')" />
-                {{ Translator.trans('document.reference.delete') }}
-              </button>
-            </template>
+          <fieldset>
+            <legend :class="prefixClass('c-statement__formblock-title')">
+              {{ Translator.trans('element.assigned') }}
+            </legend>
+
             <button
-              v-else
+              v-if="formData.r_element_id === ''"
+              aria-labelledby="documentReference"
               :disabled="formData.r_isNegativeReport !== '0'"
               data-cy="statementModal:elementAssign"
               @click="gotoTab('procedureDetailsDocumentlist')"
@@ -210,20 +188,67 @@
                 :class="prefixClass('fa fa-plus')" />
               {{ Translator.trans('element.assign') }}
             </button>
-          </p>
-          <p
-            v-if="formData.r_element_id !== ''"
-            aria-hidden="true"
-            :class="[prefixClass('u-mb-0_5 u-ph-0_5 u-pv-0_25'), highlighted.documents ? prefixClass(' animation--bg-highlight-grey--light-2') : prefixClass('bg-color--grey-light-2')]">
-            {{ Translator.trans('document') }}: {{ formData.r_element_title }}
-            <br>
-            <template v-if="formData.r_paragraph_id !== ''">
-              {{ Translator.trans('paragraph') }}: {{ formData.r_paragraph_title }}
-            </template>
-            <template v-if="formData.r_document_id !== ''">
-              {{ Translator.trans('file') }}: {{ formData.r_document_title }}
-            </template>
-          </p>
+
+            <div
+              v-if="formData.r_element_id !== ''"
+              :class="prefixClass('mb-3')">
+              <button
+                aria-labelledby="documentReference"
+                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up w-fit')"
+                @click="gotoTab('procedureDetailsDocumentlist')">
+                <i
+                  aria-hidden="true"
+                  :class="prefixClass('fa fa-pencil')" />
+                {{ Translator.trans('document.reference.change') }}
+              </button>
+
+              <button
+                aria-labelledby="documentReference"
+                :class="prefixClass('btn--blank o-link--default u-mr-0_5-lap-up w-fit')"
+                :href="Routing.generate( 'DemosPlan_procedure_public_detail', { procedure: procedureId }) + '#procedureDetailsDocumentlist'"
+                @click="removeDocumentRelation">
+                <i
+                  aria-hidden="true"
+                  :class="prefixClass('fa fa-trash')" />
+                {{ Translator.trans('document.reference.delete') }}
+              </button>
+            </div>
+
+            <dl
+              v-if="formData.r_element_id !== ''"
+              :class="[highlighted.documents ? prefixClass('animation--bg-highlight-grey--light-2 space-y-2') : prefixClass('bg-color--grey-light-2'), 'mb-1 py-1 px-2']">
+              <div :class="prefixClass('md:flex')">
+                <dt :class="prefixClass('font-semibold w-1/6')">
+                  {{ Translator.trans('document') }}:
+                </dt>
+                <dd :class="prefixClass('ml-0')">
+                  {{ formData.r_element_title }}
+                </dd>
+              </div>
+
+              <div
+                v-if="formData.r_paragraph_id !== ''"
+                :class="prefixClass('md:flex')">
+                <dt :class="prefixClass('font-semibold w-1/6')">
+                  {{ Translator.trans('paragraph') }}:
+                </dt>
+                <dd :class="prefixClass('ml-0')">
+                  {{ formData.r_paragraph_title }}
+                </dd>
+              </div>
+
+              <div
+                v-if="formData.r_document_id !== ''"
+                :class="prefixClass('md:flex')">
+                <dt :class="prefixClass('font-semibold w-1/6')">
+                  {{ Translator.trans('file') }}:
+                </dt>
+                <dd :class="prefixClass('ml-0')">
+                  {{ formData.r_document_title }}
+                </dd>
+              </div>
+            </dl>
+          </fieldset>
         </template>
 
         <!-- location reference -->

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -27,9 +27,9 @@
       <template v-slot:closeButton>
         <button
           aria-describedby="statementDialogCloseTitle"
-          aria-label="Stellungnahme-Formular minimieren"
+          :aria-label="Translator.trans('statement.dialog.close')"
           :class="prefixClass('c-statement__close btn-icns color-highlight u-m-0_25 p-0 absolute u-right-0')"
-          title="Stellungnahme-Formular minimieren"
+          :title="Translator.trans('statement.dialog.close')"
           type="button"
           @click="toggleModal(false)">
           <span

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -13,10 +13,10 @@
       ref="statementModal"
       @modal:toggled="handleModalToggle"
       content-header-classes="border--none">
-      <template v-slot:header>
-        <span
-          :class="prefixClass('color-highlight')"
-          v-if="showHeader">
+      <template
+        v-if="showHeader"
+        v-slot:header>
+        <span :class="prefixClass('color-highlight')">
           <i
             aria-hidden="true"
             class="fa"
@@ -76,13 +76,15 @@
           <dp-inline-notification
             v-if="loggedIn === false"
             type="info">
-            <p v-cleanhtml="statementFormHintStatement" />
+            <p
+              v-if="statementFormHintStatement"
+              v-cleanhtml="statementFormHintStatement" />
             <p v-cleanhtml="Translator.trans('statement.modal.step.write.privacy_policy')" />
             <p>{{ Translator.trans('error.mandatoryfields') }}</p>
           </dp-inline-notification>
 
         <dp-inline-notification
-          v-show="dpValidate.statementForm === false"
+          v-if="dpValidate.statementForm === false"
           id="statementFormErrors"
           aria-labelledby="statementFormErrorsContent"
           tabindex="0">
@@ -91,33 +93,33 @@
             v-cleanhtml="createErrorMessage('statementForm')" />
         </dp-inline-notification>
 
-        <template v-if="loggedIn && hasPermission('feature_elements_use_negative_report') && planningDocumentsHasNegativeStatement">
-          <div class="flex">
-            <dp-radio
-              name="r_isNegativeReport"
-              id="negative_report_false"
-              data-cy="statementModal:publicParticipationParticipate"
-              class="u-mr-2"
-              :checked="formData.r_isNegativeReport === '0'"
-              @change="() => { setStatementData({ r_isNegativeReport: '0'}) }"
-              :label="{
-                text: Translator.trans('public.participation.participate')
-              }"
-              value="0" />
-            <dp-radio
-              :disabled="canNotBeNegativeReport"
-              name="r_isNegativeReport"
-              id="negative_report_true"
-              data-cy="statementModal:indicationerror"
-              :checked="formData.r_isNegativeReport === '1'"
-              @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
-              :label="{
-                hint: Translator.trans('link.title.indicationerror'),
-                text: Translator.trans('indicationerror')
-              }"
-              value="1" />
-          </div>
-        </template>
+        <div
+          v-if="loggedIn && hasPermission('feature_elements_use_negative_report') && planningDocumentsHasNegativeStatement"
+          class="flex mt-4">
+          <dp-radio
+            name="r_isNegativeReport"
+            id="negative_report_false"
+            data-cy="statementModal:publicParticipationParticipate"
+            class="u-mr-2"
+            :checked="formData.r_isNegativeReport === '0'"
+            @change="() => { setStatementData({ r_isNegativeReport: '0'}) }"
+            :label="{
+              text: Translator.trans('public.participation.participate')
+            }"
+            value="0" />
+          <dp-radio
+            :disabled="canNotBeNegativeReport"
+            name="r_isNegativeReport"
+            id="negative_report_true"
+            data-cy="statementModal:indicationerror"
+            :checked="formData.r_isNegativeReport === '1'"
+            @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
+            :label="{
+              hint: Translator.trans('link.title.indicationerror'),
+              text: Translator.trans('indicationerror')
+            }"
+            value="1" />
+        </div>
 
         <div :class="prefixClass('c-statement__text')">
           <dp-label

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -179,10 +179,10 @@
             <button
               v-if="formData.r_element_id === ''"
               aria-labelledby="documentReference"
-              :disabled="formData.r_isNegativeReport !== '0'"
+              :class="prefixClass('btn--blank o-link--default text-left')"
               data-cy="statementModal:elementAssign"
-              @click="gotoTab('procedureDetailsDocumentlist')"
-              :class="prefixClass('btn--blank o-link--default text-left')">
+              :disabled="formData.r_isNegativeReport !== '0'"
+              @click="gotoTab('procedureDetailsDocumentlist')">
               <i
                 aria-hidden="true"
                 :class="prefixClass('fa fa-plus')" />

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -44,11 +44,10 @@
       </template>
 
       <header
+        v-if="loggedIn === false && showHeader"
         role="banner"
         :class="prefixClass('c-statement__header u-mb-0_5')">
         <dp-multistep-nav
-          v-if="loggedIn === false && showHeader"
-          @change-step="val => step = val"
           :active-step="step"
           :steps="[{
             label: Translator.trans('statement.yours'),
@@ -62,7 +61,8 @@
             label: Translator.trans('recheck'),
             icon: 'fa-check',
             title: Translator.trans('statement.modal.step.recheck')
-          }]" />
+          }]"
+          @change-step="val => step = val" />
       </header>
       <dp-inline-notification
         dismissible

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -49,6 +49,7 @@
         :class="prefixClass('c-statement__header u-mb-0_5')">
         <dp-multistep-nav
           :active-step="step"
+          :class="prefixClass('pb-0')"
           :steps="[{
             label: Translator.trans('statement.yours'),
             icon: commentingIcon,
@@ -64,11 +65,13 @@
           }]"
           @change-step="val => step = val" />
       </header>
+
       <dp-inline-notification
         dismissible
         dismissible-key="statementModalCloseExplanation"
         :message="Translator.trans('explanation.statement.autosave')"
         type="info" />
+
       <!-- Statement form incl. documents and location -->
       <section
         v-show="step === 0"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -455,21 +455,22 @@
           id="submitterFormErrors"
           tabindex="0"
           aria-labelledby="submitterFormErrorsContent"
-          :class="prefixClass('c-statement__formhint flash-error u-mb-0_5')">
+          :class="prefixClass('c-statement__formhint flash-error mb-2')">
           <i
             aria-hidden="true"
             :class="prefixClass('c-statement__hint-icon fa fa-lg fa-exclamation-circle')" />
           <div
             id="submitterFormErrorsContent"
-            :class="prefixClass('u-ml')"
+            :class="prefixClass('ml-4')"
             v-cleanhtml="createErrorMessage('submitterForm')" />
         </div>
 
         <fieldset
-          role="radiogroup"
-          required
           aria-required="true"
-          id="personalInfoFieldset">
+          :class="prefixClass('mt-5')"
+          id="personalInfoFieldset"
+          role="radiogroup"
+          required>
           <div
             aria-live="polite"
             aria-relevant="all"
@@ -479,25 +480,26 @@
             ]"
             aria-labelledby="statement-detail-post-publicly">
             <dp-radio
-              id="r_useName_1"
-              name="r_useName"
-              data-cy="submitPublicly"
-              value="1"
-              @change="val => setPrivacyPreference({r_useName: '1'})"
               :checked="formData.r_useName === '1'"
+              :class="prefixClass('mb-1')"
+              data-cy="submitPublicly"
+              id="r_useName_1"
               :label="{
                 text: Translator.trans('statement.detail.form.personal.post_publicly')
-              }" />
+              }"
+              name="r_useName"
+              value="1"
+              @change="val => setPrivacyPreference({r_useName: '1'})"  />
             <div
               v-show="formData.r_useName === '1'"
-              :class="prefixClass('layout')">
+              :class="prefixClass('layout mb-3 ml-2')">
               <component
                 v-for="formDefinition in personalDataFormDefinitions"
                 :is="formDefinition.component"
                 :draft-statement-id="draftStatementId"
                 :required="formDefinition.required"
                 :form-options="formOptions"
-                :class="prefixClass('layout__item u-1-of-1-palm u-mt-0_5 ' + formDefinition.width)"
+                :class="prefixClass('layout__item u-1-of-1-palm mt-1 ' + formDefinition.width)"
                 :key="formDefinition.key" />
             </div>
           </div>
@@ -507,16 +509,16 @@
               prefixClass('c-statement__formblock')
             ]">
             <dp-radio
-              id="r_useName_0"
-              name="r_useName"
-              value="0"
-              @change="val => setPrivacyPreference({r_useName: '0'})"
+              aria-labelledby="statement-detail-post-anonymously"
               :checked="formData.r_useName === '0'"
+              data-cy="submitAnonymously"
+              id="r_useName_0"
               :label="{
                 text: Translator.trans('statement.detail.form.personal.post_anonymously')
               }"
-              aria-labelledby="statement-detail-post-anonymously"
-              data-cy="submitAnonymously" />
+              name="r_useName"
+              value="0"
+              @change="val => setPrivacyPreference({r_useName: '0'})" />
           </div>
         </fieldset>
 
@@ -526,7 +528,7 @@
           :key="formDefinition.key"
           :draft-statement-id="draftStatementId"
           :required="formDefinition.required" />
-        <div :class="prefixClass('text-right u-mt-0_5')">
+        <div :class="prefixClass('text-right mt-3')">
           <button
             type="button"
             data-cy="submitterForm"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -26,14 +26,15 @@
       </template>
       <template v-slot:closeButton>
         <button
-          type="button"
-          @click="toggleModal(false)"
-          aria-label="Stellungnahme-Formular minimieren"
           aria-describedby="statementDialogCloseTitle"
-          :class="prefixClass('c-statement__close btn-icns u-m-0 u-p-0')">
+          aria-label="Stellungnahme-Formular minimieren"
+          :class="prefixClass('c-statement__close btn-icns color-highlight u-m-0_25 p-0 absolute u-right-0')"
+          title="Stellungnahme-Formular minimieren"
+          type="button"
+          @click="toggleModal(false)">
           <span
             id="statementDialogCloseTitle"
-            :class="prefixClass('show-lap-up-i')">
+            :class="prefixClass('sr-only')">
             {{ Translator.trans('explanation.statement.autosave') }}
           </span>
           <i
@@ -63,7 +64,11 @@
             title: Translator.trans('statement.modal.step.recheck')
           }]" />
       </header>
-
+      <dp-inline-notification
+        dismissible
+        dismissible-key="statementModalCloseExplanation"
+        :message="Translator.trans('explanation.statement.autosave')"
+        type="info" />
       <!-- Statement form incl. documents and location -->
       <section
         v-show="step === 0"

--- a/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
@@ -13,27 +13,20 @@
     id="check"
     tabindex="-1">
     <legend
-      class="sr-only"
+      :class="prefixClass('sr-only')"
       v-text="Translator.trans('statement.recheck')" />
-    <p :class="prefixClass('c-statement__formhint flash-warning')">
-      <i
-        :class="prefixClass('c-statement__hint-icon fa fa-lg fa-exclamation-circle')"
-        aria-hidden="true" />
-      <span :class="prefixClass('block u-ml')">
-        {{ Translator.trans('statement.recheck') }}
-      </span>
-    </p>
 
-    <p
+    <dp-inline-notification
+      :class="prefixClass('mt-1')"
+      :message="Translator.trans('statement.recheck')"
+      type="warning"
+      />
+
+    <dp-inline-notification
       v-if="statementFormHintRecheck !== ''"
-      :class="prefixClass('c-statement__formhint flash-info')">
-      <i
-        :class="prefixClass('c-statement__hint-icon fa fa-lg fa-info-circle')"
-        aria-hidden="true" />
-      <span
-        :class="prefixClass('block u-ml')"
-        v-cleanhtml="statementFormHintRecheck" />
-    </p>
+      type="info">
+      <p v-cleanhtml="statementFormHintRecheck" />
+    </dp-inline-notification>
 
     <div
       v-if="hasPermission('field_statement_public_allowed') && publicParticipationPublicationEnabled"
@@ -232,10 +225,14 @@
 </template>
 
 <script>
-import { CleanHtml, prefixClassMixin } from '@demos-europe/demosplan-ui'
+import { CleanHtml, DpInlineNotification, prefixClassMixin } from '@demos-europe/demosplan-ui'
 
 export default {
   name: 'StatementModalRecheck',
+
+  components: {
+    DpInlineNotification
+  },
 
   directives: {
     cleanhtml: CleanHtml

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
@@ -22,13 +22,13 @@
 
     <div
       v-show="statement.r_getFeedback === 'on'"
-      :class="prefixClass('u-mb-0_5')">
+      :class="prefixClass('mb-2')">
       <dp-radio
         v-if="hasPermission('feature_statements_feedback_postal')"
         id="r_getEvaluation"
         name="r_getEvaluation"
         data-cy="personalAnswerEmail"
-        :class="prefixClass('u-mt-0_5')"
+        :class="prefixClass('mt-2')"
         @change="val => setStatementData({r_getEvaluation: 'email'})"
         :checked="statement.r_getEvaluation === 'email' && statement.r_getFeedback === 'on'"
         aria-labelledby="statement-detail-require-response-email"
@@ -38,14 +38,14 @@
         value="email" />
 
       <!--              {# email address #}-->
-      <div :class="prefixClass('layout u-pl')">
+      <div :class="prefixClass('layout pl-4')">
         <dp-input
           id="r_email_feedback"
           ref="emailFeedback"
           data-cy="statementDetailEmail"
           aria-labelledby="statement-detail-email"
           autocomplete="email"
-          :class="prefixClass('layout__item u-1-of-2')"
+          :class="prefixClass('u-pl-1_5 mt-1')"
           data-dp-validate-if="#r_getEvaluation"
           :label="{
             text: Translator.trans('email')
@@ -54,6 +54,7 @@
           :required="statement.r_getEvaluation === 'email'"
           type="email"
           :value="statement.r_email"
+          width="u-1-of-1-palm u-1-of-2"
           @input="val => hasPermission('feature_statements_feedback_check_email') ? setStatementData({r_email: val}) : setStatementData({r_email: val, r_email2: val})" /><!--
 
         if repeating of email input is enforced, display second email field
@@ -64,7 +65,7 @@
           data-cy="statementDetailEmailConfirm"
           aria-labelledby="statement-detail-email-confirm"
           autocomplete="email"
-          :class="prefixClass('layout__item u-1-of-2')"
+          :class="prefixClass('u-pl-1_5 mt-2')"
           data-dp-validate-if="#r_getEvaluation"
           data-dp-validate-should-equal="[name=r_email]"
           :label="{
@@ -74,12 +75,13 @@
           :required="statement.r_getEvaluation === 'email'"
           type="email"
           :value="statement.r_email2"
+          width="u-1-of-1-palm u-1-of-2"
         @input="val => setStatementData({r_email2: val})" /><!--
      --><dp-radio
           v-if="hasPermission('feature_statements_feedback_postal')"
           id="r_getEvaluation_snailmail"
           data-cy="personalAnswerPost"
-          :class="prefixClass('u-mt-0_5')"
+          :class="prefixClass('mt-3')"
           name="r_getEvaluation"
           :disabled="statement.r_useName === '0'"
           @change="val => setStatementData({r_getEvaluation: 'snailmail'})"
@@ -91,12 +93,12 @@
           value="snailmail" />
         <form-group-street-and-number
           v-show="statement.r_useName !== '0'"
-          :class="prefixClass('layout__item u-1-of-1-palm u-1-of-2 u-mt-0_5 ')"
+          :class="prefixClass('layout__item u-1-of-1-palm u-2-of-3 mt-2 u-pl-1_5')"
           :disabled="statement.r_useName === '0'"
           :required="statement.r_getFeedback === 'on' && statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" /><!--
      --><form-group-postal-and-city
           v-show="statement.r_useName !== '0'"
-          :class="prefixClass('layout__item u-1-of-1-palm u-1-of-2 u-mt-0_5 ')"
+          :class="prefixClass('layout__item u-1-of-1-palm u-2-of-3 mt-2 u-pl-1_5')"
           :disabled="statement.r_useName === '0'"
           :required="statement.r_getFeedback === 'on' && statement.r_getEvaluation === 'snailmail' && statement.r_useName !== '0'" />
       </div>

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
@@ -15,8 +15,8 @@
     aria-labelledby="statementMapReference"
     aria-required="true"
     id="locationFieldset">
-    <p
-      :class="prefixClass('c-statement__formblock-title weight--bold u-mt u-mb-0')"
+    <legend
+      :class="prefixClass('c-statement__formblock-title mt-0 mb-0')"
       id="statementMapReference">
       {{ Translator.trans('statement.map.reference') }}
       <span

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
@@ -22,19 +22,38 @@
       <span
         v-if="required"
         aria-hidden="true">*</span>
-    </p>
+    </legend>
+
+    <div
+      :class="[
+        statement.r_location === 'notLocated' ? prefixClass('bg-color--grey-light-2') : '',
+        prefixClass('block m-0 py-1 px-2 h-[36px] u-1-of-1-palm')
+      ]">
+      <dp-radio
+        id="locationNone"
+        :label="{
+          text: Translator.trans('statement.map.no_reference')
+        }"
+        name="r_location"
+        :class="prefixClass('u-mb-0_25')"
+        data-cy="formGroupMap:notLocated"
+        :checked="statement.r_location === 'notLocated'"
+        @change="() => { setStatementData({r_location: 'notLocated', location_is_set: 'notLocated'}) }"
+        value="notLocated" />
+    </div>
+
     <div
       v-if="isMapEnabled && hasPermission('area_map_participation_area')"
       :class="[
         isLocationSelected ? prefixClass('bg-color--grey-light-2') : '',
-        prefixClass('c-statement__formblock layout__item sm:h-8 u-3-of-10 u-1-of-1-palm'),
+        prefixClass('m-0 pt-1 px-2 h-[66px]'),
         highlighted.location ? prefixClass('animation--bg-highlight-grey--light-2') : ''
       ]"
       ref="mapStatementRadio">
       <dp-radio
         id="locationPoint"
         name="r_location"
-        class="u-mb-0_25"
+        :class="prefixClass('pb-1')"
         data-cy="formGroupMap:statementMapReference"
         :checked="isLocationSelected"
         :disabled="disabled"
@@ -46,7 +65,11 @@
 
       <a
         href="#"
-        class="o-link--default"
+        :class="[
+          isLocationSelected ? prefixClass('bg-color--grey-light-2') : '',
+          prefixClass('o-link--default block u-pl-1_5 pb-1 px-2'),
+          highlighted.location ? prefixClass('animation--bg-highlight-grey--light-2') : ''
+        ]"
         data-cy="formGroupMap:procedureDetailsMap"
         v-show="isLocationSelected"
         @click.prevent="gotoTab('procedureDetailsMap')">
@@ -99,25 +122,6 @@
           {{ county.label }}
         </option>
       </select>
-    </div>
-
-    <div
-      :class="[
-        statement.r_location === 'notLocated' ? prefixClass('bg-color--grey-light-2') : '',
-        loggedIn ? prefixClass('u-1-of-3') : prefixClass('u-2-of-10'),
-        prefixClass('c-statement__formblock layout__item sm:h-8 u-1-of-1-palm')
-      ]">
-      <dp-radio
-        id="locationNone"
-        :label="{
-          text: Translator.trans('statement.map.no_reference')
-        }"
-        name="r_location"
-        class="u-mb-0_25"
-        data-cy="formGroupMap:notLocated"
-        :checked="statement.r_location === 'notLocated'"
-        @change="() => { setStatementData({r_location: 'notLocated', location_is_set: 'notLocated'}) }"
-        value="notLocated" />
     </div>
   </fieldset>
 </template>

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1,5 +1,5 @@
 # Use `sed 's/:.*//' messages.de.yml | sort | uniq -cd` to list all duplicated keys in this file with the number of occurrences of each one
-# you can also use `php app/console lint:yaml $filename` for a general yaml check
+# you can also use `php app/console lint:yaml $filename ` for a general yaml check
 2fa: "Zwei-Faktor-Authentifizierung"
 2fa.email: "Authentifizierung per Email"
 2fa.email.activate: 'Um die Zwei-Faktor-Authentifizierung per Email zu aktivieren, wurde Ihnen ein Code an Ihre Email-Adresse gesendet. Bitte prüfen Sie Ihr Postfach und geben Sie diesen bitte ein und speichern Sie das Formular. Sollte der Token abgelaufen sein, <a href="{link}">lassen Sie sich den aktuellen Code erneut an Ihre Email-Adresse senden</a>'


### PR DESCRIPTION
### Ticket
[DPLAN-12516](https://demoseurope.youtrack.cloud/issue/DPLAN-12516/Unnotiger-Leerraum-im-Stellungnahme-Fenster)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Fixes several layout issues in the statement modal:
- extra white space is removed where possible
- the layout is made responsive (this was broken)
- the 'minimize' button (instead of close button) is restored and adjusted: instead of displaying the hint always next to the button, it is displayed as a dismissible inline notification
- semantic html is used in some places to improve accessibility
- some css classes were replaced with tailwind classes (but probably not all)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
The best way of reviewing this PR would be to check the statement modal (first tab only in the case of users that are not logged in) in different configurations, for different users, and for different screen sizes. The layout should not appear broken.

For a logged-in citizen, the modal should look like this:

![Screenshot Capture - 2024-10-08 - 12-17-20](https://github.com/user-attachments/assets/bbde5a7b-a5ca-4601-8946-70ff7e481ecd)


### Linked PRs (optional)
- [x] https://github.com/demos-europe/demosplan-ui/pull/1042

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
