### PR TITLE
feat(refs DPLAN-12968, #AB21840): set margin outside of component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## UNRELEASED
 
+### Changed
+
+DpInlineNotification: Set margin from outside the component (instead of inside)
+
 ## 2.20.0
 
 - Added: Admin institution list: Institutions can now be tagged filtered by categories.

--- a/client/js/components/document/ElementsAdminBulkEdit/ElementsAdminBulkEdit.vue
+++ b/client/js/components/document/ElementsAdminBulkEdit/ElementsAdminBulkEdit.vue
@@ -60,6 +60,7 @@
         class="border--bottom u-mt u-pb-0_5">
         <p v-html="confirmStateChangeMessage" />
         <dp-inline-notification
+          class="mt-3 mb-2"
           :message="Translator.trans('elements.bulk.edit.change.state.hint')"
           type="warning" />
       </div>

--- a/client/js/components/map/admin/MapAdminScales.vue
+++ b/client/js/components/map/admin/MapAdminScales.vue
@@ -35,6 +35,7 @@
     </p>
     <dp-inline-notification
       v-if="!areScalesSuitable"
+      class="mt-3 mb-2"
       :message="Translator.trans('map.scales.select.error')"
       type="error" />
   </div>

--- a/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImportErrors.vue
+++ b/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImportErrors.vue
@@ -10,6 +10,7 @@
 <template>
   <div>
     <dp-inline-notification
+      class="mt-3 mb-2"
       :message="Translator.trans('excel.import.error', { count: errors.length, entities: Translator.trans(context) })"
       type="error" />
 

--- a/client/js/components/procedure/SegmentsBulkEdit/ActionStepper/ActionStepperResponse.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/ActionStepper/ActionStepperResponse.vue
@@ -9,6 +9,7 @@
 
 <template>
   <dp-inline-notification
+    class="mt-3 mb-2"
     :message="success ? descriptionSuccess : descriptionError"
     :type="success ? 'confirm' : 'error'">
     <slot />

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -153,13 +153,13 @@
         <dp-inline-notification
           type="info"
           :message="Translator.trans('bulk.edit.info.assigned', { count: segments.length})"
-          class="border-between-none" />
+          class="border-between-none mt-3 mb-2" />
 
         <dp-inline-notification
           v-if="actions.addRecommendations.text === '' && addRecommendationsChecked"
           type="warning"
           :message="emptyRecommendationWarning"
-          class="border-between-none" />
+          class="border-between-none mt-3 mb-2" />
 
         <div
           v-if="hasPermission('feature_statement_assignment') && assignSegmentCheckedAndSelected"

--- a/client/js/components/procedure/StatementSegmentsList/SegmentCommentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentCommentsList.vue
@@ -49,7 +49,7 @@
     <dp-inline-notification
       v-else
       type="info"
-      class="u-mt-1_5 u-mb"
+      class="u-mt-1_5 mb-4"
       :message="Translator.trans('explanation.noentries')" />
   </div>
 </template>

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -87,7 +87,7 @@
         class="border space-inset-s">
         <dp-inline-notification
           v-if="segmentDraftList"
-          class="mt-1"
+          class="mt mb-2"
           :message="Translator.trans('warning.statement.in.segmentation.cannot.be.edited')"
           type="warning" />
         <p class="weight--bold">

--- a/client/js/components/procedure/admin/DpNewProcedure/CoupleTokenInput.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/CoupleTokenInput.vue
@@ -23,7 +23,7 @@
       @input="validateToken" />
     <dp-inline-notification
       v-if="notification"
-      class="u-mb-0"
+      class="mt-3 mb-0"
       id="token-notification"
       :message="notification.text"
       :type="notification.type" />

--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -193,6 +193,7 @@
         <div v-text="Translator.trans('procedure.couple_token.vht.info')" />
 
         <dp-inline-notification
+          class="mt-3 mb-2"
           :message="Translator.trans('procedure.couple_token.vht.inline_notification')"
           type="warning" />
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -10,6 +10,7 @@
 <template>
   <div>
     <dp-inline-notification
+      class="mt-3 mb-2"
       dismissible
       :message="Translator.trans('explanation.invitable_institution.group.tags')"
       type="info" />

--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
@@ -43,7 +43,7 @@
         <dp-inline-notification
           v-if="tagCategoriesWithTags.length === 0"
           type="info"
-          class="u-mt-1_5 u-mb"
+          class="u-mt-1_5 mb-4"
           :message="Translator.trans('explanation.noentries')" />
 
         <dp-tree-list

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -77,7 +77,7 @@
           mode="out-in">
           <dp-inline-notification
             v-if="showAutoSwitchToAnalysisHint"
-            class="u-mb-0"
+            class="mt-3 mb-0"
             :message="Translator.trans('period.autoswitch.hint', { phase: Translator.trans(isInternal ? 'procedure.phases.internal.analysis' : 'procedure.phases.external.evaluating')})"
             type="warning" />
         </transition>
@@ -85,7 +85,7 @@
 
       <dp-inline-notification
         v-if="hasPermission('feature_auto_switch_to_procedure_end_phase') && isParticipationPhaseSelected"
-        class="u-mb-0"
+        class="mt-3 mb-0"
         :message="Translator.trans('period.autoswitch.hint', { phase: Translator.trans(isInternal ? 'procedure.phases.internal.analysis' : 'procedure.phases.external.evaluating')})"
         type="warning" />
     </transition>

--- a/client/js/components/procedure/basicSettings/ExportSettings.vue
+++ b/client/js/components/procedure/basicSettings/ExportSettings.vue
@@ -14,6 +14,7 @@
     </p>
     <dp-inline-notification
       v-if="singleCheckedFieldId"
+      class="mt-3 mb-2"
       :message="Translator.trans('field.selectionRequired')"
       type="warning" />
     <dp-checkbox

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -30,6 +30,7 @@
     </div>
 
     <dp-inline-notification
+      class="mt-3 mb-2"
       :message="permissionMessageText"
       type="warning" />
 

--- a/client/js/components/procedure/listSubscriptions/ListSubscriptions.vue
+++ b/client/js/components/procedure/listSubscriptions/ListSubscriptions.vue
@@ -98,6 +98,7 @@
 
     <dp-inline-notification
       v-else
+      class="mt-3 mb-2"
       :message="Translator.trans('explanation.noentries')"
       type="info" />
   </form>

--- a/client/js/components/statement/assessmentTable/AssessmentTableFilter.vue
+++ b/client/js/components/statement/assessmentTable/AssessmentTableFilter.vue
@@ -52,6 +52,7 @@
       </div>
       <dp-inline-notification
         v-if="hasActiveFilters && hasChangedStatements"
+        class="mt-3 mb-2"
         :message="Translator.trans('filter.settings_not_current')"
         type="warning" />
     </fieldset>

--- a/client/js/components/statement/listOriginalStatements/ListOriginalStatements.vue
+++ b/client/js/components/statement/listOriginalStatements/ListOriginalStatements.vue
@@ -225,6 +225,7 @@
 
       <dp-inline-notification
         v-else
+        class="mt-3"
         :message="Translator.trans('statements.none')"
         type="info" />
     </template>

--- a/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
+++ b/client/js/components/statement/publicStatementLists/DpPublicStatement.vue
@@ -225,7 +225,7 @@
       </div>
       <dp-inline-notification
         v-if="rejectedReason"
-        class="u-mt"
+        class="mt"
         type="info">
         <div>{{ Translator.trans('statement.rejected.with.reason') }}:</div>
         <div>{{ rejectedReason }}</div>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -67,6 +67,7 @@
       </header>
 
       <dp-inline-notification
+        :class="prefixClass('mt-3 mb-2')"
         dismissible
         dismissible-key="statementModalCloseExplanation"
         :message="Translator.trans('explanation.statement.autosave')"
@@ -78,6 +79,7 @@
         data-dp-validate="statementForm">
         <dp-inline-notification
           v-if="loggedIn === false"
+          :class="prefixClass('mt-3')"
           type="info">
           <p
             v-if="statementFormHintStatement"
@@ -88,6 +90,7 @@
 
         <dp-inline-notification
           v-if="dpValidate.statementForm === false"
+          :class="prefixClass('mt-3 mb-2')"
           id="statementFormErrors"
           aria-labelledby="statementFormErrorsContent"
           tabindex="0">
@@ -441,6 +444,7 @@
         v-show="step === 1"
         data-dp-validate="submitterForm">
         <dp-inline-notification
+          :class="prefixClass('mt-3 mb-2')"
           type="info">
           <p
             v-if="statementFormHintPersonalData"

--- a/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
@@ -17,12 +17,13 @@
       v-text="Translator.trans('statement.recheck')" />
 
     <dp-inline-notification
-      :class="prefixClass('mt-1')"
+      :class="prefixClass('mt-1 mb-2')"
       :message="Translator.trans('statement.recheck')"
       type="warning" />
 
     <dp-inline-notification
       v-if="statementFormHintRecheck !== ''"
+      :class="prefixClass('mt-3 mb-2')"
       type="info">
       <p v-cleanhtml="statementFormHintRecheck" />
     </dp-inline-notification>

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -16,6 +16,7 @@
           class="u-pv-0_25 flow-root">
           <dp-inline-notification
             v-if="!isLoading && isSegmentDraftUpdated"
+            class="mt-3 mb-2"
             :message="Translator.trans('last.saved', { date: lastSavedTime })"
             type="info" />
           <h1 class="font-size-h1 align-bottom inline-block u-m-0">

--- a/client/js/components/statement/statement/DpVersionHistory.vue
+++ b/client/js/components/statement/statement/DpVersionHistory.vue
@@ -44,9 +44,9 @@
               colspan="4"
               class="u-mr">
               <dp-inline-notification
-                type="info"
+                class="mt-3 mb-2"
                 :message="Translator.trans('explanation.noentries')"
-              />
+                type="info" />
             </td>
           </tr>
           <!-- if there are history items -->

--- a/client/js/components/statement/statement/StatementPublish.vue
+++ b/client/js/components/statement/statement/StatementPublish.vue
@@ -72,6 +72,7 @@
 
       <dp-inline-notification
         v-if="hasPermission('feature_statements_vote')"
+        class="mt-3 mb-2"
         :message="Translator.trans('explanation.statement.public.activate.voting')"
         type="info" />
     </div>

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_flash.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_flash.scss
@@ -79,7 +79,6 @@ $flash-colors-interactive:
 %flash {
 
     //  basic styling for box
-    margin: 1.5 * $inuit-base-spacing-unit--small 0 $inuit-base-spacing-unit--small;
     padding: $inuit-base-spacing-unit--small $inuit-base-spacing-unit * .8;
 
     color: $dp-color-text-default;


### PR DESCRIPTION
### Ticket
[DPLAN-12968](https://demoseurope.youtrack.cloud/issue/DPLAN-12968/ADO-Issue-21840-Admin-Institutionsliste-Institutionen-konnen-durchsucht-werden)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Previously, margin was set via the `flash` class on the root `div` in `DpInlineNotification`. When setting dismissible to true and then dismissing the notification in the interface, the hint icon has no margin. Instead of defining it directly in the component, the margin can now simply be set from outside the component and will be applied to the root `div` (whether it's the notification or the icon):

```
  <dp-inline-notification
      classs="mt-3 mb-2"
      dismissible
      :dismissible-key="helpTextDismissibleKey"
      :message="helpText"
      type="info" />
```

I tested only some usages and found that sometimes, the extra margin was not needed. In other cases I added the same margin as was previously set in the component, so things should look as before.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Update changelog 
