### PR TITLE
chore: provide a symfony toolbar entry for addons

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -237,6 +237,13 @@ services:
                 id: 'app.geo_json_data_collector'
                 priority: -101
 
+    demosplan\DemosPlanCoreBundle\DataCollector\AddonInfoDataCollector:
+        tags:
+            -   name: data_collector
+                template: '@DemosPlanCore/data_collector/addon_info.html.twig'
+                id: 'app.addon_info_collector'
+                priority: -99
+
     demosplan\DemosPlanCoreBundle\DataCollector\UserInfoDataCollector:
         tags:
             -   name: data_collector

--- a/demosplan/DemosPlanCoreBundle/DataCollector/AddonInfoDataCollector.php
+++ b/demosplan/DemosPlanCoreBundle/DataCollector/AddonInfoDataCollector.php
@@ -24,7 +24,7 @@ class AddonInfoDataCollector extends DataCollector
     {
     }
 
-    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $addonsLoaded = $this->addonManifestCollectionWrapper->load();
         $addons = [];

--- a/demosplan/DemosPlanCoreBundle/DataCollector/AddonInfoDataCollector.php
+++ b/demosplan/DemosPlanCoreBundle/DataCollector/AddonInfoDataCollector.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\DataCollector;
+
+use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
+
+use function compact;
+
+class AddonInfoDataCollector extends DataCollector
+{
+    public function __construct(private readonly AddonManifestCollectionWrapper $addonManifestCollectionWrapper)
+    {
+    }
+
+    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    {
+        $addonsLoaded = $this->addonManifestCollectionWrapper->load();
+        $addons = [];
+        foreach ($addonsLoaded as $name => $addonLoaded) {
+            $addons[] = [
+                'name'    => $name,
+                'enabled' => $addonLoaded['enabled'] ? 'true' : 'false',
+                'version' => $addonLoaded['version'] ?? '-',
+            ];
+        }
+
+        $this->data = compact('addons');
+    }
+
+    public function getName(): string
+    {
+        return 'app.addon_info_collector';
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+
+    public function getAddons(): array
+    {
+        return $this->data['addons'];
+    }
+}

--- a/templates/bundles/DemosPlanCoreBundle/data_collector/addon_info.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/data_collector/addon_info.html.twig
@@ -1,0 +1,53 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+<svg fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="#ccc">
+    <svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-puzzle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1" /></svg>
+    {% endset %}
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <strong>Addons installed {{ collector.addons|length }}</strong>
+            {% for addon in collector.addons %}
+                <br> {{ addon.name }} {{ addon.version }}
+            {% endfor %}
+        </div>
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+{% endblock toolbar %}
+
+{% block menu %}
+    {# This left-hand menu appears when using the full-screen profiler. #}
+    <span class="label">
+        <span class="icon">
+         <svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-puzzle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1" /></svg>
+        </span>
+        <strong>Addons</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Addons</h2>
+
+    <p>The following addons are installed:</p>
+
+    <table>
+        <tr>
+            <th>Addon Name</th>
+            <th>Addon version</th>
+            <th>Enabled</th>
+        </tr>
+
+        {% for addon in collector.addons %}
+            <tr>
+                <td>
+                    {{ addon.name }}
+                </td>
+                <td>{{ addon.version }}</td>
+                <td><strong>{{ addon.enabled ? '[x]' : '[ ]' }}</strong></td>
+            </tr>
+        {% endfor %}
+    </table>
+
+{% endblock %}


### PR DESCRIPTION
Provide a new  symfony toolbar entry for installed addons to be easily able to see which addons are installed in which version in the symfony toolbar

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
