### PR TITLE
fix(refs DPLAN-12498): check for length of object keys

### DIFF
--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -387,7 +387,8 @@ export default {
 
     isNotEmptyFeatureCollection (string) {
       try {
-        return Object.keys(JSON.parse(string).features).length > 0
+        const parsedFeatures = JSON.parse(string).features
+        return Array.isArray(parsedFeatures) ? parsedFeatures.length > 0 : Object.keys(JSON.parse(string).features).length > 0
       } catch (e) {
         return true
       }

--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -388,7 +388,8 @@ export default {
     isNotEmptyFeatureCollection (string) {
       try {
         const parsedFeatures = JSON.parse(string).features
-        return Array.isArray(parsedFeatures) ? parsedFeatures.length > 0 : Object.keys(JSON.parse(string).features).length > 0
+
+        return Array.isArray(parsedFeatures) ? parsedFeatures.length > 0 : Object.keys(parsedFeatures).length > 0
       } catch (e) {
         return true
       }

--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -387,7 +387,7 @@ export default {
 
     isNotEmptyFeatureCollection (string) {
       try {
-        return JSON.parse(string).features.length > 0
+        return Object.keys(JSON.parse(string).features).length > 0
       } catch (e) {
         return true
       }

--- a/client/js/components/document/DpMapSettingsPreview.vue
+++ b/client/js/components/document/DpMapSettingsPreview.vue
@@ -65,9 +65,9 @@
  --><div class="layout__item u-1-of-2">
       <ul>
         <li
-          v-for="(link, index) in permittedLinks"
-          class="layout__item"
-          :key="link.tooltipContent">
+          v-for="link in permittedLinks"
+          :key="link.tooltipContent"
+          class="layout__item">
           <a
             v-tooltip="Translator.trans(link.tooltipContent)"
             class="o-link"


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12498/Nach-zeichnen-von-Geltungsbereich-der-Text-andert-sich-nicht-zu-Geltungsbereich-ist-gezeichnet

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Since `features` is an object, checking for its length did not work

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
