### PR TITLE
feat (refs DPLAN-12984): Raise jwt token rate limit for api requests

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -19,5 +19,5 @@ framework:
         # the bearer token is reset at every page reload
         jwt_token:
             policy: 'fixed_window'
-            limit: 10
+            limit: 100
             interval: '30 days'

--- a/tests/backend/core/Core/Functional/RatelimitRequestSubscriberTest.php
+++ b/tests/backend/core/Core/Functional/RatelimitRequestSubscriberTest.php
@@ -23,6 +23,7 @@ use Tests\Base\JsonApiTest;
 class RatelimitRequestSubscriberTest extends JsonApiTest
 {
     private ?string $jwtToken = '';
+    private const RATE_LIMIT = 100;
 
     public function testAnyValidRequest(): void
     {
@@ -40,7 +41,7 @@ class RatelimitRequestSubscriberTest extends JsonApiTest
         $this->enablePermissions(['area_documents']);
         $this->expectException(Exception::class);
         // call the same request 10 times, this should work
-        for ($i = 0; $i < 10; ++$i) {
+        for ($i = 0; $i < self::RATE_LIMIT; ++$i) {
             $this->executeListRequest(
                 PlanningDocumentCategoryResourceType::getName(),
                 $user


### PR DESCRIPTION
### Ticket: [DPLAN-12984](https://demoseurope.youtrack.cloud/issue/DPLAN-12984/Nicht-moglich-um-eine-neue-Kategorie-zu-hinzufugen)

Raise jwt token rate limit for api requests from 10 to 100 to allow the creation of more categories (institution tagging).

### How to review/test
code review, you should be able to create more categories without page reload as before.

### PR Checklist
<!-- Reminders for handling PRs -->
https://github.com/demos-europe/demosplan-core/pull/4061

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
