### PR TITLE
fix(refs dplan-12776): Make TS-Components mount

### DIFF
--- a/client/js/InitVue.js
+++ b/client/js/InitVue.js
@@ -94,7 +94,7 @@ function initialize (components = {}, storeModules = {}, apiStoreModules = [], p
 
     Object.keys(components).forEach(comp => {
       if (components[comp]) {
-        app.component(components[comp].name, components[comp])
+        app.component(comp, components[comp])
       } else {
         console.log(`${components[comp]} is undefined}`, components)
       }


### PR DESCRIPTION
It looks like the name of the components for written in TS is not accessible like before. So we have to put the name straight away which is even cleaner imho

### Ticket
DPLAN-12776


Part of the vue3-Migration DPLAN-12315 
https://github.com/demos-europe/demosplan-core/pull/1151
