### PR TITLE
chore: use named arguments to fix incorrect fileupload params

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -1017,19 +1017,15 @@
                                             </a>
                                         {% else %}
                                             {{  fileupload(
-                                                "r_pictogram",
-                                                '<p class="lbl__hint">'
+                                                fieldName: "r_pictogram",
+                                                fieldLabel: '<p class="lbl__hint">'
                                                 ~ "text.procedure.edit.external.pictogram"|trans
                                                 ~ '</p>',
-                                                "img",
-                                                "form.button.upload.file",
-                                                1,
-                                                true,
-                                                false,
-                                                true,
-                                                false,
-                                                0,
-                                                5242880
+                                                type: "img",
+                                                label: "form.button.upload.file",
+                                                required: true,
+                                                multiInstance: true,
+                                                maxFileSize: 5242880
                                             )
                                             }}
                                         {% endif %}


### PR DESCRIPTION
### Ticket
DPLAN-14947

The arguments to create the fileupload component where improperly set. To avoid further confusion named arguments can be used.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
