### PR TITLE
Fix(DPLAN-14776): formatting issue after the spit statement view

### DIFF
--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -62,6 +62,18 @@ export default {
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
         marks: {
           ...schema.spec.marks,
+          bold: {
+            parseDOM: [{ tag: 'strong' }],
+            toDOM() {
+              return ['strong']
+            }
+          },
+          italic: {
+            parseDOM: [{ tag: 'em' }],
+            toDOM() {
+              return ['em']
+            }
+          },
           link: {
             attrs: {
               href: {},

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -52,7 +52,19 @@ export default {
 
   data () {
     return {
-      customMarks: {
+      marks: {
+        bold: {
+          parseDOM: [{ tag: 'strong' }],
+          toDOM() {
+            return ['strong']
+          }
+        },
+        italic: {
+          parseDOM: [{ tag: 'em' }],
+          toDOM() {
+            return ['em']
+          }
+        },
         underline: {
           parseDOM: [{ tag: 'u' }],
           toDOM() {
@@ -85,20 +97,10 @@ export default {
   },
 
   methods: {
-   extendMarks (baseMarks, newMarks) {
-      let extendedMarks = baseMarks
-
-      for (const [key, value] of Object.entries(newMarks)) {
-        extendedMarks = extendedMarks.update(key, value)
-      }
-
-      return extendedMarks
-    },
-
     initialize () {
       const proseSchema = new Schema({
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
-        marks: this.extendMarks(schema.spec.marks, this.customMarks)
+        marks: this.marks
       })
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -52,19 +52,7 @@ export default {
 
   data () {
     return {
-      marks: {
-        bold: {
-          parseDOM: [{ tag: 'strong' }],
-          toDOM() {
-            return ['strong']
-          }
-        },
-        italic: {
-          parseDOM: [{ tag: 'em' }],
-          toDOM() {
-            return ['em']
-          }
-        },
+      customMarks: {
         underline: {
           parseDOM: [{ tag: 'u' }],
           toDOM() {
@@ -97,10 +85,20 @@ export default {
   },
 
   methods: {
+    extendMarks (baseMarks, newMarks) {
+      let extendedMarks = baseMarks
+
+      for (const [key, value] of Object.entries(newMarks)) {
+        extendedMarks = extendedMarks.update(key, value)
+      }
+
+      return extendedMarks
+    },
+
     initialize () {
       const proseSchema = new Schema({
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
-        marks: this.marks
+        marks: this.extendMarks(schema.spec.marks, this.customMarks)
       })
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -52,49 +52,53 @@ export default {
 
   data () {
     return {
+      customMarks: {
+        underline: {
+          parseDOM: [{ tag: 'u' }],
+          toDOM() {
+            return ['u']
+          }
+        },
+        link: {
+          attrs: {
+            href: {},
+            class: { default: null }
+          },
+          inclusive: false,
+          parseDOM: [{
+            tag: 'a[href]',
+            getAttrs (dom) {
+              return {
+                href: dom.getAttribute('href'),
+                class: dom.getAttribute('class')
+              }
+            }
+          }],
+          toDOM (node) {
+            const { href, class: className } = node.attrs
+            return ['a', { href, class: className }, 0]
+          }
+        }
+      },
       maxRange: 0
     }
   },
 
   methods: {
+   extendMarks (baseMarks, newMarks) {
+      let extendedMarks = baseMarks
+
+      for (const [key, value] of Object.entries(newMarks)) {
+        extendedMarks = extendedMarks.update(key, value)
+      }
+
+      return extendedMarks
+    },
+
     initialize () {
       const proseSchema = new Schema({
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
-        marks: {
-          ...schema.spec.marks,
-          bold: {
-            parseDOM: [{ tag: 'strong' }],
-            toDOM() {
-              return ['strong']
-            }
-          },
-          italic: {
-            parseDOM: [{ tag: 'em' }],
-            toDOM() {
-              return ['em']
-            }
-          },
-          link: {
-            attrs: {
-              href: {},
-              class: { default: null }
-            },
-            inclusive: false,
-            parseDOM: [{
-              tag: 'a[href]',
-              getAttrs (dom) {
-                return {
-                  href: dom.getAttribute('href'),
-                  class: dom.getAttribute('class')
-                }
-              }
-            }],
-            toDOM (node) {
-              const { href, class: className } = node.attrs
-              return ['a', { href, class: className }, 0]
-            }
-          }
-        }
+        marks: this.extendMarks(schema.spec.marks, this.customMarks)
       })
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''


### PR DESCRIPTION
### Ticket
[DPLAN-14776](https://demoseurope.youtrack.cloud/issue/DPLAN-14776/Nach-Aufteilen-von-eine-Stellungnahme-ist-die-Formatierung-von-Text-komplett-weg)

Description: This PR fixes an issue with text formatting after splitting the statement view. The problem was that after extending `schema.spec.marks`, the standard marks from ProseMirror were overwritten. So found a way to extend it without overwriting the default marks and to added an underline mark as well.

### How to review/test
EIne STN mit Formatierung erstellen -> Aufteilen -> Abschnitte durch checken

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
