### PR TITLE
chore: add additional check during user login for valid orga

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
@@ -168,6 +168,13 @@ class UserService extends CoreService implements UserServiceInterface
                 throw new NullPointerException('The orga of a user that is not in the role group of customer master users is null. This is probably an invalid database state.');
             }
 
+            // orga should not be soft deleted
+            if ($orga->isDeleted()) {
+                $this->getLogger()->info('User Orga is soft deleted', ['orgaId' => $orga->getId()]);
+
+                return null;
+            }
+
             // user needs to have a role in current customer
             if (0 === count($user->getRoles())) {
                 $this->getLogger()->info('User is not registered in current customer',

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
@@ -53,6 +53,7 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use DOMDocument;
 use Exception;
+use Illuminate\Support\Collection as IlluminateCollection;
 use LSS\XML2Array;
 use Pagerfanta\Pagerfanta;
 use RuntimeException;
@@ -60,7 +61,6 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Illuminate\Support\Collection as IlluminateCollection;
 
 use function array_key_exists;
 
@@ -122,7 +122,7 @@ class UserService extends CoreService implements UserServiceInterface
         private readonly TranslatorInterface $translator,
         private readonly UserPasswordHasherInterface $userPasswordHasher,
         private readonly UserRepository $userRepository,
-        private readonly UserRoleInCustomerRepository $userRoleInCustomerRepository
+        private readonly UserRoleInCustomerRepository $userRoleInCustomerRepository,
     ) {
         $this->addressService = $addressService;
         $this->contentService = $serviceContent;
@@ -1014,7 +1014,7 @@ class UserService extends CoreService implements UserServiceInterface
     /**
      * Change the login and the email of a user.
      *
-     * @return user|bool - User in case of successfully set Email, otherwise false
+     * @return User|bool - User in case of successfully set Email, otherwise false
      *
      * @throws Exception
      */


### PR DESCRIPTION
Users of a soft deleted orga should not be able to login. It is a rare case but can be used to quickly ban all users of an organisation

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
