### PR TITLE
feat(refs DPLAN-12916): add function to redirect back to import center

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -376,7 +376,8 @@
         :href="Routing.generate('DemosPlan_procedure_dashboard', { procedure: procedureId })"
         primary
         secondary
-        @primary-action="submit" />
+        @primary-action="submit"
+        @secondary-action="abort" />
     </form>
   </div>
 </template>
@@ -580,6 +581,11 @@ export default {
   },
 
   methods: {
+    abort () {
+      const href = `${Routing.generate('DemosPlan_procedure_import', { procedureId: this.procedureId })}/#import#StatementPdfImport`
+      window.location.replace(href)
+    },
+
     setInitialValues () {
       this.values = { ...this.initValues }
 


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12916/Abbrechen-Button-funktioniert-nicht-im-Schritt-Import-bestatigen-und-auch-im-Schritt-Uberprufen

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR adds a secondary action explicitly for the `DpSimplifiedStatementForm.vue`'s dp-button-row component to redirect the user back to the import center instead of the overview.

- for some reason I still do not understand the `<a>`-tag does not redirect when clicking the secondary button of dp-button-row
- hence a secondary action was added for redirecting back to the import center

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
