### PR TITLE
F dplan 12526 add statement quicksave button after ocr text recognition

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -323,6 +323,8 @@
         hidden-input="r_text"
         v-model="values.text" />
 
+      <slot />
+
       <!-- File upload fields -->
       <template v-if="allowFileUpload">
         <dp-label
@@ -473,6 +475,7 @@ export default {
       required: false,
       default: () => ({
         authoredDate: '',
+        quickSave: '',
         submittedDate: '',
         tags: [],
         text: '',
@@ -529,6 +532,7 @@ export default {
       values: {
         authoredDate: '',
         memo: '',
+        quickSave: '',
         submittedDate: '',
         tags: [],
         text: '',
@@ -578,6 +582,7 @@ export default {
   methods: {
     setInitialValues () {
       this.values = { ...this.initValues }
+
       // Set default values to ensure reactivity.
       if (typeof this.values.submitter !== 'undefined' && typeof this.values.submitter.institution === 'undefined') {
         // Since Data sends us the key toeb instead of institution, we need to transform this for now but keep all init values

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3384,6 +3384,7 @@ statement.representation.creation: "Die Stellungnahme im Namen folgender Institu
 statement.save.altered: "Stellungnahme verändert speichern"
 statement.save.as.draft: "Stellungnahme als Entwurf speichern"
 statement.save.immediate: "Stellungnahme direkt einreichen"
+statement.save.quickSave: "Text zwischenspeichern"
 statement.save.text: "Sie haben Änderungen am Text der Stellungnahme vorgenommen. Wenn Sie fortfahren, werden diese ebenfalls gespeichert."
 statement.send.email: "Stellungnahme per E-Mail versenden"
 statement.send.email.label: "Sende unten stehende Stellungnahme an"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12526/3-2-Als-Importerin-mochte-ich-meine-Anpassungen-nach-der-OCR-Texterkennung-zwischenspeichern-konnen-um-sicherzugehen-dass-meine

Description: this changes are picked from https://github.com/demos-europe/demosplan-core/pull/3992