### PR TITLE
fix(BEAA2-14): add required attribute to the fileupload component

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -877,7 +877,7 @@
                                 {% if hasPermission('field_procedure_pictogram') and hasPermission('area_public_participation') %}
                                     <div class="u-mb">
                                         <label class="inline-block u-mb-0" for="r_pictogram">
-                                            {{ 'procedure.pictogram'|trans }}
+                                            {{ 'procedure.pictogram'|trans }}*
                                         </label>
                                         {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
                                             helpText: 'text.procedure.edit.external.pictogram'|trans,
@@ -907,7 +907,8 @@
                                                 "img",
                                                 "form.button.upload.file",
                                                 1,
-                                                true
+                                                true,
+                                                required: 'true'
                                             )
                                             }}
                                         {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -908,7 +908,8 @@
                                                 "form.button.upload.file",
                                                 1,
                                                 true,
-                                                required: 'true'
+                                                false,
+                                                true
                                             )
                                             }}
                                         {% endif %}


### PR DESCRIPTION
### Ticket
[BEAA2-14](https://demoseurope.youtrack.cloud/issue/BEAA2-14/Piktogramm-wird-nicht-als-Pflichtfeld-angezeigt)

**Description:** This PR adds a required attribute to the pictogram.
