### PR TITLE
fix(refs DPLAN 12667) move receiver address into globalconfig - env variable

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,7 @@ S3_KEY=
 S3_SECRET=
 #may be local.storage for files on the same system or s3.storage
 FILES_SOURCE=local.storage
+PROCEDURE_METRICS_MAIL=
 ###< demos/demosplan ###
 
 ###> symfony/framework-bundle ###

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -184,6 +184,7 @@ parameters:
     email_test_from: "testMailSender@localhost.de"
     email_test_to: "testMailReceiver@localhost.de"
     email_system: "systememail@localhost.de"
+    procedure_metrics_receiver: "%env(string:PROCEDURE_METRICS_MAIL)%"
     email_bounce_check: false
     # #refactor: path and file could be used as one
     email_bouncefile_path: ""

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureMetricsEmailEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureMetricsEmailEventSubscriber.php
@@ -68,7 +68,6 @@ class ProcedureMetricsEmailEventSubscriber extends BaseEventSubscriber
         $from = $this->globalConfig->getEmailSystem();
         $to = $this->globalConfig->getProcedureMetricsReceiver();
         if ('' === $to) {
-
             return;
         }
         try {

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureMetricsEmailEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ProcedureMetricsEmailEventSubscriber.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostNewProcedureCreatedEventInterface;
@@ -22,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedureRepository;
-use demosplan\DemosPlanCoreBundle\Resources\config\GlobalConfig;
 use Doctrine\Common\Collections\Criteria;
 use Exception;
 
@@ -37,7 +37,7 @@ class ProcedureMetricsEmailEventSubscriber extends BaseEventSubscriber
         private readonly CustomerService $customerService,
         private readonly CurrentUserService $currentUser,
         private readonly MailService $mailService,
-        private readonly GlobalConfig $globalConfig,
+        private readonly GlobalConfigInterface $globalConfig,
         private readonly ProcedureRepository $procedureRepository,
         private array $mailVars = ['mailsubject' => '', 'mailbody' => ''],
     ) {

--- a/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
+++ b/demosplan/DemosPlanCoreBundle/Resources/config/GlobalConfig.php
@@ -113,6 +113,8 @@ class GlobalConfig implements GlobalConfigInterface
 
     /** @var string */
     protected $emailFromDomainValidRegex;
+
+    protected string $procedureMetricsReceiver = '';
     /**
      * @var string
      */
@@ -612,6 +614,7 @@ class GlobalConfig implements GlobalConfigInterface
         $this->emailSubjectPrefix = $parameterBag->get('email_subject_prefix');
         $this->emailUseSystemMailAsSender = $parameterBag->get('email_use_system_mail_as_sender');
         $this->emailFromDomainValidRegex = $parameterBag->get('email_from_domain_valid_regex');
+        $this->procedureMetricsReceiver = $parameterBag->get('procedure_metrics_receiver');
         $this->emailUseDataportBounceSystem = $parameterBag->get('email_use_bounce_dataport_system');
 
         // @todo this might be wrong (and is also deprecated)
@@ -1025,6 +1028,11 @@ class GlobalConfig implements GlobalConfigInterface
     public function getEmailFromDomainValidRegex(): string
     {
         return $this->emailFromDomainValidRegex;
+    }
+
+    public function getProcedureMetricsReceiver(): string
+    {
+        return $this->procedureMetricsReceiver;
     }
 
     /**


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12667

Description:
move receiver address into globalconfig - env variable

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
