### PR TITLE
chore: any functional user needs a default orga

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
@@ -19,7 +19,6 @@ class AiApiUser extends FunctionalUser
 
     public function __construct()
     {
-
         $this->id = self::AI_API_USER_ID;
         $this->login = self::AI_API_USER_LOGIN;
 
@@ -31,6 +30,4 @@ class AiApiUser extends FunctionalUser
 
         parent::__construct();
     }
-
-
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AiApiUser.php
@@ -23,8 +23,6 @@ class AiApiUser extends FunctionalUser
         $this->id = self::AI_API_USER_ID;
         $this->login = self::AI_API_USER_LOGIN;
 
-        $this->setDefaultOrgaDepartment();
-
         $role = new Role();
         $role->setCode(RoleInterface::API_AI_COMMUNICATOR);
         $role->setGroupCode(RoleInterface::GAICOM);

--- a/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
@@ -15,9 +15,6 @@ use RuntimeException;
 
 class AnonymousUser extends FunctionalUser
 {
-    /**
-     * {@inheritdoc}
-     */
     public function __construct()
     {
         $this->id = self::ANONYMOUS_USER_ID;
@@ -33,9 +30,6 @@ class AnonymousUser extends FunctionalUser
         parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getDraftStatementSubmissionReminderEnabled(): bool
     {
         return false;
@@ -43,7 +37,7 @@ class AnonymousUser extends FunctionalUser
 
     public function setDplanroles(
         array $roles,
-        $customer = null
+        $customer = null,
     ): void {
         if (null === $this->dplanRoles || 0 === $this->dplanRoles->count()) {
             parent::setDplanroles($roles, $customer);

--- a/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/AnonymousUser.php
@@ -23,7 +23,6 @@ class AnonymousUser extends FunctionalUser
         $this->id = self::ANONYMOUS_USER_ID;
         $this->login = self::ANONYMOUS_USER_LOGIN;
         $this->lastname = self::ANONYMOUS_USER_NAME;
-        $this->setDefaultOrgaDepartment();
 
         $role = new Role();
         $role->setCode(RoleInterface::GUEST);

--- a/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
@@ -44,6 +44,7 @@ class FunctionalUser extends User
             self::FUNCTIONAL_USER_CUSTOMER_NAME,
             self::FUNCTIONAL_USER_CUSTOMER_SUBDOMAIN
         );
+        $this->setDefaultOrgaDepartment();
 
         parent::__construct();
     }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/FunctionalUser.php
@@ -84,7 +84,7 @@ class FunctionalUser extends User
     /**
      * Has to be overridden to ignore the customer.
      */
-    public function getDplanroles(CustomerInterface $customer = null): Collection
+    public function getDplanroles(?CustomerInterface $customer = null): Collection
     {
         return $this->dplanRoles;
     }
@@ -97,7 +97,7 @@ class FunctionalUser extends User
      */
     public function setDplanroles(
         array $roles,
-        $customer = null
+        $customer = null,
     ): void {
         $this->dplanRoles = new ArrayCollection();
 


### PR DESCRIPTION
As any functional user needs a default orga this might be called in the parent class and might be overridden by `setDefaultOrgaDepartment()`


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
run `bin/project dplan:frontend:integrator`

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
