### PR TITLE
B dplan 12666 remove stats permission

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -413,9 +413,11 @@ class DemosPlanProcedureController extends BaseController
 
         // collect for each status their priority aggregations
         // therefore several Elasticsearch requests needs to be fired
-        if (!$permissions->hasPermission('feature_statements_statistic_state_and_priority')) {
+        // Permission 'area_statement_segmentation' is required for the "Splitting statement box" in the dashboard.
+        if (!$permissions->hasPermissions(['feature_statements_statistic_state_and_priority', 'area_statement_segmentation'], 'OR')) {
             return null;
         }
+
 
         $statementStatusData = [];
         // generate a statementStatusData item for each statement status

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -418,7 +418,6 @@ class DemosPlanProcedureController extends BaseController
             return null;
         }
 
-
         $statementStatusData = [];
         // generate a statementStatusData item for each statement status
         foreach ($statementStatuses as $statusKey => $statusLabel) {


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12666/Alte-Informationen-auf-Ubersichtsseite-sollen-bei-EWM-Integration-entfernt-werden

The stats in the Procedure Page are displayed based on this permission feature_statements_statistic_state_and_priority
Due the MVP also having stats (the ones that are in EWM), we do not need the old ones.

### How to review/test
Go to a details page of Verfahren and the old stats should not be there

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [x ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
