### PR TITLE
chore (refs AB#17164): remove unused unmaintained symfony/inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,6 @@
         "symfony/form": "5.*.*",
         "symfony/http-client": "5.*.*",
         "symfony/http-foundation": "5.*.*",
-        "symfony/inflector": "5.*.*",
         "symfony/intl": "5.*.*",
         "symfony/mailer": "5.*.*",
         "symfony/mime": "5.*.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84a497bec703f934acc104931b729bdc",
+    "content-hash": "8d06344b4251cd304361e03fe3a20e27",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -14290,79 +14290,6 @@
             "time": "2024-10-27T12:51:44+00:00"
         },
         {
-            "name": "symfony/inflector",
-            "version": "v5.4.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/inflector.git",
-                "reference": "9acefb9d8017fd3382e1723bdb06132246b9cead"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/inflector/zipball/9acefb9d8017fd3382e1723bdb06132246b9cead",
-                "reference": "9acefb9d8017fd3382e1723bdb06132246b9cead",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/string": "^5.4.41|^6.4.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Inflector\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Converts words between their singular and plural forms (English only)",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "inflection",
-                "pluralize",
-                "singularize",
-                "string",
-                "symfony",
-                "words"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/inflector/tree/v5.4.45"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "EnglishInflector from the String component",
-            "time": "2024-09-25T14:11:13+00:00"
-        },
-        {
             "name": "symfony/intl",
             "version": "v5.4.45",
             "source": {
@@ -23803,5 +23730,5 @@
     "platform-overrides": {
         "php": "8.1.12"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -869,9 +869,6 @@
     "symfony/http-kernel": {
         "version": "v4.4.29"
     },
-    "symfony/inflector": {
-        "version": "v4.4.27"
-    },
     "symfony/intl": {
         "version": "v5.3.4"
     },


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/17164

symfony/inflector is not used any more by the code and is unmaintained. It could be deleted entirely

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
