### PR TITLE
bug(refs DPLAN-1967): Add min height (3793)

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -106,7 +106,7 @@
           data-cy="segment:imgModal"/>
         <dp-data-table
           ref="dataTable"
-          class="overflow-x-auto pb-3"
+          class="overflow-x-auto pb-3 min-h-12"
           :class="{ 'px-2 overflow-y-scroll grow': isFullscreen, 'scrollbar-none': !isFullscreen }"
           data-cy="segmentsList"
           has-flyout


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12460/Bei-Abschnittsliste-mit-wenigen-Eintragen-sind-nach-Klick-auf-drei-Punkte-die-Optionen-abgeschnitten

This PR is a cherry pick from https://github.com/demos-europe/demosplan-core/pull/3793 to add this bugfix to the deployment branch. I have overseen that this fix is missing for the deployment branch it is relevant for.

(cherry picked from commit 878698f01aa917edced7b27b2b4527efc1718973)

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly