### PR TITLE
fix(refs DPLAN-12643) Add procedureId and change route to retrieve file.

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/new_public_participation_statement_confirm_entry.html.twig
@@ -54,7 +54,7 @@
                     <a
                         target="_blank"
                         rel="noopener"
-                        href="{{ path("core_file", { 'hash': file|getFile('hash') }) }}" title="{{ file|getFile('name') }}">
+                        href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': file|getFile('hash') }) }}" title="{{ file|getFile('name') }}">
                         {{ file|getFile('name') }}
                     </a>
                     {% if not loop.last %}<span>,</span>{% endif %}


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12643/Datei-unter-Stellungnahme-Mitzeichnen-Seite-nicht-verfugbar-und-weiterleitet-zu-Fehlerseite

Description:
Use the correct route to get file entities with related procedure id


- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
