### PR TITLE
chore: Bump Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,8 +177,8 @@
     "webpack-merge": "^6.0.1"
   },
   "engines": {
-    "npm": ">= 9.8.1",
-    "node": ">= 18.18.0"
+    "npm": ">= 10.5.0",
+    "node": ">= 20.18.1"
   },
   "browserslist": [
     "last 5 versions",


### PR DESCRIPTION

The Container now is shipped with node 20. So we can require it.

After this is merged, https://github.com/demos-europe/demosplan-core/pull/3785 can be merged.