### PR TITLE
fix(refs DPLAN-14736): reduce number of requests

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationFormFields.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationFormFields.vue
@@ -204,12 +204,14 @@
       <addon-wrapper
         hook-name="addon.additional.field"
         :addon-props="{
+          additionalFieldOptions,
           class: 'ml-4',
+          isValueRemovable: true,
           relationshipId: this.organisationId,
-          relationshipKey: 'orga',
-          isValueRemovable: true
+          relationshipKey: 'orga'
         }"
         class="w-1/2"
+        @resourceList:loaded="setAdditionalFieldOptions"
         @selected="updateAddonPayload"
         @blur="updateAddonPayload" />
 
@@ -793,6 +795,12 @@ export default {
   },
 
   props: {
+    additionalFieldOptions: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+
     availableOrgaTypes: {
       type: Array,
       required: true
@@ -961,6 +969,17 @@ export default {
       return hasPermission('feature_orga_edit_all_fields') && this.writableFields.includes(field)
     },
 
+    /**
+     * On this event DpOrganisationListItem will call the set mutation to update the store so that on save the saveAction
+     * can use the data from the store
+     */
+    emitOrganisationUpdate () {
+      // NextTick is needed because the selects do not update the local user before the emitUserUpdate method is invoked
+      Vue.nextTick(() => {
+        this.$emit('organisation-update', this.localOrganisation)
+      })
+    },
+
     hasChanged (field) {
       if (typeof this.initialOrganisation.attributes !== 'undefined') {
         return hasOwnProp(this.initialOrganisation.attributes, field)
@@ -991,17 +1010,6 @@ export default {
       return Translator.trans(orgaType.label)
     },
 
-    /**
-     * On this event DpOrganisationListItem will call the set mutation to update the store so that on save the saveAction
-     * can use the data from the store
-     */
-    emitOrganisationUpdate () {
-      // NextTick is needed because the selects do not update the local user before the emitUserUpdate method is invoked
-      Vue.nextTick(() => {
-        this.$emit('organisation-update', this.localOrganisation)
-      })
-    },
-
     saveNewRegistrationStatus () {
       // Update the local organisation state
       this.localOrganisation.attributes.registrationStatuses.push({
@@ -1011,6 +1019,10 @@ export default {
       })
       this.emitOrganisationUpdate()
       this.resetRegistrationStatus()
+    },
+
+    setAdditionalFieldOptions (options) {
+      this.$emit('addonOptions:loaded', options)
     },
 
     updateAddonPayload (payload) {

--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -31,14 +31,15 @@
           class="o-list o-list--card u-mb"
           data-cy="pendingOrganisationList">
           <dp-organisation-list-item
-            class="o-list__item"
             v-for="(item, idx) in pendingOrgs"
             :key="`pendingOrganisation:${idx}`"
             :available-orga-types="availableOrgaTypes"
+            class="o-list__item"
+            data-cy="pendingOrganisationListBlk"
+            module-name="Pending"
             :organisation="item"
             :selectable="false"
-            module-name="Pending"
-            data-cy="pendingOrganisationListBlk" />
+            @addonOptions:loaded="setAdditionalFieldOptions" />
         </ul>
         <dp-sliding-pagination
           v-if="pendingOrganisationsTotalPages > 1"
@@ -134,14 +135,16 @@
         data-cy="organisationList">
         <ul class="o-list o-list--card u-mb">
           <dp-organisation-list-item
-            class="o-list__item"
             v-for="(item, idx) in items"
             :key="`organisation:${idx}`"
+            :additional-field-options="additionalFieldOptions"
             :available-orga-types="availableOrgaTypes"
+            class="o-list__item"
+            data-cy="organisationListBlk"
             :selected="hasOwnProp(itemSelections, item.id) && itemSelections[item.id] === true"
             :selectable="hasPermission('feature_orga_delete')"
             :organisation="item"
-            data-cy="organisationListBlk"
+            @addonOptions:loaded="setAdditionalFieldOptions"
             @item:selected="dpToggleOne" />
         </ul>
 
@@ -304,6 +307,7 @@ export default {
 
   data () {
     return {
+      additionalFieldOptions: [],
       filterItems: this.availableOrgaTypes.map(el => ({ id: el.value, label: Translator.trans(el.label) })),
       filterLabel: Translator.trans('organisation.kind') + ':',
       isInitialLoad: true,
@@ -504,6 +508,10 @@ export default {
       this.searchTerm = ''
       this.noResults = false
       this.getItemsByPage()
+    },
+
+    setAdditionalFieldOptions (options) {
+      this.additionalFieldOptions = options
     }
   },
 

--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -33,6 +33,7 @@
           <dp-organisation-list-item
             v-for="(item, idx) in pendingOrgs"
             :key="`pendingOrganisation:${idx}`"
+            :additional-field-options="additionalFieldOptions"
             :available-orga-types="availableOrgaTypes"
             class="o-list__item"
             data-cy="pendingOrganisationListBlk"

--- a/client/js/components/user/DpOrganisationList/DpOrganisationListItem.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationListItem.vue
@@ -52,12 +52,14 @@
       data-dp-validate="organisationForm">
       <!-- Form fields -->
       <dp-organisation-form-fields
+        :additional-field-options="additionalFieldOptions"
         :available-orga-types="availableOrgaTypes"
         :initial-organisation="initialOrganisation"
         :organisation="organisation"
         :organisation-id="organisation.id"
-        @organisation-update="updateOrganisation"
-        @addon-update="updateAddonPayload" />
+        @addon-update="updateAddonPayload"
+        @addonOptions:loaded="setAdditionalFieldOptions"
+        @organisation-update="updateOrganisation" />
 
       <!-- Button row -->
       <dp-button-row
@@ -92,6 +94,12 @@ export default {
   ],
 
   props: {
+    additionalFieldOptions: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+
     availableOrgaTypes: {
       type: Array,
       required: false,
@@ -251,6 +259,10 @@ export default {
             this.$root.$emit('get-items')
           }
         })
+    },
+
+    setAdditionalFieldOptions (options) {
+      this.$emit('addonOptions:loaded', options)
     },
 
     setItem (payload) {


### PR DESCRIPTION
### Ticket
[DPLAN-14736](https://demoseurope.youtrack.cloud/issue/DPLAN-14736/Orga-Filter-funktioniert-nicht-richtig)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- in the mein berlin addon additional field, after requesting the dropdown options once, there is not really any need to request them again without reloading the page
- when filtering the organisation list, the list items are destroyed and mounted again, so the request was fired 10 times (for each list item once) with each click on a filter checkbox, leading to a 'too many requests' error when changing the filters a lot
- now, after requesting the dropdown options in the addon component once, they are emitted to the organisation list component which is not re-mounted when filtering. the organisation list component then passes them down via prop back to the addon component. if available, the request is not fired again. that way, we still have 10 requests initially (which is not ideal, and we might want to find a solution for that), but no more requests when filtering

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

It may take a while to get the addon running and test the changes locally, so I recommend only doing a code review. 
My main question is: Do you think this approach is fine from an architectural point of view or could there be a better solution?

### Linked PRs

- [x] https://github.com/demos-europe/demosplan-addon-mein-berlin/pull/28

### Tasks
- [x] Release new version of demosplan-addon-mein-berlin
- [x] Bump version of demosplan-addon-mein-berlin in demosplan-core

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
