### PR TITLE
chore: improve router performance

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Router.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Router.php
@@ -146,20 +146,20 @@ class Router implements RouterInterface, WarmableInterface
         return $parameters;
     }
 
-    private function slugifyProcedureIdParam(string $procedureIdOrSlug): string
+    private function slugifyProcedureIdParam(string $procedureId): string
     {
         // the cache is only useful, when $procedureId is the slug
         // as otherwise doctrine will cache the query result itself
-        if (array_key_exists($procedureIdOrSlug, $this->procedureIdCache)) {
-            return $this->procedureIdCache[$procedureIdOrSlug];
+        if (array_key_exists($procedureId, $this->procedureIdCache)) {
+            return $this->procedureIdCache[$procedureId];
         }
 
-        $this->procedureIdCache[$procedureIdOrSlug] = $procedureIdOrSlug;
-        $slug = $procedureIdOrSlug;
-        $procedure = $this->procedureRepository->find($procedureIdOrSlug);
-        if ($procedure instanceof Procedure && '' !== $procedure->getShortUrl()) {
-            $this->procedureIdCache[$procedureIdOrSlug] = $procedure->getShortUrl();
-            $slug = $procedure->getShortUrl();
+        $this->procedureIdCache[$procedureId] = $procedureId;
+        $slug = $procedureId;
+        $shortUrl = $this->procedureRepository->findShortUrlById($procedureId);
+        if ($shortUrl) {
+            $this->procedureIdCache[$procedureId] = $shortUrl;
+            $slug = $shortUrl;
         }
 
         return $slug;

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -1449,4 +1449,19 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
     {
         return $this->getEntityManager()->getRepository(User::class);
     }
+
+    /**
+     * Extra method to get the shortUrl of a procedure by its id to avoid
+     * hydrating the whole procedure.
+     */
+    public function findShortUrlById(string $procedureId): string
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->select('p.shortUrl')
+            ->where('p.id = :id')
+            ->setParameter('id', $procedureId)
+            ->getQuery();
+
+        return $qb->getSingleScalarResult();
+    }
 }


### PR DESCRIPTION
The hydration of objects is quite expensive and when a lot of links with procedureIds are generated this PR improves the performance by fetching only the needed property from the database.
In my testcase with only 19 Procedures it improved the overall performance by almost 40%

### How to review/test
Any links within a procedure should work

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
