### PR TITLE
fix(BEAA2-19): remove label from the pictogram

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -879,11 +879,6 @@
                                         <label class="inline-block u-mb-0" for="r_pictogram">
                                             {{ 'procedure.pictogram'|trans }}
                                         </label>
-                                        {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                            helpText: 'text.procedure.edit.external.pictogram'|trans,
-                                            cssClasses:'mb-1',
-                                            showPlainHint: true
-                                        } %}
                                         {% if proceduresettings.settings.pictogram is defined and proceduresettings.settings.pictogram != "" %}
                                             <br><br>
                                             <img class="layout__item u-1-of-6 u-pl-0 u-mb" src="{{ path("core_logo", { 'hash': proceduresettings.settings.pictogram|getFile('hash') }) }}"><!--
@@ -900,7 +895,9 @@
                                         {% else %}
                                             {{  fileupload(
                                                 "r_pictogram",
-                                                "hide",
+                                                '<p class="lbl__hint">'
+                                                ~ "text.procedure.edit.external.pictogram"|trans
+                                                ~ '</p>',
                                                 "img",
                                                 "form.button.upload.file",
                                                 1,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -900,10 +900,7 @@
                                         {% else %}
                                             {{  fileupload(
                                                 "r_pictogram",
-                                                '<p class="lbl__hint">'
-                                                ~ "explanation.procedure.pictogram.missing"|trans
-                                                ~ "explanation.procedure.pictogram.dimensions"|trans
-                                                ~ '</p>',
+                                                "hide",
                                                 "img",
                                                 "form.button.upload.file",
                                                 1,


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/BEAA2-19/Text-zu-Piktogramm-widerspricht-sich-in-Tooltip-und-in-Hinweistext

**Description:** This PR removes the label from the pictogram.