### PR TITLE
Fix(DPLAN-14776): formatting issue after the spit statement view - release_ewm

### DIFF
--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -52,37 +52,53 @@ export default {
 
   data () {
     return {
+      customMarks: {
+        underline: {
+          parseDOM: [{ tag: 'u' }],
+          toDOM() {
+            return ['u']
+          }
+        },
+        link: {
+          attrs: {
+            href: {},
+            class: { default: null }
+          },
+          inclusive: false,
+          parseDOM: [{
+            tag: 'a[href]',
+            getAttrs (dom) {
+              return {
+                href: dom.getAttribute('href'),
+                class: dom.getAttribute('class')
+              }
+            }
+          }],
+          toDOM (node) {
+            const { href, class: className } = node.attrs
+            return ['a', { href, class: className }, 0]
+          }
+        }
+      },
       maxRange: 0
     }
   },
 
   methods: {
+    extendMarks (baseMarks, newMarks) {
+      let extendedMarks = baseMarks
+
+      for (const [key, value] of Object.entries(newMarks)) {
+        extendedMarks = extendedMarks.update(key, value)
+      }
+
+      return extendedMarks
+    },
+
     initialize () {
       const proseSchema = new Schema({
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
-        marks: {
-          ...schema.spec.marks,
-          link: {
-            attrs: {
-              href: {},
-              class: { default: null }
-            },
-            inclusive: false,
-            parseDOM: [{
-              tag: 'a[href]',
-              getAttrs(dom) {
-                return {
-                  href: dom.getAttribute('href'),
-                  class: dom.getAttribute('class')
-                }
-              }
-            }],
-            toDOM(node) {
-              let { href, class: className } = node.attrs
-              return ['a', { href, class: className }, 0]
-            }
-          }
-        }
+        marks: this.extendMarks(schema.spec.marks, this.customMarks)
       })
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -85,10 +85,10 @@ export default {
   },
 
   methods: {
-    extendMarks (baseMarks, newMarks) {
-      let extendedMarks = baseMarks
+    getExtendedMarks () {
+      let extendedMarks = schema.spec.marks
 
-      for (const [key, value] of Object.entries(newMarks)) {
+      for (const [key, value] of Object.entries(this.customMarks)) {
         extendedMarks = extendedMarks.update(key, value)
       }
 
@@ -98,7 +98,7 @@ export default {
     initialize () {
       const proseSchema = new Schema({
         nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
-        marks: this.extendMarks(schema.spec.marks, this.customMarks)
+        marks: this.getExtendedMarks()
       })
       const wrapper = document.createElement('div')
       wrapper.innerHTML = this.initStatementText ?? ''


### PR DESCRIPTION
### Ticket
[DPLAN-14776](https://demoseurope.youtrack.cloud/issue/DPLAN-14776/Nach-Aufteilen-von-eine-Stellungnahme-ist-die-Formatierung-von-Text-komplett-weg)

Description: This PR fixes an issue with text formatting after splitting the statement view. The problem was that after extending `schema.spec.marks`, the standard marks from ProseMirror were overwritten. So found a way to extend it without overwriting the default marks and to added an underline mark as well.

### How to review/test
EIne STN mit Formatierung erstellen -> Aufteilen -> Abschnitte durch checken
