### PR TITLE
feat (DPLAN-12714): show link to public view

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementListController.php
@@ -53,6 +53,7 @@ class StatementListController extends BaseController
             '@DemosPlanCore/DemosPlanStatement/list_statements.html.twig',
             [
                 'procedureId'    => $procedureId,
+                'procedure'      => $procedureId, // legacy twig code in twigs
                 'title'          => 'statements',
                 'templateVars'   => [
                     'isSourceAndCoupledProcedure' => $isSourceAndCoupledProcedure,
@@ -88,6 +89,7 @@ class StatementListController extends BaseController
             '@DemosPlanCore/DemosPlanStatement/list_original_statements.html.twig',
             [
                 'procedureId' => $procedureId,
+                'procedure'      => $procedureId, // legacy twig code in twigs
                 'title'       => 'statements.original',
             ]
         );


### PR DESCRIPTION
### Ticket
[DPLAN-12714](https://demoseurope.youtrack.cloud/issue/DPLAN-12714/Keine-Verlinkung-zu-Offentlichkeitsansicht-Institutionsansicht-in-STN-Liste-und-Original-STN-Liste)

This PR sends the procedureId as procedureId and procedure to the twig files for statement and original statement list to match legacy naming in base twig file.

### How to review/test
code review. check the interface if the link is back

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
