### PR TITLE
chore: Bump Sass-loader to 16.0.3

### DIFF
--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -160,13 +160,16 @@ const moduleRules =
         {
           loader: 'sass-loader',
           options: {
-            implementation: require('sass-embedded'),
-            additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
+            api: 'modern',
             sassOptions: {
-              includePaths: [
-                config.projectRoot + 'web/',
-                config.publicPath
-              ]
+              implementation: require('sass-embedded'),
+              additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
+              sassOptions: {
+                includePaths: [
+                  config.projectRoot + 'web/',
+                  config.publicPath
+                ]
+              }
             }
           }
         }

--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -160,16 +160,14 @@ const moduleRules =
         {
           loader: 'sass-loader',
           options: {
-            api: 'modern',
+            api: 'modern-compiler',
             sassOptions: {
               implementation: require('sass-embedded'),
               additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
-              sassOptions: {
-                includePaths: [
-                  config.projectRoot + 'web/',
-                  config.publicPath
-                ]
-              }
+              loadPaths: [
+                config.projectRoot + 'web/',
+                config.publicPath
+              ]
             }
           }
         }

--- a/client/fe/webpack/plugins.js
+++ b/client/fe/webpack/plugins.js
@@ -97,7 +97,21 @@ const webpackDefaultPlugins = [
   // Provide Vue instance to all modules (is configured in InitVue.js before initialization).
   new webpack.ProvidePlugin({
     Vue: 'vue'
-  })
+  }),
+  /*
+   * Exiting webpack after build manually is necessary because sass-loader has some issues doing it by itself.
+   * It should be evaluated from time to time, if this is still necessary.
+   * @see https://github.com/demos-europe/demosplan-core/pull/4095
+   */
+  {
+    apply: compiler => {
+      compiler.hooks.done.tap('DonePlugin', () => {
+        setTimeout(() => {
+          process.exit(0)
+        }, 500)
+      })
+    }
+  }
 ]
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "postcss-preset-env": "^9.6.0",
     "purgecss-webpack-plugin": "^6.0.0",
     "sass-embedded": "^1.77.8",
-    "sass-loader": "^14.2.1",
+    "sass-loader": "^16.0.3",
     "source-map-loader": "^5.0.0",
     "stylelint": "^14.16.1",
     "stylelint-config-standard-scss": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13280,7 +13280,7 @@ __metadata:
     raf: "npm:^3.4.1"
     regenerator-runtime: "npm:^0.14.1"
     sass-embedded: "npm:^1.77.8"
-    sass-loader: "npm:^14.2.1"
+    sass-loader: "npm:^16.0.3"
     source-map-loader: "npm:^5.0.0"
     source-sans-pro: "npm:^3.6.0"
     stream: "npm:^0.0.3"
@@ -13624,9 +13624,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^14.2.1":
-  version: 14.2.1
-  resolution: "sass-loader@npm:14.2.1"
+"sass-loader@npm:^16.0.3":
+  version: 16.0.3
+  resolution: "sass-loader@npm:16.0.3"
   dependencies:
     neo-async: "npm:^2.6.2"
   peerDependencies:
@@ -13646,7 +13646,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/9a48d454584d96d6c562eb323bb9e3c6808e930eeaaa916975b97d45831e0b87936a8655cdb3a4512a25abc9587dea65a9616e42396be0d7e7c507a4795a8146
+  checksum: 10c0/2dc188dd0d5276ed0251eee7f245848ccf9df6ec121227462403f322c17a3dbe100fb60d47968f078e585e4aced452eb7fa1a8e55b415d5de3151fa1bbf2d561
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since I had to adjust some options, I had to create the PR manually.
For details, why I had to change things see https://webpack.js.org/loaders/sass-loader/#api