### PR TITLE
refac(DPLAN-12013): issue with displaying messages from the msgBag

### DIFF
--- a/client/js/components/tags/TagListEditForm.vue
+++ b/client/js/components/tags/TagListEditForm.vue
@@ -10,14 +10,12 @@
       <div
         class="flex-1"
         v-text="nodeElement.attributes.title" />
-
       <div class="text-center w-9">
         <dp-contextual-help
           v-if="nodeElement.relationships?.boilerplate"
           icon="file"
           :text="nodeElement.relationships.boilerplate.attributes.title" />
       </div>
-
       <addon-wrapper
         hook-name="tag.edit.form"
         :addon-props="{
@@ -25,7 +23,7 @@
         }" />
     </template>
     <div class="flex-0 pl-2 w-8">
-      <template  v-if="isInEditState !== nodeElement.id">
+      <template v-if="isInEditState !== nodeElement.id">
         <button
           :aria-label="Translator.trans('item.edit')"
           class="btn--blank o-link--default"

--- a/client/js/components/tags/TagsImportForm.vue
+++ b/client/js/components/tags/TagsImportForm.vue
@@ -20,7 +20,6 @@
           :text="Translator.trans('tags.import')"
           for="uploadTags"
           :tooltip="Translator.trans('tags.import.help')" />
-
         <dp-upload
           id="uploadTags"
           name="r_importCsv"
@@ -30,9 +29,14 @@
           :translations="{ dropHereOr: Translator.trans('form.button.upload.csv', { browse: '{browse}', maxUploadSize: '10GB' }) }"
           :max-number-of-files="1"
           @upload-success="importCSVs" />
-
-        <input type="hidden" name="r_importCsv" :value="this.uploadedCSV" />
-        <input type="hidden" name="uploadedFiles" :value="this.uploadedFiles" />
+        <input
+          type="hidden"
+          name="r_importCsv"
+          :value="this.uploadedCSV" />
+        <input
+          type="hidden"
+          name="uploadedFiles"
+          :value="this.uploadedFiles" />
         <dp-button
           class="float-right mt-1"
           data-cy="listTags:tagsImport"

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -76,7 +76,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
                 // If the response body is empty, contentType will be null
                 const contentType = success.headers.get('Content-Type')
 
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.includes('json')) {
                   const response = await success.json()
 
                   const meta = response.data?.meta
@@ -97,7 +97,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
                 // If the response body is empty, contentType will be null
                 const contentType = error.headers.get('Content-Type')
 
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.includes('json')) {
                   const response = await error.json()
 
                   const meta = response.data?.meta


### PR DESCRIPTION
Description: There was a problem with displaying messages/errors after merging with the main branch.

- error messages are not being displayed: there was an issue with handling callbacks in initStore: the contentType can be not only `application/json` but also other strings like `application/vnd.api+json`. Therefore, it must be checked if the type contains `'json'` and not just if it equals `'application/json'`
- some code style adjustment
