### PR TITLE
Filter query to not show guest only procedures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -182,9 +182,11 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
                 ->select('p')
                 ->from(Procedure::class, 'p')
                 ->join('p.dataInputOrganisations', 'o')
+                ->join('p.procedureBehaviorDefinition', 'pb')
                 ->andWhere('o.id = :orgaId')
                 ->andWhere('p.deleted = 0')
                 ->andWhere('p.closed = 0')
+                ->andWhere('pb.participationGuestOnly = 0')
                 ->setParameter('orgaId', $orgaId)
                 ->orderBy('p.name', 'ASC');
 


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12843/BEDatenerfasser-Navigieren-zu-einem-Verfahren-Ein-Fehler-ist-aufgetreten-Seite


Description: User as a data input role has access to some procedures and not some else. It happens because procedure can be set to show guest only or not. If procedure be set to show just for guest, data input user ca not access to that and see an error.

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
