### PR TITLE
bug(refs DPLAN-14849): Add confirm notification for deleting layers

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -379,7 +379,10 @@ const LayersStore = {
       }
 
       return dpApi.delete(Routing.generate('api_resource_delete', { resourceType: currentType, resourceId: id }))
-        .then(this.api.checkResponse)
+        .then(response => this.api.checkResponse(response, { 204: {
+            text: Translator.trans('confirm.gislayer.delete'),
+            type: 'confirm'
+          },}))
         .then(() => {
           commit('removeElement', {
             id: element.id,


### PR DESCRIPTION
### Ticket
DPLAN-14849

Add confirm message for deleting layers in checkResponse. 

### How to review/test
Verfahren -> Planungsdokumente und Planzeichnung -> Kartenebenen definieren -> Add a new layer eg `https://sgx.geodatenzentrum.de/wms_topplus_open?SERVICE=WMS` -> Delete layer -> there should be a confirmation message

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
