### PR TITLE
deprecation: octal numbers needs to be prefixed

### DIFF
--- a/config/packages/exercise_html_purifier.yaml
+++ b/config/packages/exercise_html_purifier.yaml
@@ -3,7 +3,7 @@ exercise_html_purifier:
     html_profiles:
         default:
             config:
-                Cache.SerializerPermissions: 0777
+                Cache.SerializerPermissions: 0o777
                 # the charset used by the original contents
                 Core.Encoding: 'UTF-8'
                 # full configuration reference: http://htmlpurifier.org/live/configdoc/plain.html


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/17164

Since symfony/yaml 5.1: Support for parsing numbers prefixed with 0 as octal numbers. They will be parsed as strings as of 6.0. Use "0o777" to represent the octal number.

### How to review/test
reload page, deprecation should be gone

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
