### PR TITLE
Access to area and documentation in statement

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -95,6 +95,7 @@
           @change="updateLocalStatementProperties" />
 
         <statement-meta-location-and-document-reference
+          v-if="hasPermission('feature_statements_location_and_document_refrence')"
           :editable="editable"
           :initially-selected-document-id="initiallySelectedDocumentId"
           :initially-selected-element-id="initiallySelectedElementId"

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2299,6 +2299,11 @@ feature_statements_like_may_like:
     label: 'Stellungnahme als anonymer Nutzer liken (Aktion ausführen)'
     loginRequired: false
     parent: feature_statement
+feature_statements_location_and_document_refrence:
+    expose: true
+    label: 'Feature Stellungnahme mit Orts- und Dokumentbezug'
+    loginRequired: true
+    parent: feature_statement
 feature_statements_manualsort:
     label: 'Manuelle Reihenfolge speichern'
     loginRequired: true

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2301,7 +2301,7 @@ feature_statements_like_may_like:
     parent: feature_statement
 feature_statements_location_and_document_refrence:
     expose: true
-    label: 'Feature Stellungnahme mit Orts- und Dokumentbezug'
+    label: 'Feature Statement with area und document reference'
     loginRequired: true
     parent: feature_statement
 feature_statements_manualsort:


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-13002/STN-Detailansicht-Wir-sollten-keine-Orts-und-Dokumentbezug-in-EWM-zeigen


Description: create a new Permission and us if condition to manage access to area and documentation in statement details

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Tests updated/created
- [ ] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Data-Cy attributes added/updated ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
