### PR TITLE
f DPLAN-12677 flush statement without container file while copying:

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -519,7 +519,15 @@ class StatementCopier extends CoreService
         }
         // persist to get an ID for the FileContainer copying below
         $this->getDoctrine()->getManager()->persist($newStatement);
-        $this->statementService->addFilesToCopiedStatement($newStatement, $statement->getId());
+        if ([] !== $statement->getFiles()) {
+            $this->statementService->addFilesToCopiedStatement($newStatement, $statement->getId());
+
+            return $newStatement;
+        }
+
+        // We do have to flush the new copied statement here if the original statement has no FileContainers otherwise
+        // the new copied statement is already flushed while copying FileContainers in the previous method 'addFilesToCopiedStatement'.
+        $this->getDoctrine()->getManager()->flush();
 
         return $newStatement;
     }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12677

Description:

Replacement for https://github.com/demos-europe/demosplan-core/pull/3862 with release as target branch.

We do have to flush the new copied statement here if the original statement has no FileContainers otherwise the new copied statement is already flushed while copying FileContainers in the previous method 'addFilesToCopiedStatement'.


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly