### PR TITLE
bug(refs dplan-12673): fix customer settings

### DIFF
--- a/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
@@ -120,13 +120,13 @@ export default {
       brandingList: 'items'
     }),
 
-    ...mapState('file', {
-      fileList: 'item'
+    ...mapState('File', {
+      fileList: 'items'
     }),
 
     branding: {
       get () {
-        return this.brandingList[this.brandingId].attributes || { styling: '', logoHash: null }
+        return this.brandingList[this.brandingId].attributes || { styling: '' }
       },
       set ({ key, value }) {
         this.updateBranding({
@@ -163,8 +163,7 @@ export default {
         id: this.brandingId,
         type: 'Branding',
         attributes: {
-          ...this.branding,
-          logoHash: null
+          ...this.branding
         },
         relationships: {
           logo: {
@@ -174,12 +173,12 @@ export default {
       }
       this.updateBranding(payload)
       this.saveBranding(this.brandingId).then(() => {
+        this.unsetFile({ fileId: this.uploadedFileId })
         dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
       })
     },
 
     setFile (file) {
-      this.branding = { key: 'logoHash', value: file.hash }
       this.updateFile({ id: file.fileId, attributes: { hash: file.hash } })
       this.uploadedFileId = file.fileId
     },
@@ -209,11 +208,11 @@ export default {
         }
       }
 
+      this.updateBranding(payload)
       this.saveBranding(this.brandingId).then(() => {
         dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
         this.isBusy = false
         this.isLogoDeletable = false
-        this.updateBranding(payload)
 
         if (payload.relationships?.logo?.data === null) {
           this.unsetFile({ fileId: this.uploadedFileId })

--- a/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
@@ -37,8 +37,8 @@
           :tus-endpoint="dplan.paths.tusEndpoint"
           @file-remove="unsetFile"
           @upload-success="setFile" />
-      </div>
-      <div
+      </div><!--
+   --><div
         v-if="uploadedFileId && uploadedFileId !== ''"
         class="layout__item u-1-of-2">
         <p

--- a/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsBranding.vue
@@ -20,33 +20,33 @@
       </div>
       <div class="layout__item u-1-of-2">
         <dp-label
-          :text="Translator.trans('logo.upload.new')"
           :hint="Translator.trans('explanation.upload.logo.dimensions')"
+          :text="Translator.trans('logo.upload.new')"
           for="r_customerLogo" />
         <dp-upload-files
+          id="r_customerLogo"
           ref="logoUpload"
           allowed-file-types="img"
-          id="r_customerLogo"
           :basic-auth="dplan.settings.basicAuth"
           :get-file-by-hash="hash => Routing.generate('core_file', { hash: hash })"
           :max-file-size="200000"
           :max-number-of-files="1"
-          needs-hidden-input
           name="r_customerLogo"
+          needs-hidden-input
           :translations="{ dropHereOr: Translator.trans('form.button.upload.file', { browse: '{browse}', maxUploadSize: '200 KB' }) }"
           :tus-endpoint="dplan.paths.tusEndpoint"
           @file-remove="unsetFile"
           @upload-success="setFile" />
-      </div><!--
-   --><div
-        class="layout__item u-1-of-2"
-        v-if="uploadedFileId && uploadedFileId !== ''">
+      </div>
+      <div
+        v-if="uploadedFileId && uploadedFileId !== ''"
+        class="layout__item u-1-of-2">
         <p
           class="weight--bold"
           v-text="Translator.trans('logo.current')" />
         <img
-          :src="Routing.generate('core_logo', { hash: uploadedFileId })"
           :alt="Translator.trans('logo.alt.customer')"
+          :src="Routing.generate('core_logo', { hash: uploadedFileId })"
           style="max-width: 300px">
         <dp-button
           class="mt-2"
@@ -57,30 +57,30 @@
       </div>
     </template>
     <div
-      class="layout__item u-1-of-1"
-      v-if="hasPermission('feature_customer_branding_edit')">
+      v-if="hasPermission('feature_customer_branding_edit')"
+      class="layout__item u-1-of-1">
       <dp-text-area
-        :hint="Translator.trans('branding.styling.hint')"
         id="r_styling"
-        name="r_styling"
         data-cy="customerSettingsBranding:brandingStylingInput"
+        :hint="Translator.trans('branding.styling.hint')"
         :label="Translator.trans('branding.styling.input')"
+        name="r_styling"
         reduced-height
         :value="branding.styling"
         @input="branding = { key: 'styling', value: $event }" />
       <dp-details
-        :summary="Translator.trans('branding.styling.details')"
-        data-cy="customerSettingsBranding:brandingStylingDetails">
+        data-cy="customerSettingsBranding:brandingStylingDetails"
+        :summary="Translator.trans('branding.styling.details')">
         <span
-          v-html="Translator.trans('branding.styling.details.description')"
-          data-cy="customerSettingsBranding:brandingStylingDetailsDescription" />
+          data-cy="customerSettingsBranding:brandingStylingDetailsDescription"
+          v-html="Translator.trans('branding.styling.details.description')" />
       </dp-details>
     </div>
     <dp-button-row
+      :busy="isBusy"
       class="layout__item u-1-of-1"
       data-cy="customerSettingsBranding"
       primary
-      :busy="isBusy"
       @primary-action="saveBrandingSettings" />
   </div>
 </template>

--- a/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
@@ -35,11 +35,11 @@
             v-model="customerContact.title"
             class="u-mb-0_75"
             data-cy="contactTitle"
-            :pattern="titlesInUsePattern"
             :data-dp-validate-error="Translator.trans(customerContact.title === '' ? 'error.name.required' : 'error.name.unique')"
             :label="{
               text: Translator.trans('contact.name')
             }"
+            :pattern="titlesInUsePattern"
             required
             type="text" />
           <dp-input
@@ -67,8 +67,8 @@
             type="email" />
           <dp-editor
             id="supportText"
-            class="u-mb-0_75"
             v-model="customerContact.text"
+            class="u-mb-0_75"
             hidden-input="supportText"
             :toolbar-items="{
               fullscreenButton: true,

--- a/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
+++ b/client/js/components/user/CustomerSettings/CustomerSettingsSupport.vue
@@ -232,6 +232,7 @@ export default {
 
     this.$on('delete', (id) => {
       this.deleteContact(id).then(() => {
+        this.getContacts()
         dplan.notify.notify('confirm', Translator.trans('contact.deleted'))
       })
     })


### PR DESCRIPTION
### Ticket
DPLAN-12673

- Support: Get contacts after deleting to refresh support list without having to refresh the whole page.
- Additionally setting a new branding logo or deleting the old did not work. Fixes: Remove logo hash from attributes. Only file id in relationships is needed, otherwise BE rejects request. Also update branding before saving and unset file after deleting.
- Order some attributes


### How to review/test
Login as Mandantenadmin -> Plattform-Einstellungen 
- Delete support contact -> contact should be removed without refreshing the page
- Add new logo and save -> should work
- Delete logo -> should be removed without refreshing the page


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
