### PR TITLE
Add node_modules cleanup after each build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,10 @@ pipeline {
 
     post {
         always {
+            // Navigate to the workspace directory and delete node_modules
+            dir("${env.WORKSPACE}") {
+            sh 'rm -rf node_modules'
+        }
             script {
                 def containerExists = sh(script: "docker ps -a -q -f name=$containerName", returnStdout: true).trim()
                 if (containerExists) {


### PR DESCRIPTION
**Overview:**

This PR updates the Jenkins pipeline script to include a cleanup step that deletes the `node_modules` folder from the workspace after each run.

**Changes Made:**

- Added a post-build step in the `post { always { ... } }` section of the Jenkinsfile.
- Included the `dir("${env.WORKSPACE}")` block to navigate to the workspace directory.
- Added the shell command `rm -rf node_modules` to remove the `node_modules` folder.

**Reasoning:**
We've been encountering issues with running low on inodes on our Jenkins workers. The `node_modules` directory contains a large number of files, which consumes a significant number of inodes. By deleting this folder after each build, we can reduce inode usage and prevent potential build failures due to inode exhaustion.