### PR TITLE
feat (DPLAN-12497): add permission for subheading

### DIFF
--- a/config/menus.yml
+++ b/config/menus.yml
@@ -333,7 +333,7 @@ submenu_procedures:
     analysis:
         label: 'analysis'
         path: ~
-        permission: 'area_admin_assessmenttable'
+        permission: 'area_admin_subheading_analysis'
         list_item_attributes:
             class: 'knp-sub-heading'
     considerationtable:

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -149,6 +149,10 @@ area_admin_statement_list:
 area_admin_statements_tag:
     label: 'Verwaltung der Schlagworte'
     loginRequired: true
+area_admin_subheading_analysis:
+    label: 'Zwischenüberschrift Auswertung'
+    loginRequired: true
+    parent: area_admin
 area_admin_submitters:
     description: 'Grants access to admin the users which have submitted Statements to a Procedure'
     label: 'Admin Statement submitters in a Procedure'


### PR DESCRIPTION
### Ticket
[DPLAN-12497](https://demoseurope.youtrack.cloud/issue/DPLAN-12497/Abwagungstabelle-in-der-Ansicht-entfernen)

This PR adds a new permission for the subheading "Auswertung" in the side menu.

### How to review/test
code review, test the interface of different projects -> is the subheading visible if permission is enabled?

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
