### PR TITLE
fix(DPLAN-12935): improve the UX by changing the separator

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_list.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_list.scss
@@ -157,15 +157,8 @@
             }
         }
 
-        &.separated {
-            &::before {
-                content: ' / ';
-
-            }
-
-            &:first-child::before {
-                content: '';
-            }
+        &.separated:not(:first-of-type)::before {
+            content: ' | ';
         }
     }
 


### PR DESCRIPTION
### Ticket
[DPLAN-12935](https://demoseurope.youtrack.cloud/issue/DPLAN-12935/UI-Formatierung-Listansicht-von-weitere-Einreichende)

**Description:** This PR improves the UX by adding a `' | '` separator instead of the `' / '` to the _Weitere Einreichende der gleichen Stellungnahme_ section.

### How to review/test
Log in as the FP-Admin > Procedure > Import > Direct input

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
