### PR TITLE
chore: pass csrf token to addon wrapper

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -27,7 +27,10 @@
         </dp-map-settings-preview>
     {% endif %}
 
-    {% set addonProps = { 'procedureId': templateVars.procedure.id } %}
+    {% set addonProps = {
+        'procedureId': templateVars.procedure.id,
+        'csrf-token': csrf_token('csrf')|json_encode
+    } %}
     <addon-wrapper
         hook-name="procedure.adminlist.fields"
         :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">


### PR DESCRIPTION
### Description:
This is the core PR part to pass a csrf token to a upload form of an addon.

### Related PRs:
https://github.com/demos-europe/demosplan-addon-bimschg-antrag/pull/36