### PR TITLE
feat (DPLAN-12809): wrap feature in permission

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -802,6 +802,11 @@ feature_customer_xplanning_edit:
     label: 'Permission to edit a xplanning page'
     loginRequired: true
     parent: area_main_xplanning
+feature_data_in_export:
+    description: 'This permission allows to configure which data of the statement should be included in the export.'
+    expose: true
+    label: 'Allow to configure which data of the statement should be included in the export.'
+    loginRequired: true
 feature_data_protection_text_customized_view:
     description: |-
         Each customer and each organisation has its own small text that is added to the overall text:

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -1095,6 +1095,7 @@
                 {% endif %}
                 {# end wizard item: Verortung des Verfahrens #}
 
+                {% if hasPermission('feature_data_in_export') %}
                 {# wizard item: Daten im Export #}
                 <fieldset
                     name="settingsForm"
@@ -1141,6 +1142,7 @@
                     </button>
                 </fieldset>
                 {# end wizard item: Daten im Export #}
+                {% endif %}
 
                 {# wizard item: Erweiterte Einstellungen #}
                 {% if hasPermission('feature_statement_notify_counties') %}


### PR DESCRIPTION
### Ticket
[DPLAN-12809](https://demoseurope.youtrack.cloud/issue/DPLAN-12809/Daten-im-Export-entfernen)

This PR adds a permission to enable or not enable the feature to configure which data will be used in export.

### How to review/test
code review, test interface in projects

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
