### PR TITLE
feat (DPLAN-12610): Allow update on non manual statements

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -644,6 +644,11 @@ feature_admin_new_procedure:
     label: 'Neues Verfahren anlegen'
     loginRequired: true
     parent: feature_admin
+feature_allow_update_on_non_manual_statements:
+    description: 'Allow to update non-manual statements'
+    expose: false
+    label: 'Allow to update non-manual statements'
+    loginRequired: true
 feature_alternative_newsletter:
     description: 'Provides links to the service of the alternative (non-internal) newsletter and disables the internal newsletter.'
     expose: false

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -33,7 +33,6 @@ use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryStatement;
 use demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer;
 use Doctrine\Common\Collections\ArrayCollection;
-use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
@@ -68,7 +67,6 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         private readonly QueryStatement $esQuery,
         private readonly StatementService $statementService,
         private readonly StatementDeleter $statementDeleter,
-        private readonly ConditionFactoryInterface $condition,
     ) {
         parent::__construct($fileService, $htmlSanitizer);
     }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -218,12 +218,9 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
      */
     protected function getProperties(): array|ResourceConfigBuilderInterface
     {
-        // The permission 'feature_allow_update_on_non_manual_statements' decides if updates are allowed
-        // for non-manual statements too.
-        $manualStatementCondition = $this->conditionFactory->true();
-        if (!$this->currentUser->hasPermission('feature_allow_update_on_non_manual_statements')) {
-            $manualStatementCondition = $this->conditionFactory->propertyHasValue(true, $this->manual);
-        }
+        // some updates are allowed for manual statements only
+        $manualStatementCondition = $this->conditionFactory->propertyHasValue(true, $this->manual);
+
         // currently updates are only needed for "normal" statements
         $simpleStatementCondition = $this->conditionFactory->allConditionsApply(
             $this->conditionFactory->propertyHasValue(false, Paths::statement()->deleted),
@@ -233,6 +230,11 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
             // all segments must have a segment set, hence the following check is used to ensure this resource type does not return segments
             $this->conditionFactory->isTargetEntityNotInstanceOf(Segment::class)
         );
+
+        $statementConditions = $this->currentUser
+            ->hasPermission('feature_allow_update_on_non_manual_statements')
+            ? [$simpleStatementCondition]
+            : [$simpleStatementCondition, $manualStatementCondition];
 
         /** @var StatementResourceConfigBuilder $configBuilder */
         $configBuilder = parent::getProperties();
@@ -307,30 +309,30 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         // updatable with special permission and on manual statements only
         if ($this->currentUser->hasPermission('area_admin_statement_list')) {
             $configBuilder->fullText
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->text);
             $configBuilder->initialOrganisationName
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaName);
             $configBuilder->initialOrganisationDepartmentName
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaDepartmentName);
             $configBuilder->initialOrganisationPostalCode
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaPostalCode);
             $configBuilder->initialOrganisationCity
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaCity);
             $configBuilder->initialOrganisationHouseNumber
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->houseNumber);
             $configBuilder->initialOrganisationStreet
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaStreet);
-            $configBuilder->authorName->updatable([$simpleStatementCondition, $manualStatementCondition]);
-            $configBuilder->submitName->updatable([$simpleStatementCondition, $manualStatementCondition]);
+            $configBuilder->authorName->updatable($statementConditions);
+            $configBuilder->submitName->updatable($statementConditions);
             $configBuilder->internId->updatable(
-                [$simpleStatementCondition, $manualStatementCondition],
+                $statementConditions,
                 function (Statement $statement, string $internIdToSet): array {
                     // check for unique
                     $isUnique = $this->statementService->isInternIdUniqueForProcedure($internIdToSet, $statement->getProcedureId());
@@ -344,7 +346,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 }
             );
             $configBuilder->authoredDate->updatable(
-                [$simpleStatementCondition, $manualStatementCondition],
+                $statementConditions,
                 function (Statement $statement, mixed $newValue): array {
                     $unrequestedChange = false;
                     // authoredDate should be less or equal to the submitDate
@@ -359,7 +361,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 }
             );
             $configBuilder->submitDate->updatable(
-                [$simpleStatementCondition, $manualStatementCondition],
+                $statementConditions,
                 static function (Statement $statement, string $value): array {
                     $statement->setSubmit(new DateTime($value));
 
@@ -367,7 +369,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 }
             );
             $configBuilder->submitType->updatable(
-                [$simpleStatementCondition, $manualStatementCondition],
+                $statementConditions,
                 static function (Statement $statement, string $submitType): array {
                     $statement->setSubmitType($submitType);
 
@@ -375,7 +377,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 }
             );
             $configBuilder->submitterEmailAddress->updatable(
-                [$simpleStatementCondition, $manualStatementCondition],
+                $statementConditions,
                 function (Statement $statement, mixed $value): array {
                     $statement->setSubmitterEmailAddress($value);
 
@@ -394,21 +396,21 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         }
 
         if ($this->currentUser->hasPermission('area_admin_consultations')) {
-            $configBuilder->submitterEmailAddress->updatable([$simpleStatementCondition, $manualStatementCondition]);
+            $configBuilder->submitterEmailAddress->updatable($statementConditions);
             $configBuilder->submitterName
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->submitName);
             $configBuilder->submitterPostalCode
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaPostalCode);
             $configBuilder->submitterCity
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaCity);
             $configBuilder->submitterHouseNumber
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->houseNumber);
             $configBuilder->submitterStreet
-                ->updatable([$simpleStatementCondition, $manualStatementCondition])
+                ->updatable($statementConditions)
                 ->aliasedPath(Paths::statement()->meta->orgaStreet);
         }
 


### PR DESCRIPTION
### Ticket
[DPLAN-12620](https://demoseurope.youtrack.cloud/issue/DPLAN-12610/Abschnitt-erstellen-funktioniert-nicht)

This PR adds a new permission 'feature_allow_update_on_non_manual_statements' to allow updates on non manual statements. 

### How to review/test
code review, assign a non manual statement in a project where the new permission is enabled.


<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
