### PR TITLE
fix(refs f_BEAA2-10) use an existing trans key.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/JsonApiResourceTypeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/JsonApiResourceTypeService.php
@@ -46,7 +46,7 @@ class JsonApiResourceTypeService implements JsonApiResourceTypeServiceInterface
         protected readonly Sorter $sorter,
         protected readonly DqlConditionFactory $conditionFactory,
         protected readonly MessageBagInterface $messageBag,
-        protected readonly EntityManagerInterface $entityManager
+        protected readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/JsonApiResourceTypeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/JsonApiResourceTypeService.php
@@ -81,6 +81,6 @@ class JsonApiResourceTypeService implements JsonApiResourceTypeServiceInterface
      */
     public function addCreationErrorMessage(array $parameters): void
     {
-        $this->messageBag->add('error', 'generic.error');
+        $this->messageBag->add('error', 'error.api.generic');
     }
 }


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/BEAA2-10/AP-1-Schnittstellenumsetzung-zwischen-DiPlanBeteiligung-und-mein.berlin.de

Description:
On create requests there was a messageBag trans key given that was missing.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
