### PR TITLE
bug(refs DPLAN-12611): Set max width

### DIFF
--- a/client/js/components/statement/StatementExportModal.vue
+++ b/client/js/components/statement/StatementExportModal.vue
@@ -32,6 +32,7 @@
             v-for="(exportType, key) in exportTypes"
             :key="key"
             :id="key"
+            class="max-w-[70%]"
             :data-cy="`exportType:${key}`"
             :label="{
               hint: active === key ? exportType.hint : '',


### PR DESCRIPTION
### Ticket
DPLAN-12611

Radio labels have word-break: break-word, but DOCX etc. seems not to count as one word and therefor breaks if there is not enough space.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Stellungnahmen -> Exportieren -> Click on XLSX -> DOCX and ZIP should not break