### PR TITLE
fix(refs DPLAN-12651): Prevent undefined header fields

### DIFF
--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -149,7 +149,7 @@ export default {
       required: false,
       default: () => [
         { field: 'legalName', label: Translator.trans('invitable_institution') },
-        hasPermission('field_organisation_competence') ? { field: 'competenceDescription', label: Translator.trans('competence.explanation') } : {}
+        ...hasPermission('field_organisation_competence') ? [{ field: 'competenceDescription', label: Translator.trans('competence.explanation') }] : []
       ]
     }
   },


### PR DESCRIPTION
 when permission field_organisation_competence is false, it produced an empty object. in some logic it ws tried to find an attribute field within that object, which lead to an error.

### Ticket
DPLAN-12651
