### PR TITLE
f_DPLAN-12928 fix non segment condition

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -111,6 +111,19 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     protected $id;
 
     /**
+     * This property is used inside this base Statement class only to be able to
+     * build conditions for resource types. e.g. to filter out segments.
+     *
+     * @var StatementInterface
+     *
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\Statement\Statement", inversedBy="segmentsOfStatement", cascade={"persist"})
+     *
+     * @ORM\JoinColumn(name="segment_statement_fk", referencedColumnName="_st_id", nullable=true)
+     */
+    #[Assert\IsNull()]
+    protected $parentStatementOfSegment = null;
+
+    /**
      * Elternstellungnahme, von der diese kopiert wurde.
      *
      * @var Statement


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-12928/E-Mail-Import-geht-nicht

Description:
The condition 
```
$this->conditionFactory->isTargetEntityNotInstanceOf(
                basename(str_replace('\\', '/', Segment::class))
            )
```
dit not work for some reason. Found a documentation for the TargetEntity used iside this method:
```
Even though this class is a FunctionInterface according to its type, it does not support any usage in that regard and thus can not be used in a ConditionEvaluator. It must be used for execution via Doctrine only.
This is because it needs to be (type) compatible with other implementations of ClauseInterface, which require their input to implement FunctionInterface too, while this class is currently unable to access the target entity when used as FunctionInterface.
```

therefore a different approach to filter segments was needed.
 
add $parentStatementOfSegment segment property to base statement entity as well in order to use it in resourcetype conditions to exclude segments. Only segments have this collection $parentStatementOfSegment not null.

There is no getter or setter needed and the segment will overwrite this property accordingly.
There is no schema change as this column is present for all sorts of statements.

### Ticket

### How to review/test
DiplanRog uses the 2.0 API to request Statements and OriginalStatements as well as Segments

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
