### PR TITLE
Add methods to boilerplateCategory and Boilerplate base on their Interfaces

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
@@ -10,6 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\BoilerplateCategoryInterface;
+use DemosEurope\DemosplanAddon\Contracts\Repositories\BoilerplateCategoryRepositoryInterface;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateCategory;
@@ -25,7 +27,7 @@ use Exception;
 /**
  * @template-extends CoreRepository<BoilerplateCategory>
  */
-class BoilerplateCategoryRepository extends CoreRepository implements ArrayInterface, ObjectInterface
+class BoilerplateCategoryRepository extends CoreRepository implements ArrayInterface, ObjectInterface, BoilerplateCategoryRepositoryInterface
 {
     /**
      * Fetch all boilerplate-categories for a certain procedure.
@@ -94,6 +96,22 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
     {
         try {
             return $this->findOneBy(['title' => $boilerplateCategoryTitle]);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * @param string $procedureId
+     *
+     * @param string $boilerplateCategoryTitle
+     *
+     * @return BoilerplateCategoryInterface|null
+     */
+    public function getByProcedureAndTitle(string $procedureId, string $boilerplateCategoryTitle): ?BoilerplateCategoryInterface
+    {
+        try {
+            return $this->findOneBy(['procedure' => $procedureId, 'title' => $boilerplateCategoryTitle]);
         } catch (Exception) {
             return null;
         }

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateCategoryRepository.php
@@ -101,13 +101,6 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
         }
     }
 
-    /**
-     * @param string $procedureId
-     *
-     * @param string $boilerplateCategoryTitle
-     *
-     * @return BoilerplateCategoryInterface|null
-     */
     public function getByProcedureAndTitle(string $procedureId, string $boilerplateCategoryTitle): ?BoilerplateCategoryInterface
     {
         try {
@@ -146,7 +139,7 @@ class BoilerplateCategoryRepository extends CoreRepository implements ArrayInter
      * @param array $data         - holds the content of the boilerplate, which is about to post
      * @param bool  $returnEntity
      *
-     * @return boilerplateCategory|bool - true if the object could be mapped to the DB, otherwise false
+     * @return BoilerplateCategory|bool - true if the object could be mapped to the DB, otherwise false
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
@@ -65,13 +65,6 @@ class BoilerplateRepository extends FluentRepository implements ArrayInterface, 
         return $this->findBy(['procedure' => $procedureId, 'group' => null], ['title' => 'asc']);
     }
 
-    /**
-     * @param string $procedureId
-     *
-     * @param string $categoryId
-     *
-     * @return BoilerplateInterface|null
-     */
     public function getByProcedureAndCategory(string $procedureId, string $categoryId): ?BoilerplateInterface
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\BoilerplateInterface;
 use DemosEurope\DemosplanAddon\Contracts\Repositories\BoilerplateRepositoryInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
@@ -69,9 +70,9 @@ class BoilerplateRepository extends FluentRepository implements ArrayInterface, 
      *
      * @param string $categoryId
      *
-     * @return Boilerplate|null
+     * @return BoilerplateInterface|null
      */
-    public function getByProcedureAndCategory(string $procedureId, string $categoryId): ?Boilerplate
+    public function getByProcedureAndCategory(string $procedureId, string $categoryId): ?BoilerplateInterface
     {
         try {
             return $this->findOneBy(['procedure' => $procedureId, 'categories' => [$categoryId]]);

--- a/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/BoilerplateRepository.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Repositories\BoilerplateRepositoryInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
@@ -29,7 +30,7 @@ use InvalidArgumentException;
 /**
  * @template-extends FluentRepository<Boilerplate>
  */
-class BoilerplateRepository extends FluentRepository implements ArrayInterface, ObjectInterface
+class BoilerplateRepository extends FluentRepository implements ArrayInterface, ObjectInterface, BoilerplateRepositoryInterface
 {
     /**
      * Fetch all boilerplates for a certain procedure.
@@ -61,6 +62,22 @@ class BoilerplateRepository extends FluentRepository implements ArrayInterface, 
     public function getBoilerplatesWhithoutGroup(string $procedureId): array
     {
         return $this->findBy(['procedure' => $procedureId, 'group' => null], ['title' => 'asc']);
+    }
+
+    /**
+     * @param string $procedureId
+     *
+     * @param string $categoryId
+     *
+     * @return Boilerplate|null
+     */
+    public function getByProcedureAndCategory(string $procedureId, string $categoryId): ?Boilerplate
+    {
+        try {
+            return $this->findOneBy(['procedure' => $procedureId, 'categories' => [$categoryId]]);
+        } catch (Exception) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
### Ticket: https://www.dev.diplanung.de/DefaultCollection/BOP-HH/_workitems/edit/23107


Description: 
- Implement BoilerplateCategory and Boilerplate with their Interfaces
- Add mthod to find Boilerplate by procedureId and CategoryID
- Add Methhod to find BoilerplateCategory by ProcedureId and Title

### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- [x] Move the tickets on the board accordingly

