### PR TITLE
fix: Use propper resourceType for User after refactoring the user resourcetype

### DIFF
--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -160,7 +160,7 @@ export default {
   },
 
   computed: {
-    ...mapState('User', {
+    ...mapState('AdministratableUser', {
       items: 'items',
       currentPage: 'currentPage',
       totalPages: 'totalPages'
@@ -196,7 +196,7 @@ export default {
     ...mapActions('Role', {
       roleList: 'list'
     }),
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       userList: 'list',
       deleteUser: 'delete'
     }),


### PR DESCRIPTION
with https://github.com/demos-europe/demosplan-core/pull/3561 the resourcetype changed. We adjusted it in several occurences, but forot about this one