### PR TITLE
fix (DPLAN-12622) Adjust permission to display button

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
@@ -5,7 +5,7 @@
         procedure is defined and
         procedure is not null and
         (
-                hasPermission('area_statements') or hasPermission('area_admin_assessmenttable')
+                hasPermission('area_statements') or hasPermission('area_public_participation')
         )
     )
 %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/pageheader.html.twig
@@ -5,7 +5,7 @@
         procedure is defined and
         procedure is not null and
         (
-                hasPermission('area_statements') or hasPermission('area_public_participation')
+                hasPermission('area_statements') or hasPermission('area_admin')
         )
     )
 %}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12622/Als-Fachplanung-kann-ich-aus-der-Offentlichkeitsansicht-nicht-zuruck-in-die-Bearbeitungsansicht-navigieren

The button "Verfahren bearbeiten" was initially linked to the `"area_admin_assessmenttable"` permission but is no longer dependent on it. I have decided to use a different permission that better aligns with the button's purpose.

- The `"area_admin_assessmenttable"`permission was originally set using the setProcedurePermissions method for ownsProcedure (see: demosplan/DemosPlanCoreBundle/Permissions/Permissions.php:528).
- With the removal of the assessment table, this permission has been eliminated from the core and shifted to projects that still use the assesment table.
- Since `"area_admin_assessmenttable"` permission  will eventually be deprecated along with the assessment table, I explored other permissions.
- I identified `"area_public_participation`" as a suitable alternative. This permission "controls access to a procedure's public details."
- I thought about creating a new permission called `"statement_list"` to replicate the old function. However, since EWM works fine without it, I didnt see the need.
- Thus, the `"area_public_participation"` permission was chosen as the most fitting option.

### How to review/test
- Login as Walter West
- Go to diplanrog, check any Verfahren
- Click on Öffentlichkeit/Institutions-Ansicht
- You should see the Public details page of the Verfahren
- Then you should see a button on the right "Verfahren bearbeiten" click on it and it will take you to the Verfahren
- Do the same with blp for example (as I removed the old permission, then this will impact the other projects) 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
