### PR TITLE
fix (DPLAN-3217) Name field on StatementVote is option on update

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementVoteResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementVoteResourceType.php
@@ -77,7 +77,7 @@ final class StatementVoteResourceType extends DplanResourceType
                 $statementVote->setLastName($name);
 
                 return [];
-            }, OptionalField::NO)
+            }, OptionalField::YES)
             )
             /* See for more details @link \EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilder::initializable */
             ->addCreationBehavior(


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-3217/ADO-Issue-15115-Integration-EWM-Part-2-Stellungnahmedetailansicht-aus-EWM-und-dplan-vereinen

Name field of statement vote should be optional on update

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
