### PR TITLE
fix: Move Sass-loader settings to the right place

### DIFF
--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -160,9 +160,8 @@ const moduleRules =
         {
           loader: 'sass-loader',
           options: {
-            api: 'modern-compiler',
+            implementation: require('sass-embedded'),
             sassOptions: {
-              implementation: require('sass-embedded'),
               additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
               loadPaths: [
                 config.projectRoot + 'web/',

--- a/client/fe/webpack/plugins.js
+++ b/client/fe/webpack/plugins.js
@@ -97,21 +97,7 @@ const webpackDefaultPlugins = [
   // Provide Vue instance to all modules (is configured in InitVue.js before initialization).
   new webpack.ProvidePlugin({
     Vue: 'vue'
-  }),
-  /*
-   * Exiting webpack after build manually is necessary because sass-loader has some issues doing it by itself.
-   * It should be evaluated from time to time, if this is still necessary.
-   * @see https://github.com/demos-europe/demosplan-core/pull/4095
-   */
-  {
-    apply: compiler => {
-      compiler.hooks.done.tap('DonePlugin', () => {
-        setTimeout(() => {
-          process.exit(0)
-        }, 500)
-      })
-    }
-  }
+  })
 ]
 
 module.exports = {


### PR DESCRIPTION
two issues in one: The implementation option was set in the wrong scope and for whatever reason the modern-compiler option prevented finishing the process. Although we want to have that option enabled and it worked with that quirk for dev. compiling the prod-assets did not work.