### PR TITLE
chore (refs DPLAN-14787): Remove duplicate role entry for planning agency admin

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -44,7 +44,7 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         GlobalConfigInterface $globalConfig,
         PermissionsInterface $permissions,
         ProcedureHandler $procedureHandler,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         parent::__construct($entityManager);
         $this->translator = $translator;

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadProcedureData.php
@@ -62,7 +62,7 @@ class LoadProcedureData extends ProdFixture implements DependentFixtureInterface
         $procedureMaster = new Procedure();
         $procedureMaster->setName('Master');
         $procedureMaster->setOrga($this->getReference('orga_demos'));
-        $procedureMaster->setOrgaName('DEMOS E-Partizipation GmbH');
+        $procedureMaster->setOrgaName('DEMOS plan GmbH');
         $procedureMaster->setPhase($masterProcedurePhase);
         $procedureMaster->setPublicParticipationPhase($masterProcedurePhase);
         $procedureMaster->setMaster(true);

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadRolesData.php
@@ -104,12 +104,6 @@ class LoadRolesData extends ProdFixture
                 'groupName' => 'Moderator',
             ],
             [
-                'code'      => RoleInterface::PLANNING_AGENCY_ADMIN,
-                'name'      => 'Fachplaner-Admin',
-                'groupCode' => RoleInterface::GLAUTH,
-                'groupName' => 'Kommune',
-            ],
-            [
                 'code'      => RoleInterface::CONTENT_EDITOR,
                 'name'      => 'Redakteur',
                 'groupCode' => RoleInterface::GTEDIT,

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -34,7 +34,7 @@ class LoadUserData extends ProdFixture implements DependentFixtureInterface
         private readonly AccessControlService $accessControlPermissionService,
         private readonly OrgaService $orgaService,
         private readonly UserHandler $userHandler,
-        private readonly UserService $userService
+        private readonly UserService $userService,
     ) {
         parent::__construct($entityManager);
     }
@@ -133,7 +133,7 @@ class LoadUserData extends ProdFixture implements DependentFixtureInterface
     public function createAnonymousCitizenUser(
         ObjectManager $manager,
         OrgaType $orgaTypeOlauth,
-        Customer $customer
+        Customer $customer,
     ): void {
         // Create Department
         $department = new Department();

--- a/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
+++ b/demosplan/DemosPlanCoreBundle/DataFixtures/ORM/ProdData/LoadUserData.php
@@ -85,7 +85,7 @@ class LoadUserData extends ProdFixture implements DependentFixtureInterface
 
         // Create Orga
         $orga = new Orga();
-        $orga->setName('DEMOS E-Partizipation GmbH');
+        $orga->setName('DEMOS plan GmbH');
         $slug = new Slug('demos');
         $orga->addSlug($slug);
         $orga->setCurrentSlug($slug);

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/01/Version20250120151616.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/01/Version20250120151616.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250120151616 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-14787: Remove duplicate role entry for planning agency admin';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        // Identify the duplicate role entries
+        $duplicateRoles = $this->connection->fetchAllAssociative('
+            SELECT _r_id
+            FROM _role
+            WHERE _r_code = :code
+        ', ['code' => RoleInterface::PLANNING_AGENCY_ADMIN]);
+
+        if (count($duplicateRoles) !== 2) {
+            return;
+        }
+
+        // Assuming the IDs of the duplicate roles are 1 and 2
+        $roleIdToKeep = $duplicateRoles[0]['_r_id'];
+        $roleIdToRemove = $duplicateRoles[1]['_r_id'];
+
+        // fetch all entries with the old id, try to update them one by one, catch
+        // non-unique constraint violations and delete the entry if it could not be updated
+        $this->updateNewsRoles($roleIdToRemove, $roleIdToKeep);
+        $this->updatePlatformContentRoles($roleIdToRemove, $roleIdToKeep);
+        $this->updateAccessControl($roleIdToRemove, $roleIdToKeep);
+        $this->updateFaqRole($roleIdToRemove, $roleIdToKeep);
+        $this->updatePlatformFaqRole($roleIdToRemove, $roleIdToKeep);
+        $this->updateRelationRoleUserCustomer($roleIdToRemove, $roleIdToKeep);
+        // Delete the duplicate role entry
+        $this->addSql('DELETE FROM `_role` WHERE _r_id = :roleIdToRemove', ['roleIdToRemove' => $roleIdToRemove]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        // revert is not possible
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+
+    private function updateNewsRoles(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+                FROM `_news_roles`
+                WHERE _r_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `_news_roles` SET _r_id = :roleIdToKeep WHERE _n_id = :id',
+                    ['roleIdToKeep' => $roleIdToKeep, 'id' => $entry['_n_id']]
+                );
+            } catch (Exception) {
+                // Entries are deleted later on in bulk
+            }
+        }
+
+        $this->addSql(
+            'DELETE FROM `_news_roles` WHERE _r_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+
+    private function updatePlatformContentRoles(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+                FROM `_platform_content_roles`
+                WHERE _r_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `_platform_content_roles` SET _r_id = :roleIdToKeep WHERE _pc_id = :id',
+                    ['roleIdToKeep' => $roleIdToKeep, 'id' => $entry['_pc_id']]
+                );
+            } catch (Exception) {
+                // Entries are deleted later on in bulk
+            }
+        }
+        $this->addSql(
+            'DELETE FROM `_platform_content_roles` WHERE _r_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+
+    private function updateAccessControl(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+                FROM `access_control`
+                WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `access_control` SET role_id = :roleIdToKeep WHERE id = :id',
+                    ['roleIdToKeep' => $roleIdToKeep, 'id' => $entry['id']]
+                );
+            } catch (Exception) {
+                // Entries are deleted later on in bulk
+            }
+        }
+        $this->addSql(
+            'DELETE FROM `access_control` WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+
+    private function updateFaqRole(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+                FROM `faq_role`
+                WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `faq_role` SET role_id = :roleIdToKeep WHERE faq_id = :id',
+                    ['roleIdToKeep' => $roleIdToKeep, 'id' => $entry['faq_id']]
+                );
+            } catch (Exception) {
+                // Entries are deleted later on in bulk
+            }
+        }
+        $this->addSql(
+            'DELETE FROM `faq_role` WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+
+    private function updatePlatformFaqRole(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+                FROM `platform_faq_role`
+                WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `platform_faq_role` SET role_id = :roleIdToKeep WHERE platformFaq_id = :id',
+                    [
+                        'roleIdToKeep' => $roleIdToKeep,
+                        'id' => $entry['platformFaq_id']
+                    ]
+                );
+            } catch (Exception) {
+                // Entries are deleted later on in bulk
+            }
+        }
+        $this->addSql(
+            'DELETE FROM `platform_faq_role` WHERE role_id = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+
+    private function updateRelationRoleUserCustomer(mixed $roleIdToRemove, mixed $roleIdToKeep): void
+    {
+        $entries = $this->connection->fetchAllAssociative(
+            'SELECT *
+            FROM `relation_role_user_customer`
+            WHERE role = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+        foreach ($entries as $entry) {
+            try {
+                $this->connection->executeStatement(
+                    'UPDATE `relation_role_user_customer` SET role = :roleIdToKeep WHERE id = :id',
+                    ['roleIdToKeep' => $roleIdToKeep, 'id' => $entry['id']]
+                );
+            } catch (Exception $e) {
+                // Entries are deleted later on in bulk
+            }
+        }
+        $this->addSql(
+            'DELETE FROM `relation_role_user_customer` WHERE role = :roleIdToRemove',
+            ['roleIdToRemove' => $roleIdToRemove]
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/01/Version20250120151616.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/01/Version20250120151616.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -26,7 +36,7 @@ class Version20250120151616 extends AbstractMigration
             WHERE _r_code = :code
         ', ['code' => RoleInterface::PLANNING_AGENCY_ADMIN]);
 
-        if (count($duplicateRoles) !== 2) {
+        if (2 !== count($duplicateRoles)) {
             return;
         }
 
@@ -58,7 +68,7 @@ class Version20250120151616 extends AbstractMigration
     private function abortIfNotMysql(): void
     {
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
             "Migration can only be executed safely on 'mysql'."
         );
     }
@@ -174,7 +184,7 @@ class Version20250120151616 extends AbstractMigration
                     'UPDATE `platform_faq_role` SET role_id = :roleIdToKeep WHERE platformFaq_id = :id',
                     [
                         'roleIdToKeep' => $roleIdToKeep,
-                        'id' => $entry['platformFaq_id']
+                        'id'           => $entry['platformFaq_id'],
                     ]
                 );
             } catch (Exception) {


### PR DESCRIPTION
### Ticket
DPLAN-14787
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/23008

Unfortunately the fixture for the roles was buggy and contained a duplicate entry for the fpa role. This PR deletes the duplicate and provides a migration that fixes the existing database entries. 
As a side effect this leads to significantly smaller log files as this warning was logged on every request.

### How to review/test
code review and probably some manual clicking if desired

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
