### PR TITLE
F dplan 12618 check if one layer al least is available

### DIFF
--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -137,6 +137,7 @@
         <h3 class="mt-4">
           {{ Translator.trans('map.bases') }}
         </h3>
+        <h5>{{ Translator.trans('info.gislayer.delete') }}</h5>
         <!-- List-Head -->
         <div class="color--grey mb-1 mt-2 mr-2">
           <div class="c-at-item__row-icon pl-0">

--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -137,7 +137,9 @@
         <h3 class="mt-4">
           {{ Translator.trans('map.bases') }}
         </h3>
-        <h5>{{ Translator.trans('info.gislayer.delete') }}</h5>
+        <h5 v-if="hasPermission('feature_map_required')">
+          {{ Translator.trans('info.gislayer.delete') }}
+        </h5>
         <!-- List-Head -->
         <div class="color--grey mb-1 mt-2 mr-2">
           <div class="c-at-item__row-icon pl-0">

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1133,6 +1133,12 @@ feature_map_attribution:
     expose: true
     loginRequired: true
     parent: area_admin_map
+feature_map_required:
+    description: "this permission will be enabled in projects where a procedure had to have at least one layer, that's means
+    that users will not be able to delete the last layer of a procedure."
+    label: check if one layer is available
+    expose: true
+    loginRequired: true
 feature_map_baselayer:
     description: |-
         Enables the usage of custom baselayers (next to the overlays) in the map

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\GisLayerInterface;
 use DemosEurope\DemosplanAddon\EntityPath\Paths;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
+use demosplan\DemosPlanCoreBundle\Repository\GisLayerCategoryRepository;
 use EDT\PathBuilding\End;
 
 /**
@@ -66,6 +68,11 @@ use EDT\PathBuilding\End;
  */
 final class GisLayerResourceType extends DplanResourceType
 {
+
+    public function __construct(private readonly GisLayerCategoryRepository $gisLayerCategoryRepository)
+    {
+    }
+
     public static function getName(): string
     {
         return 'GisLayer';
@@ -88,6 +95,15 @@ final class GisLayerResourceType extends DplanResourceType
 
     public function isDeleteAllowed(): bool
     {
+        if ($this->currentUser->hasPermission('area_map_participation_area')) {
+            $currentProcedure = $this->currentProcedureService->getProcedure();
+            $rootCategory = $this->gisLayerCategoryRepository->getRootLayerCategory($currentProcedure->getId());
+            $gislayer = $rootCategory->getGisLayers();
+            $baseGislayer = $gislayer->filter(fn (GisLayerInterface $gisLayer) => $gisLayer->getType() === 'base');
+
+            return $this->hasManagementPermission() && (count($baseGislayer) > 1);
+        }
+
         return $this->hasManagementPermission();
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/GisLayerResourceType.php
@@ -100,6 +100,9 @@ final class GisLayerResourceType extends DplanResourceType
             $rootCategory = $this->gisLayerCategoryRepository->getRootLayerCategory($currentProcedure->getId());
             $gislayer = $rootCategory->getGisLayers();
             $baseGislayer = $gislayer->filter(fn (GisLayerInterface $gisLayer) => $gisLayer->getType() === 'base');
+            if (1 === count($baseGislayer)) {
+                $this->messageBag->add('error', 'mindestens eine Grundkarte muss vorhanden sein');
+            }
 
             return $this->hasManagementPermission() && (count($baseGislayer) > 1);
         }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2126,6 +2126,7 @@ map.base.url: "URL der Grundkarte"
 map.base.url.hint: "Geben Sie hier die Web-Adresse für einen Web-Map-Service (WMS) ein. Die in der Adresse angegebene Kartenebene wird auf der Startseite als Grundkarte angezeigt. Die Kartenebene muss die Projektion EPSG:3857 (Web Mercator) unterstützen."
 map.base.settings.preview: "Hier können Sie prüfen, ob die URL und Layer Eingaben korrekt sind"
 map.bases: "Grundkarten"
+info.gislayer.delete: " Hinweis: mindestens eine Grundkarte musste vorhanden sein"
 map.base.minimap: "Übersichtskarte"
 map.base.minimap.hint: "Legen Sie hier eine eigene Kartenebene für die Übersichtskarte fest. Sie können aus den eingerichteten Grundkarten wählen. Standardmäßig wird die aktuell sichtbare Grundkarte genutzt."
 # uhuh...

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2126,7 +2126,7 @@ map.base.url: "URL der Grundkarte"
 map.base.url.hint: "Geben Sie hier die Web-Adresse für einen Web-Map-Service (WMS) ein. Die in der Adresse angegebene Kartenebene wird auf der Startseite als Grundkarte angezeigt. Die Kartenebene muss die Projektion EPSG:3857 (Web Mercator) unterstützen."
 map.base.settings.preview: "Hier können Sie prüfen, ob die URL und Layer Eingaben korrekt sind"
 map.bases: "Grundkarten"
-info.gislayer.delete: " Hinweis: mindestens eine Grundkarte musste vorhanden sein"
+info.gislayer.delete: " Hinweis: mindestens eine Grundkarte muss vorhanden sein"
 map.base.minimap: "Übersichtskarte"
 map.base.minimap.hint: "Legen Sie hier eine eigene Kartenebene für die Übersichtskarte fest. Sie können aus den eingerichteten Grundkarten wählen. Standardmäßig wird die aktuell sichtbare Grundkarte genutzt."
 # uhuh...


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12618/Es-muss-immer-ein-Gis-Dienst-hinterlegt-sein-dieser-muss-aber-nicht-zwingend-die-Basemap-sein

Description: in some projects, a procedure had to have at least one layer, that's means that users supposed not be able to all existing layers. The resource type is adjusted in this pr to check and make sure that users can not anymore delete all layers and introduce a new permission that will be only used in projects where procedure had to have at least one layer.

Note:  we don't have in this case a bulk delete that's why this approach cover not that.

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

