### PR TITLE
Fix dubble ExternalId for synchronized statements

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -50,7 +50,7 @@ class StatementSynchronizer
         private readonly StatementRepository $statementRepository,
         private readonly StatementService $statementService,
         private readonly TransactionService $transactionService,
-        private readonly ValidatorInterface $validator
+        private readonly ValidatorInterface $validator,
     ) {
     }
 
@@ -140,7 +140,7 @@ class StatementSynchronizer
      */
     private function copyAsOriginalStatement(
         Statement $sourceStatement,
-        Procedure $targetProcedure
+        Procedure $targetProcedure,
     ): array {
         if ($sourceStatement->isOriginal()) {
             throw new InvalidArgumentException('Given statement is an original statement.');
@@ -167,7 +167,6 @@ class StatementSynchronizer
             // if the externId is not used, set the externId to the new statement
             $newOriginalStatement->setExternId($sourceStatement->getExternId());
         }
-
 
         // warning: order of the method calls matter, as later methods may use information
         // of fields set previously
@@ -265,7 +264,7 @@ class StatementSynchronizer
      */
     private function copyFileContainersBetweenStatements(
         Statement $sourceStatement,
-        Statement $newOriginalStatement
+        Statement $newOriginalStatement,
     ): array {
         $sourceFileContainers = $this->statementService->getFileContainersForStatement($sourceStatement->getId());
 
@@ -281,7 +280,7 @@ class StatementSynchronizer
      */
     private function copyFileContainersToStatement(
         array $fileContainers,
-        Statement $targetStatement
+        Statement $targetStatement,
     ): array {
         $fileContainerCopies = [];
         foreach ($fileContainers as $fileContainer) {
@@ -311,7 +310,7 @@ class StatementSynchronizer
      */
     public function cloneFileContainersToStatement(
         array $originalfileContainers,
-        Statement $newStatement
+        Statement $newStatement,
     ): void {
         $fileStrings = [];
         foreach ($originalfileContainers as $oldFileContainer) {

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -155,18 +155,18 @@ class StatementSynchronizer
         $this->statementRepository->persistEntities([$newOriginalStatement]);
 
         // check if the externId is already used in the target procedure
-        $targetProcedureStatemnts = $targetProcedure->getStatements();
-        foreach ($targetProcedureStatemnts as $targetProcedureStatemnt) {
-            if ($targetProcedureStatemnt->getExternId() === $sourceStatement->getExternId()) {
-                // if the externId is already used, add a -1 to the externId
-                $newOriginalStatement->setExternId($sourceStatement->getExternId().'-1');
-                // if find a match, break the loop
-                break;
-            }
+        /** @var Statement[] $targetProcedureStatements */
+        $targetProcedureStatements = $targetProcedure->getStatements();
+        $externId = $sourceStatement->getExternId();
+        $suffix = 1;
 
-            // if the externId is not used, set the externId to the new statement
-            $newOriginalStatement->setExternId($sourceStatement->getExternId());
+        foreach ($targetProcedureStatements as $targetProcedureStatement) {
+            if ($targetProcedureStatement->getExternId() === $externId) {
+                $externId = $sourceStatement->getExternId().'-'.$suffix++;
+            }
         }
+
+        $newOriginalStatement->setExternId($externId);
 
         // warning: order of the method calls matter, as later methods may use information
         // of fields set previously

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -154,6 +154,21 @@ class StatementSynchronizer
         $newOriginalStatement = new Statement();
         $this->statementRepository->persistEntities([$newOriginalStatement]);
 
+        // check if the externId is already used in the target procedure
+        $targetProcedureStatemnts = $targetProcedure->getStatements();
+        foreach ($targetProcedureStatemnts as $targetProcedureStatemnt) {
+            if ($targetProcedureStatemnt->getExternId() === $sourceStatement->getExternId()) {
+                // if the externId is already used, add a -1 to the externId
+                $newOriginalStatement->setExternId($sourceStatement->getExternId().'-1');
+                // if find a match, break the loop
+                break;
+            }
+
+            // if the externId is not used, set the externId to the new statement
+            $newOriginalStatement->setExternId($sourceStatement->getExternId());
+        }
+
+
         // warning: order of the method calls matter, as later methods may use information
         // of fields set previously
 
@@ -161,7 +176,6 @@ class StatementSynchronizer
         $newOriginalStatement->setSubmitTypeTranslated($sourceStatement->getSubmitTypeTranslated());
         $newOriginalStatement->setMapFile($sourceStatement->getMapFile());
         $newOriginalStatement->setSubmit($sourceStatement->getSubmitObject()->add(new DateInterval('PT1S')));
-        $newOriginalStatement->setExternId($sourceStatement->getExternId());
         $newOriginalStatement->setProcedure($targetProcedure);
         $newOriginalStatement->setOrganisation($sourceStatement->getOrganisation());
         $newOriginalStatement->setManual($sourceStatement->isManual());


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-4237/STN-Nr-wird-doppelt-vergeben


Description: check existed statements external ID in target procedure to find same and if true then change it with '-1' and if false continue. And create a migration to fix old ones in EWM project 

Delete the checkbox if it doesn't apply/isn't necessary.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
