### PR TITLE
fix(refs DPLAN-12969, #AB21841): use correct operator

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -248,7 +248,7 @@ export default {
 
         acc[id] = {
           id,
-          comparisonOperator: '=',
+          comparisonOperator: 'ARRAY_CONTAINS_VALUE',
           label: attributes.name,
           rootPath: 'assignedTags',
           selected: false,


### PR DESCRIPTION
### Ticket
[DPLAN-12969](https://demoseurope.youtrack.cloud/issue/DPLAN-12969/ADO-Issue-21841-Admin-Institutionsliste-Institutionen-konnen-nach-Schlagworten-gefiltert-werden)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

With the previous operator, applying filter options from different dropdowns simultaneously did not work; now it does.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
