### PR TITLE
B dplan 12733 fix entity manager closed

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Paragraph.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Paragraph.php
@@ -82,7 +82,7 @@ class Paragraph extends CoreEntity implements UuidEntityInterface, ParagraphInte
     /**
      * @var ElementsInterface
      *
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Document\Elements")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Document\Elements", inversedBy="paragraphs")
      *
      * @ORM\JoinColumn(name="_e_id", referencedColumnName="_e_id", nullable=false, onDelete="CASCADE")
      **/

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
@@ -21,10 +21,15 @@ class DraftStatementFileHandler
     {
     }
 
-    public function getDraftStatementRelatedToThisFile(string $fileString): array
-    {
-        $file = $this->fileService->getFileFromFileString($fileString);
 
+    public function getDraftStatementRelatedToThisFile(string $fileId): array
+
+    {
+        $file = $this->fileService->getFileById($fileId);
+        if (null === $file) {
+            return [];
+        }
         return $this->draftStatementFileRepository->getDraftStatementFilesByFile($file);
     }
+
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
@@ -10,27 +10,21 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
-use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Repository\DraftStatementFileRepository;
-use demosplan\DemosPlanCoreBundle\Repository\DraftStatementRepository;
-use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 
 class DraftStatementFileHandler
 {
-
     public function __construct(
         private readonly FileService $fileService,
-       private readonly DraftStatementFileRepository $draftStatementFileRepository)
+        private readonly DraftStatementFileRepository $draftStatementFileRepository)
     {
     }
-
 
     public function getDraftStatementRelatedToThisFile(string $fileString): array
-
     {
         $file = $this->fileService->getFileFromFileString($fileString);
-       return $this->draftStatementFileRepository->getDraftStatementFilesByFile($file);
-    }
 
+        return $this->draftStatementFileRepository->getDraftStatementFilesByFile($file);
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Logic\FileService;
+use demosplan\DemosPlanCoreBundle\Repository\DraftStatementFileRepository;
+use demosplan\DemosPlanCoreBundle\Repository\DraftStatementRepository;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+
+class DraftStatementFileHandler
+{
+
+    public function __construct(
+        private readonly FileService $fileService,
+       private readonly DraftStatementFileRepository $draftStatementFileRepository)
+    {
+    }
+
+
+    public function getDraftStatementRelatedToThisFile(string $fileString): array
+
+    {
+        $file = $this->fileService->getFileFromFileString($fileString);
+       return $this->draftStatementFileRepository->getDraftStatementFilesByFile($file);
+    }
+
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementFileHandler.php
@@ -21,15 +21,13 @@ class DraftStatementFileHandler
     {
     }
 
-
     public function getDraftStatementRelatedToThisFile(string $fileId): array
-
     {
         $file = $this->fileService->getFileById($fileId);
         if (null === $file) {
             return [];
         }
+
         return $this->draftStatementFileRepository->getDraftStatementFilesByFile($file);
     }
-
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
@@ -22,9 +22,6 @@ use demosplan\DemosPlanCoreBundle\Logic\CoreService;
 use demosplan\DemosPlanCoreBundle\Logic\EntityContentChangeService;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
-use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftStatementFileHandler;
-use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftStatementHandler;
-use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftStatementService;
 use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
@@ -73,7 +70,7 @@ class StatementAnonymizeService extends CoreService
         bool $recursively,
         bool $forceOriginal,
         string $userId,
-        bool $revokeGdpr
+        bool $revokeGdpr,
     ): Statement {
         $statement = $this->forceAnonymizationOfOriginal($forceOriginal, $statement);
         if (null === $statement->getGdprConsent()) {
@@ -181,10 +178,9 @@ class StatementAnonymizeService extends CoreService
 
             if (null === $draftStatements) {
                 $this->fileService->deleteFileFromFileString($fileString); //
-                //we cannot delete the file if it belongs to a draft statement because it means it belongs to a priveate user
-                //this is the line that trigger the error
+                // we cannot delete the file if it belongs to a draft statement because it means it belongs to a priveate user
+                // this is the line that trigger the error
             }
-
         }
         $statement->setFile('');
         $statement->setFiles([]);
@@ -195,6 +191,7 @@ class StatementAnonymizeService extends CoreService
     private function anonymizeText(string $anonymizedTextWithTags): string
     {
         $blackSharpie = '<span class="anonymized">***</span>';
+
         /*
          * (.+?) means:
          * - a group: ()
@@ -420,7 +417,7 @@ class StatementAnonymizeService extends CoreService
         bool $recursively,
         Statement $statement,
         string $userId,
-        bool $revokeGdpr
+        bool $revokeGdpr,
     ): void {
         if ($recursively) {
             /** @var Statement[] $children */

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
@@ -32,7 +32,15 @@ class StatementAnonymizeService extends CoreService
     /** @var string Tag before anonymization, it means: "this still needs to be anonymized!" */
     private const TAG = 'anonymize-text';
 
-    public function __construct(private readonly EntityContentChangeService $entityContentChangeService, private readonly FileService $fileService, private PermissionsInterface $permissions, private readonly ReportService $reportService, private readonly StatementService $statementService, private readonly StatementAttachmentService $statementAttachmentService, private readonly TranslatorInterface $translator, private readonly DraftStatementService $draftStatementService, private readonly DraftStatementHandler $draftStatementHandler, private readonly DraftStatementFileHandler $draftStatementFileHandler)
+    public function __construct(
+        private readonly EntityContentChangeService $entityContentChangeService,
+        private readonly FileService $fileService,
+        private PermissionsInterface $permissions,
+        private readonly ReportService $reportService,
+        private readonly StatementService $statementService,
+        private readonly StatementAttachmentService $statementAttachmentService,
+        private readonly TranslatorInterface $translator,
+        private readonly DraftStatementFileHandler $draftStatementFileHandler)
     {
     }
 
@@ -174,9 +182,9 @@ class StatementAnonymizeService extends CoreService
         foreach ($statement->getFiles() as $fileString) {
             $fileStringParts = explode(':', $fileString);
             $this->fileService->deleteFileContainer($fileStringParts[1], $statement->getId());
-            $draftStatements = $this->draftStatementFileHandler->getDraftStatementRelatedToThisFile($fileString);
+            $draftStatements = $this->draftStatementFileHandler->getDraftStatementRelatedToThisFile($fileStringParts[1]);
 
-            if (null === $draftStatements) {
+            if (0 === sizeof($draftStatements)) {
                 $this->fileService->deleteFileFromFileString($fileString); //
                 // we cannot delete the file if it belongs to a draft statement because it means it belongs to a priveate user
                 // this is the line that trigger the error

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementAnonymizeService.php
@@ -182,12 +182,11 @@ class StatementAnonymizeService extends CoreService
         foreach ($statement->getFiles() as $fileString) {
             $fileStringParts = explode(':', $fileString);
             $this->fileService->deleteFileContainer($fileStringParts[1], $statement->getId());
-            $draftStatements = $this->draftStatementFileHandler->getDraftStatementRelatedToThisFile($fileStringParts[1]);
 
-            if (0 === sizeof($draftStatements)) {
-                $this->fileService->deleteFileFromFileString($fileString); //
-                // we cannot delete the file if it belongs to a draft statement because it means it belongs to a priveate user
-                // this is the line that trigger the error
+            // Do not delete the file if it belongs to a draft statement (private user)
+            $draftStatements = $this->draftStatementFileHandler->getDraftStatementRelatedToThisFile($fileStringParts[1]);
+            if (0 === count($draftStatements)) {
+                $this->fileService->deleteFileFromFileString($fileString);
             }
         }
         $statement->setFile('');

--- a/demosplan/DemosPlanCoreBundle/Repository/DraftStatementFileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/DraftStatementFileRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Repository;
+
+use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
+use demosplan\DemosPlanCoreBundle\Entity\File;
+use demosplan\DemosPlanCoreBundle\Entity\FileContainer;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatementFile;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Repository\IRepository\ObjectInterface;
+use Doctrine\ORM\NoResultException;
+use Exception;
+
+use function collect;
+
+/**
+ * @template-extends FluentRepository<DraftStatementFile>
+ */
+class DraftStatementFileRepository extends FluentRepository
+{
+    public function getDraftStatementFilesByFile(File $file): array
+    {
+        try {
+            $query = $this->getEntityManager()
+                ->createQueryBuilder()
+                ->select('draftStatementFile')
+                ->from(DraftStatementFile::class, 'draftStatementFile')
+                ->where('draftStatementFile.file = :file')
+                ->setParameter('file', $file);
+
+            return $query->getQuery()->getResult();
+        } catch (NoResultException $e) {
+            $this->logger->error('Get DraftStatementFile failed.', [$e]);
+
+            return [];
+        }
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Repository/DraftStatementFileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/DraftStatementFileRepository.php
@@ -12,14 +12,8 @@ namespace demosplan\DemosPlanCoreBundle\Repository;
 
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 use demosplan\DemosPlanCoreBundle\Entity\File;
-use demosplan\DemosPlanCoreBundle\Entity\FileContainer;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatementFile;
-use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
-use demosplan\DemosPlanCoreBundle\Repository\IRepository\ObjectInterface;
 use Doctrine\ORM\NoResultException;
-use Exception;
-
-use function collect;
 
 /**
  * @template-extends FluentRepository<DraftStatementFile>


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12733/Stellungnahme-anonymisieren-Fehler-bei-Loschen-von-Anhangen

- The anonymization of attachments means to delete all attachments of original statement
- If you try to delete all attachments from an original statement created by a private user, an error occurs because the files are linked to the user's draft statement.
- More concrete, the error is: An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`YOUR_PROJECT_DB`.`draft_statement_file`, CONSTRAINT `FK_XXXXXXXXX` FOREIGN KEY (`file_id`) REFERENCES `_files` (`_f_ident`))

### How to review/test
- In order to solve it, this PRs checks if there are draft statements related to the file. If not, then anonymization will proceed to delete the files.
- Create an stn as a private user, and then go as FP admin and select Anhänge der Stellungnahme löschen in the Anonymisierung workflow, it should work
- Create a manual stn, same workflow as before, everything should work as normal 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
