### PR TITLE
feat(refs DPLAN-12969,#AB21841): Fix tags in filters 

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -83,7 +83,7 @@
             </ul>
           </template>
           <template
-            v-for="(category, idx) in institutionTagCategories"
+            v-for="(category, idx) in institutionTagCategoriesCopy"
             v-slot:[category.attributes.name]="institution">
             <dp-multiselect
               v-if="institution.edit"
@@ -192,6 +192,12 @@ export default {
     initialFilter: {
       type: [Object, Array],
       default: () => ({})
+    },
+
+    isActive: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 
@@ -203,6 +209,7 @@ export default {
       editingInstitution: null,
       editingInstitutionTags: {},
       initialSelection: [],
+      institutionTagCategoriesCopy: {},
       isLoading: true,
       searchTerm: ''
     }
@@ -308,7 +315,7 @@ export default {
     },
 
     institutionTagCategoriesValues () {
-      return Object.values(this.institutionTagCategories)
+      return Object.values(this.institutionTagCategoriesCopy)
     },
 
     selectableColumns () {
@@ -325,6 +332,14 @@ export default {
           category: relationships?.category?.data
         }
       })
+    }
+  },
+
+  watch: {
+    isActive (newValue) {
+      if (newValue) {
+        this.getInstitutionTagCategories()
+      }
     }
   },
 
@@ -404,7 +419,7 @@ export default {
     },
 
     createFilterOptions (categoryId) {
-      let filterOptions = this.institutionTagCategories[categoryId]?.relationships?.tags?.data.length > 0 ? this.institutionTagCategories[categoryId].relationships.tags.list() : []
+      let filterOptions = this.institutionTagCategoriesCopy[categoryId]?.relationships?.tags?.data.length > 0 ? this.institutionTagCategoriesCopy[categoryId].relationships.tags.list() : []
 
       if (Object.keys(filterOptions).length > 0) {
         filterOptions = Object.values(filterOptions).map(option => {
@@ -445,7 +460,7 @@ export default {
     },
 
     getCategoryTags (categoryId) {
-      const tags = this.institutionTagCategories[categoryId].relationships?.tags?.data.length > 0 ? this.institutionTagCategories[categoryId].relationships.tags.list() : []
+      const tags = this.institutionTagCategoriesCopy[categoryId].relationships?.tags?.data.length > 0 ? this.institutionTagCategoriesCopy[categoryId].relationships.tags.list() : []
 
       return Object.values(tags).map(tag => {
         return {
@@ -455,7 +470,7 @@ export default {
       })
     },
 
-    getInstitutionsByPage (page, categoryId = null, isInitial = false) {
+    getInstitutionsByPage (page, categoryId = null) {
       const args = {
         page: {
           number: page,
@@ -503,11 +518,6 @@ export default {
           if (categoryId) {
             this.setIsFilterFlyoutLoading({ categoryId, isLoading: false })
           }
-          // We need to call getInstitutionTagCategories again to get all available tags for the filter,
-          // because fetchInvitableInstitution will update the institutionTagCategory store with the filtered tags
-          if (!isInitial) {
-            this.getInstitutionTagCategories()
-          }
         })
         .catch(err => {
           console.error(err)
@@ -532,14 +542,16 @@ export default {
           'tags.category'
         ].join()
       })
-        .then(() => {
-          if (isInitial) {
-            this.setInitialSelection()
-          }
-        })
-        .catch(err => {
-          console.error(err)
-        })
+      .then(() => {
+        // Copy the object to avoid issues with filter requests that update the categories in the store
+        this.institutionTagCategoriesCopy = { ...this.institutionTagCategories }
+        if (isInitial) {
+          this.setInitialSelection()
+        }
+      })
+      .catch(err => {
+        console.error(err)
+      })
     },
 
     getTagById (tagId) {
@@ -631,9 +643,7 @@ export default {
     this.isLoading = true
 
     const promises = [
-      this.getInstitutionsByPage(1, null, true),
-      // Initial fetch here instead of in getInstitutionsByPage, because otherwise the initialSelection is not ready
-      // when the column selector is mounted
+      this.getInstitutionsByPage(1),
       this.getInstitutionTagCategories(true)
     ]
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
@@ -17,7 +17,7 @@
       id="institutionList"
       :label="Translator.trans('invitable_institution.group')">
       <slot>
-        <institution-list />
+        <institution-list :is-active="isInstitutionListActive" />
       </slot>
     </dp-tab>
     <dp-tab
@@ -53,6 +53,12 @@ export default {
     return {
       activeTabId: 'institutionList',
       needToReset: false
+    }
+  },
+
+  computed: {
+    isInstitutionListActive () {
+      return this.activeTabId === 'institutionList'
     }
   },
 


### PR DESCRIPTION
### Ticket
DPLAN-12969

We need to call the institution tag categories again after applying a filter to get all available tags, because the filter request also updates the institution tag category store.


### How to review/test
Login as Mandatenadmin -> Institutionen verschlagworten -> Apply filter -> Check other categories if there are still filter options (tags) available -> Click Zurücksetzen and check if filter options are still valid


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
