### PR TITLE
fix(refs f_BEAA2-10) update to demosplan-addon v0.43

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "cebe/php-openapi": "^1.5",
         "cocur/slugify": "^4.0",
         "composer/package-versions-deprecated": "1.11.99.5",
-        "demos-europe/demosplan-addon": "0.42",
+        "demos-europe/demosplan-addon": "0.43",
         "doctrine/annotations": "^2.0",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0ea86649f596543f87db71c5e75ff71",
+    "content-hash": "eb2576c9b0dbb4625594a3803d63c922",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1548,16 +1548,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.42",
+            "version": "v0.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "401f160d477cf77f8b0ffcce9063a24f3d626dd5"
+                "reference": "4328e44cf7db6e853e90271416f8f47916671b9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/401f160d477cf77f8b0ffcce9063a24f3d626dd5",
-                "reference": "401f160d477cf77f8b0ffcce9063a24f3d626dd5",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/4328e44cf7db6e853e90271416f8f47916671b9c",
+                "reference": "4328e44cf7db6e853e90271416f8f47916671b9c",
                 "shasum": ""
             },
             "require": {
@@ -1622,9 +1622,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.42"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.43"
             },
-            "time": "2024-10-25T13:26:47+00:00"
+            "time": "2024-11-04T11:21:49+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/config/services.yml
+++ b/config/services.yml
@@ -192,6 +192,9 @@ services:
     DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface:
         class: demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure
 
+    DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface:
+        class: demosplan\DemosPlanCoreBundle\Entity\User\Orga
+
     DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface:
         class: demosplan\DemosPlanCoreBundle\Entity\Statement\Segment
 


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/BEAA2-10/AP-1-Schnittstellenumsetzung-zwischen-DiPlanBeteiligung-und-mein.berlin.de

Description:
Update Demosplan-Addon to v0.43 to include an OrgaResourceTypeInterface

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
