### PR TITLE
fix(refs DPLAN-14901): Catch mapSettings-Request

### DIFF
--- a/client/js/store/map/ProcedureMapSettings.js
+++ b/client/js/store/map/ProcedureMapSettings.js
@@ -94,7 +94,7 @@ export default {
             const procedureMapSettings = {
               attributes: {
                 availableScales: data.availableScales.map(scale => ({ label: `1:${scale.toLocaleString('de-DE')}`, value: scale })) ?? [],
-                coordinate: convertExtentToFlatArray(data.coordinate) ?? '',
+                coordinate: convertExtentToFlatArray(data.coordinate) ?? [],
                 copyright: data.copyright ?? '',
                 defaultBoundingBox,
                 defaultMapExtent,
@@ -111,7 +111,11 @@ export default {
             }
 
             commit('setItem', { key: 'procedureMapSettings', value: procedureMapSettings })
+
             return procedureMapSettings
+          })
+          .catch(() => {
+            dplan.notify.error(Translator.trans('error.api.generic'))
           })
       } catch (e) {
         console.error(e)


### PR DESCRIPTION
In some circumstances - not understood by now - the request fails to load the map settings in the admin area. If so, no map is displayed. To prevent error on the side.
This doesn't fix the issue, that the map is not displayed when the request fails. Without informations, we can't display the map.
And hence we get an 404 from the Backend

ado: 22818

### Ticket
DPLAN-14901
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/22818
