### PR TITLE
feat (DPLAN-12730): show original attachment link

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -90,7 +90,7 @@
               <template v-if="statement">
                 <div class="overflow-x-scroll break-words max-h-13 max-w-14 w-max">
 
-                  <span class="block weight--bold">{{ Translator.trans('original.pdf') }}</span>
+                  <span v-if="originalAttachment.hash" class="block weight--bold">{{ Translator.trans('original.pdf') }}</span>
                   <statement-meta-attachments-link
                     v-if="originalAttachment.hash"
                     class="block whitespace-normal u-mr-0_75"

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -90,9 +90,9 @@
               <template v-if="statement">
                 <div class="overflow-x-scroll break-words max-h-13 max-w-14 w-max">
 
-                  <span v-if="hasPermission('area_admin_import')" class="block weight--bold">{{ Translator.trans('original.pdf') }}</span>
+                  <span class="block weight--bold">{{ Translator.trans('original.pdf') }}</span>
                   <statement-meta-attachments-link
-                    v-if="originalAttachment.hash && hasPermission('area_admin_import')"
+                    v-if="originalAttachment.hash"
                     class="block whitespace-normal u-mr-0_75"
                     :attachment="originalAttachment"
                     :procedure-id="procedure.id" />


### PR DESCRIPTION
### Ticket
[DPLAN-12730](https://demoseurope.youtrack.cloud/issue/DPLAN-12730/Original-STN-Anhang-wird-in-Detailansicht-nicht-angezeigt
)

I removed this permission check to show original attachment link. Do you think we need a permission check here? If yes, maybe we need a new permission, because the previous one is not suitable anymore.

### How to review/test
code review, check link in interface

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
