### PR TITLE
chore: only load aws s3 sdk api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,6 +184,9 @@
         }
     },
     "extra": {
+      "aws/aws-sdk-php": [
+        "S3"
+      ],
       "bamarni-bin": {
         "bin-links": false,
         "target-directory": "."
@@ -194,6 +197,9 @@
             "allow-contrib": true,
             "require": "5.*.*"
         }
+    },
+    "scripts": {
+      "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices"
     },
     "config": {
         "process-timeout": 600,


### PR DESCRIPTION
The package aws/aws-sdk-php contains a lot of aws apis that are not needed. According to https://github.com/aws/aws-sdk-php/tree/master/src/Script/Composer they can be reduced, which shrinks the size of the dependency (and thus the container) by 45 MB.

### How to review/test
run composer install and check that vendor/aws/aws-sdk-php/src/data contains only a few subfolders (including s3), not 50+

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
