### PR TITLE
chore: remove deprecated xss_protection

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -43,9 +43,6 @@ nelmio_security:
     content_type:
         nosniff: true
 
-    xss_protection:
-        enabled: true
-        mode_block: true
 
     # Send a full URL in the `Referer` header when performing a same-origin request,
     # only send the origin of the document to secure destination (HTTPS->HTTPS),


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/17164

Ancient IE XSS Protection has been deprecated and needs to be removed https://github.com/nelmio/NelmioSecurityBundle/pull/342

Since nelmio/security-bundle 3.4.0: The "xss_protection" option is deprecated, use Content Security Policy without allowing "unsafe-inline" scripts instead.

### How to review/test
Deprecation should be gone

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
