### PR TITLE
chore refs(DPLAN-12660): massively improve performance in docx export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1558,7 +1558,7 @@ class StatementService extends CoreService implements StatementServiceInterface
             );
         }
 
-        $this->reportService->persistAndFlushReportEntries($entries);
+        $this->reportService->persistAndFlushReportEntries(... $entries);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1524,7 +1524,8 @@ class StatementService extends CoreService implements StatementServiceInterface
 
     /**
      * Add a report entry to the DB.
-     * @var StatementViewed[] $viewsToLog
+     *
+     * @var StatementViewed[]
      *
      * @throws ORMException
      * @throws OptimisticLockException
@@ -1555,7 +1556,6 @@ class StatementService extends CoreService implements StatementServiceInterface
                 $procedureId,
                 $accessMap
             );
-
         }
 
         $this->reportService->persistAndFlushReportEntries($entries);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1558,7 +1558,7 @@ class StatementService extends CoreService implements StatementServiceInterface
             );
         }
 
-        $this->reportService->persistAndFlushReportEntries(... $entries);
+        $this->reportService->persistAndFlushReportEntries(...$entries);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementViewed.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementViewed.php
@@ -15,9 +15,9 @@ namespace demosplan\DemosPlanCoreBundle\ValueObject\Statement;
 use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
 
 /**
- * @method string      getProcedureId()
- * @method array       getAccessMap()
- * @method string      getStatementId()
+ * @method string getProcedureId()
+ * @method array  getAccessMap()
+ * @method string getStatementId()
  */
 class StatementViewed extends ValueObject
 {

--- a/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementViewed.php
+++ b/demosplan/DemosPlanCoreBundle/ValueObject/Statement/StatementViewed.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ValueObject\Statement;
+
+use demosplan\DemosPlanCoreBundle\ValueObject\ValueObject;
+
+/**
+ * @method string      getProcedureId()
+ * @method array       getAccessMap()
+ * @method string      getStatementId()
+ */
+class StatementViewed extends ValueObject
+{
+    public function __construct(
+        protected string $procedureId,
+        protected array $accessMap,
+        protected string $statementId,
+    ) {
+        $this->lock();
+    }
+}


### PR DESCRIPTION
### Ticket
DPLAN-12660

This change improves export performance by 82% by creating bulk report entries instead of single entries

![image](https://github.com/user-attachments/assets/ed1c3f4e-c52f-452f-a2bf-285a25b71699)
20.9 s → 3.79 s

for the complete export even more
![image](https://github.com/user-attachments/assets/c7b2cf5e-9ba6-4d90-a226-9ab40e6f7338)
12 min 19 s → 23.2 s

### How to review/test
Export statements in ATabelle

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
