### PR TITLE
fix: use `bg-surface` as `white` is not defined

### DIFF
--- a/client/js/components/statement/splitStatement/AssignedTags.vue
+++ b/client/js/components/statement/splitStatement/AssignedTags.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="segment && segment.tags.length > 0"
-    class="flex flex-wrap gap-1 bg-white">
+    class="flex flex-wrap gap-1 bg-surface">
     <div
       v-for="(tag, idx) in segment.tags"
       :key="`tag_${idx}`"

--- a/client/js/components/statement/splitStatement/FloatingContextButton.vue
+++ b/client/js/components/statement/splitStatement/FloatingContextButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     v-show="isVisible"
-    class="bg-white rounded shadow absolute p-0.5"
+    class="bg-surface rounded shadow absolute p-0.5"
     :aria-controls="section"
     :aria-expanded="isContentCollapsed"
     :data-cy="`sidebar:floatingContextButton:${section}`"


### PR DESCRIPTION
demosplan-ui does only define semantic tokens for tailwind colors, not primitive ones.
