### PR TITLE
chore(refs dplan-12315): Set deep for watcher explicitly

### DIFF
--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -671,11 +671,17 @@ export default {
   },
 
   watch: {
-    index () {
-      this.setOrderPosition()
+    index: {
+      handler () {
+        this.setOrderPosition()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
-    parentOrderPosition () {
-      this.setOrderPosition()
+    parentOrderPosition: {
+      handler () {
+        this.setOrderPosition()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/map/admin/MapAdminScales.vue
+++ b/client/js/components/map/admin/MapAdminScales.vue
@@ -77,8 +77,11 @@ export default {
   },
 
   watch: {
-    selectedScales (newVal) {
-      this.scales = newVal
+    selectedScales: {
+      handler (newVal) {
+        this.scales = newVal
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -95,8 +95,11 @@ export default {
   },
 
   watch: {
-    defaultAttributions () {
-      this.source.setAttributions(this.defaultAttributions)
+    defaultAttributions: {
+      handler (newVal) {
+        this.source.setAttributions(newVal)
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/map/map/DpOlMapLayerVector.vue
+++ b/client/js/components/map/map/DpOlMapLayerVector.vue
@@ -74,9 +74,12 @@ export default {
   },
 
   watch: {
-    features () {
-      this.map.removeLayer(this.layer)
-      this.addLayer()
+    features: {
+      handler () {
+        this.map.removeLayer(this.layer)
+        this.addLayer()
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/map/map/DpOlMapScaleSelect.vue
+++ b/client/js/components/map/map/DpOlMapScaleSelect.vue
@@ -52,8 +52,11 @@ export default {
    * should not be necessary
    */
   watch: {
-    olMapState () {
-      this.init()
+    olMapState: {
+      handler () {
+        this.init()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/map/map/MapView.vue
+++ b/client/js/components/map/map/MapView.vue
@@ -245,8 +245,11 @@ export default {
   },
 
   watch: {
-    defaultAttribution () {
-      this.$refs.map.updateMapInstance()
+    defaultAttribution: {
+      handler () {
+        this.$refs.map.updateMapInstance()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
+++ b/client/js/components/map/publicdetail/controls/layerlist/DpPublicLayerList.vue
@@ -111,10 +111,13 @@ export default {
   },
 
   watch: {
-    isMapAndLayersReady () {
-      if (this.layerType === 'base' && this.firstActiveBaseLayerId === '') {
-        this.$root.$emit('layer:toggleLayer', { layerId: this.layers[0].id.replace(/-/g, ''), isVisible: true })
-      }
+    isMapAndLayersReady: {
+      handler () {
+        if (this.layerType === 'base' && this.firstActiveBaseLayerId === '') {
+          this.$root.$emit('layer:toggleLayer', { layerId: this.layers[0].id.replace(/-/g, ''), isVisible: true })
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -575,8 +575,11 @@ export default {
 
   watch: {
     // We have to watch it because the values are loaded from the async request response
-    initValues () {
-      this.setInitialValues()
+    initValues: {
+      handler () {
+        this.setInitialValues()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
@@ -232,7 +232,8 @@ export default {
           this.resetSourceAttachment()
           this.setLocalOriginalAttachment(this.initialAttachments.originalAttachment)
         }
-      }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
     'initialAttachments.additionalAttachments': {
       handler (newVal) {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -551,6 +551,22 @@ export default {
     }
   },
 
+  watch: {
+    isCollapsed: {
+      handler (newVal) {
+        if (!newVal) {
+          this.$nextTick(() => {
+            if (this.$refs.recommendationContainer) {
+              this.$refs.imageModal.addClickListener(this.$refs.recommendationContainer.querySelectorAll('img'))
+            }
+          })
+        }
+      },
+      deep: false, // Set default for migrating purpose. To know this occurrence is checked
+      immediate: true // This ensures the handler is executed immediately after the component is created
+    }
+  },
+
   methods: {
     ...mapActions('AssignableUser', {
       fetchAssignableUsers: 'list'
@@ -873,21 +889,6 @@ export default {
     updateSegment (key, val) {
       const updated = { ...this.segment, ...{ attributes: { ...this.segment.attributes, ...{ [key]: val } } } }
       this.setSegment({ ...updated, id: this.segment.id })
-    }
-  },
-
-  watch: {
-    isCollapsed: {
-      handler: function (newVal, oldVal) {
-        if (!newVal) {
-          this.$nextTick(() => {
-            if (this.$refs.recommendationContainer) {
-              this.$refs.imageModal.addClickListener(this.$refs.recommendationContainer.querySelectorAll('img'))
-            }
-          })
-        }
-      },
-      immediate: true // This ensures the handler is executed immediately after the component is created
     }
   },
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -455,8 +455,11 @@ export default {
   },
 
   watch: {
-    currentAction () {
-      this.showInfobox = this.currentAction === 'editText'
+    currentAction: {
+      handler () {
+        this.showInfobox = this.currentAction === 'editText'
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement.vue
@@ -56,10 +56,13 @@ export default {
   },
 
   watch: {
-    needToReset (newValue) {
-      if (newValue === true) {
-        this.getInstitutionsByPage(1)
-      }
+    needToReset: {
+      handler (newValue) {
+        if (newValue) {
+          this.getInstitutionsByPage(1)
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -225,16 +225,22 @@ export default {
   },
 
   watch: {
-    selectedCurrentPhase () {
-      this.setSelectedPhase()
+    selectedCurrentPhase: {
+      handler () {
+        this.setSelectedPhase()
 
-      if (hasPermission('feature_auto_switch_to_procedure_end_phase')) {
-        this.autoSwitchPhase = this.isParticipationPhaseSelected
-      }
+        if (hasPermission('feature_auto_switch_to_procedure_end_phase')) {
+          this.autoSwitchPhase = this.isParticipationPhaseSelected
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
 
-    switchDate (newVal) {
-      this.startDate = formatDate(newVal)
+    switchDate: {
+      handler (newVal) {
+        this.startDate = formatDate(newVal)
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/procedure/basicSettings/DpProcedureCoordinateInput.vue
+++ b/client/js/components/procedure/basicSettings/DpProcedureCoordinateInput.vue
@@ -76,8 +76,11 @@ export default {
   },
 
   watch: {
-    coordinate (coordinates) {
-      this.updateCoordinates(coordinates)
+    coordinate: {
+      handler (coordinates) {
+        this.updateCoordinates(coordinates)
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/procedure/basicSettings/ProcedureCoordinateGeolocation.vue
+++ b/client/js/components/procedure/basicSettings/ProcedureCoordinateGeolocation.vue
@@ -119,13 +119,17 @@ export default {
   },
 
   watch: {
-    coordinate (coordinates) {
-      if (coordinates.length === 2) {
-        this.latitude = coordinates[0]
-        this.longitude = coordinates[1]
+    coordinate: {
+      handler (coordinates) {
+        if (coordinates.length === 2) {
+          this.latitude = coordinates[0]
+          this.longitude = coordinates[1]
 
-        this.queryLocation()
-      }
+          this.queryLocation()
+        }
+      },
+      deep: true
+
     }
   },
 

--- a/client/js/components/procedure/publicindex/map/Map.vue
+++ b/client/js/components/procedure/publicindex/map/Map.vue
@@ -214,19 +214,26 @@ export default {
   },
 
   watch: {
-    currentView (newVal) {
-      if (newVal === 'DpDetailView') {
-        this.zoomToMarker(this.currentProcedureId)
-      }
-      if (newVal === 'DpList') {
-        this.setZoom()
-      }
+    currentView: {
+      handler (newVal) {
+        if (newVal === 'DpDetailView') {
+          this.zoomToMarker(this.currentProcedureId)
+        }
+        if (newVal === 'DpList') {
+          this.setZoom()
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
+
     },
 
-    shouldMapZoomBeSet (newVal) {
-      if (newVal === true) {
-        this.$nextTick(() => this.setZoom())
-      }
+    shouldMapZoomBeSet: {
+      handler (newVal) {
+        if (newVal) {
+          this.$nextTick(() => this.setZoom())
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/assessmentTable/DpEditField.vue
+++ b/client/js/components/statement/assessmentTable/DpEditField.vue
@@ -180,10 +180,13 @@ export default {
     /*
      * When `editable` being set to false from outside, editing is also being disabled.
      */
-    editable (newVal) {
-      if (newVal === false) {
-        this.editingEnabled = false
-      }
+    editable: {
+      handler (newVal) {
+        if (newVal === false) {
+          this.editingEnabled = false
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/assessmentTable/DpEditFieldSingleSelect.vue
+++ b/client/js/components/statement/assessmentTable/DpEditFieldSingleSelect.vue
@@ -141,8 +141,11 @@ export default {
   },
 
   watch: {
-    value () {
-      this.updateSelectedValue()
+    value: {
+      handler () {
+        this.updateSelectedValue()
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/assessmentTable/DpFilterModal.vue
+++ b/client/js/components/statement/assessmentTable/DpFilterModal.vue
@@ -328,9 +328,13 @@ export default {
   },
 
   watch: {
-    noFilterSelected: function () {
-      // If no filter is selected, uncheck the filter.saveFilterSet checkbox
-      this.saveFilterSet = false
+    noFilterSelected: {
+      handler () {
+        // If no filter is selected, uncheck the filter.saveFilterSet checkbox
+        this.saveFilterSet = false
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
+
     },
 
     selectedOptionsInStore: {

--- a/client/js/components/statement/assessmentTable/DpMoveStatementModal.vue
+++ b/client/js/components/statement/assessmentTable/DpMoveStatementModal.vue
@@ -197,9 +197,12 @@ export default {
   },
 
   watch: {
-    procedurePermissions () {
-      //  Reset selection when radio list changes
-      this.selectedProcedureId = ''
+    procedurePermissions: {
+      handler () {
+        //  Reset selection when radio list changes
+        this.selectedProcedureId = ''
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -202,8 +202,11 @@ export default {
   },
 
   watch: {
-    selectedElements () {
-      this.fetchRelatedFragments()
+    selectedElements: {
+      handler () {
+        this.fetchRelatedFragments()
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/statement/assessmentTable/StatementReplySelect.vue
+++ b/client/js/components/statement/assessmentTable/StatementReplySelect.vue
@@ -78,10 +78,13 @@ export default {
   },
 
   watch: {
-    checked () {
-      if (!this.checked) {
-        this.setEmptyValue()
-      }
+    checked: {
+      handler (val) {
+        if (!val) {
+          this.setEmptyValue()
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/assessmentTable/TocView/SearchAndSorting.vue
+++ b/client/js/components/statement/assessmentTable/TocView/SearchAndSorting.vue
@@ -86,16 +86,22 @@ export default {
   },
 
   watch: {
-    showFilterModal (val) {
-      if (val) {
-        this.$refs.filterModal.openModal()
-      }
+    showFilterModal: {
+      handler (val) {
+        if (val) {
+          this.$refs.filterModal.openModal()
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
 
-    showSearchModal (val) {
-      if (val) {
-        this.$refs.searchModal.toggleModal()
-      }
+    showSearchModal: {
+      handler (val) {
+        if (val) {
+          this.$refs.searchModal.toggleModal()
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/fragment/SelectDocument.vue
+++ b/client/js/components/statement/fragment/SelectDocument.vue
@@ -222,18 +222,24 @@ export default {
   },
 
   watch: {
-    elementsHasParagraph (hasParagraph) {
-      if (hasParagraph === false) {
-        this.currentParagraphTitle = ''
-        this.currentParagraphId = ''
-      }
+    elementsHasParagraph: {
+      handler (hasParagraph) {
+        if (hasParagraph === false) {
+          this.currentParagraphTitle = ''
+          this.currentParagraphId = ''
+        }
+      },
+      deep: true
     },
 
-    elementsHasFiles (hasFiles) {
-      if (hasFiles === false) {
-        this.currentFileTitle = ''
-        this.currentFileId = ''
-      }
+    elementsHasFiles: {
+      handler (hasFiles) {
+        if (hasFiles === false) {
+          this.currentFileTitle = ''
+          this.currentFileId = ''
+        }
+      },
+      deep: true
     }
   }
 }

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -326,20 +326,26 @@ export default {
   },
 
   watch: {
-    editModeActive (newVal) {
-      if (newVal) {
-        window.addEventListener('scroll', this.handleScroll, false)
-      } else {
-        window.removeEventListener('scroll', this.handleScroll, false)
-        this.displayScrollButton = false
-      }
+    editModeActive: {
+      handler (newVal) {
+        if (newVal) {
+          window.addEventListener('scroll', this.handleScroll, false)
+        } else {
+          window.removeEventListener('scroll', this.handleScroll, false)
+          this.displayScrollButton = false
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
 
-    initialData (newVal) {
-      this.calculateProcessingTime()
-      if (newVal) {
-        this.isLoading = false
-      }
+    initialData: {
+      handler (newVal) {
+        this.calculateProcessingTime()
+        if (newVal) {
+          this.isLoading = false
+        }
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 

--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -403,24 +403,30 @@ export default {
   },
 
   watch: {
-    currentRole: function () {
-      //  Reset Multiselect + fields upon selection of `r_roles`-radio
-      this.submitter = {}
-      this.submitterData = emptySubmitterData
+    currentRole: {
+      handler () {
+        //  Reset Multiselect + fields upon selection of `r_roles`-radio
+        this.submitter = {}
+        this.submitterData = emptySubmitterData
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
 
-    submitter: function (submitterSelected) {
-      //  When `submitter` changes via the `currentRole` watcher, lets not trigger an update
-      if (
-        typeof submitterSelected === 'undefined' ||
-        (
-          hasOwnProp(submitterSelected, 'entityId') || hasOwnProp(submitterSelected, 'entityType')
-        ) === false
-      ) {
-        return
-      }
+    submitter: {
+      handler (submitterSelected) {
+        //  When `submitter` changes via the `currentRole` watcher, lets not trigger an update
+        if (
+          typeof submitterSelected === 'undefined' ||
+          (
+            hasOwnProp(submitterSelected, 'entityId') || hasOwnProp(submitterSelected, 'entityType')
+          ) === false
+        ) {
+          return
+        }
 
-      this.submitterData = this.submitter.submitter
+        this.submitterData = this.submitter.submitter
+      },
+      deep: true
     }
   },
 

--- a/client/js/components/user/DpTableCardList/DpTableCard.vue
+++ b/client/js/components/user/DpTableCardList/DpTableCard.vue
@@ -38,8 +38,11 @@ export default {
   },
 
   watch: {
-    open (newVal) {
-      this.isOpen = newVal
+    open: {
+      handler (newVal) {
+        this.isOpen = newVal
+      },
+      deep: false // Set default for migrating purpose. To know this occurrence is checked
     }
   },
 


### PR DESCRIPTION
### Ticket
DPLAN-12315
DPLAN-12921


even though `deep: false` is the default, we should set it during the migration process so we can easily check if we already checked that occurrence. Otherwise we will get a warning again and again and never know if we can ignore it.