### PR TITLE
f DPLAN-12923 use right translation key

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -400,7 +400,7 @@
                                         }]) %}
                                     {% endfor %}
                                     <participation-phases
-                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.internal.evaluating'|trans }) }}"
+                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.internal.analysis'|trans }) }}"
                                         data-cy="internalPhase"
                                         field-name="r_phase"
                                         help-text="{{ 'text.procedure.edit.internal.change_phase'|trans }}"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12923/BOB-SH-SuSe-Code-Bezeichnung-erscheint-im-Beschreibungstext


Description: use 'procedure.phases.internal.analysis' instad 'procedure.phases.internal.evaluating' : the 'procedure.phases.internal.evaluating' does not exist,''procedure.phases.internal.analysis' has to be used for the evaluation phase in the intern phases

Delete the checkbox if it doesn't apply/isn't necessary.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

