### PR TITLE
B dplan 13034 use api2 to create user

### DIFF
--- a/client/js/bundles/user/listUser.js
+++ b/client/js/bundles/user/listUser.js
@@ -26,10 +26,10 @@ const components = {
   DpUserListExtended
 }
 const apiStores = [
+  'AdministratableUser',
   'Department',
   'Orga',
-  'Role',
-  'User'
+  'Role'
 ]
 
 initialize(components, stores, apiStores)

--- a/client/js/components/user/DpCreateItem.vue
+++ b/client/js/components/user/DpCreateItem.vue
@@ -175,13 +175,6 @@ export default {
   },
 
   computed: {
-    /**
-     * Needed for entity === 'user'
-     */
-    ...mapState('Role', {
-      roles: 'items'
-    }),
-
     dynamicComponent () {
       return this.customComponent[this.entity].componentName
     },
@@ -195,8 +188,9 @@ export default {
     },
 
     itemResource () {
+      const type = this.entity === 'user' ? 'AdministratableUser' : this.entity
       return {
-        type: this.entity,
+        type,
         ...this.item
       }
     }
@@ -206,7 +200,7 @@ export default {
     ...mapActions('Orga', {
       createOrganisation: 'create'
     }),
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       createUser: 'create'
     }),
 

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -402,7 +402,7 @@ export default {
     setCurrentUserOrganisation (organisation, rels) {
       this.currentUserOrga = { ...organisation, relationships: rels }
       this.localUser.relationships.orga.data = { id: organisation.id, type: organisation.type }
-      this.localUser.relationships.orga.relationships = rels
+     // this.localUser.relationships.orga.relationships = rels
     },
 
     setDefaultDepartment (organisation) {

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -322,7 +322,7 @@ export default {
      * Fetch organisation of user or, in DpCreateItem, of currently logged-in user
      */
     fetchCurrentOrganisation () {
-      const orgaId = this.user.relationships.orga?.data?.id
+      const orgaId = this.user.relationships?.orga?.data?.id
         ? this.user.relationships.orga.data.id
         : this.presetUserOrgaId
       if (orgaId !== '') {
@@ -362,11 +362,21 @@ export default {
      *  @param types {Array}
      */
     handleUndefinedRelationships (types) {
+      if (!this.localUser.relationships) {
+        this.localUser.relationships = {}
+      }
+
       types.forEach(type => {
-        if (typeof this.localUser.relationships[type] === 'undefined' || this.localUser.relationships[type] === null) {
-          this.localUser.relationships[type] = {
-            data: {
-              id: ''
+        if (!this.localUser.relationships[type]) {
+          if (type === 'roles') {
+            this.localUser.relationships.roles = {
+              data: []
+            }
+          } else {
+            this.localUser.relationships[type] = {
+              data: {
+                id: ''
+              }
             }
           }
         }
@@ -496,7 +506,7 @@ export default {
 
   created () {
     this.localUser = JSON.parse(JSON.stringify(this.user))
-    this.handleUndefinedRelationships(['orga', 'department'])
+    this.handleUndefinedRelationships(['department', 'orga', 'roles'])
   },
 
   mounted () {

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -412,7 +412,6 @@ export default {
     setCurrentUserOrganisation (organisation, rels) {
       this.currentUserOrga = { ...organisation, relationships: rels }
       this.localUser.relationships.orga.data = { id: organisation.id, type: organisation.type }
-     // this.localUser.relationships.orga.relationships = rels
     },
 
     setDefaultDepartment (organisation) {

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -242,7 +242,7 @@ export default {
       if (this.currentUserOrga.id === '') {
         allowedRoles = this.rolesInRelationshipFormat
       } else if (hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
-        allowedRoles = Object.values(this.organisations[this.currentUserOrga.id].relationships.allowedRoles.list())
+        allowedRoles = this.organisations[this.currentUserOrga.id].relationships.allowedRoles.data
       } else {
         allowedRoles = this.getOrgaAllowedRoles(this.currentUserOrga.id)
       }
@@ -350,7 +350,7 @@ export default {
       this.fetchOrgaById(orgaId).then((orga) => {
         this.setOrga(orga.data.data)
         if (this.currentUserOrga.id && hasOwnProp(this.organisations[this.currentUserOrga.id].relationships, 'allowedRoles')) {
-          allowedRoles = this.organisations[this.currentUserOrga.id].relationships.allowedRoles.list()
+          allowedRoles = this.organisations[this.currentUserOrga.id].relationships.allowedRoles.data
         }
       })
 

--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -160,7 +160,7 @@ export default {
   },
 
   computed: {
-    ...mapState('User', {
+    ...mapState('AdministratableUser', {
       items: 'items',
       currentPage: 'currentPage',
       totalPages: 'totalPages'
@@ -196,7 +196,7 @@ export default {
     ...mapActions('Role', {
       roleList: 'list'
     }),
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       userList: 'list',
       deleteUser: 'delete'
     }),

--- a/client/js/components/user/DpUserList/DpUserListItem.vue
+++ b/client/js/components/user/DpUserList/DpUserListItem.vue
@@ -162,7 +162,7 @@ export default {
   },
 
   computed: {
-    ...mapState('User', {
+    ...mapState('AdministratableUser', {
       initialUser (state) {
         return state.initial[this.user.id]
       }
@@ -228,12 +228,12 @@ export default {
   },
 
   methods: {
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       saveUserAction: 'save',
       restoreUser: 'restoreFromInitial'
     }),
 
-    ...mapMutations('User', ['setItem']),
+    ...mapMutations('AdministratableUser', ['setItem']),
 
     // Close item and reset roles multiselect
     reset () {

--- a/client/js/components/user/DpUserListExtended.vue
+++ b/client/js/components/user/DpUserListExtended.vue
@@ -117,7 +117,7 @@ export default {
     ...mapState('Role', {
       roles: 'items'
     }),
-    ...mapState('User', {
+    ...mapState('AdministratableUser', {
       users: 'items',
       currentPage: 'currentPage',
       totalPages: 'totalPages'
@@ -140,7 +140,7 @@ export default {
     ...mapActions('Role', {
       roleList: 'list'
     }),
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       userList: 'list',
       deleteUser: 'delete'
     }),

--- a/client/js/components/user/DpUserListExtendedItem.vue
+++ b/client/js/components/user/DpUserListExtendedItem.vue
@@ -164,7 +164,7 @@ export default {
   },
 
   methods: {
-    ...mapActions('User', {
+    ...mapActions('AdministratableUser', {
       saveUserAction: 'save'
     }),
 
@@ -268,7 +268,7 @@ export default {
         this.resetCurrentDepartment()
       }
 
-      const url = Routing.generate('api_resource_update', { resourceType: 'User', resourceId: this.user.id })
+      const url = Routing.generate('api_resource_update', { resourceType: 'AdministratableUser', resourceId: this.user.id })
       const payload = {
         data: {
           id: this.user.id,
@@ -286,7 +286,7 @@ export default {
               }
             }
           },
-          type: 'User'
+          type: 'AdministratableUser'
         }
       }
 

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2411,6 +2411,7 @@ feature_use_xplanbox:
     loginRequired: true
 feature_user_add:
     description: 'allows the user to create a new user'
+    expose: true
     label: 'add user'
     loginRequired: true
     parent: feature_user

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
@@ -10,8 +10,6 @@
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
-use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\InstitutionTagInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserRoleInCustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
@@ -200,18 +198,17 @@ class Role extends CoreEntity implements UuidEntityInterface, RoleInterface, Str
     {
         if (!$this->userRoleInCustomers->contains($userRoleInCustomer)) {
             $this->userRoleInCustomers->add($userRoleInCustomer);
-           // $userRoleInCustomer->($this);
+            // $userRoleInCustomer->($this);
         }
     }
-
 
     public function getUserRoleInCustomers(): Collection
     {
         return $this->userRoleInCustomers;
     }
 
-    public function removeUserRoleInCustomer(UserRoleInCustomerInterface $userRoleInCustomer) {
+    public function removeUserRoleInCustomer(UserRoleInCustomerInterface $userRoleInCustomer)
+    {
         $this->userRoleInCustomers->removeElement($userRoleInCustomer);
-
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
@@ -10,6 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\InstitutionTagInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserRoleInCustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
@@ -192,5 +194,24 @@ class Role extends CoreEntity implements UuidEntityInterface, RoleInterface, Str
     public function getGroupName()
     {
         return $this->groupName;
+    }
+
+    public function addUserRoleInCustomer(UserRoleInCustomerInterface $userRoleInCustomer): void
+    {
+        if (!$this->userRoleInCustomers->contains($userRoleInCustomer)) {
+            $this->userRoleInCustomers->add($userRoleInCustomer);
+           // $userRoleInCustomer->($this);
+        }
+    }
+
+
+    public function getUserRoleInCustomers(): Collection
+    {
+        return $this->userRoleInCustomers;
+    }
+
+    public function removeUserRoleInCustomer(UserRoleInCustomerInterface $userRoleInCustomer) {
+        $this->userRoleInCustomers->removeElement($userRoleInCustomer);
+
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1485,13 +1485,7 @@ class User implements SamlUserInterface, AddonUserInterface
     {
         // prevents the same role being set multiple times (if they have been set previously)
         if ($this->hasRole($role->getCode(), $customer)) {
-            $roleInCustomer = $this->roleInCustomers->filter(
-                function (UserRoleInCustomerInterface $roleInCustomer) use ($role, $customer) {
-                    return $roleInCustomer->getRole()->getId() === $role->getId() && $roleInCustomer->getCustomer()->getId() === $customer->getId();
-                }
-            )->first();
-
-            return $roleInCustomer;
+            return;
         }
 
         $customer ??= $this->getCurrentCustomer();
@@ -1502,8 +1496,6 @@ class User implements SamlUserInterface, AddonUserInterface
         $userRoleInCustomer->setCustomer($customer);
 
         $this->roleInCustomers->add($userRoleInCustomer);
-
-        return $userRoleInCustomer;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1085,12 +1085,6 @@ class User implements SamlUserInterface, AddonUserInterface
         }
     }
 
-    public function removeRolesInCustomer(array $roles, $customer): void
-    {
-        foreach ($roles as $role) {
-            $this->removeRoleInCustomer($role, $customer);
-        }
-    }
 
     public function removeRoleInCustomer(RoleInterface $role, CustomerInterface $customer): UserRoleInCustomerInterface
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -997,7 +997,6 @@ class User implements SamlUserInterface, AddonUserInterface
         $this->orga = new ArrayCollection([]);
     }
 
-
     /**
      * Department des Users.
      *
@@ -1095,7 +1094,6 @@ class User implements SamlUserInterface, AddonUserInterface
 
     public function removeRoleInCustomer(RoleInterface $role, CustomerInterface $customer): UserRoleInCustomerInterface
     {
-
         $roleInCustomer = $this->getRoleInCustomers()->filter(
             function (UserRoleInCustomerInterface $roleInCustomer) use ($role, $customer) {
                 return $roleInCustomer->getRole()->getId() === $role->getId() && $roleInCustomer->getCustomer()->getId() === $customer->getId();
@@ -1103,12 +1101,9 @@ class User implements SamlUserInterface, AddonUserInterface
         )->first();
 
         $this->roleInCustomers->removeElement($roleInCustomer);
-       return $roleInCustomer;
 
-
-
+        return $roleInCustomer;
     }
-
 
     /**
      * Unset Department.
@@ -1347,7 +1342,6 @@ class User implements SamlUserInterface, AddonUserInterface
         return $roles;
     }
 
-
     public function getRolesInCustomer(?CustomerInterface $customer = null)
     {
         $roles = new ArrayCollection();
@@ -1496,6 +1490,7 @@ class User implements SamlUserInterface, AddonUserInterface
                     return $roleInCustomer->getRole()->getId() === $role->getId() && $roleInCustomer->getCustomer()->getId() === $customer->getId();
                 }
             )->first();
+
             return $roleInCustomer;
         }
 
@@ -1510,8 +1505,6 @@ class User implements SamlUserInterface, AddonUserInterface
 
         return $userRoleInCustomer;
     }
-
-
 
     /**
      * Check whether user has role (code) with a specified customer (current is default).

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1336,31 +1336,6 @@ class User implements SamlUserInterface, AddonUserInterface
         return $roles;
     }
 
-    public function getRolesInCustomer(?CustomerInterface $customer = null)
-    {
-        $roles = new ArrayCollection();
-        $relations = $this->roleInCustomers->toArray();
-
-        // get customer to check
-        if (!$customer instanceof CustomerInterface) {
-            $specifiedCustomerId = $this->currentCustomer instanceof Customer ? $this->currentCustomer->getId() : '';
-        } else {
-            $specifiedCustomerId = $customer->getId();
-        }
-
-        /** @var UserRoleInCustomerInterface $relation */
-        foreach ($relations as $relation) {
-            $relationCustomerId = $relation->getCustomer() instanceof CustomerInterface ? $relation->getCustomer()->getId() : '';
-            if ($specifiedCustomerId === $relationCustomerId
-                && !$roles->contains($relation->getRole())
-                && in_array($relation->getRole()->getCode(), (array) $this->rolesAllowed, true)) {
-                $roles->add($relation);
-            }
-        }
-
-        return $roles;
-    }
-
     /**
      * Returns an array of the code of roles the user has with a specified customer (current is default).
      *

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
@@ -12,22 +12,16 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 
-use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\DepartmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
-use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseInstitutionTagResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseUserResourceConfigBuilder;
-use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
-use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
-use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilder;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-
 
 /**
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $profileCompleted
@@ -40,5 +34,5 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga
  */
 class UserResourceConfigBuilder extends BaseUserResourceConfigBuilder
- {
+{
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\DepartmentInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseInstitutionTagResourceConfigBuilder;
+use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseUserResourceConfigBuilder;
+use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
+use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
+use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
+use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilder;
+use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+
+/**
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $profileCompleted
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $accessConfirmed
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $invited
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $newsletter
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $noPiwik
+ * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,RoleInterface> $roles
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,DepartmentInterface> $department
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga
+ */
+class UserResourceConfigBuilder extends BaseUserResourceConfigBuilder
+ {
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -187,8 +187,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
 
         $configBuilder->roles
             ->updatable([], [], function (User $user, array $roles): array {
-
                 $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+
                 return [];
             })
             ->setRelationshipType($this->getTypes()->getRoleResourceType())

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -224,6 +224,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->addCreationBehavior(
                 CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Department $department): array {
                     $user->setDepartment($department);
+                    $department->addUser($user);
 
                     return [];
                 }, [], OptionalField::NO, [])
@@ -235,6 +236,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->addCreationBehavior(
                 CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Orga $orga): array {
                     $user->setOrga($orga);
+                    $orga->addUser($user);
 
                     return [];
                 }, [], OptionalField::NO, [])

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -32,6 +32,7 @@ use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
 use EDT\Wrapping\EntityDataInterface;
 use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
+use EDT\Wrapping\PropertyBehavior\Relationship\ToMany\CallbackToManyRelationshipSetBehavior;
 use EDT\Wrapping\PropertyBehavior\Relationship\ToOne\CallbackToOneRelationshipSetBehavior;
 use Elastica\Index;
 
@@ -206,10 +207,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             }, DefaultField::YES)
             ->setRelationshipType($this->getTypes()->getRoleResourceType())
             ->addCreationBehavior(
-                CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Role $role): array {
-                    $user->setDplanroles([$role], $this->currentCustomerService->getCurrentCustomer());
-
-                    // $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+                CallbackToManyRelationshipSetBehavior::createFactory(function (User $user, array $roles): array {
+                    $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
                     return [];
                 }, [], OptionalField::NO, [])
             );

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -21,6 +21,8 @@ use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
@@ -51,7 +53,7 @@ use Elastica\Index;
  */
 final class AdministratableUserResourceType extends DplanResourceType implements ReadableEsResourceTypeInterface
 {
-    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService, private readonly UserRepository $userRepository, private readonly UserHandler $userHandler, private readonly UserService $userService)
+    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService, private readonly UserRepository $userRepository, private readonly UserHandler $userHandler, private readonly UserService $userService, private readonly RoleService $roleService, private readonly RoleHandler $roleHandler)
     {
     }
 
@@ -221,6 +223,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->department
             ->setRelationshipType($this->getTypes()->getDepartmentResourceType())
             ->readable(true, static fn (User $user): ?Department => $user->getDepartment())
+            ->updatable([], [], function (User $user, Department $department): array {
+                $user->setDepartment($department);
+                $department->addUser($user);
+                return [];
+            })
             ->initializable(true, function (User $user, Department $department): array {
                 $user->setDepartment($department);
                 $department->addUser($user);
@@ -231,6 +238,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->orga
             ->setRelationshipType($this->getTypes()->getOrgaResourceType())
             ->readable(true, static fn (User $user): ?Orga => $user->getOrga())
+            ->updatable([], [], function (User $user, Orga $orga): array {
+                $user->setOrga($orga);
+                $orga->addUser($user);
+                return [];
+            })
             ->initializable(true, function (User $user, Orga $orga): array {
                 $user->setOrga($orga);
                 $orga->addUser($user);

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -193,9 +193,6 @@ final class AdministratableUserResourceType extends DplanResourceType implements
 
         $configBuilder->roles
             ->updatable([], [], function (User $user, array $newRoles): array {
-                // $user->getRoleInCustomers();
-                // $this->userService->setUserRoles($user->getId(), []);
-
                 $roles = $user->getDplanroles($this->currentCustomerService->getCurrentCustomer())->toArray();
 
                 // Remove roles that are not in the new roles array
@@ -209,8 +206,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
                 // Add new roles that the user does not already have
                 $addedRoles = $this->getAddedRoles($roles, $newRoles);
                 foreach ($addedRoles as $role) {
-                    $userRoleInCustomer = $user->addDplanrole($role, $this->currentCustomerService->getCurrentCustomer());
-                    // $role->addUserRoleInCustomer($userRoleInCustomer);
+                    $user->addDplanrole($role, $this->currentCustomerService->getCurrentCustomer());
                 }
 
                 return [];

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use demosplan\DemosPlanCoreBundle\Entity\Faq;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
@@ -165,7 +166,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->email
             ->readable(true)
             ->sortable()
-            ->updatable()
+            ->updatable([], function (User $user, string $email): array {
+                $user->setLogin($email);
+                $user->setEmail($email);
+                return [];
+            })
             ->initializable()
             ->filterable();
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -305,7 +305,6 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $userAttributes = $entityData->getAttributes();
 
         if (array_key_exists($this->email->getAsNamesInDotNotation(), $userAttributes)) {
-
             $modifiedEntity = parent::updateEntity($entityId, $entityData);
             $this->userHandler->inviteUser($modifiedEntity->getEntity());
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -15,7 +15,6 @@ namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 use DemosEurope\DemosplanAddon\EntityPath\Paths;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
-use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -23,7 +22,6 @@ use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
-use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\InstitutionTagResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryUser;
@@ -138,10 +136,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         return [];
     }
 
-
     protected function getProperties(): ResourceConfigBuilderInterface
     {
-
         $configBuilder = $this->getConfig(UserResourceConfigBuilder::class);
 
         $configBuilder->id
@@ -186,8 +182,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->setReadableByCallable(static fn (User $user): bool => $user->getNoPiwik(), DefaultField::YES);
 
         $configBuilder->roles
-            //->setAliasedPath(Paths::user()->roleInCustomers)
-            ->setReadableByCallable( function (User $user): array {
+            // ->setAliasedPath(Paths::user()->roleInCustomers)
+            ->setReadableByCallable(function (User $user): array {
                 $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
 
                 return $user->getRoleInCustomers()
@@ -206,11 +202,9 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->setRelationshipType($this->getTypes()->getDepartmentResourceType());
 
         $configBuilder->orga
-            ->setReadableByCallable( static fn (User $user): ?Orga => $user->getOrga(), DefaultField::YES)
+            ->setReadableByCallable(static fn (User $user): ?Orga => $user->getOrga(), DefaultField::YES)
             ->setRelationshipType($this->getTypes()->getOrgaResourceType());
 
         return $configBuilder;
     }
-
-
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -21,13 +21,8 @@ use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
-use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
-use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
-use demosplan\DemosPlanCoreBundle\Repository\RoleRepository;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
-use demosplan\DemosPlanCoreBundle\Repository\UserRoleInCustomerRepository;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryUser;
@@ -56,9 +51,9 @@ use Elastica\Index;
 final class AdministratableUserResourceType extends DplanResourceType implements ReadableEsResourceTypeInterface
 {
     public function __construct(private readonly QueryUser $esQuery,
-                                private readonly JsonApiEsService $jsonApiEsService,
-                                private readonly UserRepository $userRepository,
-                                private readonly UserHandler $userHandler)
+        private readonly JsonApiEsService $jsonApiEsService,
+        private readonly UserRepository $userRepository,
+        private readonly UserHandler $userHandler)
     {
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -209,6 +209,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->addCreationBehavior(
                 CallbackToManyRelationshipSetBehavior::createFactory(function (User $user, array $roles): array {
                     $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+
                     return [];
                 }, [], OptionalField::NO, [])
             );

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -71,6 +71,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         return $this->currentUser->hasPermission('feature_user_list');
     }
 
+    public function isCreateAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('feature_user_add');
+    }
+
     protected function getAccessConditions(): array
     {
         $conditions = [
@@ -131,10 +136,10 @@ final class AdministratableUserResourceType extends DplanResourceType implements
     {
         return [
             $this->createIdentifier()->readable()->filterable()->sortable(),
-            $this->createAttribute($this->firstname)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->lastname)->readable(true)->filterable()->sortable(),
+            $this->createAttribute($this->firstname)->readable(true)->filterable()->sortable()->initializable(),
+            $this->createAttribute($this->lastname)->readable(true)->filterable()->sortable()->initializable(),
             $this->createAttribute($this->login)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->email)->readable(true)->filterable()->sortable(),
+            $this->createAttribute($this->email)->readable(true)->filterable()->sortable()->initializable(),
             $this->createAttribute($this->profileCompleted)
                 ->readable(true, static fn (User $user): bool => $user->isProfileCompleted()),
             $this->createAttribute($this->accessConfirmed)
@@ -158,11 +163,14 @@ final class AdministratableUserResourceType extends DplanResourceType implements
                             static fn (UserRoleInCustomer $roleInCustomer): Role => $roleInCustomer->getRole()
                         )
                         ->getValues();
-                }),
+                })
+                ->initializable(), // This one is not working yet
             $this->createToOneRelationship($this->department)
-                ->readable(true, static fn (User $user): ?Department => $user->getDepartment()),
+                ->readable(true, static fn (User $user): ?Department => $user->getDepartment())
+                ->initializable(),
             $this->createToOneRelationship($this->orga)
-                ->readable(true, static fn (User $user): ?Orga => $user->getOrga()),
+                ->readable(true, static fn (User $user): ?Orga => $user->getOrga())
+                ->initializable(),
         ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -226,6 +226,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->updatable([], [], function (User $user, Department $department): array {
                 $user->setDepartment($department);
                 $department->addUser($user);
+
                 return [];
             })
             ->initializable(true, function (User $user, Department $department): array {
@@ -241,6 +242,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->updatable([], [], function (User $user, Orga $orga): array {
                 $user->setOrga($orga);
                 $orga->addUser($user);
+
                 return [];
             })
             ->initializable(true, function (User $user, Orga $orga): array {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -46,6 +46,7 @@ use Elastica\Index;
  * resource type are the only ones that are technically administratable.
  *
  * @property-read End $login
+ * @property-read End $email
  * @property-read End $deleted
  * @property-read OrgaResourceType $orga
  * @property-read UserRoleInCustomerResourceType $roleInCustomers
@@ -154,12 +155,6 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->initializable()
             ->filterable();
 
-        $configBuilder->login
-            ->readable(true)
-            ->sortable()
-            ->initializable()
-            ->filterable();
-
         $configBuilder->email
             ->readable(true)
             ->sortable()
@@ -232,6 +227,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
                 });
 
         $configBuilder->addPostConstructorBehavior(new FixedSetBehavior(function (User $user, EntityDataInterface $entityData): array {
+            $attributes = $entityData->getAttributes();
+            $user->setLogin($attributes[$this->email->getAsNamesInDotNotation()]);
             $this->userRepository->persistEntities([$user]);
 
             return [];

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -21,6 +21,8 @@ use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
@@ -49,7 +51,7 @@ use Elastica\Index;
  */
 final class AdministratableUserResourceType extends DplanResourceType implements ReadableEsResourceTypeInterface
 {
-    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService, private readonly UserRepository $userRepository)
+    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService, private readonly UserRepository $userRepository, private readonly UserHandler $userHandler, private readonly UserService $userService)
     {
     }
 
@@ -187,8 +189,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
 
         $configBuilder->roles
             ->updatable([], [], function (User $user, array $roles): array {
+                $this->userService->setUserRoles($user->getId(), []);
                 $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
-
                 return [];
             })
             ->setRelationshipType($this->getTypes()->getRoleResourceType())

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -191,6 +191,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->updatable([], [], function (User $user, array $roles): array {
                 $this->userService->setUserRoles($user->getId(), []);
                 $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+
                 return [];
             })
             ->setRelationshipType($this->getTypes()->getRoleResourceType())

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -45,17 +45,8 @@ use Elastica\Index;
  * administrate the accessed resources. It does **not** mean that the {@link User}s covered by this
  * resource type are the only ones that are technically administratable.
  *
- * @property-read End $firstname
- * @property-read End $lastname
  * @property-read End $login
- * @property-read End $email
  * @property-read End $deleted
- * @property-read End $profileCompleted
- * @property-read End $accessConfirmed
- * @property-read End $invited
- * @property-read End $newsletter
- * @property-read End $noPiwik
- * @property-read DepartmentResourceType $department
  * @property-read OrgaResourceType $orga
  * @property-read UserRoleInCustomerResourceType $roleInCustomers
  * @property-read RoleResourceType $roles @deprecated use relation to {@link AdministratableUserResourceType::$roleInCustomers} instead

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -166,7 +166,6 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->readable(true)
             ->sortable()
             ->updatable([], function (User $user, string $email): array {
-                $user->setLogin($email);
                 $user->setEmail($email);
 
                 return [];

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -284,6 +284,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             $user->setLogin($attributes[$this->email->getAsNamesInDotNotation()]);
             $this->userRepository->persistEntities([$user]);
 
+            $this->userHandler->inviteUser($user);
+
             return [];
         }));
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
 use DemosEurope\DemosplanAddon\EntityPath\Paths;
-use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
-use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementVote;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
@@ -25,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
-use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\InstitutionTagResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryUser;
@@ -210,7 +207,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->addCreationBehavior(
                 CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Role $role): array {
                     $user->setDplanroles([$role], $this->currentCustomerService->getCurrentCustomer());
-                    //$user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+
+                    // $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
                     return [];
                 }, [], OptionalField::NO, [])
             );
@@ -225,24 +223,28 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->addCreationBehavior(
                 CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Department $department): array {
                     $user->setDepartment($department);
+
                     return [];
                 }, [], OptionalField::NO, [])
             );
 
         $configBuilder->orga
-            ->setReadableByCallable( static fn (User $user): ?Orga => $user->getOrga(), DefaultField::YES)
+            ->setReadableByCallable(static fn (User $user): ?Orga => $user->getOrga(), DefaultField::YES)
             ->setRelationshipType($this->getTypes()->getOrgaResourceType())
             ->addCreationBehavior(
                 CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Orga $orga): array {
                     $user->setOrga($orga);
+
                     return [];
                 }, [], OptionalField::NO, [])
             );
 
         $configBuilder->addPostConstructorBehavior(new FixedSetBehavior(function (User $user, EntityDataInterface $entityData): array {
             $this->userRepository->persistEntities([$user]);
+
             return [];
         }));
+
         return $configBuilder;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
-use demosplan\DemosPlanCoreBundle\Entity\Faq;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
@@ -169,6 +168,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->updatable([], function (User $user, string $email): array {
                 $user->setLogin($email);
                 $user->setEmail($email);
+
                 return [];
             })
             ->initializable()

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -165,6 +165,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->login
             ->setReadableByPath(DefaultField::YES)
             ->setSortable()
+            ->addPathCreationBehavior()
             ->setFilterable();
 
         $configBuilder->email

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -55,7 +55,10 @@ use Elastica\Index;
  */
 final class AdministratableUserResourceType extends DplanResourceType implements ReadableEsResourceTypeInterface
 {
-    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService, private readonly UserRepository $userRepository, private readonly UserHandler $userHandler, private readonly UserService $userService, private readonly RoleService $roleService, private readonly RoleHandler $roleHandler, private readonly RoleRepository $roleRepository, private readonly UserRoleInCustomerRepository $userRoleInCustomerRepository)
+    public function __construct(private readonly QueryUser $esQuery,
+                                private readonly JsonApiEsService $jsonApiEsService,
+                                private readonly UserRepository $userRepository,
+                                private readonly UserHandler $userHandler)
     {
     }
 

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -193,9 +193,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
 
         $configBuilder->roles
             ->updatable([], [], function (User $user, array $newRoles): array {
-                //$user->getRoleInCustomers();
-                //$this->userService->setUserRoles($user->getId(), []);
-
+                // $user->getRoleInCustomers();
+                // $this->userService->setUserRoles($user->getId(), []);
 
                 $roles = $user->getDplanroles($this->currentCustomerService->getCurrentCustomer())->toArray();
 
@@ -210,9 +209,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
                 // Add new roles that the user does not already have
                 $addedRoles = $this->getAddedRoles($roles, $newRoles);
                 foreach ($addedRoles as $role) {
-
-                    $userRoleInCustomer =$user->addDplanrole($role, $this->currentCustomerService->getCurrentCustomer());
-                    //$role->addUserRoleInCustomer($userRoleInCustomer);
+                    $userRoleInCustomer = $user->addDplanrole($role, $this->currentCustomerService->getCurrentCustomer());
+                    // $role->addUserRoleInCustomer($userRoleInCustomer);
                 }
 
                 return [];

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -73,6 +73,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         return $this->currentUser->hasPermission('feature_user_add');
     }
 
+    public function isUpdateAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('feature_user_edit');
+    }
+
     protected function getAccessConditions(): array
     {
         $conditions = [
@@ -141,18 +146,22 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->firstname
             ->readable(true)
             ->sortable()
+            ->updatable()
             ->initializable()
             ->filterable();
 
         $configBuilder->lastname
             ->readable(true)
             ->sortable()
+            ->updatable()
             ->initializable()
+            ->updatable()
             ->filterable();
 
         $configBuilder->email
             ->readable(true)
             ->sortable()
+            ->updatable()
             ->initializable()
             ->filterable();
 
@@ -177,6 +186,11 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             ->sortable();
 
         $configBuilder->roles
+            ->updatable([], [], function (User $user, array $roles): array {
+
+                $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+                return [];
+            })
             ->setRelationshipType($this->getTypes()->getRoleResourceType())
             ->readable(true, function (User $user): array {
                 $currentCustomer = $this->currentCustomerService->getCurrentCustomer();

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -138,53 +138,57 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder = $this->getConfig(UserResourceConfigBuilder::class);
 
         $configBuilder->id
-            ->setReadableByPath(DefaultField::YES)
-            ->setSortable()
-            ->setFilterable();
+            ->readable()
+            ->sortable()
+            ->filterable();
 
         $configBuilder->firstname
-            ->setReadableByPath(DefaultField::YES)
-            ->setSortable()
-            ->addPathCreationBehavior()
-            ->setFilterable();
+            ->readable(true)
+            ->sortable()
+            ->initializable()
+            ->filterable();
 
         $configBuilder->lastname
-            ->setReadableByPath(DefaultField::YES)
-            ->setSortable()
-            ->addPathCreationBehavior()
-            ->setFilterable();
+            ->readable(true)
+            ->sortable()
+            ->initializable()
+            ->filterable();
 
         $configBuilder->login
-            ->setReadableByPath(DefaultField::YES)
-            ->setSortable()
-            ->addPathCreationBehavior()
-            ->setFilterable();
+            ->readable(true)
+            ->sortable()
+            ->initializable()
+            ->filterable();
 
         $configBuilder->email
-            ->setReadableByPath(DefaultField::YES)
-            ->setSortable()
-            ->addPathCreationBehavior()
-            ->setFilterable();
+            ->readable(true)
+            ->sortable()
+            ->initializable()
+            ->filterable();
 
         $configBuilder->profileCompleted
-            ->setSortable()
-            ->setReadableByCallable(static fn (User $user): bool => $user->isProfileCompleted(), DefaultField::YES);
+            ->readable(true, static fn (User $user): bool => $user->isProfileCompleted())
+            ->sortable();
 
         $configBuilder->accessConfirmed
-            ->setReadableByCallable(static fn (User $user): bool => $user->isAccessConfirmed(), DefaultField::YES);
+            ->readable(true, static fn (User $user): bool => $user->isAccessConfirmed())
+            ->sortable();
 
         $configBuilder->invited
-            ->setReadableByCallable(static fn (User $user): bool => $user->isInvited(), DefaultField::YES);
+            ->readable(true, static fn (User $user): bool => $user->isInvited())
+            ->sortable();
 
         $configBuilder->newsletter
-            ->setReadableByCallable(static fn (User $user): bool => $user->getNewsletter(), DefaultField::YES);
+            ->readable(true, static fn (User $user): bool => $user->getNewsletter())
+            ->sortable();
 
         $configBuilder->noPiwik
-            ->setReadableByCallable(static fn (User $user): bool => $user->getNoPiwik(), DefaultField::YES);
+            ->readable(true, static fn (User $user): bool => $user->getNoPiwik())
+            ->sortable();
 
         $configBuilder->roles
-            // ->setAliasedPath(Paths::user()->roleInCustomers)
-            ->setReadableByCallable(function (User $user): array {
+            ->setRelationshipType($this->getTypes()->getRoleResourceType())
+            ->readable(true, function (User $user): array {
                 $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
 
                 return $user->getRoleInCustomers()
@@ -195,43 +199,37 @@ final class AdministratableUserResourceType extends DplanResourceType implements
                         static fn (UserRoleInCustomer $roleInCustomer): Role => $roleInCustomer->getRole()
                     )
                     ->getValues();
-            }, DefaultField::YES)
-            ->setRelationshipType($this->getTypes()->getRoleResourceType())
-            ->addCreationBehavior(
-                CallbackToManyRelationshipSetBehavior::createFactory(function (User $user, array $roles): array {
-                    $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+            })
+            ->sortable()
+            ->initializable(true, function (User $user, array $roles): array {
+                $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
 
-                    return [];
-                }, [], OptionalField::NO, [])
-            );
+                return [];
+            });
 
         $configBuilder->roleInCustomers
             ->setRelationshipType($this->getTypes()->getUserRoleInCustomerResourceType())
-            ->setReadableByPath(DefaultField::YES);
+            ->readable();
 
         $configBuilder->department
-            ->setReadableByCallable(static fn (User $user): ?Department => $user->getDepartment(), DefaultField::YES)
             ->setRelationshipType($this->getTypes()->getDepartmentResourceType())
-            ->addCreationBehavior(
-                CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Department $department): array {
+            ->readable(true, static fn (User $user): ?Department => $user->getDepartment())
+            ->initializable(true, function (User $user, Department $department): array {
                     $user->setDepartment($department);
                     $department->addUser($user);
 
                     return [];
-                }, [], OptionalField::NO, [])
-            );
+                });
 
         $configBuilder->orga
-            ->setReadableByCallable(static fn (User $user): ?Orga => $user->getOrga(), DefaultField::YES)
             ->setRelationshipType($this->getTypes()->getOrgaResourceType())
-            ->addCreationBehavior(
-                CallbackToOneRelationshipSetBehavior::createFactory(function (User $user, Orga $orga): array {
+            ->readable(true, static fn (User $user): ?Orga => $user->getOrga())
+            ->initializable(true, function (User $user, Orga $orga): array {
                     $user->setOrga($orga);
                     $orga->addUser($user);
 
                     return [];
-                }, [], OptionalField::NO, [])
-            );
+                });
 
         $configBuilder->addPostConstructorBehavior(new FixedSetBehavior(function (User $user, EntityDataInterface $entityData): array {
             $this->userRepository->persistEntities([$user]);


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-13034

- Move to using AdministratableUserResourceType instead of old 1.0 api
- Important things to check: 
- Updating Roles,Department and Orga relationships
- When a user is created, login field is set same as email field

### How to review/test
1. Create a user and check that emails has been sent (not possible to test in local)
2. Update user all possible combinations: roles, orga, email.
3. when updating email, check that login is also updated


Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
