### PR TITLE
fix-DPLAN-12816-retain-layers-preselection-after-saving-or-updating-layers

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapHandler.php
@@ -200,7 +200,7 @@ class MapHandler extends CoreHandler
         // in case of GisLayer is member of visibilityGroup, set incoming defaultVisibility
         // to all member of visibilityGroup
         if (array_key_exists('defaultVisibility', $gisLayerData) && $isMemberOfVisibilityGroup) {
-            $this->setVisibilityOfVisibilityGroup($visibilityGroupId, $gisLayerData['defaultVisibility']);
+            $this->setVisibilityOfVisibilityGroup($visibilityGroupId, $gisLayerData);
         }
 
         // in case of GisLayer is member of visibilityGroup, do not allow to unset userToggleVisibility
@@ -242,10 +242,12 @@ class MapHandler extends CoreHandler
      *
      * @throws Exception
      */
-    public function setVisibilityOfVisibilityGroup($visibilityGroupId, $visibility)
+    public function setVisibilityOfVisibilityGroup($visibilityGroupId, $gisLayerData)
     {
+        $visibility = $gisLayerData['defaultVisibility'];
+        $procedureId = $gisLayerData['procedureId'];
         try {
-            $visibilityGroup = $this->getVisibilityGroup($visibilityGroupId);
+            $visibilityGroup = $this->getVisibilityGroup($visibilityGroupId, $procedureId);
             $doctrineConnection = $this->entityManager->getConnection();
             $doctrineConnection->beginTransaction();
 
@@ -344,9 +346,9 @@ class MapHandler extends CoreHandler
      *
      * @throws Exception
      */
-    public function getVisibilityGroup($visibilityGroupId)
+    public function getVisibilityGroup($visibilityGroupId, $procedureId)
     {
-        return $this->mapService->getVisibilityGroup($visibilityGroupId);
+        return $this->mapService->getVisibilityGroup($visibilityGroupId, $procedureId);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
@@ -717,9 +717,9 @@ class MapService extends CoreService
      *
      * @throws Exception
      */
-    public function getVisibilityGroup($visibilityGroupId)
+    public function getVisibilityGroup($visibilityGroupId, $procedureId)
     {
-        return $this->mapRepository->getByVisibilityGroupId($visibilityGroupId);
+        return $this->mapRepository->getByVisibilityGroupId($visibilityGroupId, $procedureId);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
@@ -215,8 +215,8 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
             $gis->setDefaultVisibility($data['default']);
 
             // set default of all group member
-            if (!is_null($gis->getVisibilityGroupId())) {
-                $gisLayers = $this->getByVisibilityGroupId($gis->getVisibilityGroupId());
+            if (null !== $gis->getVisibilityGroupId() && "" !== $gis->getVisibilityGroupId()) {
+                $gisLayers = $this->getByVisibilityGroupId($gis->getVisibilityGroupId(), $gis->getProcedureId());
                 foreach ($gisLayers as $gisLayer) {
                     $gisLayer->setDefaultVisibility($gis->hasDefaultVisibility());
                     $this->updateObject($gisLayer);
@@ -228,8 +228,8 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
             $gis->setDefaultVisibility($data['defaultVisibility']);
 
             // set default of all group member
-            if (!is_null($gis->getVisibilityGroupId())) {
-                $gisLayers = $this->getByVisibilityGroupId($gis->getVisibilityGroupId());
+            if (null !== $gis->getVisibilityGroupId() && "" !== $gis->getVisibilityGroupId()) {
+                $gisLayers = $this->getByVisibilityGroupId($gis->getVisibilityGroupId(), $gis->getProcedureId());
                 foreach ($gisLayers as $gisLayer) {
                     $gisLayer->setDefaultVisibility($gis->hasDefaultVisibility());
                     $this->updateObject($gisLayer);
@@ -589,8 +589,8 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
         if (array_key_exists('enabled', $data)) {
             $gisLayer->setEnabled($data['enabled']);
 
-            if (!is_null($gisLayer->getVisibilityGroupId())) {
-                $gisLayers = $this->getByVisibilityGroupId($gisLayer->getVisibilityGroupId());
+            if (null !== $gisLayer->getVisibilityGroupId() && "" !== $gisLayer->getVisibilityGroupId()) {
+                $gisLayers = $this->getByVisibilityGroupId($gisLayer->getVisibilityGroupId(), $gisLayer->getProcedureId());
                 foreach ($gisLayers as $gisLayerOfGroup) {
                     $gisLayerOfGroup->setEnabled($gisLayer->getVisible());
                     $this->updateObject($gisLayerOfGroup);
@@ -668,13 +668,17 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
     }
 
     /**
-     * @param string $visibilityGroupId
      *
      * @return GisLayer[]
      */
-    public function getByVisibilityGroupId($visibilityGroupId)
+    public function getByVisibilityGroupId(string $visibilityGroupId, string $procedureId)
     {
-        return $this->findBy(['visibilityGroupId' => $visibilityGroupId]);
+        return $this->findBy(
+            [
+                'visibilityGroupId' => $visibilityGroupId,
+                'procedureId'       => $procedureId,
+            ]
+        );
     }
 
     /**

--- a/tests/backend/core/Map/Functional/MapHandlerTest.php
+++ b/tests/backend/core/Map/Functional/MapHandlerTest.php
@@ -778,20 +778,28 @@ class MapHandlerTest extends FunctionalTestCase
         $gisLayer1 = $this->fixtures->getReference('invisibleGisLayer1');
         /** @var GisLayer $gisLayer2 */
         $gisLayer2 = $this->fixtures->getReference('invisibleGisLayer2');
-        /** @var GisLayer $gisLayer2 */
+
+        // set default visibility of gisLayer1 to true
+        $gisLayer1->setDefaultVisibility(true);
         $visibilityGroupId = $gisLayer1->getVisibilityGroupId();
 
         static::assertEquals($visibilityGroupId, $gisLayer1->getVisibilityGroupId());
         static::assertEquals($visibilityGroupId, $gisLayer2->getVisibilityGroupId());
-        static::assertFalse($gisLayer1->hasDefaultVisibility());
+        static::assertTrue($gisLayer1->hasDefaultVisibility());
         static::assertFalse($gisLayer2->hasDefaultVisibility());
 
-        $successful = $this->sut->setVisibilityOfVisibilityGroup($visibilityGroupId, true);
+        $successful = $this->sut->setVisibilityOfVisibilityGroup(
+            $visibilityGroupId,
+            [
+                'defaultVisibility' => $gisLayer1->hasDefaultVisibility(),
+                'procedureId' => $gisLayer2->getProcedureId()
+            ]
+        );
         static::assertTrue($successful);
 
-        $gisLayer1 = $this->sut->getGisLayer($gisLayer1->getId());
         $gisLayer2 = $this->sut->getGisLayer($gisLayer2->getId());
-        static::assertTrue($gisLayer1->hasDefaultVisibility());
+
+        // default visibility of gisLayer2 was updated via visibilityGroup und has to be true
         static::assertTrue($gisLayer2->hasDefaultVisibility());
     }
 

--- a/tests/backend/core/Map/Functional/MapHandlerTest.php
+++ b/tests/backend/core/Map/Functional/MapHandlerTest.php
@@ -792,7 +792,7 @@ class MapHandlerTest extends FunctionalTestCase
             $visibilityGroupId,
             [
                 'defaultVisibility' => $gisLayer1->hasDefaultVisibility(),
-                'procedureId' => $gisLayer2->getProcedureId()
+                'procedureId'       => $gisLayer2->getProcedureId(),
             ]
         );
         static::assertTrue($successful);


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12816/ROBOBSH-Stage-Basemap-bleibt-nicht-vorausgewahlt-nach-Speichern-neuer-Kartenlayer


Description: 
adjust condition :
- 'VisibilityGroupId' can be null (default value) or can be an empty string. Layers in the same group can be updated only when 'VisibilityGroupId' is not null and has to be not empty too otherwise the layer does not have any group. That's why the condition has to be adjusted to have the expected behavior.
- the 'getVisibilityGroupId' method is adjusted too : we must retrieve only layers that's belong to the current procedure. Using only the 'visibilityGroupId' to get procedure relevant layers leads to have wrong result and updating layers that's does not belong to the current procedure

Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
