### PR TITLE
fix(refs  dplan-12767): Make create statement work again

### DIFF
--- a/client/js/components/assessmenttable/DpNewStatement.vue
+++ b/client/js/components/assessmenttable/DpNewStatement.vue
@@ -126,6 +126,12 @@ export default {
       required: false,
       type: Array,
       default: () => []
+    },
+
+    usedInternIdsPattern: {
+      required: false,
+      type: Array,
+      default: () => []
     }
   },
 
@@ -174,11 +180,23 @@ export default {
         return this.procedurePhases({
           internal: true,
           external: false
+        }).map(el => {
+          return {
+            ...el,
+            value: el.key,
+            label: el.name
+          }
         })
       } else {
         return this.procedurePhases({
           internal: false,
           external: true
+        }).map(el => {
+          return {
+            ...el,
+            value: el.key,
+            label: el.name
+          }
         })
       }
     }
@@ -230,8 +248,9 @@ export default {
     },
 
     setPhaseValue (value) {
+      console.log('setPhaseValue', value)
       if (value) {
-        this.values.phase = value
+        this.values.phase = this.phases.find(el => el.value === value)
       }
     },
 

--- a/client/js/components/assessmenttable/DpNewStatement.vue
+++ b/client/js/components/assessmenttable/DpNewStatement.vue
@@ -248,7 +248,6 @@ export default {
     },
 
     setPhaseValue (value) {
-      console.log('setPhaseValue', value)
       if (value) {
         this.values.phase = this.phases.find(el => el.value === value)
       }

--- a/client/js/components/button/BackToTopButton.vue
+++ b/client/js/components/button/BackToTopButton.vue
@@ -1,7 +1,7 @@
 <template>
   <dp-button
     class="sticky z-above-zero"
-    :class="{ 'sr-only': hide }"
+    :class="{ 'sr-only border-none p-0': hide }"
     hide-text
     icon="arrow-up"
     icon-size="large"
@@ -17,7 +17,7 @@
 import { DpButton } from '@demos-europe/demosplan-ui'
 
 export default {
-  name: 'DpBackToTop',
+  name: 'BackToTop',
 
   components: {
     DpButton

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -342,7 +342,7 @@ export default {
      */
 
     updateFilterHash (state, value) {
-      set(state, 'filterHash', value)
+      state.filterHash = value
     },
 
     updatePagination (state, value) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
@@ -24,6 +24,11 @@
     {% endfor %}
     {% set participationGuestOnly = templateVars.table.procedure.procedureBehaviorDefinition.participationGuestOnly ? true : false %}
 
+    {% set usedInternIds = [] %}
+    {% if hasPermission('field_statement_intern_id') %}
+        {% set usedInternIds = templateVars.table.usedInternIds|default([]) %}
+    {% endif %}
+
     <dp-new-statement
         inline-template
         procedure-id="{{ templateVars.table.procedure.ident }}"
@@ -37,6 +42,7 @@
         :request-municipalities="JSON.parse('{{ app.request.get('r_municipalities')|default([])|json_encode|e('js', 'utf-8') }}')"
         :request-counties="JSON.parse('{{ app.request.get('r_counties')|default([])|json_encode|e('js', 'utf-8') }}')"
         :request-priority-areas="JSON.parse('{{ app.request.get('r_priorityAreas')|default([])|json_encode|e('js', 'utf-8') }}')"
+        used-intern-ids-pattern="{{ usedInternIds|length > 0 ? '^(?!(?:' ~ usedInternIds|join('|') ~ '+)$)[0-9a-zA-Z-_ ]{1,}$' : '^[0-9a-zA-Z-_ ]{1,}$' }}"
     >
         <form
             id="bpform"
@@ -47,6 +53,7 @@
             novalidate
             data-dp-validate="newStatementForm"
         >
+            {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
             <input type="hidden" name="r_ident" value="{{ templateVars.table.procedure.ident }}">
             <input type="hidden" name="r_action" value="new">
 
@@ -182,11 +189,6 @@
                             {% endfor %}
                         {% endif %}
 
-                        {% set usedInternIds = [] %}
-                        {% if hasPermission('field_statement_intern_id') %}
-                            {% set usedInternIds = templateVars.table.usedInternIds|default([]) %}
-                        {% endif %}
-
                         <div class="layout u-mb-0_75">
                             <div class="u-1-of-4 layout__item">
                                 <dp-label
@@ -242,7 +244,7 @@
                                     }"
                                     name="r_internId"
                                     data-cy="submitterForm:internId"
-                                    pattern="{{ usedInternIds|length > 0 ? '^(?!(?:' ~ usedInternIds|join('|') ~ '+)$)[0-9a-zA-Z-_ ]{1,}$' : '^[0-9a-zA-Z-_ ]{1,}$' }}"
+                                    :pattern="usedInternIdsPattern"
                                     value="{{ app.request.get('r_internId') }}">
                                 </dp-input>
                                 <p
@@ -258,35 +260,26 @@
                     {# depending on which option is selected in the role radio, internal or external phases are displayed
                        - unless only external phases should be displayed here in the project
                      #}
-                    {% if hasPermission('field_statement_phase') %}
-                        <div class="layout u-mb-0_75">
-                            <div class="u-1-of-2 layout__item">
-                                <label class="o-form__label">
-                                    {{ "procedure.public.phase"|trans }}*
-                                </label>
-                                <dp-multiselect
-                                    class="o-form__control-wrapper"
-                                    data-cy="submitterForm:procedurePublicPhase"
-                                    label="name"
-                                    :options="phases"
-                                    required
-                                    track-by="key"
-                                    :value="values.phase"
-                                    @input="setPhaseValue">
-                                    <template v-slot:option="{ props }">
-                                        <span
-                                            class="weight--normal"
-                                            :data-cy="`procedurePublicPhase-${props.option.name.replace(/\s+/g, '-').toLowerCase()}`">
-                                            {% verbatim %}{{ props.option.name }}{% endverbatim %}
-                                        </span>
-                                    </template>
-                                </dp-multiselect>
-                                <input type="hidden" :value="values.phase.key" name="r_phase"/>
-                            </div>
+                    <div
+                        v-if="hasPermission('field_statement_phase')"
+                        class="layout u-mb-0_75">
+                        <div class="u-1-of-2 layout__item">
+                            <dp-select
+                                class="o-form__control-wrapper"
+                                data-cy="submitterForm:procedurePublicPhase"
+                                :label="{
+                                    text: Translator.trans('procedure.public.phase')
+                                }"
+                                :options="phases"
+                                required
+                                :selected="values.phase.key"
+                                @select="setPhaseValue">
+                            </dp-select>
+                            <input type="hidden" :value="values.phase.key" name="r_phase"/>
                         </div>
-                    {% endif %}
+                    </div>
 
-                    {% if hasPermission('feature_statement_cluster') %}
+                    <template v-if="hasPermission('feature_statement_cluster')">
                         {% set clusters = [] %}
                         {% if templateVars.table.procedure.clusterStatements is defined %}
                             {% for key, clusterStatement in templateVars.table.procedure.clusterStatements %}
@@ -310,26 +303,27 @@
                             :ignore-last-claimed="true"
                             :key="'cluster_' + values.headStatement"
                         ></dp-select-statement-cluster>
-                    {% endif %}
+                    </template>
 
-                    {% if hasPermission('field_procedure_elements') %}
-                        <label class="o-form__label">
-                            {{ "plandocument"|trans }}
-                        </label>
-                        <dp-multiselect
-                            v-model="values.element"
-                            class="o-form__control-wrapper u-mb-0_75"
-                            label="title"
-                            data-cy="submitterForm:elements"
-                            :options="elements"
-                            track-by="id"
-                            @input="checkForParagraphsAndFiles()">
-                            <template v-slot:option="{ props }">
-                                {% verbatim %}{{ props.option.title }}{% endverbatim %}
-                            </template>
-                        </dp-multiselect>
-                        <input type="hidden" :value="values.element.id" name="r_element"/>
-                    {% endif %}
+
+                    <label
+                        v-if="hasPermission('field_procedure_elements')"
+                        class="o-form__label">
+                        {{ "plandocument"|trans }}
+                    </label>
+                    <dp-multiselect
+                        v-model="values.element"
+                        class="o-form__control-wrapper u-mb-0_75"
+                        label="title"
+                        data-cy="submitterForm:elements"
+                        :options="elements"
+                        track-by="id"
+                        @input="checkForParagraphsAndFiles()">
+                        <template v-slot:option="{ props }">
+                            {% verbatim %}{{ props.option.title }}{% endverbatim %}
+                        </template>
+                    </dp-multiselect>
+                    <input type="hidden" :value="values.element.id" name="r_element"/>
 
                     {% if hasPermission('field_procedure_paragraphs') %}
                         <template v-if="elementHasParagraphs">


### PR DESCRIPTION
### Ticket
DPLAN-12767

This is part of the Vue3 Migration https://github.com/demos-europe/demosplan-core/pull/1151

The validation for a dropdown (dpmultiselect used as single select) didn't work. So I decided to swap it with a  simple dpSelect. For that the datastructure had to be changed a little 