### PR TITLE
build: bump demosplan-ui to v.0.3.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0.3.37",
+    "@demos-europe/demosplan-ui": "^0.3.38",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.2",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,9 +2430,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:^0.3.37":
-  version: 0.3.37
-  resolution: "@demos-europe/demosplan-ui@npm:0.3.37"
+"@demos-europe/demosplan-ui@npm:^0.3.38":
+  version: 0.3.38
+  resolution: "@demos-europe/demosplan-ui@npm:0.3.38"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2507,7 +2507,7 @@ __metadata:
       optional: true
     prosemirror-view:
       optional: true
-  checksum: 10c0/cdb8d4a81779fcc2e1835ad16c4205b9194402b6f7bd6884c0f17c0d54544a38abb130353eb771f0d486559827dedbdb4525824ef3a7b350d10a77445536f273
+  checksum: 10c0/4ca7b42606f9c7a8901ef239a22e28871491964baf23948830a6c959de86df503be0cdee0d6dfbb1bf3d73b61f4acd697adadf2764baf75cba5d52e38e9acdbb
   languageName: node
   linkType: hard
 
@@ -13012,7 +13012,7 @@ __metadata:
     "@babel/plugin-transform-runtime": "npm:^7.25.9"
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
-    "@demos-europe/demosplan-ui": "npm:^0.3.37"
+    "@demos-europe/demosplan-ui": "npm:^0.3.38"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.2"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"


### PR DESCRIPTION

The new demosplan-ui 0.3.x release includes the following fixes:
- allow passing v-tooltip options to `DpContextualHelp` (needed for [DPLAN-12746](https://demoseurope.youtrack.cloud/issue/DPLAN-12746/Hinzufugen-von-Textbaustein-zu-Mitteilung-Invalid-Prop))
- apply 'sr-only' class to `DpLabel` if `hide` prop is set to `true` (needed for [DPLAN-12808](https://demoseurope.youtrack.cloud/issue/DPLAN-12808/Button-verschoben-Einreichende-suchen))
- fix import of `DpUploadFiles` in `DpUploadModal` (needed for [DPLAN-12907](https://demoseurope.youtrack.cloud/issue/DPLAN-12907/Bild-einfugen-nicht-moglich-Erwiderung-verfassen))
- allow setting `DpButton` `type` prop to 'reset' (needed for [DPLAN-12823](https://demoseurope.youtrack.cloud/issue/DPLAN-12823/Nach-dem-zurucksetzen-von-Orgadaten-nicht-mehr-moglich-um-eine-Offizieller-Name-zu-reinschreiben))

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs (optional)
- [ ] https://github.com/demos-europe/demosplan-core/pull/4023
- [ ] https://github.com/demos-europe/demosplan-core/pull/4016
- [x] https://github.com/demos-europe/demosplan-core/pull/3984


### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
