### PR TITLE
chore: Extend eslint config

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -46,6 +46,8 @@ module.exports = {
     }
   ],
   ignorePatterns: [
+    '**/addons/**/*',
+    '**/local_modules/**/*',
     '**/node_modules/**/*',
     '**/vendor/**/*',
     'client/js/legacy/**/*.js',


### PR DESCRIPTION
We don't want to check addons and local modules in core.