### PR TITLE
chore: symfony/http-client has the same versions as other core bundles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,7 +82,6 @@ updates:
           - "symfony/deprecation-contracts"
           - "symfony/event-dispatcher-contracts"
           - "symfony/flex"
-          - "symfony/http-client"
           - "symfony/http-client-contracts"
           - "symfony/maker-bundle"
           - "symfony/monolog-bundle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,7 +59,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "09:01"
       timezone: Europe/Berlin
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
symfony/http-client has the same versions as other core bundles

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs -->

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
