### PR TITLE
fix(refs dplan-12776): Remove Email Boilerplates in Customer Settings Update mail

### DIFF
--- a/client/js/bundles/user/customersettingsmail.js
+++ b/client/js/bundles/user/customersettingsmail.js
@@ -10,26 +10,16 @@
 /**
  * This is the entrypoint for customer_settings_update_mail.html.twig
  */
-import { DpLabel, dpValidate, hasPermission } from '@demos-europe/demosplan-ui'
-import BoilerplatesStore from '@DpJs/store/procedure/Boilerplates'
-import { defineAsyncComponent } from 'vue'
-import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
+import { DpEditor, DpLabel, DpInput, dpValidate, } from '@demos-europe/demosplan-ui'
 import { initialize } from '@DpJs/InitVue'
 
 const components = {
   DpLabel,
-  DpEditor: defineAsyncComponent(async () => {
-    const { DpEditor } = await import('@demos-europe/demosplan-ui')
-    return DpEditor
-  })
+  DpInput,
+  DpEditor
 }
 
 const stores = {}
-
-if (hasPermission('area_admin_boilerplates')) {
-  stores.boilerplates = BoilerplatesStore
-  components.DpBoilerPlateModal = DpBoilerPlateModal
-}
 
 initialize(components, stores).then(() => {
   dpValidate()

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -47,7 +47,7 @@ class DemosPlanCustomerController extends BaseController
         EntityWrapperFactory $wrapperFactory,
         PrefilledResourceTypeProvider $resourceTypeProvider,
         TranslatorInterface $translator,
-        RouterInterface $router
+        RouterInterface $router,
     ): Response {
         try {
             // Using a resource instead of the unrestricted entity is done here to easily notice
@@ -94,7 +94,7 @@ class DemosPlanCustomerController extends BaseController
         CustomerHandler $customerHandler,
         Request $request,
         FileUploadService $fileUploadService,
-        FileService $fileService
+        FileService $fileService,
     ): Response {
         try {
             $messageBag = $this->getMessageBag();
@@ -136,7 +136,7 @@ class DemosPlanCustomerController extends BaseController
         MailService $mailService,
         Request $request,
         TranslatorInterface $translator,
-        UserService $userService
+        UserService $userService,
     ): Response {
         $templateVars = [];
         $vars = [];

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -129,7 +129,7 @@ class DemosPlanCustomerController extends BaseController
      *
      * @throws MessageBagException
      */
-    #[Route(path: '/einstellungen/plattform/send/mail', methods: ['GET', 'POST'], name: 'dplan_customer_mail_send_all_users')]
+    #[Route(path: '/einstellungen/plattform/send/mail', methods: ['GET', 'POST'], name: 'dplan_customer_mail_send_all_users', options: ['expose' => true])]
     public function sendMailToAllCustomersAction(
         CustomerHandler $customerHandler,
         HTMLSanitizer $HTMLSanitizer,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/customer_settings_update_mail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/customer_settings_update_mail.html.twig
@@ -1,10 +1,10 @@
 {% extends '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 
-
 {% block component_part %}
+    {% set urlBase = 'https://' ~ app.request.host %}
 
     <form
-        action="{{ path('dplan_customer_mail_send_all_users') }}"
+        :action="Routing.generate('dplan_customer_mail_send_all_users')"
         method="post"
         data-dp-validate>
         {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
@@ -17,26 +17,16 @@
             </legend>
 
             <p>{{ 'customer.settings.update.mail.help'|trans }}</p>
-            {% set urlBase = 'https://' ~ app.request.host %}
 
-            {{ uiComponent('form.row', {
-                elements: [
-                    {
-                        label: { text: 'subject'|trans },
-                        control: {
-                            name: 'r_email_subject',
-                            attributes: [
-                                'data-cy=customerSettingsMail:emailSubject',
-                                'maxlength=78'
-                            ]
-                        },
-                        id: 'r_email_subject',
-                        type: 'text',
-                        required: true,
-                        value: 'customer.settings.update.mail.default.subject'|trans
-                    }
-                ]
-            }) }}
+            <dp-input
+                :label="{ text: Translator.trans('subject') }"
+                id="r_email_subject"
+                data-cy="customerSettingsMail:emailSubject"
+                maxlength="78"
+                name="r_email_subject"
+                required
+                :value="Translator.trans('customer.settings.update.mail.default.subject')"
+            />
 
             <div class="{{ 'u-mb-0_75'|prefixClass }}">
                 <dp-label
@@ -52,25 +42,6 @@
                     }"
                     required
                     value="{{ 'customer.settings.update.mail.default.text'|trans({ termsOfUseUrl: urlBase ~ path('DemosPlan_misccontent_static_terms'), dataProtectionUrl: urlBase ~ path('DemosPlan_misccontent_static_dataprotection') }) }}">
-                    <template v-slot:modal="modalProps">
-                        <dp-boiler-plate-modal
-                            v-if="hasPermission('area_admin_boilerplates')"
-                            ref="boilerPlateModal"
-                            boiler-plate-type="email"
-                            procedure-id="{{ procedure }}"
-                            @insert="text => modalProps.handleInsertText(text)">
-                        </dp-boiler-plate-modal>
-                    </template>
-                    <template v-slot:button>
-                        <button
-                            v-if="hasPermission('area_admin_boilerplates')"
-                            class="{{ 'menubar__button'|prefixClass }}"
-                            type="button"
-                            v-tooltip="'{{ 'boilerplate.insert'|trans }}'"
-                            @click.stop="$refs.boilerPlateModal.toggleModal()">
-                            <i class="{{ 'fa fa-puzzle-piece'|prefixClass }}"></i>
-                        </button>
-                    </template>
                 </dp-editor>
             </div>
 


### PR DESCRIPTION
since we are not in a procedure, we can't have a procedureId which is required by the boilerplate component.
An Error Occured only in dev-mode. Bit also in prod-Mode no Boilerplates where shown, So we can remove the code.

On my way I moved something closer to vue


### Ticket
DPLAN-12776

