### PR TITLE
fix(refs dplan-12775): Move customerBranding logic to Store

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettings.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettings.vue
@@ -21,7 +21,6 @@
         is-open
         :title="Translator.trans('customer.branding.label')">
         <customer-settings-branding
-          :branding="branding"
           :branding-id="customerBrandingId"
           @saveBrandingUpdate="fetchCustomerData" />
       </customer-settings-section>
@@ -331,10 +330,6 @@ export default {
 
   data () {
     return {
-      branding: {
-        cssvars: '',
-        logoHash: ''
-      },
       customer: {
         accessibilityExplanation: '',
         dataProtection: '',
@@ -412,17 +407,13 @@ export default {
       this.fetchCustomer(payload)
         .then(res => {
           // Update fields
-          const response = res.data
           const currentCustomer = this.customerList[this.currentCustomerId]
           const currentData = currentCustomer.attributes
-          const fileId = response.file ? Object.keys(response.file).toString() : ''
-          const fileHash = response.file ? response.file[fileId]?.attributes?.hash : ''
 
           this.customer = {
             ...this.customer,
             ...currentData
           }
-          this.branding.logoHash = fileHash
         })
         .catch(err => {
           console.error(err)
@@ -445,7 +436,7 @@ export default {
 
       if (hasPermission('feature_customer_branding_edit')) {
         this.requestIncludes.push('branding')
-        this.addAttributesToField('Branding', ['cssvars'])
+        this.addAttributesToField('Branding', ['cssvars', 'styling'])
         this.addAttributesToField('Customer', ['branding'])
       }
 

--- a/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
@@ -126,7 +126,6 @@ export default {
         return this.brandingList[this.brandingId].attributes || { styling: '', logoHash: null }
       },
       set ({ key, value }) {
-        console.log('set', key, value)
         this.updateBranding({
           ...this.brandingList[this.brandingId],
           attributes: {
@@ -204,8 +203,6 @@ export default {
           }
         }
       }
-
-      console.log('saveBrandingSettings', payload)
 
       this.updateBranding(payload)
       this.saveBranding(this.brandingId).then(() => {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/BrandingResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/BrandingResourceType.php
@@ -49,6 +49,7 @@ class BrandingResourceType extends DplanResourceType
         if ($this->currentUser->hasPermission('feature_customer_branding_edit')) {
             $properties[] = $this->createAttribute($this->styling)
                 ->updatable([$customerCondition])
+                ->readable()
                 ->aliasedPath(Paths::branding()->cssvars);
         }
 


### PR DESCRIPTION
it always was supposed to work like so
and it makes more sense.
Now we don't have to pass the data to the component anymore.

Before it worked, but it was'nt possible to save styling-changes if no img where present.

As Support goto customer-settings page and try to change the styling without an uploaded image


### Ticket
DPLAN-12775
