### PR TITLE
bug(refs DPLAN-14923): Fix resetting filter

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -609,10 +609,10 @@ export default {
         })
       } else {
         if (isReset) {
-          const filteredFilter = Object.fromEntries(
+          const filtersWithConditions = Object.fromEntries(
             Object.entries(this.filterQuery).filter(([key, value]) => value.condition)
           )
-          this.appliedFilterQuery = Object.keys(filteredFilter).length ? filteredFilter : []
+          this.appliedFilterQuery = Object.keys(filtersWithConditions).length ? filtersWithConditions : []
         } else {
           this.appliedFilterQuery = filter
         }

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -609,7 +609,10 @@ export default {
         })
       } else {
         if (isReset) {
-          this.appliedFilterQuery = Object.keys(this.filterQuery).length ? this.filterQuery : []
+          const filteredFilter = Object.fromEntries(
+            Object.entries(this.filterQuery).filter(([key, value]) => value.condition)
+          )
+          this.appliedFilterQuery = Object.keys(filteredFilter).length ? filteredFilter : []
         } else {
           this.appliedFilterQuery = filter
         }


### PR DESCRIPTION
### Ticket
DPLAN-14923


When resetting we need to filter out the group entries and only store the condition entries in the applied filter query.

### How to review/test
Login as Mandantenadmin -> Institutionen verschlagworten -> Play around with applying filters and deselecting applied filters again

