### PR TITLE
f DPLAN-12620 adjust InvitablePublicAgencyResourceType :

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
@@ -90,7 +90,7 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
             $this->conditionFactory->propertyHasValue(
                 OrgaStatusInCustomer::STATUS_ACCEPTED,
                 $this->statusInCustomers->status
-            )
+            ),
         ];
         // avoid already invited organisations
         $invitedOrgaIdsCondition[] = [] === $invitedOrgaIds->toArray()

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
@@ -72,7 +72,7 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
             static fn (Orga $orga): string => $orga->getId()
         );
 
-        return [
+        $conditions = [
             $this->conditionFactory->propertyHasValue(false, $this->deleted),
             $this->conditionFactory->propertyHasValue(true, $this->showlist),
             $this->conditionFactory->propertyHasValue(
@@ -90,12 +90,14 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
             $this->conditionFactory->propertyHasValue(
                 OrgaStatusInCustomer::STATUS_ACCEPTED,
                 $this->statusInCustomers->status
-            ),
-            // avoid already invited organisations
-            [] === $invitedOrgaIds->toArray()
-                ? $this->conditionFactory->false()
-                : $this->conditionFactory->propertyHasNotAnyOfValues($invitedOrgaIds->toArray(), $this->id),
+            )
         ];
+        // avoid already invited organisations
+        $invitedOrgaIdsCondition[] = [] === $invitedOrgaIds->toArray()
+            ? $this->conditionFactory->true()
+            : $this->conditionFactory->propertyHasNotAnyOfValues($invitedOrgaIds->toArray(), $this->id);
+
+        return array_merge($conditions, $invitedOrgaIdsCondition);
     }
 
     public function getDefaultSortMethods(): array


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12620/Institutionen-hinzufugen-nicht-moglich


Description: 
 since the last EDT update, we have to check and disallow empty lists for propertyHasNotAnyOfValues. In this case the 'invitedOrgaIdsCondition' has to be returned even with a empty value ( when there are no invited institutions yet ) otherwise the condition will return null.



Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

