### PR TITLE
fix(refs DPLAN-14938): display correct file size for pictogram upload

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -1026,7 +1026,10 @@
                                                 1,
                                                 true,
                                                 false,
-                                                true
+                                                true,
+                                                false,
+                                                0,
+                                                5242880
                                             )
                                             }}
                                         {% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/Extension/fileupload.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/Extension/fileupload.html.twig
@@ -3,20 +3,21 @@
 
     requires:
         DpUploadFiles.vue and var uploadPath (uploader endpoint set in base.html.twig)
+        Params need to be passeed in this order:
     params:
         field_name:         used for ids + fieldname    default: "r_file"
         field_label:        label for upload field      default: "pdf.document"|trans, set to "hide" to hide label
-        chunksize: set chunk size when uploading large files, defaults to "0" (disable chunked uploads)
         type:      sets mime_types             possible values: pdf (default), pdf-img, pdf-zip, img, import, all, zip, antragx,
         label:     button label                default: "form.button.upload.pdf"|trans({ maxUploadSize: human_max_upload_size })
-        maxfiles   limit max uploadable files  default: 1
-                            linked to multi_selection   default: not set, will be set to true if maxfiles > 1
-        maxfilesize: Max file size if other than `ini_get('upload_max_filesize')`
-        multi_instance      use for multiple instances  default: false
-                            of uploader in one form
-        field_hint:         additional hint below label default: false
+        maxfiles:   limit max uploadable files    default: 1
+                        linked to multi_selection    default: not set, will be set to true if maxfiles > 1
+        multi_instance:      use for multiple instances  default: false
+                                    of uploader in one form
+        field_hint:         additional hint below label     default: false
         field_required:     is this field required to fill out (needed for frontend validation)
         callback:           function to execute in FileUploaded
+        chunksize: set chunk size when uploading large files,   defaults to "0" (disable chunked uploads)
+        maxfilesize: Max file size if other than `ini_get('upload_max_filesize')`
 
 #}
 


### PR DESCRIPTION
### Ticket
[DPLAN-14938](https://demoseurope.youtrack.cloud/issue/DPLAN-14938)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- pass correct `maxuploadsize` to `fileupload.html.twig`
- fix the doc block, since parameters were not in correct order

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Update documentation
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
