### PR TITLE
fix(refs dplan-12823): Reset orga form only for editable fields

### DIFF
--- a/client/js/bundles/user/editOrga.js
+++ b/client/js/bundles/user/editOrga.js
@@ -26,23 +26,4 @@ const components = {
 initialize(components).then(() => {
   UrlPreview()
   dpValidate()
-
-  if (hasPermission('feature_change_submission_type')) {
-    const form = document.querySelector('#content form')
-    const orgaId = form.getAttribute('data-orga-id')
-    const precheckSubmit = (e) => {
-      const currentSubmissionType = document.querySelector('input[name="' + orgaId + ':current_submission_type"]').value
-      const selectedSubmissionType = document.querySelector('input[name="' + orgaId + ':submission_type"]:checked').value
-
-      if (currentSubmissionType !== selectedSubmissionType &&
-        !window.dpconfirm(Translator.trans('confirm.statement.orgaedit.change'))) {
-        e.preventDefault()
-        return false
-      }
-
-      return true
-    }
-
-    document.querySelector('#content form [type=submit]').addEventListener('click', precheckSubmit)
-  }
 })

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -305,12 +305,6 @@ export default {
       default: false
     },
 
-    hasPaperCopySection: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-
     projectName: {
       type: String,
       required: true
@@ -363,11 +357,25 @@ export default {
     }
   },
 
+  data () {
+    return {
+      displayCustomer: hasPermission('feature_display_customer_names') && this.customers?.length > 0,
+      displaySlug: hasPermission('feature_orga_slug')
+        && !hasPermission('feature_orga_slug_edit')
+        && this.organisation.currentSlugName !== '',
+      hasPaperCopyPermission: hasPermission('field_organisation_paper_copy') ||
+        hasPermission('field_organisation_paper_copy_spec') ||
+        hasPermission('field_organisation_competence')
+    }
+  },
+
   computed: {
-    displaySlug () {
-      return hasPermission('feature_orga_slug') &&
-        !hasPermission('feature_orga_slug_edit') &&
-        this.organisation.currentSlugName !== ''
+    displayButtons () {
+      return this.isOrgaDataEditable
+        || this.hasPaperCopyPermission
+        || this.hasNotificationSection
+        || this.showDetailedInfo
+        || hasPermission('feature_change_submission_type')
     },
   },
   methods: {

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -28,7 +28,7 @@
         <dp-input
           id="orga_name"
           v-model="organisation.name"
-          class="mb-2"
+          :class="prefixClass('mb-2')"
           data-cy="organisationData:name"
           :name="`${organisation.id}:name`"
           :label="{
@@ -38,11 +38,11 @@
           required />
 
         <!-- Street -->
-        <div class="flex items-start gap-1 mb-2">
+        <div :class="prefixClass('flex items-start gap-1 mb-2')">
           <dp-input
             id="orga_address_street"
             v-model="organisation.street"
-            :class="{ 'w-4': !organisation.street.length }"
+            :class="!organisation.street.length ? prefixClass('w-4') : ''"
             data-cy="organisationData:address:street"
             :name="`${organisation.id}:address_street`"
             :label="{
@@ -65,14 +65,12 @@
         </div>
 
         <!-- Postal Code and City -->
-        <div
-          class="flex items-start gap-1 mb-2"
-          :class="showDetailedInfo ? 'flex-row' : 'flex-col'">
+        <div :class="[prefixClass(showDetailedInfo ? 'flex-row' : 'flex-col'), prefixClass('flex items-start gap-1 mb-2')]">
           <dp-input
             id="orga_address_postalcode"
             v-model="organisation.postalcode"
             data-cy="organisationData:address:postalcode"
-            class="shrink"
+            :class="prefixClass('shrink')"
             :name="`${organisation.id}:address_postalcode`"
             :label="{
               text: Translator.trans('postalcode')
@@ -96,7 +94,7 @@
         <dp-input
           v-if="hasPermission('field_organisation_phone')"
           id="orga_address_phone"
-          class="mb-2"
+          :class="prefixClass('mb-2')"
           v-model="organisation.phone"
           data-cy="organisationData:phone"
           :name="`${organisation.id}:address_phone`"
@@ -109,7 +107,7 @@
         <dp-select
           v-if="hasTypes"
           id="orga_type"
-          class="mb-2"
+          :class="prefixClass('mb-2')"
           data-cy="organisationData:type"
           :name="`${organisation.id}:type`"
           :options="orgaTypes"
@@ -124,15 +122,15 @@
         <div v-if="hasPermission('feature_orga_slug') && hasPermission('feature_orga_slug_edit')">
           <label
             for="orga_slug"
-            class="o-form__label">
+            :class="prefixClass('o-form__label')">
             {{ Translator.trans('organisation.procedurelist.slug') }}
           </label>
-          <small class="lbl_hint block">
+          <small :class="prefixClass('lbl_hint block')">
             {{ Translator.trans('organisation.procedurelist.slug.explanation') }}
           </small>
 
-          <div class="flex flex-row items-center">
-            <span class="color--grey">
+          <div :class="prefixClass('flex flex-row items-center')">
+            <span :class="prefixClass('color--grey')">
               {{ proceduresDirectlinkPrefix }}
             </span>
             <dp-input
@@ -146,7 +144,7 @@
           <div>
             <label
               :for="`${organisation.id}:urlPreview`"
-              class="o-form__label">
+              :class="prefixClass('o-form__label')">
               {{ Translator.trans('preview') }}
             </label>
             <p
@@ -161,24 +159,24 @@
       <template v-if="showDetailedInfo">
         <dl
           v-if="displaySlug || displayCustomer"
-          class="description-list space-stack-s">
+          :class="prefixClass('description-list space-stack-s')">
           <div v-if="displaySlug">
             <dt class="font-semibold">
               {{ Translator.trans('organisation.procedurelist.slug') }}
             </dt>
-            <dd class="color--grey">
+            <dd :class="prefixClass('color--grey')">
               {{ proceduresDirectlinkPrefix }}/{{ organisation.currentSlugName }}
             </dd>
           </div>
 
           <div v-if="displayCustomer">
-            <dt class="font-semibold">
+            <dt :class="prefixClass('font-semibold')">
               {{ Translator.trans('customer', { count: customers.length }) }}
             </dt>
             <dd
               v-for="(customer, index) in customers"
               :key="customer.id"
-              class="color--grey inline">
+              :class="prefixClass('color--grey inline')">
               {{ customer.name }}<span v-if="index < customers.length - 1">, </span>
             </dd>
           </div>
@@ -190,8 +188,8 @@
     <fieldset
       v-if="hasPermission('feature_change_submission_type')"
       id="submissionType"
-      class="w-3/4 mb-2">
-      <legend class="font-size-large weight--normal mb-3">
+      :class="prefixClass('w-3/4 mb-2')">
+      <legend :class="prefixClass('font-size-large weight--normal mb-3')">
         {{ Translator.trans('statement.submission.type') }}
       </legend>
       <input

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -380,6 +380,16 @@ export default {
         return false
       }
     }
+  },
+
+  mounted () {
+    this.$el.querySelectorAll('input[type=text]').forEach((input) => {
+      input.defaultValue = input.value
+    })
+
+    this.$el.querySelectorAll('input[type=radio]').forEach((input) => {
+      input.defaultChecked = input.checked
+    })
   }
 }
 </script>

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -2,7 +2,6 @@
   <form
     :class="prefixClass('u-mt')"
     :action="Routing.generate('DemosPlan_orga_edit_save', { orgaId: organisation.id })"
-    @submit="precheckSubmit"
     method="post"
     data-dp-validate="orgadata">
     <input
@@ -238,9 +237,9 @@
       v-if="displayButtons"
       :class="prefixClass('text-right space-inline-s')">
       <dp-button
-        type="submit"
         data-cy="organisationData:saveButton"
-        :text="Translator.trans('save')" />
+        :text="Translator.trans('save')"
+        @click="handleSubmit" />
 
       <dp-button
         type="reset"
@@ -375,14 +374,16 @@ export default {
     },
   },
   methods: {
-    precheckSubmit (e) {
+    handleSubmit () {
       if (hasPermission('feature_change_submission_type')
         && this.organisation.submissionType === this.submissionTypeShort
         && !window.dpconfirm(Translator.trans('confirm.statement.orgaedit.change'))) {
-        e.preventDefault()
 
+        this.$el.reset()
         return false
       }
+
+      this.$el.submit()
     }
   },
 

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -226,13 +226,11 @@
       :organisation="organisation"
       :user="user"
       :will-receive-new-statement-notification="willReceiveNewStatementNotification"
-      :has-notification-section="hasNotificationSection">
-    </email-notification-settings>
+      :has-notification-section="hasNotificationSection" />
 
     <paper-copy-preferences
-      v-if="hasPaperCopySection"
-      :organisation="organisation">
-    </paper-copy-preferences>
+      v-if="hasPaperCopyPermission"
+      :organisation="organisation" />
 
     <organisation-branding-settings
       :organisation="organisation"

--- a/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
+++ b/client/js/components/user/orgaDataEntry/OrganisationDataForm.vue
@@ -1,7 +1,26 @@
 <template>
-  <div>
-    <fieldset class="w-3/4">
-      <legend class="font-size-large weight--normal mb-3">
+  <form
+    :class="prefixClass('u-mt')"
+    :action="Routing.generate('DemosPlan_orga_edit_save', { orgaId: organisation.id })"
+    @submit="precheckSubmit"
+    method="post"
+    data-dp-validate="orgadata">
+    <input
+      data-cy="editOrga:organisationId"
+      type="hidden"
+      name="organisation_ident"
+      :value="organisation.id">
+    <input
+      data-cy="editOrga:addressIdent"
+      type="hidden"
+      name="address_ident"
+      :value="organisation.addressId">
+    <input
+      type="hidden"
+      name="_token"
+      :value="csrfToken">
+    <fieldset :class="prefixClass('w-3/4')">
+      <legend :class="prefixClass('font-size-large weight--normal mb-3')">
         {{ Translator.trans('organisation.data') }}
       </legend>
 
@@ -217,13 +236,27 @@
 
     <organisation-branding-settings
       :organisation="organisation"
-      :project-name="projectName">
-    </organisation-branding-settings>
-  </div>
+      :project-name="projectName" />
+
+    <div
+      v-if="displayButtons"
+      :class="prefixClass('text-right space-inline-s')">
+      <dp-button
+        type="submit"
+        data-cy="organisationData:saveButton"
+        :text="Translator.trans('save')" />
+
+      <dp-button
+        type="reset"
+        color="secondary"
+        data-cy="organisationData:abortButton"
+        :text="Translator.trans('reset')" />
+    </div>
+  </form>
 </template>
 
 <script>
-import { DpInput, DpRadio, DpSelect } from '@demos-europe/demosplan-ui'
+import { DpButton, DpInput, DpRadio, DpSelect, prefixClassMixin } from '@demos-europe/demosplan-ui'
 import EmailNotificationSettings from '@DpJs/components/user/orgaDataEntry/EmailNotificationSettings'
 import OrganisationBrandingSettings from '@DpJs/components/user/orgaDataEntry/OrganisationBrandingSettings'
 import PaperCopyPreferences from '@DpJs/components/user/orgaDataEntry/PaperCopyPreferences'
@@ -231,7 +264,10 @@ import PaperCopyPreferences from '@DpJs/components/user/orgaDataEntry/PaperCopyP
 export default {
   name: 'OrganisationDataForm',
 
+  mixins: [prefixClassMixin],
+
   components: {
+    DpButton,
     DpInput,
     DpRadio,
     DpSelect,
@@ -241,6 +277,11 @@ export default {
   },
 
   props: {
+    csrfToken: {
+      type: String,
+      required: true
+    },
+
     customers: {
       type: Array,
       required: false,
@@ -328,9 +369,16 @@ export default {
         !hasPermission('feature_orga_slug_edit') &&
         this.organisation.currentSlugName !== ''
     },
+  },
+  methods: {
+    precheckSubmit (e) {
+      if (hasPermission('feature_change_submission_type')
+        && this.organisation.submissionType === this.submissionTypeShort
+        && !window.dpconfirm(Translator.trans('confirm.statement.orgaedit.change'))) {
+        e.preventDefault()
 
-    displayCustomer () {
-      return hasPermission('feature_display_customer_names') && this.customers?.length
+        return false
+      }
     }
   }
 }

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
@@ -138,7 +138,7 @@ class DemosPlanOrgaController extends BaseController
      *
      * @throws MessageBagException
      */
-    #[Route(name: 'DemosPlan_orga_edit_save', path: '/organisation/edit/{orgaId}', methods: ['POST'])]
+    #[Route(name: 'DemosPlan_orga_edit_save', path: '/organisation/edit/{orgaId}', methods: ['POST'], options: ['expose' => true])]
     public function editOrgaSaveAction(
         CurrentUserService $currentUser,
         EventDispatcherPostInterface $eventDispatcherPost,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/edit_orga.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/edit_orga.html.twig
@@ -12,21 +12,7 @@
 
         {% block content %}
 
-        <form class="{{ 'u-mt'|prefixClass }}" action="{{ path('DemosPlan_orga_edit_save', {'orgaId': organisation.ident|default}) }}" data-orga-id="{{ organisation.ident|default }}" method="post" data-dp-validate="orgadata">
-            <input
-                data-cy="editOrga:organisationIdent"
-                type="hidden"
-                name="organisation_ident"
-                value="{% if organisation is defined %}{{ organisation.ident|default }}{% endif %}">
-            <input
-                data-cy="editOrga:addressIdent"
-                type="hidden"
-                name="address_ident"
-                value="{% if organisation is defined %}{{ organisation.address_ident|default }}{% endif %}">
-            {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
-
             {% include '@DemosPlanCore/DemosPlanUser/orga_data_entry.html.twig' %}
-        </form>
 
         {% endblock content %}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
@@ -57,8 +57,7 @@
         :has-types="Boolean({{ hasTypes }})"
         :user="JSON.parse('{{ userData|json_encode|e('js', 'utf-8') }}')"
         :will-receive-new-statement-notification="Boolean({{ willReceiveNewStatementNotification }})"
-        :has-notification-section="Boolean({{ hasNotificationSection }})"
-        :has-paper-copy-section="Boolean({{ hasPaperCopySection }})">
+        :has-notification-section="Boolean({{ hasNotificationSection }})">
     </organisation-data-form>
 {% endblock content %}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/orga_data_entry.html.twig
@@ -8,6 +8,7 @@
 {% set organisationData = {
     id: organisation.ident|default,
     name: organisation.nameLegal|default,
+    addressId: organisation.address_ident|default,
     street: organisation.street|default,
     houseNumber: organisation.houseNumber|default,
     postalcode: organisation.postalcode|default,
@@ -41,10 +42,10 @@
 {% set showDetailedInfo = true %}
 {% set hasNotificationSection =  true %}
 {% set hasTypes = false %}
-{% set hasPaperCopySection = true %}
 
 {% block content %}
     <organisation-data-form
+        :csrf-token="{{ csrf_token('csrf')|json_encode }}"
         :customers="JSON.parse('{{ customers|default([])|json_encode|e('js', 'utf-8') }}')"
         :is-orga-data-editable="Boolean({{ mayEditOrgaData }})"
         :organisation="JSON.parse('{{ organisationData|default({})|json_encode|e('js', 'utf-8') }}')"
@@ -60,10 +61,3 @@
         :has-notification-section="Boolean({{ hasNotificationSection }})">
     </organisation-data-form>
 {% endblock content %}
-
-{% block buttonRow %}
-    {{ uiComponent('button-row', {
-        primary: uiComponent('button', { type: 'submit' }),
-        secondary: uiComponent('button', { color: 'secondary', type: 'reset' })
-    }) }}
-{% endblock buttonRow %}


### PR DESCRIPTION
### Ticket
DPLAN-12823

On Orga-Edit page (e.g. as FPA)
`/organisation/edit/<orga-id>`

When resetting the page, non-editable should not change (not be cleared)
Other Fields should change to the initial value (not be cleared if there was initial content)


In addition I moved some code. Sorry. That should have been a separate PR. If wanted I can guide through the changes.
The Commits are quite clear to follow.