### PR TITLE
fix(refs DPLAN-12672): rename datacy hook

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_original_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_original_statements.html.twig
@@ -20,7 +20,7 @@
             {
             href: path(path, { procedureId: procedureId }),
             label:  'statement.new'|trans,
-            datacy: 'listStatements:statementNew',
+            datacy: 'createStatement',
             icon: 'fa-plus',
             feature: permission
             }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -20,7 +20,7 @@
                 {
                     href: path(path, { procedureId: procedureId }),
                     label:  'statement.new'|trans,
-                    datacy: 'listStatements:statementNew',
+                    datacy: 'createStatement',
                     icon: 'fa-plus',
                     feature: permission
                 }


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12672


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The hook in the statement list should be changed back to `createStatement` as that is how it is used in cypress tests already (and the original statement list should have the same hook).

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [x] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
