### PR TITLE
fix(refs DPLAN-12740): Get correct Getter "tags"

### DIFF
--- a/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
+++ b/client/js/components/statement/assessmentTable/DetailView/DetailView.vue
@@ -141,7 +141,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('AssessmentTable', ['counties', 'municipalities', 'priorityAreas', 'tag'])
+    ...mapGetters('AssessmentTable', ['counties', 'municipalities', 'priorityAreas', 'tags'])
   },
 
   methods: {


### PR DESCRIPTION
### Ticket
DPLAN-12740

ADO 21091

For whatever reason the call for the getter "tags" was changed to "tag". But it has to stay tags
