### PR TITLE
feat(refs DPLAN-12460): add style to always display flyout properly

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_flyout.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_flyout.scss
@@ -62,6 +62,7 @@
     &.is-expanded {
         .o-flyout__content {
             display: block;
+            position: absolute;
         }
     }
 }


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12460/Bei-Abschnittsliste-mit-wenigen-Eintragen-sind-nach-Klick-auf-drei-Punkte-die-Optionen-abgeschnitten


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This change ensures that the flyout menu is always visible on re-sizable data tables

### Related PRs:
https://github.com/demos-europe/demosplan-ui/pull/1100

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
