### PR TITLE
chore (refs AB#19470): routes are not allowed to have / suffix

### DIFF
--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -22,7 +22,7 @@ const api1_0Routes = [
   {
     module: 'Orga',
     action: 'create',
-    url: '/1.0/organisation/'
+    url: '/1.0/organisation'
   },
   {
     module: 'Orga',
@@ -58,12 +58,12 @@ const api1_0Routes = [
   {
     module: 'User',
     action: 'list',
-    url: '/1.0/user/'
+    url: '/1.0/user'
   },
   {
     module: 'User',
     action: 'create',
-    url: '/1.0/user/'
+    url: '/1.0/user'
   },
   {
     module: 'User',

--- a/client/js/store/core/VuexApiRoutes.js
+++ b/client/js/store/core/VuexApiRoutes.js
@@ -35,7 +35,7 @@ const api1_0Routes = [
   {
     module: 'role',
     action: 'list',
-    url: '/1.0/role/'
+    url: '/1.0/role'
   },
   {
     module: 'report',
@@ -92,7 +92,7 @@ const api1_0Routes = [
   {
     module: 'FaqCategory',
     action: 'list',
-    url: '/1.0/FaqCategory/'
+    url: '/1.0/FaqCategory'
   }
 ]
 

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
@@ -49,7 +49,7 @@ class DemosPlanStatementFragmentUpdateAPIController extends APIController
     public function createAction(
         CurrentProcedureService $currentProcedureService,
         StatementFragmentService $statementFragmentService,
-        ValidatorInterface $validator
+        ValidatorInterface $validator,
     ): Response {
         if (!($this->requestData instanceof TopLevel)) {
             throw BadRequestException::normalizerFailed();

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
@@ -45,7 +45,7 @@ class DemosPlanStatementFragmentUpdateAPIController extends APIController
      *
      * @throws Exception
      */
-    #[Route(path: '/api/1.0/statement-fragment-update/', methods: ['POST'], name: 'dplan_api_assessment_table_statement_fragment_update_create', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/statement-fragment-update', methods: ['POST'], name: 'dplan_api_assessment_table_statement_fragment_update_create', options: ['expose' => true])]
     public function createAction(
         CurrentProcedureService $currentProcedureService,
         StatementFragmentService $statementFragmentService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
@@ -26,7 +26,7 @@ class APIDocumentationController extends BaseController
     /**
      * @DplanPermissions("area_demosplan")
      */
-    #[Route(path: '/api/', methods: ['GET', 'HEAD'])]
+    #[Route(path: '/api', methods: ['GET', 'HEAD'])]
     public function indexAction(): Response
     {
         if ('dev' !== $this->globalConfig->getKernelEnvironment()) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
@@ -24,7 +24,7 @@ class FaqCategoryApiController extends APIController
     /**
      * @DplanPermissions("area_admin_faq")
      */
-    #[Route(path: '/api/1.0/FaqCategory/', methods: ['GET'], name: 'dp_api_faq_category_list', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/FaqCategory', methods: ['GET'], name: 'dp_api_faq_category_list', options: ['expose' => true])]
     public function listAction(FaqHandler $faqHandler): APIResponse
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -79,7 +79,7 @@ class DemosPlanProcedureAPIController extends APIController
     /**
      * @DplanPermissions("area_public_participation")
      */
-    #[Route(path: '/api/1.0/procedure/', methods: ['GET'], name: 'dplan_api_procedure_')]
+    #[Route(path: '/api/1.0/procedure', methods: ['GET'], name: 'dplan_api_procedure_')]
     public function listAction(Request $request): APIResponse
     {
         $rawData = $this->forward(

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -386,7 +386,7 @@ class DemosPlanStatementAPIController extends APIController
     /**
      * @DplanPermissions("area_admin_assessmenttable")
      */
-    #[Route(path: '/api/1.0/assessmentqueryhash/{filterSetHash}/statements/{procedureId}/', methods: ['GET'], name: 'dplan_assessmentqueryhash_get_procedure_statement_list', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/assessmentqueryhash/{filterSetHash}/statements/{procedureId}', methods: ['GET'], name: 'dplan_assessmentqueryhash_get_procedure_statement_list', options: ['expose' => true])]
     public function listAction(
         AssessmentHandler $assessmentHandler,
         HashedQueryService $filterSetService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
@@ -30,7 +30,7 @@ class TagTopicAPIController extends APIController
     /**
      * @DplanPermissions("feature_json_api_tag_topic_create")
      */
-    #[Route(path: '/api/1.0/TagTopic/', methods: ['POST'], name: 'dplan_api_tag_topic_create', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/TagTopic', methods: ['POST'], name: 'dplan_api_tag_topic_create', options: ['expose' => true])]
     public function createAction(
         CurrentProcedureService $currentProcedureService,
         PermissionsInterface $permissions,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
@@ -35,7 +35,7 @@ class TagTopicAPIController extends APIController
         CurrentProcedureService $currentProcedureService,
         PermissionsInterface $permissions,
         StatementHandler $statementHandler,
-        TagTopicResourceType $tagTopicResourceType
+        TagTopicResourceType $tagTopicResourceType,
     ): APIResponse {
         if (!($this->requestData instanceof TopLevel)) {
             throw BadRequestException::normalizerFailed();

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
@@ -25,7 +25,7 @@ class DemosPlanDepartmentAPIController extends APIController
      *
      * @param string $organisationId
      */
-    #[Route(path: '/api/1.0/{organisationId}/department/', methods: ['GET'], name: 'dplan_api_department_list', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/{organisationId}/department', methods: ['GET'], name: 'dplan_api_department_list', options: ['expose' => true])]
     public function listAction(ApiResourceService $apiResourceService, OrgaHandler $orgaHandler, $organisationId): APIResponse
     {
         $orga = $orgaHandler->getOrga($organisationId);

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -93,7 +93,7 @@ class DemosPlanOrganisationAPIController extends APIController
      *
      * @return APIResponse
      */
-    #[Route(path: '/api/1.0/organisation/', name: 'dplan_api_organisation_list', options: ['expose' => true], methods: ['GET'])]
+    #[Route(path: '/api/1.0/organisation', name: 'dplan_api_organisation_list', options: ['expose' => true], methods: ['GET'])]
     public function listAction(
         CustomerHandler $customerHandler,
         OrgaResourceType $orgaResourceType,
@@ -294,7 +294,7 @@ class DemosPlanOrganisationAPIController extends APIController
      *
      * @throws MessageBagException
      */
-    #[Route(path: '/api/1.0/organisation/', options: ['expose' => true], methods: ['POST'], name: 'organisation_create')]
+    #[Route(path: '/api/1.0/organisation', options: ['expose' => true], methods: ['POST'], name: 'organisation_create')]
     public function createOrgaAction(Request $request,
         UserHandler $userHandler,
         CustomerHandler $customerHandler,

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
@@ -25,7 +25,7 @@ class DemosPlanRoleAPIController extends APIController
     /**
      * @DplanPermissions("area_manage_users")
      */
-    #[Route(path: '/api/1.0/role/', methods: ['GET'], name: 'dplan_api_role_list', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/role', methods: ['GET'], name: 'dplan_api_role_list', options: ['expose' => true])]
     public function listAction(RoleService $roleService, OrgaService $orgaService, CurrentUserInterface $currentUser): APIResponse
     {
         try {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
@@ -126,7 +126,7 @@ class DemosPlanUserAPIController extends APIController
      *
      * @throws MessageBagException
      */
-    #[Route(path: '/api/1.0/user/', methods: ['GET'], name: 'dplan_api_users_get', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/user', methods: ['GET'], name: 'dplan_api_users_get', options: ['expose' => true])]
     public function listAction(
         AdministratableUserResourceType $userType,
         DrupalFilterParser $filterParser,
@@ -188,7 +188,7 @@ class DemosPlanUserAPIController extends APIController
      *
      * @deprecated Use `/api/2.0/User` instead ({@link GenericApiController::createAction()})
      */
-    #[Route(path: '/api/1.0/user/', methods: ['POST'], name: 'dplan_api_user_create', options: ['expose' => true])]
+    #[Route(path: '/api/1.0/user', methods: ['POST'], name: 'dplan_api_user_create', options: ['expose' => true])]
     public function createAction(UserHandler $userHandler): APIResponse
     {
         try {


### PR DESCRIPTION
### Ticket
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/19470

In ingress context routes are not allowed to have / suffix as the requests will be redirected to /

### How to review/test
In not ingress context everything should work as before

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
