### PR TITLE
fix(refs f_BEAA2-10) save copyright and alt texts for

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -660,6 +660,8 @@ class DemosPlanProcedureController extends BaseController
                 'r_oldSlug',
                 'r_phase',
                 'r_pictogram',
+                'r_pictogramCopyright',
+                'r_pictogramAltText',
                 'r_procedure_categories',
                 'r_publicParticipation',
                 'r_publicParticipationContact',

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureToLegacyConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureToLegacyConverter.php
@@ -67,6 +67,8 @@ class ProcedureToLegacyConverter extends CoreService
             $procedureArray['phaseObject'] = $this->entityHelper->toArray($procedure->getPhaseObject());
             $procedureArray['publicParticipationPhaseObject'] = $this->entityHelper->toArray($procedure->getPublicParticipationPhaseObject());
             $procedureArray['pictogram'] = $procedureArray['settings']['pictogram'];
+            $procedureArray['pictogramCopyright'] = $procedureArray['settings']['pictogramCopyright'];
+            $procedureArray['pictogramAltText'] = $procedureArray['settings']['pictogramAltText'];
         }
 
         $procedureArray['isMapEnabled'] = false;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -106,7 +106,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         private readonly ProcedureTypeService $procedureTypeService,
         ParameterBagInterface $parameterBag,
         private readonly ReportService $reportService,
-        private readonly TranslatorInterface $translator
+        private readonly TranslatorInterface $translator,
     ) {
         $this->contentService = $contentService;
         $this->customerService = $customerService;
@@ -969,7 +969,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
     protected function checkSwitchDateMandatoryFields(
         $data,
         $fieldsToCheck,
-        $mandatoryErrors
+        $mandatoryErrors,
     ): array {
         $hasMandatoryAutoSwitchError = false;
         foreach ($fieldsToCheck as $fieldToCheck => $fieldTranslationLabel) {
@@ -1002,7 +1002,7 @@ class ServiceStorage implements ProcedureServiceStorageInterface
     protected function checkSwitchDateValidFields(
         string $startDate,
         string $endDate,
-        $mandatoryErrors
+        $mandatoryErrors,
     ) {
         $hasMandatoryAutoSwitchError = false;
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -625,6 +625,12 @@ class ServiceStorage implements ProcedureServiceStorageInterface
             if (array_key_exists('r_deletePictogram', $data)) {
                 $procedure['settings']['pictogram'] = '';
             }
+            if (array_key_exists('r_pictogramCopyright', $data)) {
+                $procedure['settings']['pictogramCopyright'] = $data['r_pictogramCopyright'];
+            }
+            if (array_key_exists('r_pictogramAltText', $data)) {
+                $procedure['settings']['pictogramAltText'] = $data['r_pictogramAltText'];
+            }
         }
 
         // Add exportSettings to procedure

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -915,7 +915,7 @@
                                             :label="{
                                                 text: Translator.trans('procedure.pictogram.copyright')
                                             }"
-                                            name="pictogramCopyright"
+                                            name="r_pictogramCopyright"
                                             value="{{ proceduresettings.pictogramCopyright|default }}"
                                             required>
                                         </dp-input>
@@ -926,7 +926,7 @@
                                             :label="{
                                                 text: Translator.trans('procedure.pictogram.altText')
                                             }"
-                                            name="pictogramAltText"
+                                            name="r_pictogramAltText"
                                             value="{{ proceduresettings.pictogramAltText|default }}"
                                             required>
                                         </dp-input>


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/BEAA2-10/AP-1-Schnittstellenumsetzung-zwischen-DiPlanBeteiligung-und-mein.berlin.de

Description:
procedure setting fields got introduced here: https://github.com/demos-europe/demosplan-core/pull/3889
handle updates containing the newly added procedure-setting fields.
provide these fields for get requests in legacy array format.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
