### PR TITLE
B dplan 12817 fix icons in plan drawing view

### DIFF
--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -321,80 +321,80 @@ export default {
 
       if (this.isActive) {
         if (this.hasSettingsThatPreventGrouping) {
-          return 'fa-lock color--grey cursor-help'
+          return 'fa fa-lock color--grey cursor-help'
         } else if (this.hasGroupId) {
           if (toggleMyIconInSameGroup && this.currentGroupSize <= 2) {
-            return 'fa-unlink color-highlight'
+            return 'fa fa-unlink color-highlight'
           } else {
             if (toggleMyIconWithoutGroup) {
-              return 'fa-link cursor-default color-highlight'
+              return 'fa fa-link cursor-default color-highlight'
             } else {
-              return 'fa-link color--grey cursor-default'
+              return 'fa fa-link color--grey cursor-default'
             }
           }
         } else {
           if (this.isHovered === false && toggleMyIconWithoutGroup) {
-            return 'fa-link color-highlight'
+            return 'fa fa-link color-highlight'
           } else {
-            return 'fa-unlink color--grey'
+            return 'fa fa-unlink color--grey'
           }
         }
       }
 
       if (this.isHovered && this.thereIsAnActiveElement === false) {
         if (this.hasSettingsThatPreventGrouping) {
-          return 'fa-lock color--grey cursor-help'
+          return 'fa fa-lock color--grey cursor-help'
         }
         if (this.hasGroupId) {
           if (this.showCurrentIconState) {
-            return 'fa-unlink color-highlight'
+            return 'fa fa-unlink color-highlight'
           } else {
-            return 'fa-link color--grey'
+            return 'fa fa-link color--grey'
           }
         } else {
           if (this.showCurrentIconState) {
-            return 'fa-link color-highlight'
+            return 'fa fa-link color-highlight'
           } else {
-            return 'fa-unlink  color-highlight cursor-default'
+            return 'fa fa-unlink  color-highlight cursor-default'
           }
         }
       }
 
       if (this.isLinkedWithCurrentlyHovered && this.thereIsAnActiveElement === false) {
-        return 'fa-link color--grey cursor-default'
+        return 'fa fa-link color--grey cursor-default'
       }
 
       if (this.isHovered && this.thereIsAnActiveElement === true) {
         if (this.hasSettingsThatPreventGrouping || this.hasDifferentDefaultVisibility || this.isInAnotherGroupThatsNotEmpty) {
-          return 'fa-lock color--grey cursor-help'
+          return 'fa fa-lock color--grey cursor-help'
         }
         if (this.hasGroupId) {
           if (this.showCurrentIconState) {
-            return 'fa-unlink color-highlight'
+            return 'fa fa-unlink color-highlight'
           } else {
-            return 'fa-link color--grey'
+            return 'fa fa-link color--grey'
           }
         } else {
           if (this.showCurrentIconState) {
-            return 'fa-link color-highlight'
+            return 'fa fa-link color-highlight'
           } else {
-            return 'fa-unlink color--grey cursor-default'
+            return 'fa fa-unlink color--grey cursor-default'
           }
         }
       }
 
       if (this.thereIsAnActiveElement) {
         if (this.hasSettingsThatPreventGrouping || this.hasDifferentDefaultVisibility || this.isInAnotherGroupThatsNotEmpty) {
-          return 'fa-lock color--grey'
+          return 'fa fa-lock color--grey'
         } else {
           if (this.hasGroupId) {
             if (toggleMyIconWithoutGroup) {
-              return 'fa-link cursor-default color-highlight'
+              return 'fa fa-link cursor-default color-highlight'
             } else {
-              return 'fa-link color--grey cursor-default'
+              return 'fa fa-link color--grey cursor-default'
             }
           } else {
-            return 'fa-unlink color--grey cursor-default'
+            return 'fa fa-unlink color--grey cursor-default'
           }
         }
       }

--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -93,6 +93,7 @@
         <a
           v-if="layer.attributes.isBaseLayer === false && isChildOfCategoryThatAppearsAsLayer === false"
           data-cy="adminLayerListItem:toggleVisibilityGroup"
+          class="w-full flex items-center justify-center"
           :title="hintTextForLockedLayer"
           @click.stop.prevent="toggleVisibilityGroup"
           @mouseover="setIconHoverState"


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12817/ROBOBSH-Icons-bei-Kartenebenen-werden-nicht-angezeigt

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR fixes broken icons in the plan drawing view for an overlay. Simply a `fa` class has been missing, which is needed to render the icons correctly. Also to center the icon within its wrapper some flex classes have been added to it.

### How to review/test
- Login as FPA
- navigate to plan drawings settings
- create an overlay
- make sure the icons will be rendered correctly (e.g. when hovering)

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/3982 (fix for the deployment branch)

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
