### PR TITLE
fix(refs DPLAN-12699): Don't request Municipalities if not enabled

### DIFF
--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -510,7 +510,7 @@ export default {
         fields.County = 'name'
       }
 
-      if (hasAnyPermissions(['field_statement_municipality', 'area_admin_assessmenttable'])) {
+      if (hasPermission('field_statement_municipality')) {
         includes.push('municipalities')
         statementFields.push('municipalities')
         fields.Municipality = 'name'
@@ -865,7 +865,6 @@ export default {
             'elements',
             'files',
             'fragmentsElements',
-            'municipalities',
             'paragraph',
             'priorityAreas',
             'tags'


### PR DESCRIPTION
### Ticket
DPLAN-12699

This issue is related to the statement-List/a-table refactoring [i_T35963_integrate_project_features](https://github.com/demos-europe/demosplan-core/tree/i_T35963_integrate_project_features)

As FPA goto A-Table -> Table should load.

Adjust permission-Check that municipalities only get requested if they are present. 

May be untestable because an Pagerfanta update crashes the a-table atm.

