### PR TITLE
Remove a permission that give institute coordinator to vote

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -355,7 +355,6 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
                 'area_manage_orgadata',  // Daten der Organisation
                 'area_mydata_organisation',  // Daten der Organisation
                 'feature_admin_export_procedure',  // Verfahren exportieren
-                'feature_statements_vote_may_vote',
             ]);
         }
 

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -124,7 +124,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
         ProcedureAccessEvaluator $procedureAccessEvaluator,
         private ProcedureRepository $procedureRepository,
         private readonly ValidatorInterface $validator,
-        private readonly AccessControlService $accessControlPermission
+        private readonly AccessControlService $accessControlPermission,
     ) {
         $this->addonPermissionInitializers = $addonRegistry->getPermissionInitializers();
         $this->globalConfig = $globalConfig;

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -3082,7 +3082,7 @@ class PermissionsTest extends FunctionalTestCase
         bool $ownsProcedure,
         bool $isMember,
         array $allowedPermissions,
-        array $disallowedPermissions
+        array $disallowedPermissions,
     ): void {
         // do debug a specific permission enable debugging and paste dataset name
         $debugPermission = false;

--- a/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
+++ b/tests/backend/core/Core/Unit/Logic/PermissionsTest.php
@@ -1665,7 +1665,6 @@ class PermissionsTest extends FunctionalTestCase
                     'feature_procedure_single_document_upload_zip',
                     'feature_procedure_sort_location',
                     'feature_procedure_sort_orga_name',
-                    'feature_statements_vote_may_vote',
                     'field_statement_recommendation',
                 ],
                 'featuresDenied'                    => [
@@ -1723,6 +1722,7 @@ class PermissionsTest extends FunctionalTestCase
                     'feature_statement_data_input_orga',
                     'feature_statement_gdpr_consent',
                     'feature_statement_gdpr_consent_submit',
+                    'feature_statements_vote_may_vote',
                     'feature_statement_to_entire_document',
                     'feature_statements_participation_area_always_citizen',
                     'feature_statements_represent_orga',


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12679/Insti-KO-kann-eine-Stellungnahme-von-eine-Privat-Person-mitzeichnen


Description: Institution Cordinator should not have access to vote statement in every Project (base on conversation with PO), Therefor we can remove this permission for this role from core

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
