### PR TITLE
fix: Find the lost whitespace in slicing tagging

### DIFF
--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -60,7 +60,7 @@
     <addon-wrapper
       :addon-props="{
         class: 'mt-1',
-        segmentStatus: segment.status
+        segmentStatus: segment.status ? segment.status : 'not confirmed'
       }"
       class="inline-block"
       hook-name="split.statement.buttons"

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -89,6 +89,8 @@ export default {
       const rangePlugin = initRangePlugin(proseSchema, this.rangeChangeCallback, this.editToggleCallback)
       const parsedContent = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper, { preserveWhitespace: 'full' })
 
+      console.log('parsedContent', parsedContent)
+
       this.maxRange = parsedContent.content.size
 
       const view = new EditorView(document.querySelector('#editor'), {

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -87,12 +87,14 @@ export default {
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''
       const rangePlugin = initRangePlugin(proseSchema, this.rangeChangeCallback, this.editToggleCallback)
-      this.maxRange = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper).content.size
+      const parsedContent = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper, { preserveWhitespace: 'full' })
+
+      this.maxRange = parsedContent.content.size
 
       const view = new EditorView(document.querySelector('#editor'), {
         editable: () => false,
         state: EditorState.create({
-          doc: DOMParser.fromSchema(rangePlugin.schema).parse(wrapper),
+          doc: parsedContent,
           plugins: rangePlugin.plugins
         })
       })

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -87,7 +87,7 @@ export default {
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''
       const rangePlugin = initRangePlugin(proseSchema, this.rangeChangeCallback, this.editToggleCallback)
-      const parsedContent = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper, { preserveWhitespace: 'full' })
+      const parsedContent = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper, { preserveWhitespace: true })
 
       console.log('parsedContent', parsedContent)
 

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -89,8 +89,6 @@ export default {
       const rangePlugin = initRangePlugin(proseSchema, this.rangeChangeCallback, this.editToggleCallback)
       const parsedContent = DOMParser.fromSchema(rangePlugin.schema).parse(wrapper, { preserveWhitespace: true })
 
-      console.log('parsedContent', parsedContent)
-
       this.maxRange = parsedContent.content.size
 
       const view = new EditorView(document.querySelector('#editor'), {


### PR DESCRIPTION
It looks like trailing Whitespaces are swallowed by prosemirror. The option "preserveWhitespace" should handle this and should have been enabled by default, which for some reason wasn't .
Enabling it, makes it better, but don't fix it in whole...