### PR TITLE
Adjustment Table width

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_original_entry.tex.twig
@@ -2,7 +2,7 @@
     {% if pdfLandscape is defined and pdfLandscape == true %}
 	\begin{longtable}{|p{6cm}|p{5.5cm}p{14.0cm}|}
     {% else %}
-	\begin{longtable}{|p{3.5cm}|p{3.5cm}p{9.75cm}|}
+	\begin{longtable}{|p{2.7cm}|p{4.8cm}p{9.75cm}|}
     {% endif %}
 		\hline
 			% Caption-Zeile - der doppelte Backslah setzt das Ende der Tabellenzeile, das & trennt die Spalten auf, \textbf setzt den Text in den geschweiften Klammern Bold (=<b></b> oder <strong></strong>)


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12590/Metadaten-und-Details-zu-nahe-aneinander-Zip-Ordner-STN-Export


Description: Adjustment exported Original statement Table width in ZIP form

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
