### PR TITLE
fix(refs dplan-12315): Send correct data on statement modal edit

### DIFF
--- a/client/js/bundles/core/listDraft.js
+++ b/client/js/bundles/core/listDraft.js
@@ -10,21 +10,23 @@
 /**
  * This is the entrypoint for list_draft.html.twig
  */
-
-import { DpModal, DpUploadFiles, prefixClass } from '@demos-europe/demosplan-ui'
+import { DpButton, DpModal, DpUploadFiles, prefixClass } from '@demos-europe/demosplan-ui'
 import DpMapModal from '@DpJs/components/statement/assessmentTable/DpMapModal'
 import DpPublicDetailNoMap from '@DpJs/components/statement/DpPublicDetailNoMap'
 import DpPublicStatementList from '@DpJs/components/statement/publicStatementLists/DpPublicStatementList'
 import { initialize } from '@DpJs/InitVue'
 import publicStatement from '@DpJs/store/statement/PublicStatement'
 import StatementForm from '@DpJs/lib/statement/StatementForm'
+import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 
 const components = {
+  DpButton,
   DpMapModal,
   DpModal,
   DpPublicDetailNoMap,
   DpPublicStatementList,
-  DpUploadFiles
+  DpUploadFiles,
+  StatementModal
 }
 
 const stores = {

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1416,7 +1416,7 @@ export default {
         r_document_id: data.draftStatement.document?.id ?? '',
         r_document_title: data.draftStatement.document?.title ?? '',
         r_represents: data.draftStatement.represents ?? '',
-        r_location: Object.keys(data.draftStatement.statementAttributes)[0] ?? 'mapLocation',
+        r_location: Object.keys(data.draftStatement.statementAttributes).pop() ?? 'mapLocation',
         r_location_geometry: data.draftStatement.polygon,
         r_location_priority_area_key: priorityAreaKey,
         r_location_priority_area_type: priorityAreaType,

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1067,36 +1067,12 @@ export default {
       })
         .then(checkResponse)
         .then(data => {
-          const priorityAreaKey = data.draftStatement.statementAttributes.priorityAreaKey || ''
-          const priorityAreaType = data.draftStatement.statementAttributes.priorityAreaType || ''
-          const statementFiles = data.draftStatement.files ? JSON.stringify(data.draftStatement.files) : ''
-          const draft = {
-            r_text: data.draftStatement.text,
-            r_files_initial: statementFiles || [],
-            r_ident: this.draftStatementId,
-            r_isNegativeReport: data.draftStatement.negativ ? '1' : '0',
-            r_element_id: data.draftStatement.elementId || '',
-            r_element_title: data.draftStatement.element?.title ?? '',
-            r_paragraph_id: data.draftStatement.paragraphId ?? '',
-            r_paragraph_title: data.draftStatement.paragraph?.title ?? '',
-            r_document_id: data.draftStatement.document?.id ?? '',
-            r_document_title: data.draftStatement.document?.title ?? '',
-            r_represents: data.draftStatement.represents ?? '',
-            r_location: Object.keys(data.draftStatement.statementAttributes)[0] ?? 'mapLocation',
-            r_location_geometry: data.draftStatement.polygon,
-            r_location_priority_area_key: priorityAreaKey,
-            r_location_priority_area_type: priorityAreaType,
-            r_location_point: '',
-            location_is_set: priorityAreaKey.length > 0 ? 'priority_area' : 'geometry',
-            r_county: data.draftStatement.statementAttributes.county ?? '',
-            r_makePublic: !!data.draftStatement.publicAllowed
-          }
-
           this.hasPlanningDocuments = data.hasPlanningDocuments || this.initHasPlanningDocuments
-          if (draft.r_location === 'noLocation') draft.r_location = 'notLocated'
-          if (draft.r_location === 'mapLocation' && data.draftStatement.polygon) draft.r_location = 'point'
 
           if (draftExists === false) {
+            const priorityAreaKey = data.draftStatement.statementAttributes.priorityAreaKey || ''
+            const priorityAreaType = data.draftStatement.statementAttributes.priorityAreaType || ''
+            const draft = this.setDraftData(data, priorityAreaKey, priorityAreaType)
             /*
              * If it is a draft, we set the data from local storage (see above).
              */
@@ -1425,6 +1401,35 @@ export default {
         .then(() => {
           this.isLoading = false
         })
+    },
+
+    setDraftData (data, priorityAreaKey, priorityAreaType) {
+      const draft = {
+        r_text: data.draftStatement.text,
+        r_files_initial: data.draftStatement.files ? JSON.stringify(data.draftStatement.files) : [],
+        r_ident: this.draftStatementId,
+        r_isNegativeReport: data.draftStatement.negativ ? '1' : '0',
+        r_element_id: data.draftStatement.elementId || '',
+        r_element_title: data.draftStatement.element?.title ?? '',
+        r_paragraph_id: data.draftStatement.paragraphId ?? '',
+        r_paragraph_title: data.draftStatement.paragraph?.title ?? '',
+        r_document_id: data.draftStatement.document?.id ?? '',
+        r_document_title: data.draftStatement.document?.title ?? '',
+        r_represents: data.draftStatement.represents ?? '',
+        r_location: Object.keys(data.draftStatement.statementAttributes)[0] ?? 'mapLocation',
+        r_location_geometry: data.draftStatement.polygon,
+        r_location_priority_area_key: priorityAreaKey,
+        r_location_priority_area_type: priorityAreaType,
+        r_location_point: '',
+        location_is_set: priorityAreaKey.length > 0 ? 'priority_area' : 'geometry',
+        r_county: data.draftStatement.statementAttributes.county ?? '',
+        r_makePublic: !!data.draftStatement.publicAllowed
+      }
+
+      if (draft.r_location === 'noLocation') draft.r_location = 'notLocated'
+      if (draft.r_location === 'mapLocation' && data.draftStatement.polygon) draft.r_location = 'point'
+
+      return draft
     },
 
     setPrivacyPreference (data) {

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -620,7 +620,6 @@
             :class="prefixClass('color-highlight')"
             id="statementModalTitle"
             data-title="confirmation"
-            tabindex="0"
             aria-describedby="successConfirmation">
             <i
               :class="prefixClass('fa fa-comment')"
@@ -1071,31 +1070,28 @@ export default {
           const priorityAreaKey = data.draftStatement.statementAttributes.priorityAreaKey || ''
           const priorityAreaType = data.draftStatement.statementAttributes.priorityAreaType || ''
           const statementFiles = data.draftStatement.files ? JSON.stringify(data.draftStatement.files) : ''
-
           const draft = {
             r_text: data.draftStatement.text,
             r_files_initial: statementFiles || [],
             r_ident: this.draftStatementId,
             r_isNegativeReport: data.draftStatement.negativ ? '1' : '0',
             r_element_id: data.draftStatement.elementId || '',
-            r_element_title: !!data.draftStatement.element && !!data.draftStatement.element.title ? data.draftStatement.element.title : '',
-            r_paragraph_id: data.draftStatement.paragraphId || '',
-            r_paragraph_title: !!data.draftStatement.paragraph && !!data.draftStatement.paragraph.title ? data.draftStatement.paragraph.title : '',
-            r_document_id: !!data.draftStatement.document && !!data.draftStatement.document.id ? data.draftStatement.document.id : '',
-            r_document_title: !!data.draftStatement.document && !!data.draftStatement.document.title ? data.draftStatement.document.title : '',
-            r_represents: data.draftStatement.represents !== null ? data.draftStatement.represents : '',
-            r_location: Object.keys(data.draftStatement.statementAttributes).reduce((acc, key) => {
-              acc = key
-              return acc
-            }, 'mapLocation'),
+            r_element_title: data.draftStatement.element?.title ?? '',
+            r_paragraph_id: data.draftStatement.paragraphId ?? '',
+            r_paragraph_title: data.draftStatement.paragraph?.title ?? '',
+            r_document_id: data.draftStatement.document?.id ?? '',
+            r_document_title: data.draftStatement.document?.title ?? '',
+            r_represents: data.draftStatement.represents ?? '',
+            r_location: Object.keys(data.draftStatement.statementAttributes)[0] ?? 'mapLocation',
             r_location_geometry: data.draftStatement.polygon,
             r_location_priority_area_key: priorityAreaKey,
             r_location_priority_area_type: priorityAreaType,
             r_location_point: '',
             location_is_set: priorityAreaKey.length > 0 ? 'priority_area' : 'geometry',
-            r_county: data.draftStatement.statementAttributes.county ? data.draftStatement.statementAttributes.county : '',
+            r_county: data.draftStatement.statementAttributes.county ?? '',
             r_makePublic: !!data.draftStatement.publicAllowed
           }
+
           this.hasPlanningDocuments = data.hasPlanningDocuments || this.initHasPlanningDocuments
           if (draft.r_location === 'noLocation') draft.r_location = 'notLocated'
           if (draft.r_location === 'mapLocation' && data.draftStatement.polygon) draft.r_location = 'point'
@@ -1218,54 +1214,27 @@ export default {
       }
     },
 
-    removeDocumentRelation () {
-      const elementFields = {
-        r_element_id: '',
-        r_element_title: '',
-        r_document_id: '',
-        r_document_title: '',
-        r_paragraph_id: '',
-        r_paragraph_title: ''
-      }
-      this.setStatementData(elementFields)
-    },
-
-    removeNotificationsFromStore () {
-      this.messages.forEach(message => {
-        this.remove(message)
-      })
-    },
-
-    removeUnsavedFile (file) {
-      const indexToRemove = this.unsavedFiles.findIndex(el => el.hash === file.hash)
-      this.unsavedFiles.splice(indexToRemove, 1)
-      this.setStatementData({ uploadedFiles: this.unsavedFiles.map(el => el.hash).join(',') })
-    },
-
-    sendStatement (e, immediateSubmit = false, keepModalOpen = false) {
-      e.preventDefault()
-
-      if (this.validateStatementStep() === false || this.validateRecheckStep() === false) {
-        return
-      }
-
-      this.isLoading = true
-
-      this.setStatementData({ immediate_submit: immediateSubmit })
-      this.setStatementData({ r_loadtime: dayjs().unix() })
-
-      const dataToSend = { ...this.formData }
+    /**
+     * Prepare the data to be sent to the backend
+     * We have to copy the store state because deleting entries is not reactive atm.
+     *
+     * @param formData
+     *
+     * @return {*}
+     */
+    prepareDataToSend (formData) {
+      const dataToSend = { ...formData }
 
       /*
        * If we have no map/county-reference enabled we can't set it as default, because then this would be preselected
        * which we don't want
        */
       if (dataToSend.location_is_set === '') {
-        this.setStatementData({ location_is_set: 'notLocated' })
+        dataToSend.location_is_set = 'notLocated'
       }
 
       if (dataToSend.r_location !== 'county') {
-        this.setStatementData({ r_county: '' })
+        dataToSend.r_county = ''
       }
 
       /*
@@ -1273,16 +1242,14 @@ export default {
        * it can't be preset to prevent the radio options from being preselected
        */
       if (dataToSend.r_submitter_role === '') {
-        this.setStatementData({ r_submitter_role: 'citizen' })
+        dataToSend.r_submitter_role = 'citizen'
       }
 
       if (dataToSend.r_location !== 'point') {
-        this.setStatementData({
-          r_location_point: '',
-          r_location_priority_area_key: '',
-          r_location_priority_area_type: '',
-          r_location_geometry: ''
-        })
+        dataToSend.r_location_point = ''
+        dataToSend.r_location_priority_area_key = ''
+        dataToSend.r_location_priority_area_type = ''
+        dataToSend.r_location_geometry = ''
       }
 
       /*
@@ -1313,14 +1280,60 @@ export default {
         delete dataToSend.r_email
       }
 
+      return dataToSend
+    },
+
+    removeDocumentRelation () {
+      const elementFields = {
+        r_element_id: '',
+        r_element_title: '',
+        r_document_id: '',
+        r_document_title: '',
+        r_paragraph_id: '',
+        r_paragraph_title: ''
+      }
+
+      this.setStatementData(elementFields)
+    },
+
+    removeNotificationsFromStore () {
+      this.messages.forEach(message => {
+        this.remove(message)
+      })
+    },
+
+    removeUnsavedFile (file) {
+      const indexToRemove = this.unsavedFiles.findIndex(el => el.hash === file.hash)
+
+      this.unsavedFiles.splice(indexToRemove, 1)
+      this.setStatementData({
+        uploadedFiles: this.unsavedFiles
+          .map(el => el.hash)
+          .join(',')
+      })
+    },
+
+    sendStatement (e, immediateSubmit = false, keepModalOpen = false) {
+      e.preventDefault()
+
+      if (this.validateStatementStep() === false || this.validateRecheckStep() === false) {
+        return
+      }
+
+      this.isLoading = true
+      this.setStatementData({ immediate_submit: immediateSubmit })
+      this.setStatementData({ r_loadtime: dayjs().unix() })
+
+      const dataToSend = this.prepareDataToSend(this.formData)
+
       let route = Routing.generate('DemosPlan_statement_public_participation_new_ajax', { procedure: this.procedureId }) + (immediateSubmit ? '?immediate_submit=true' : '')
 
       // Draft statements
       if (this.draftStatementId !== '') {
-        this.setStatementData({ action: 'statementedit' })
+        dataToSend.action = 'statementedit'
         route = Routing.generate('DemosPlan_statement_edit', { statementID: this.draftStatementId, procedure: this.procedureId })
       } else {
-        this.setStatementData({ action: 'statementpublicnew' })
+        dataToSend.action = 'statementpublicnew'
       }
 
       return makeFormPost(dataToSend, route)
@@ -1337,7 +1350,7 @@ export default {
           }
           /*
            * Handling for successful responses
-           * if its not an HTML-Response like after creating a new one
+           * if it's not an HTML-Response like after creating a new one
            */
           if (response.status === 200) {
             dplan.notify.notify('confirm', Translator.trans('confirm.statement.saved'))
@@ -1433,7 +1446,7 @@ export default {
       this.updateStatement({ r_ident: this.draftStatementId, ...data })
     },
 
-    toggleModal (resetOnClose = true, data) {
+    toggleModal (resetOnClose = true, data = null) {
       // Check if browser is in fullscreen mode
       if (isActiveFullScreen()) {
         toggleFullscreen()
@@ -1549,8 +1562,7 @@ export default {
       const sessionStorageBegunStatement = localStorage.getItem(`publicStatement:${this.userId}:${this.procedureId}:new`)
       const sessionStorageBegunStatementParsed = JSON.parse(sessionStorageBegunStatement)
       if (sessionStorageBegunStatement && sessionStorageBegunStatement !== this.initFormDataJSON && sessionStorageBegunStatementParsed.r_ident === '') {
-        const existingData = sessionStorageBegunStatementParsed
-        this.setStatementData(existingData)
+        this.setStatementData(sessionStorageBegunStatementParsed)
       } else {
         this.setStatementData({ r_county: this.counties.find(el => el.selected) ? this.counties.find(el => el.selected).value : '' })
       }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
@@ -1,8 +1,6 @@
 {% extends '@DemosPlanCore/DemosPlanCore/procedure.html.twig' %}
 
 {% block demosplanbundlecontent %}
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}"><div>
-
     {% set owndraftText = "text.statements.owndraft"|trans %}
     {% set permissionSubmit = 'feature_statements_released_group_submit' %}
 
@@ -19,7 +17,6 @@
     {% endfor %}
 
     {% block title_text %}
-
         {# Wenn shorthand, anderer Text #}
         {#  pageheader - display procedure title + nav link #}
         {% include '@DemosPlanCore/DemosPlanCore/includes/pageheader.html.twig' with {
@@ -35,6 +32,24 @@
         %}
     {% endblock %}
 
+    {# grouped formFields for statement form #}
+    {%  set statementFields = [] %}
+    {%  set personalDataFields = [] %}
+    {%  set feedbackFields = [] %}
+    {% for field in templateVars.statementFormDefinition.fieldDefinitions|default([]) %}
+        {% if field.enabled|default(false) %}
+            {% set formField = {name: field.name|default, required: field.required|default(false)} %}
+            {% if field.name == 'countyReference' or field.name == 'mapAndCountyReference' %}
+                {% set statementFields = statementFields|merge([formField]) %}
+            {% elseif field.name == 'getEvaluationMailViaEmail' or field.name == 'getEvaluationMailViaSnailMailOrEmail' %}
+                {% set feedbackFields = feedbackFields|merge([formField]) %}
+            {% else %}
+                {% set personalDataFields = personalDataFields|merge([formField]) %}
+            {% endif %}
+        {% endif %}
+    {%  endfor %}
+
+    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}"><div>
     <div class="{{ 'o-page__padded--spaced u-pv'|prefixClass }}">
         <form class="{{ 'layout flow-root'|prefixClass }}" name="sortform" action="{{ path('DemosPlan_statement_list_draft',{'procedure':procedure}) }}" method="post">
             {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
@@ -77,19 +92,16 @@
                                     {{ 'statements.marked.release'|trans }}
                                 </template>
 
-                                <template>
-                                    <p>
-                                        {{ 'check.statement.marked.release'|trans }}
-                                    </p>
+                                <p>
+                                    {{ 'check.statement.marked.release'|trans }}
+                                </p>
 
-                                    <dp-button
-                                        data-cy="submitStatement"
-                                        name="statement_release"
-                                        :text="Translator.trans('statements.marked.release')"
-                                        @click="dpValidateAction('draftForm', () => submitForm('draftForm', 'statement_release'), false)"
-                                    ></dp-button>
-                                </template>
-
+                                <dp-button
+                                    data-cy="submitStatement"
+                                    name="statement_release"
+                                    :text="Translator.trans('statements.marked.release')"
+                                    @click="dpValidateAction('draftForm', () => submitForm('draftForm', 'statement_release'), false)"
+                                ></dp-button>
                             </dp-modal>
 
                             <button
@@ -115,18 +127,16 @@
                                     {{ 'statements.marked.submit'|trans }}
                                 </template>
 
-                                <template>
-                                    {# The dropdown for `feature_statement_notify_counties is shown in the draft list
-                                        only if short submission process is enabled because then, statements are directly
-                                        submitted from this view. If the default submission process is enabled, the dropdown
-                                        is shown in the `list_released_group` view instead. #}
-                                    {% include '@DemosPlanCore/DemosPlanStatement/includes/list_statement_nofity_contries.html.twig' with {
-                                        showDropdown: hasPermission(['feature_statement_notify_counties', permissionSubmit]) and
-                                            templateVars.hasPermissionsetWrite == true and
-                                            proceduresettings.settings.sendMailsToCounties == true,
-                                        targetForm: 'draftForm'
-                                    } %}
-                                </template>
+                                {# The dropdown for `feature_statement_notify_counties is shown in the draft list
+                                    only if short submission process is enabled because then, statements are directly
+                                    submitted from this view. If the default submission process is enabled, the dropdown
+                                    is shown in the `list_released_group` view instead. #}
+                                {% include '@DemosPlanCore/DemosPlanStatement/includes/list_statement_nofity_contries.html.twig' with {
+                                    showDropdown: hasPermission(['feature_statement_notify_counties', permissionSubmit]) and
+                                        templateVars.hasPermissionsetWrite == true and
+                                        proceduresettings.settings.sendMailsToCounties == true,
+                                    targetForm: 'draftForm'
+                                } %}
 
                             </dp-modal>
 
@@ -148,18 +158,18 @@
             </fieldset>
 
             {% block statementList %}
-                <dp-public-statement-list
-                    class="layout__item"
-                    :statements="JSON.parse('{{ templateVars.list.statementlist|default([])|json_encode|e('js', 'utf-8') }}')"
-                    :counties="JSON.parse('{{ counties|default([])|json_encode|e('js', 'utf-8') }}')"
-                    procedure-id="{{ templateVars.procedure|default('') }}"
-                    show-author
-                    show-checkbox
-                    show-delete
-                    show-edit
-                    show-pdf-download
-                    show-versions
-                    target="draft"></dp-public-statement-list>
+            <dp-public-statement-list
+                class="layout__item"
+                :statements="JSON.parse('{{ templateVars.list.statementlist|default([])|json_encode|e('js', 'utf-8') }}')"
+                :counties="JSON.parse('{{ counties|default([])|json_encode|e('js', 'utf-8') }}')"
+                procedure-id="{{ templateVars.procedure|default('') }}"
+                show-author
+                show-checkbox
+                show-delete
+                show-edit
+                show-pdf-download
+                show-versions
+                target="draft"></dp-public-statement-list>
             {% endblock %}
         </form>
     </div>
@@ -169,23 +179,6 @@
         map-options-route="dplan_api_map_options_public"
     >
     </dp-map-modal>
-
-    {# grouped formFields for statement form #}
-    {%  set statementFields = [] %}
-    {%  set personalDataFields = [] %}
-    {%  set feedbackFields = [] %}
-    {% for field in templateVars.statementFormDefinition.fieldDefinitions|default([]) %}
-        {% if field.enabled|default(false) %}
-            {% set formField = {name: field.name|default, required: field.required|default(false)} %}
-            {% if field.name == 'countyReference' or field.name == 'mapAndCountyReference' %}
-                {% set statementFields = statementFields|merge([formField]) %}
-            {% elseif field.name == 'getEvaluationMailViaEmail' or field.name == 'getEvaluationMailViaSnailMailOrEmail' %}
-                {% set feedbackFields = feedbackFields|merge([formField]) %}
-            {% else %}
-                {% set personalDataFields = personalDataFields|merge([formField]) %}
-            {% endif %}
-        {% endif %}
-    {%  endfor %}
 
     <statement-modal
         ref="statementModal"


### PR DESCRIPTION
### Ticket
DPLAN-12315
DPLAN-12921

It seems, that the reactivity broke in the statmentModal while upgrading to vue3. I should't have worked before, but it did. Now its not clean, but consistent.

Since I moved a block to a separate method, the changes are not so easy to spot. Sorry for that. 
The main thing I did was using the local `dataToSend` instead of `this.setStatementData` which interacts with the store to prepare the statement data before updating
