### PR TITLE
fix(refs DPLAN-3217): Double handling the Voters data to make it reac…

### DIFF
--- a/client/js/bundles/procedure/administrationStatementSegmentsList.js
+++ b/client/js/bundles/procedure/administrationStatementSegmentsList.js
@@ -26,8 +26,7 @@ const components = {
 const stores = {
   ProcedureMapSettings: procedureMapSettings,
   SegmentSlidebar,
-  SplitStatement: SplitStatementStore,
-  Voter
+  SplitStatement: SplitStatementStore
 }
 
 if (hasPermission('area_admin_boilerplates')) {


### PR DESCRIPTION
…tive

There is a bug in the vuex-json-api which leads to un-reactive behaviour especially when using the delete mutation. To make it work anyway, we have to hold the voters data within the component too, so it remains reactive here. But we still need the propper state in the store to handle the api requests.

This only has to stay like so until we migrate to vue 3, which is hopefully in the near future

### Ticket
DPLAN-XXXXX
or
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/XXXXX


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
