### PR TITLE
fix(DPLAN-12125): display layer-type label only if the permission is on

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -11,10 +11,10 @@
         {% block layerType %}
             {%- apply spaceless %}
 
-                <label class="u-mt-0_5 u-mb-0_5">
-                    {{ "map"|trans }}*
-                </label>
                {% if hasPermission('feature_map_baselayer') %}
+                   <label class="u-mt-0_5 u-mb-0_5">
+                       {{ "map"|trans }}*
+                   </label>
                     <ul class="layout__item u-4-of-5 o-list bg-color--grey-light-2 u-p-0_5 u-mb">
                         <li>
                             <label class="cursor-pointer u-mb-0_25" title="Mit Grundkarte können Sie weitere Karten anlegen.">


### PR DESCRIPTION
### Ticket
[DPLAN-12125](https://demoseurope.youtrack.cloud/issue/DPLAN-12125/Kartentyp-kann-beim-Anlegen-eines-GIS-Layers-nicht-ausgewahlt-werden)


**Description:** This PR fixes an issue with the display of the label for the part that should not be shown in projects with disabled permissions:

- move label to the `if` block
