### PR TITLE
chore: switch to new ProcedureDeleter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -98,7 +98,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         QueryProcedure $esQueryProcedure,
         ServiceOutput $serviceOutput,
         ServiceStorage $serviceStorage,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         parent::__construct($messageBag);
         $this->contentService = $contentService;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -92,6 +92,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         private readonly OrgaService $orgaService,
         private readonly PermissionsInterface $permissions,
         private readonly PrepareReportFromProcedureService $prepareReportFromProcedureService,
+        private readonly ProcedureDeleter $procedureDeleter,
         private readonly ProcedureService $procedureService,
         PublicAffairsAgentHandler $publicAffairsAgentHandler,
         QueryProcedure $esQueryProcedure,
@@ -655,7 +656,9 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         foreach ($this->procedureService->getDeletedProcedures($limit) as $deletedProcedure) {
             $procedureId = $deletedProcedure->getId();
             try {
-                $this->procedureService->purgeProcedure($procedureId);
+                $this->procedureDeleter->beginTransactionAndDisableForeignKeyChecks();
+                $this->procedureDeleter->deleteProcedures([$procedureId], false);
+                $this->procedureDeleter->commitTransactionAndEnableForeignKeyChecks();
                 ++$proceduresPurged;
             } catch (Exception $e) {
                 $this->logger->warning("Delete Procedure '$procedureId' failed", [$e]);


### PR DESCRIPTION
The maintenance command should use the new and more reliable ProcedureDeleter that is used and tested in the procedure delete command as well.

### How to review/test
Delete procedures and purge them via maintenance command

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
