### PR TITLE
chore (refs DPLAN-14791): fix type error in importer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -498,7 +498,7 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
             $this->addImportViolations($violations, $line, $currentWorksheetTitle);
         }
 
-        $statementText = $this->getValidatedStatementText($statementData[self::STATEMENT_TEXT], $line, $currentWorksheetTitle);
+        $statementText = $this->getValidatedStatementText($statementData[self::STATEMENT_TEXT] ?? '', $line, $currentWorksheetTitle);
         $newOriginalStatement->setText($statementText);
         $newOriginalStatement->setProcedure($currentProcedure);
         $newStatementMeta->setAuthorName($statementData['Name'] ?? '');


### PR DESCRIPTION
### Ticket
DPLAN-14791

In case of an empty statement text the validation page should be shown, no 500 error

### How to review/test
create an import document with only an id in the first column and import

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
