### PR TITLE
fix(refs DPLAN-3217): re-add div for consistent spacing

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaLocationAndDocumentReference.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaLocationAndDocumentReference.vue
@@ -14,7 +14,7 @@
     </div>
 
     <div class="space-y-4">
-      <template v-if="hasPermission('field_statement_polygon')">
+      <div v-if="hasPermission('field_statement_polygon')">
         <template v-if="statement.attributes.polygon">
           <dp-button
             :aria-label="Translator.trans('location.reference_view')"
@@ -29,7 +29,7 @@
         <template v-else>
           -
         </template>
-      </template>
+      </div>
 
       <!-- Document reference -->
       <div


### PR DESCRIPTION
the div is needed when there is no location, because without it there is not enough space between this field and the one below