### PR TITLE
Show attachments in statement detail by zip importer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
@@ -155,7 +155,10 @@ class StatementFromRowBuilderWithZipSupport extends AbstractStatementFromRowBuil
                     $fileContainer,
                     [new Type(FileContainer::class), new NotNull()]
                 );
-
+                /*
+                 * the files have to be copied later from the generated original Statement object that's why
+                 * they have to be set at this point otherwise they will be missing in new generated statement
+                 */
                 $fileString = $fileContainer?->getFileString();
                 $statement->setFiles([$fileString]);
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
@@ -38,7 +38,7 @@ class StatementFromRowBuilderWithZipSupport extends AbstractStatementFromRowBuil
         protected readonly FileService $fileService,
         private readonly EntityManagerInterface $entityManager,
         private readonly StatementFromRowBuilder $baseStatementFromRowBuilder,
-        private readonly StatementAttachmentService $statementAttachmentService
+        private readonly StatementAttachmentService $statementAttachmentService,
     ) {
         parent::__construct();
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
@@ -155,6 +155,9 @@ class StatementFromRowBuilderWithZipSupport extends AbstractStatementFromRowBuil
                     $fileContainer,
                     [new Type(FileContainer::class), new NotNull()]
                 );
+
+                $fileString = $fileContainer?->getFileString();
+                $statement->setFiles([$fileString]);
             }
 
             $violations->addAll($newViolations);


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12936/Beteiligungs-Import-Weitere-Anhange-wird-nicht-mit-ins-EWM-importiert


Description: Add setFiles method to persist files 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
