### PR TITLE
fix(DPLAN-13108): datapicker css issue

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/vendor/_a11y-datepicker.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/vendor/_a11y-datepicker.scss
@@ -1,1 +1,35 @@
 @import '~a11y-datepicker/dist/css/themes/light.css';
+
+/* The Content Security Policy (CSP) prevents cross-site scripting attacks by blocking inline execution of scripts and style sheets.
+   Because of this, the styles need to be duplicated here. */
+
+.a1-div[data-ad-selector="datepicker-container"] {
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    z-index: 1001;
+}
+
+.a1-div[data-ad-selector="group-container"] {
+    position: relative;
+}
+
+.a1-p.visuallyhidden:not(:focus):not(:active) {
+    position: absolute;
+
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+
+    white-space: nowrap;
+
+    clip-path: inset(100%);
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+}
+
+.a1-td:empty::after {
+    content: "\00a0";
+}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-13108/Zeitraum-Infotext-ist-sichtbar


Description: This PR duplicates the styles from a11y-datepicker (previously added directly in the head > style type=text/css) into css file, due to issues with the Content Security Policy (CSP). The CSP prevents cross-site scripting attacks by blocking the inline execution of scripts and stylesheets.

![image](https://github.com/user-attachments/assets/6842614f-17d7-4bb0-9efb-62c52e103325)
