### PR TITLE
chore: fix deprecation in InputBag::get

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
@@ -54,7 +54,7 @@ class AuthorizedUsersController extends BaseController
         TranslatorInterface $translator,
         string $procedureId
     ): Response {
-        $tokenList = $consultationTokenService->getTokenListFromResourceType($procedureId, $request->query->get('sort'));
+        $tokenList = $consultationTokenService->getTokenListFromResourceType($procedureId, $request->query->all('sort'));
 
         try {
             $bulkLetterExport = new BulkLetterExporter($translator);

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
@@ -52,7 +52,7 @@ class AuthorizedUsersController extends BaseController
         FileResponseGeneratorStrategy $responseGenerator,
         Request $request,
         TranslatorInterface $translator,
-        string $procedureId
+        string $procedureId,
     ): Response {
         $tokenList = $consultationTokenService->getTokenListFromResourceType($procedureId, $request->query->all('sort'));
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -447,10 +447,7 @@ class DemosPlanProcedureAPIController extends APIController
                 $requestData['name'] = str_replace('[]', '', (string) $requestData['name']);
             }
             if ($multiselect) {
-                $filter = $request->request->get($requestData['name'], []);
-                if (is_string($filter)) {
-                    $filter = [];
-                }
+                $filter = $request->request->all($requestData['name']);
                 $filter[] = $requestData['value'];
                 $request->request->set($requestData['name'], $filter);
             } else {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -61,7 +61,7 @@ class DemosPlanProcedureAPIController extends APIController
         GlobalConfigInterface $globalConfig,
         MessageBagInterface $messageBag,
         MessageFormatter $messageFormatter,
-        SchemaPathProcessor $schemaPathProcessor
+        SchemaPathProcessor $schemaPathProcessor,
     ) {
         parent::__construct(
             $apiLogger,
@@ -181,7 +181,7 @@ class DemosPlanProcedureAPIController extends APIController
         Request $request,
         StatementFilterHandler $statementFilterHandler,
         $procedureId,
-        $filterHash = ''
+        $filterHash = '',
     ) {
         return $this->getStatementFilter(
             $assessmentHandler,
@@ -213,7 +213,7 @@ class DemosPlanProcedureAPIController extends APIController
         Request $request,
         StatementFilterHandler $statementFilterHandler,
         $procedureId,
-        $filterHash = ''
+        $filterHash = '',
     ) {
         return $this->getStatementFilter(
             $assessmentHandler,
@@ -237,7 +237,7 @@ class DemosPlanProcedureAPIController extends APIController
     public function updateNonOriginalFilterSetAction(
         AssessmentHandler $assessmentHandler,
         Request $request,
-        $procedureId
+        $procedureId,
     ): APIResponse {
         return $this->updateFilterSet($assessmentHandler, $request, $procedureId, false);
     }
@@ -251,7 +251,7 @@ class DemosPlanProcedureAPIController extends APIController
     public function updateOriginalFilterSetAction(
         AssessmentHandler $assessmentHandler,
         Request $request,
-        $procedureId
+        $procedureId,
     ): APIResponse {
         return $this->updateFilterSet($assessmentHandler, $request, $procedureId, true);
     }
@@ -308,7 +308,7 @@ class DemosPlanProcedureAPIController extends APIController
         StatementFilterHandler $statementFilterHandler,
         $procedureId,
         $filterHash,
-        $original
+        $original,
     ) {
         // @improve T14122
         $filterSet = $filterSetService->findHashedQueryWithHash($filterHash);
@@ -470,7 +470,7 @@ class DemosPlanProcedureAPIController extends APIController
     public function addInvitedPublicAffairsAgentsAction(
         Request $request,
         ResourceLinkageFactory $linkageFactory,
-        string $procedureId
+        string $procedureId,
     ): JsonResponse {
         // Check if normalizer succeeded, even if we don't need its object here
         if (null === $this->requestData) {
@@ -501,7 +501,7 @@ class DemosPlanProcedureAPIController extends APIController
         ProcedureResourceType $procedureResourceType,
         PublicIndexProcedureLister $procedureLister,
         ProcedureService $procedureService,
-        Request $request
+        Request $request,
     ) {
         $this->fractal->parseFieldsets([
             $procedureResourceType::getName() => $this->buildSparseFieldsetString(

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
@@ -46,7 +46,7 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
         NameGenerator $nameGenerator,
         ProcedureServiceOutput $procedureServiceOutput,
         TranslatorInterface $translator,
-        $procedure
+        $procedure,
     ) {
         // is the user permitted to view the procedure at all?
         if (!$permissions->ownsProcedure() && (!$currentUser->getUser()->isLoggedIn() || !$permissions->hasPermissionsetRead())) {
@@ -91,7 +91,7 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
         NameGenerator $nameGenerator,
         ProcedureServiceOutput $procedureServiceOutput,
         Request $request,
-        $procedure
+        $procedure,
     ) {
         $requestPost = $request->request->all();
         $selectedOrgas = $request->request->all('orga_selected');
@@ -139,7 +139,7 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
         CurrentUserService $currentUser,
         ExportService $exportService,
         PermissionsInterface $permissions,
-        $procedure
+        $procedure,
     ) {
         $user = $currentUser->getUser();
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
@@ -94,7 +94,7 @@ class DemosPlanProcedureExportController extends DemosPlanProcedureController
         $procedure
     ) {
         $requestPost = $request->request->all();
-        $selectedOrgas = $request->request->get('orga_selected', []);
+        $selectedOrgas = $request->request->all('orga_selected');
 
         // Lösche bestimmte RequestVariablen, die für den Export nicht benötigt werden
         $contentNotToTransferToPDF = ['r_emailTitle', 'r_emailCc', 'r_emailText'];

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
@@ -65,7 +65,7 @@ class DemosPlanReportAPIController extends APIController
         Assert::isInstanceOf($resourceType, JsonApiResourceTypeInterface::class);
 
         $pagination = $paginationParser->parseApiPaginationProfile(
-            $this->request->query->get('page', []),
+            $this->request->query->all('page'),
             $this->request->query->get('sort', '')
         );
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -64,7 +64,7 @@ class SegmentsExportController extends BaseController
         string $statementId
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
-        $tableHeaders = $this->requestStack->getCurrentRequest()->query->get('tableHeaders', []);
+        $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
         $fileNameTemplate = $this->requestStack->getCurrentRequest()->query->get('fileNameTemplate', '');
         $procedure = $this->procedureHandler->getProcedureWithCertainty($procedureId);
         $statement = $statementHandler->getStatementWithCertainty($statementId);
@@ -99,7 +99,7 @@ class SegmentsExportController extends BaseController
         string $procedureId
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
-        $tableHeaders = $this->requestStack->getCurrentRequest()->query->get('tableHeaders', []);
+        $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
         $procedure = $this->procedureHandler->getProcedureWithCertainty($procedureId);
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
@@ -187,7 +187,7 @@ class SegmentsExportController extends BaseController
         string $procedureId
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
-        $tableHeaders = $this->requestStack->getCurrentRequest()->query->get('tableHeaders', []);
+        $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
         $fileNameTemplate = $this->requestStack->getCurrentRequest()->query->get('fileNameTemplate', '');
         $procedure = $this->procedureHandler->getProcedureWithCertainty($procedureId);
         // This method applies mostly the same restrictions as the generic API access to retrieve statements.

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -61,7 +61,7 @@ class SegmentsExportController extends BaseController
         StatementHandler $statementHandler,
         SegmentExporterFileNameGenerator $fileNameGenerator,
         string $procedureId,
-        string $statementId
+        string $statementId,
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
         $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
@@ -96,7 +96,7 @@ class SegmentsExportController extends BaseController
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
         JsonApiActionService $requestHandler,
-        string $procedureId
+        string $procedureId,
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
         $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
@@ -136,7 +136,7 @@ class SegmentsExportController extends BaseController
         JsonApiActionService $jsonApiActionService,
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
-        string $procedureId
+        string $procedureId,
     ): StreamedResponse {
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
@@ -184,7 +184,7 @@ class SegmentsExportController extends BaseController
         StatementResourceType $statementResourceType,
         JsonApiActionService $requestHandler,
         ZipExportService $zipExportService,
-        string $procedureId
+        string $procedureId,
     ): StreamedResponse {
         /** @var array<string, string> $tableHeaders */
         $tableHeaders = $this->requestStack->getCurrentRequest()->query->all('tableHeaders');
@@ -208,7 +208,7 @@ class SegmentsExportController extends BaseController
                 array_map(
                     static function (
                         Statement $statement,
-                        string $filePathInZip
+                        string $filePathInZip,
                     ) use ($exporter, $zipExportService, $zipStream, $procedure, $tableHeaders): void {
                         $docx = $exporter->exportStatementSegmentsInSeparateDocx($statement, $procedure, $tableHeaders);
                         $writer = IOFactory::createWriter($docx);
@@ -229,7 +229,7 @@ class SegmentsExportController extends BaseController
 
     private function setResponseHeaders(
         StreamedResponse $response,
-        string $filename
+        string $filename,
     ): void {
         $response->headers->set('Pragma', 'public');
         $response->headers->set(

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -406,7 +406,7 @@ class DemosPlanStatementAPIController extends APIController
             $filterSetHash = $hashNew->getHash();
 
             $pagination = $paginationParser->parseApiPaginationProfile(
-                $this->request->query->get('page', []),
+                $this->request->query->all('page'),
                 $this->request->query->get('sort', ''),
                 25
             );

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -132,7 +132,7 @@ class DemosPlanOrganisationAPIController extends APIController
 
             // pagination
             $pagination = $paginationParser->parseApiPaginationProfile(
-                $this->request->query->get('page', []),
+                $this->request->query->all('page'),
                 $this->request->query->get('sort', ''),
                 $this->request->query->get('size', '10')
             );

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
@@ -138,7 +138,7 @@ class DemosPlanUserAPIController extends APIController
     ): APIResponse {
         try {
             if ($request->query->has(UrlParameter::FILTER)) {
-                $filterArray = $request->query->get(UrlParameter::FILTER);
+                $filterArray = $request->query->all(UrlParameter::FILTER);
                 $filterArray = $filterParser->validateFilter($filterArray);
                 $conditions = $filterParser->parseFilter($filterArray);
             } else {
@@ -150,7 +150,7 @@ class DemosPlanUserAPIController extends APIController
                 $sortMethodFactory->propertyAscending($userType->firstname),
             ];
 
-            $searchParams = SearchParams::createOptional($request->query->get(JsonApiEsServiceInterface::SEARCH, []));
+            $searchParams = SearchParams::createOptional($request->query->all(JsonApiEsServiceInterface::SEARCH));
             if (!$searchParams instanceof SearchParams) {
                 $listResult = $jsonApiActionService->listObjects($userType, $conditions, $sortMethods);
             } else {
@@ -161,7 +161,7 @@ class DemosPlanUserAPIController extends APIController
             $adapter = new ArrayAdapter($users);
             $paginator = new DemosPlanPaginator($adapter);
             $pagination = $paginationParser->parseApiPaginationProfile(
-                $this->request->query->get(UrlParameter::PAGE, []),
+                $this->request->query->all(UrlParameter::PAGE),
                 $this->request->query->get(UrlParameter::SORT, ''),
                 25
             );

--- a/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
@@ -53,7 +53,7 @@ class JsonApiActionService
         private readonly JsonApiEsService $jsonApiEsService,
         private readonly JsonApiPaginationParser $paginationParser,
         private readonly DrupalFilterParser $filterParser,
-        private readonly JsonApiSortingParser $sortingParser
+        private readonly JsonApiSortingParser $sortingParser,
     ) {
         $this->eventDispatcher = $eventDispatcher;
     }
@@ -69,7 +69,7 @@ class JsonApiActionService
         JsonApiResourceTypeInterface $type,
         array $conditions,
         array $sortMethods = [],
-        ?APIPagination $pagination = null
+        ?APIPagination $pagination = null,
     ): ApiListResultInterface {
         if (null === $pagination) {
             $filteredEntities = $type->getEntities($conditions, $sortMethods);
@@ -97,7 +97,7 @@ class JsonApiActionService
         array $sortMethods = [],
         array $filterAsArray = [],
         bool $requireEntities = true,
-        ?APIPagination $pagination = null
+        ?APIPagination $pagination = null,
     ): ApiListResult {
         // we do not need to apply any sorting here, because it needs to be applied later
         $entityIdentifiers = $type->listEntityIdentifiers($conditions, []);
@@ -111,7 +111,7 @@ class JsonApiActionService
      */
     public function getObjectsByQueryParams(
         ParameterBag $query,
-        ResourceTypeInterface $type
+        ResourceTypeInterface $type,
     ): ApiListResult {
         $filters = $this->getFilters($query);
         $sortMethods = $this->getSorting($query);
@@ -123,7 +123,7 @@ class JsonApiActionService
         ResourceTypeInterface $type,
         array $filters,
         array $sortMethods,
-        ParameterBag $query
+        ParameterBag $query,
     ): ApiListResultInterface {
         $searchParams = SearchParams::createOptional($query->all(JsonApiEsServiceInterface::SEARCH));
         $pagination = $this->getPagination($query);

--- a/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
@@ -125,7 +125,7 @@ class JsonApiActionService
         array $sortMethods,
         ParameterBag $query
     ): ApiListResultInterface {
-        $searchParams = SearchParams::createOptional($query->get(JsonApiEsServiceInterface::SEARCH, []));
+        $searchParams = SearchParams::createOptional($query->all(JsonApiEsServiceInterface::SEARCH));
         $pagination = $this->getPagination($query);
 
         if (null === $searchParams) {
@@ -159,7 +159,7 @@ class JsonApiActionService
             return [];
         }
 
-        $filterParam = $query->get(UrlParameter::FILTER);
+        $filterParam = $query->all(UrlParameter::FILTER);
         $filterParam = $this->filterParser->validateFilter($filterParam);
         $conditions = $this->filterParser->parseFilter($filterParam);
         $query->remove(UrlParameter::FILTER);


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/17164

InputBag::get should only return scalar values, when an array is needed InputBag::all should be used. Like it or not. See https://github.com/symfony/symfony/issues/44788

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
