### PR TITLE
fix(refs DPLAN-12981, #AB17874): update prop on save

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
@@ -59,12 +59,14 @@
           <template v-slot:branch="{ nodeElement }">
             <tag-list-item
               :item="nodeElement"
-              @item:deleted="handleItemDeleted" />
+              @item:deleted="handleItemDeleted"
+              @item:saved="handleItemSaved" />
           </template>
           <template v-slot:leaf="{ nodeElement }">
             <tag-list-item
               :item="nodeElement"
-              @item:deleted="handleItemDeleted" />
+              @item:deleted="handleItemDeleted"
+              @item:saved="handleItemSaved" />
           </template>
         </dp-tree-list>
       </template>
@@ -188,6 +190,28 @@ export default {
 
       if (isCategory) {
         this.tagCategoriesWithTags = this.tagCategoriesWithTags.filter(category => category.id !== item.id)
+      }
+    },
+
+    handleItemSaved (item) {
+      const isTag = !!item.categoryId
+      const isCategory = !item.categoryId
+
+      if (isTag) {
+        const category = this.tagCategoriesWithTags.find(category => category.id === item.categoryId)
+
+        if (category) {
+          const tag = category.children.find(tag => tag.id === item.id)
+          tag.name = item.name
+        }
+      }
+
+      if (isCategory) {
+        const category = this.tagCategoriesWithTags.find(category => category.id === item.id)
+
+        if (category) {
+          category.name = item.name
+        }
       }
     },
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
@@ -276,6 +276,8 @@ export default {
         .then(() => {
           dplan.notify.confirm(Translator.trans('confirm.category.updated'))
           this.isEditing = false
+          this.$emit('item:saved', { ...this.item, name: this.name })
+
         })
         .catch(() => {
           dplan.notify.error(Translator.trans('error.api.generic'))
@@ -299,6 +301,7 @@ export default {
         .then(() => {
           dplan.notify.confirm(Translator.trans('confirm.tag.edited'))
           this.isEditing = false
+          this.$emit('item:saved', { ...this.item, name: this.name })
         })
         .catch(() => {
           this.restoreTagFromInitial(id)


### PR DESCRIPTION
### Ticket
[DPLAN-12981](https://demoseurope.youtrack.cloud/issue/DPLAN-12981/Editierte-Schlagworte-Kategorie-Schlagwort-Name-wird-richtig-nur-nach-einem-Seitenrefresh-angezeigt)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

To display the updated name in non-edit mode, we need to update the `item` prop, as we use it in non-edit mode (while in edit mode, `this.name` is used)

### PR Checklist
<!-- Reminders for handling PRs -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
