### PR TITLE
feat (refs DPLAN-12917): show statement in assessmenttable again

### DIFF
--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -154,9 +154,9 @@ function transformStatementStructure ({ el, includes, meta }) {
           statement[relationKey] = includes.filter(incl => ids.includes(incl.id) && type === incl.type)
           statement[relationKey] = statement[relationKey].map(statementRel => Object.assign(statementRel.attributes, { id: statementRel.id }))
 
-          if (type === 'StatementAttachment' && hasOwnProp(statement[relationKey][0], 'id')) {
+          if (type === 'SourceStatementAttachment' && hasOwnProp(statement[relationKey][0], 'id')) {
             const attachment = includes
-              .filter(incl => incl.type === 'StatementAttachment')
+              .filter(incl => incl.type === 'SourceStatementAttachment')
               .filter(incl => statement[relationKey][0].id === incl.id)
 
             if (hasOwnProp(attachment[0], 'relationships')) {
@@ -606,7 +606,7 @@ export default {
               'parentId',
               'title'
             ].join(),
-            StatementAttachment: [
+            SourceStatementAttachment: [
               'file',
               'attachmentType'
             ].join()


### PR DESCRIPTION
### Ticket
[DPLAN-12917](https://demoseurope.youtrack.cloud/issue/DPLAN-12917/STN-werden-nicht-geladen)

The StatementResourceType was renamed to SourceStatementResourceType and handles the SourceAttachment only. For other attachments the GenericStatementAttachmentResourceType was created.

### How to review/test
code review, maybe more adjustments needed in frontend

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
