### PR TITLE
bug(refs DPLAN-12402): Remove redundant error message

### DIFF
--- a/client/js/components/assessmenttable/DpNewStatement.vue
+++ b/client/js/components/assessmenttable/DpNewStatement.vue
@@ -250,8 +250,6 @@ export default {
     submit () {
       if (this.dpValidate.newStatementForm) {
         document.querySelector('[data-dp-validate="newStatementForm"]').submit()
-      } else {
-        dplan.notify.notify('error', Translator.trans('error.mandatoryfields.no_asterisk'))
       }
     },
 


### PR DESCRIPTION
### Ticket
DPLAN-12402

We don't need the error notification in the else block, because data-dp-validate in the form already throws an error if it is not validated. With the else block there are two error notifications shown. 

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Neues Verfahren erstellen -> Leave the Stellungnahmetext empty -> There should be only one error notification


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
