### PR TITLE
fix(refs DPLAN-14848): check content type

### DIFF
--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -109,6 +109,8 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
 
                   return Promise.reject(response)
                 }
+
+                return Promise.reject(error)
               }
             ]
           }),

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -72,16 +72,22 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
             },
             successCallbacks: [
               async (success) => {
-                const response = await success.json()
+                // If the response body is empty, contentType will be null
+                const contentType = success.headers.get('Content-Type')
 
-                const meta = response.data?.meta
-                  ? response.data.meta
-                  : response.meta || null
-                if (meta?.messages) {
-                  handleResponseMessages(meta)
+                if (contentType && contentType.includes('application/json')) {
+                  const response = await success.json()
+
+                  const meta = response.data?.meta
+                    ? response.data.meta
+                    : response.meta || null
+                  if (meta?.messages) {
+                    handleResponseMessages(meta)
+                  }
+
+                  return Promise.resolve(response)
                 }
-
-                return Promise.resolve(response)
+                return Promise.resolve(success)
               }
             ],
             errorCallbacks: [

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -87,6 +87,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
 
                   return Promise.resolve(response)
                 }
+
                 return Promise.resolve(success)
               }
             ],

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -92,17 +92,22 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
             ],
             errorCallbacks: [
               async (error) => {
-                const response = await error.json()
+                // If the response body is empty, contentType will be null
+                const contentType = success.headers.get('Content-Type')
 
-                const meta = response.data?.meta
-                  ? response.data.meta
-                  : response.meta || null
+                if (contentType && contentType.includes('application/json')) {
+                  const response = await error.json()
 
-                if (meta?.messages) {
-                  handleResponseMessages(meta)
+                  const meta = response.data?.meta
+                    ? response.data.meta
+                    : response.meta || null
+
+                  if (meta?.messages) {
+                    handleResponseMessages(meta)
+                  }
+
+                  return Promise.reject(response)
                 }
-
-                return Promise.reject(response)
               }
             ]
           }),

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -93,7 +93,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
             errorCallbacks: [
               async (error) => {
                 // If the response body is empty, contentType will be null
-                const contentType = success.headers.get('Content-Type')
+                const contentType = error.headers.get('Content-Type')
 
                 if (contentType && contentType.includes('application/json')) {
                   const response = await error.json()


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-14848/Speichern-von-Institution-Tags-geht-nicht

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Without checking the content type, this error occurred:
```
SyntaxError: Failed to execute 'json' on 'Response': Unexpected end of JSON input
```
It seems that this happens when the response body is empty and no content type is set.

### Linked PRs 

- https://github.com/demos-europe/demosplan-core/pull/4221

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
