### PR TITLE
fix(refs dplan-12874): Request isPrint for layers to allow cheicking against the attr

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -222,6 +222,7 @@ const LayersStore = {
             'isBplan',
             'isEnabled',
             'isMinimap',
+            'isPrint',
             'isScope',
             'layers',
             'layerType',


### PR DESCRIPTION
### Ticket
DPLAN-12874

we need isPrint for the layers in the public detail to determine if we wasnt to show them or not. When we dont get the info, we will show them by default.