### PR TITLE
getEmailAuthCode can to return null

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -31,7 +31,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
-use LogicException;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface as EmailTwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfiguration;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1825,11 +1825,7 @@ class User implements AddonUserInterface, TotpTwoFactorInterface, EmailTwoFactor
 
     public function getEmailAuthCode(): string
     {
-        if (null === $this->authCode) {
-            throw new LogicException('The email authentication code was not set');
-        }
-
-        return $this->authCode;
+        return $this->authCode ?? '';
     }
 
     public function setEmailAuthCode(string $authCode): void

--- a/tests/backend/core/DemosPlanCoreBundle/Entity/User/SecurityUserTest.php
+++ b/tests/backend/core/DemosPlanCoreBundle/Entity/User/SecurityUserTest.php
@@ -78,6 +78,23 @@ class SecurityUserTest extends TestCase
         $this->assertFalse($securityUser->isLoggedIn());
     }
 
+    public function testGetEmailAuthCode()
+    {
+        $user = new User();
+        $expectedAuthCode = 'someAuthCode';
+
+        // Assuming there is a method to set the auth code
+        $user->setEmailAuthCode($expectedAuthCode);
+
+        $this->assertEquals($expectedAuthCode, $user->getEmailAuthCode());
+    }
+
+    public function testAuthCodeIsNull()
+    {
+        $user = new User();
+        $this->assertNull($user->getEmailAuthCode());
+    }
+
     private function getSecurityUser(array $roles = ['ROLE_ADMIN', 'ROLE_USER']): SecurityUser
     {
         $userMock = $this->createMock(User::class);


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12868


Description: remove logic exception and set return empty string, if Email Auth code is not set. Because in `portal_profile_2fa.html.twig` we need null value, that user can to set 2fa .

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
