### PR TITLE
Use if condition to access voting and publication area

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -58,7 +58,7 @@
           @save="(data) => save(data)" />
 
         <statement-publication-and-voting
-          v-if="hasPermission('feature_statements_vote')"
+          v-if="hasPermission('feature_statements_vote') || hasPermission('feature_statements_publication')"
           :editable="editable"
           :statement="statement"
           @save="(data) => save(data)"

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -58,6 +58,7 @@
           @save="(data) => save(data)" />
 
         <statement-publication-and-voting
+          v-if="hasPermission('feature_statements_vote')"
           :editable="editable"
           :statement="statement"
           @save="(data) => save(data)"

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2331,6 +2331,11 @@ feature_statements_public_statement_recommendation_visible:
     expose: true
     label: 'Enables statement recommendations to be published in the public area.'
     loginRequired: false
+feature_statements_publication:
+    expose: true
+    label: 'Stellungnahme veroeffentlichen bereich'
+    loginRequired: true
+    parent: feature_statement
 feature_statements_publication_request_approval_or_rejection_notification_email:
     description: |-
         If citizens decided that one of their statements should be public, this still has to be verified by a planner,


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12986


Description: Use If condition to access Voting and public area in Statement

Delete the checkbox if it doesn't apply/isn't necessary.

- [x] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
