### PR TITLE
fix(refs DPLAN-12746): use new tooltipOptions prop

### DIFF
--- a/client/js/components/statement/DpBoilerPlate.vue
+++ b/client/js/components/statement/DpBoilerPlate.vue
@@ -14,7 +14,7 @@
       <label class="u-mb-0_5">
         <dp-contextual-help
           class="float-right u-mt-0_125"
-          :text="Translator.trans(tooltipContent)" />
+          :tooltip-options="tooltipOptions" />
         {{ title }}
       </label>
       <dp-multiselect
@@ -111,10 +111,10 @@ export default {
   },
 
   computed: {
-    tooltipContent () {
+    tooltipOptions () {
       return {
-        content: Translator.trans('boilerplates.categories.explanation'),
-        classes: 'z-modal'
+        classes: 'z-modal',
+        content: Translator.trans('boilerplates.categories.explanation')
       }
     }
   },


### PR DESCRIPTION
### Ticket

[DPLAN-12746](https://demoseurope.youtrack.cloud/issue/DPLAN-12746/Hinzufugen-von-Textbaustein-zu-Mitteilung-Invalid-Prop)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The `DpContextualHelp` `text` prop was used to pass an object with v-tooltip options, but it expected a string. In https://github.com/demos-europe/demosplan-ui/pull/1084, a new prop `tooltipOptions` was added that can be used to pass both text and other tooltip options. It is now used here to prevent the console error.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Go to the 'Aktuelles' view and create a new message. Try to add a boilerplate text via the text editor. There should be no error in the console.

### Linked PRs

- [x] https://github.com/demos-europe/demosplan-ui/pull/1084

### Tasks (optional)

- [x] Merge https://github.com/demos-europe/demosplan-ui/pull/1084
- [x] Release new demosplan-ui version

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly