### PR TITLE
feat(refs DPLAN-12969, #AB21841): allow grouping filter options with 'OR' conjunction

### DIFF
--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -300,7 +300,7 @@ export default {
             }
           }
 
-          if (this.memberOf !== '') {
+          if (this.memberOf) {
             filter[id].condition = {
               ...filter[id].condition,
               memberOf: this.memberOf

--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -107,12 +107,12 @@
           </span>
           <filter-flyout-checkbox
             v-for="option in group.options"
-            @change="updateQuery"
-            :checked="isChecked(option.id)"
-            :option="option"
-            :instance="group.id"
             :key="option.id"
-            :show-count="showCount.groupedOptions" />
+            :checked="isChecked(option.id)"
+            :instance="group.id"
+            :option="option"
+            :show-count="showCount.groupedOptions"
+            @change="updateQuery" />
         </ul>
 
         <span v-if="searchedGroupedOptions.length === 0 && searchedUngroupedOptions?.length === 0">
@@ -207,6 +207,21 @@ export default {
       default: () => ([])
     },
 
+    /**
+     * Set to group id if the filter options should be applied with an 'OR' conjunction,
+     * i.e. they need to be a member of a group:
+     * 'groupId' : {
+     *   group: {
+     *     conjunction: 'OR'
+     *   }
+     * }
+     */
+    memberOf: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     operator: {
       type: String,
       required: true
@@ -267,6 +282,7 @@ export default {
      */
     filter () {
       const filter = {}
+
       this.currentQuery.forEach(id => {
         if (id === 'unassigned') {
           filter[id] = {
@@ -283,8 +299,16 @@ export default {
               operator: this.operator
             }
           }
+
+          if (this.memberOf !== '') {
+            filter[id].condition = {
+              ...filter[id].condition,
+              memberOf: this.memberOf
+            }
+          }
         }
       })
+
       return filter
     },
 
@@ -467,15 +491,22 @@ export default {
       this.appliedQuery = JSON.parse(JSON.stringify(query))
     },
 
+    /**
+     *
+     * @param {Boolean} isSelected
+     * @param {Object} option - { id: string, label: string, selected: boolean }
+     */
     updateQuery (isSelected, option) {
       if (isSelected) {
         this.currentQuery.push(option.id)
         const query = {}
         query[option.id] = this.filter[option.id]
+
         this.updateFilters(query)
       } else if (!isSelected) {
         const query = {}
         query[option.id] = this.filter[option.id]
+
         this.updateFilters(query)
         this.currentQuery.splice(this.currentQuery.indexOf(option.id), 1)
       }
@@ -499,8 +530,10 @@ export default {
   mounted () {
     this.setIsLoading({ categoryId: this.category.id, isLoading: true })
     this.setIsExpanded({ categoryId: this.category.id, isExpanded: false })
+
     if (this.initialQuery.length) {
       const isInitialWithQuery = true
+
       this.requestFilterOptions(isInitialWithQuery)
     }
   }

--- a/client/js/components/procedure/SegmentsList/FilterFlyoutCheckbox.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyoutCheckbox.vue
@@ -58,6 +58,9 @@ export default {
       default: 'list'
     },
 
+    /**
+     * { id: string, label: string, selected: boolean }
+     */
     option: {
       type: Object,
       required: true

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -37,6 +37,7 @@
               class="first:mr-1 first:mt-1 inline-block"
               :data-cy="`institutionListFilter:${filter.label}`"
               :initial-query="queryIds"
+              :member-of="filter.memberOf"
               :operator="filter.comparisonOperator"
               :path="filter.rootPath"
               @filterApply="(filtersToBeApplied) => applyFilterQuery(filtersToBeApplied, filter.id)"
@@ -234,13 +235,18 @@ export default {
 
     filters () {
       return this.institutionTagCategoriesValues.reduce((acc, category) => {
-        acc[category.id] = {
-          id: category.id,
+        const { id, attributes } = category
+        const groupKey = `${id}_group`
+
+        acc[id] = {
+          id,
           comparisonOperator: '=',
-          label: category.attributes.name,
+          label: attributes.name,
           rootPath: 'assignedTags',
-          selected: false
+          selected: false,
+          memberOf: groupKey
         }
+
         return acc
       }, {})
     },


### PR DESCRIPTION
### Ticket
[DPLAN-12969](https://demoseurope.youtrack.cloud/issue/DPLAN-12969/ADO-Issue-21841-Admin-Institutionsliste-Institutionen-konnen-nach-Schlagworten-gefiltert-werden)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds the option to have filter options applied with an 'OR' conjunction within a filter category (i.e. within a filter flyout) by adding the `memberOf` property to the filter category. In DpFilterFylout.vue, the property will then be added to each selected filter option.

When applying selected filter options and updating the filter query in the store, a filter group will be added to the query:
```
filterQuery: {
  [group_id]: {
    group: {
      conjunction: 'OR'
    }
  }
}
```
This filterQuery is then used in the BE request for fetching the filtered invitableInstitutions.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

If you would like to test this in the interface
- log in as customer admin
- go to "Institutionen verschlagworten"
- add some categories and tags in the "Schlagworte verwalten" tab
- add some tags to different institutions
- filter the list by selecting several options from one filter flyout
- **NOTE**: after applying filters once, filter dropdowns don't show any options anymore - this will be fixed in a separate PR

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Link all relevant tickets
