### PR TITLE
Revert "Adjust File name in pdf export"

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/export_assessment_table_entry.tex.twig
@@ -58,11 +58,7 @@
     {% if statement.element.title is defined and statement.element.title != '' %} & {{ "document"|trans }}: & {{ statement.element.title|latex|raw }}{% if statement.document is defined and statement.document.title != '' %} / {{ statement.document.title|latex|raw }} {% endif %} \\ {% endif %}
     {% if statement.paragraph.title is defined and statement.paragraph.title != '' %} & {{ "paragraph"|trans }}:  & {{ statement.paragraph.title|latex|raw }}\\{% endif %}
     {% for attachment in statement.attachments %} & {{ "attachment.original"|trans }}: & {{ attachment.file.filename|latex|raw }}\\{% endfor %}
-    {% if statement.files|default([])|length > 0 %}
-        {% for file in statement.files %}
-            & {{ "file"|trans }}: & {{ '{' }}{{ file|getFile('name')|replace({'_': '\_'})|latex|raw }}{{ '}' }}\\
-        {% endfor %}
-    {% endif %}
+    {% if statement.files|default([])|length > 0 %}{% for file in statement.files %} & {{ "file"|trans }}: & {{ file|getFile('name')|latex|raw }}\\{% endfor %}{% endif %}
     {% block priority %} {% endblock %}
     {% block caseworker %} {% endblock %}
   			\hline

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/pdfexport.tex.twig
@@ -26,8 +26,6 @@
 \usepackage{{ '{' }}textcomp{{ '}' }}
 \usepackage{{ '{' }}pifont{{ '}' }}
 \usepackage{{ '{' }}titlesec{{ '}' }}
-\usepackage[hyphens]{url} % breakurl
-\usepackage{underscore}    % If underscores are common in filenames
 \PassOptionsToPackage{{ '{' }}hyphens{{ '}' }}{{ '{' }}url{{ '}' }}\usepackage[hidelinks]{{ '{' }}hyperref{{ '}' }}
 \usepackage{{ '{' }}breakurl{{ '}' }}
 \DeclareUnicodeCharacter{00A0}{ }


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-2197

Reverts demos-europe/demosplan-core#3772
There are missing latex packages at suse. This fix isn't needed for the current release, therefore it can be postponed.