### PR TITLE
f DPLAN-12711 adjust statement intern id length

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/10/Version20241022180950.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/10/Version20241022180950.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -21,9 +31,7 @@ class Version20241022180950 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-
         $this->addSql('ALTER TABLE _statement CHANGE _st_intern_id _st_intern_id CHAR(255)');
-
     }
 
     /**
@@ -33,9 +41,7 @@ class Version20241022180950 extends AbstractMigration
     {
         $this->abortIfNotMysql();
 
-
         $this->addSql('ALTER TABLE _statement CHANGE _st_intern_id _st_intern_id CHAR(35)');
-
     }
 
     /**
@@ -44,7 +50,7 @@ class Version20241022180950 extends AbstractMigration
     private function abortIfNotMysql(): void
     {
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
             "Migration can only be executed safely on 'mysql'."
         );
     }

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/10/Version20241022180950.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2024/10/Version20241022180950.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20241022180950 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-12711 : adjust statement intern id length';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+
+        $this->addSql('ALTER TABLE _statement CHANGE _st_intern_id _st_intern_id CHAR(255)');
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+
+        $this->addSql('ALTER TABLE _statement CHANGE _st_intern_id _st_intern_id CHAR(35)');
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -197,9 +197,9 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      *
      * @var string|null
      *
-     * @ORM\Column(name="_st_intern_id", type="string", length=35, nullable=true, options={"fixed":true, "comment":"manuelle Eingangsnummer"})
+     * @ORM\Column(name="_st_intern_id", type="string", length=255, nullable=true, options={"fixed":true, "comment":"manuelle Eingangsnummer"})
      */
-    #[Assert\Length(max: 35)]
+    #[Assert\Length(max: 255)]
     protected $internId;
 
     /**


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12711/Eingangsnummer-Lange-muss-angepasst-werden


Description: The input/entry number length can have a maximum of 35 characters but it can be sometimes too long, that' why it has to be adjusted

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

