### PR TITLE
fix(refs DPLAN-12814): Get Projection per Layer in Public Detail

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -228,6 +228,7 @@ const LayersStore = {
             'mapOrder',
             'name',
             'opacity',
+            'projectionLabel',
             'treeOrder',
             'url',
             'visibilityGroupId'


### PR DESCRIPTION
### Ticket
DPLAN-12814

The Layer didn't know in which projection it was saved, so the request defaulted to the map projection. To fix that, the field in the api request had to be added.