### PR TITLE
feat(refs DPLAN-14634, #AB22463): sort categories + tags by creationDate

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -316,7 +316,7 @@ export default {
 
     institutionTagCategoriesValues () {
       return Object.values(this.institutionTagCategoriesCopy)
-        .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
+        .sort((a, b) => new Date(a.attributes.creationDate) - new Date(b.attributes.creationDate))
     },
 
     selectableColumns () {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -316,6 +316,7 @@ export default {
 
     institutionTagCategoriesValues () {
       return Object.values(this.institutionTagCategoriesCopy)
+        .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
     },
 
     selectableColumns () {
@@ -528,10 +529,12 @@ export default {
       return this.fetchInstitutionTagCategories({
         fields: {
           InstitutionTagCategory: [
+            'creationDate',
             'name',
             'tags'
           ].join(),
           InstitutionTag: [
+            'creationDate',
             'isUsed',
             'name',
             'category'
@@ -542,16 +545,17 @@ export default {
           'tags.category'
         ].join()
       })
-      .then(() => {
-        // Copy the object to avoid issues with filter requests that update the categories in the store
-        this.institutionTagCategoriesCopy = { ...this.institutionTagCategories }
-        if (isInitial) {
-          this.setInitialSelection()
-        }
-      })
-      .catch(err => {
-        console.error(err)
-      })
+        .then(() => {
+          // Copy the object to avoid issues with filter requests that update the categories in the store
+          this.institutionTagCategoriesCopy = { ...this.institutionTagCategories }
+
+          if (isInitial) {
+            this.setInitialSelection()
+          }
+        })
+        .catch(err => {
+          console.error(err)
+        })
     },
 
     getTagById (tagId) {
@@ -637,7 +641,7 @@ export default {
 
     setInitialSelection () {
       this.initialSelection = this.institutionTagCategoriesValues
-        .slice(0, 7)
+        .slice(0, 5)
         .map(category => category.attributes.name)
     }
   },

--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
@@ -140,10 +140,12 @@ export default {
       this.listInstitutionTagCategories({
         fields: {
           InstitutionTagCategory: [
+            'creationDate',
             'name',
             'tags'
           ].join(),
           InstitutionTag: [
+            'creationDate',
             'isUsed',
             'name',
             'category'
@@ -222,27 +224,31 @@ export default {
     },
 
     transformTagsAndCategories () {
-      return Object.values(this.institutionTagCategories).map(category => {
-        const { attributes, id, type } = category
-        const tags = category.relationships?.tags?.data.length > 0 ? category.relationships.tags.list() : []
+      return Object.values(this.institutionTagCategories)
+        .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
+        .map(category => {
+          const { attributes, id, type } = category
+          const tags = category.relationships?.tags?.data.length > 0 ? category.relationships.tags.list() : []
 
-        return {
-          id,
-          name: attributes.name,
-          children: Object.values(tags).map(tag => {
-            const { id, attributes, type } = tag
+          return {
+            id,
+            name: attributes.name,
+            children: Object.values(tags)
+              .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
+              .map(tag => {
+                const { id, attributes, type } = tag
 
-            return {
-              id,
-              categoryId: category.id,
-              isUsed: attributes.isUsed,
-              name: attributes.name,
-              type
-            }
-          }),
-          type
-        }
-      })
+                return {
+                  id,
+                  categoryId: category.id,
+                  isUsed: attributes.isUsed,
+                  name: attributes.name,
+                  type
+                }
+            }),
+            type
+          }
+        })
     }
   },
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
@@ -225,7 +225,7 @@ export default {
 
     transformTagsAndCategories () {
       return Object.values(this.institutionTagCategories)
-        .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
+        .sort((a, b) => new Date(a.attributes.creationDate) - new Date(b.attributes.creationDate))
         .map(category => {
           const { attributes, id, type } = category
           const tags = category.relationships?.tags?.data.length > 0 ? category.relationships.tags.list() : []
@@ -234,7 +234,7 @@ export default {
             id,
             name: attributes.name,
             children: Object.values(tags)
-              .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
+              .sort((a, b) => new Date(a.attributes.creationDate) - new Date(b.attributes.creationDate))
               .map(tag => {
                 const { id, attributes, type } = tag
 

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
@@ -79,7 +79,7 @@ class InstitutionTag extends CoreEntity implements UuidEntityInterface, Institut
      *
      * @ORM\Column(type="datetime", nullable=false)
      */
-    private $creationDate;
+    protected $creationDate;
 
     /**
      * @var DateTime

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTagCategory.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTagCategory.php
@@ -68,7 +68,7 @@ class InstitutionTagCategory extends CoreEntity implements UuidEntityInterface, 
      *
      * @ORM\Column(type="datetime", nullable=false)
      */
-    private DateTime $creationDate;
+    protected DateTime $creationDate;
 
     /**
      * @Gedmo\Timestampable(on="update")

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagCategoryResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagCategoryResourceConfigBuilder.php
@@ -26,6 +26,7 @@ use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTagCategory> $name
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory,InstitutionTag> $tags
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory,CustomerInterface> $customer
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTagCategory> $creationDate
  *
  * @template-extends MagicResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory>
  */

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagResourceConfigBuilder.php
@@ -24,6 +24,7 @@ use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $name
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $isUsed
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTag,InstitutionTagCategory> $category
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $creationDate
  */
 class InstitutionTagResourceConfigBuilder extends BaseInstitutionTagResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagCategoryResourceType.php
@@ -55,6 +55,9 @@ class InstitutionTagCategoryResourceType extends DplanResourceType
             ->setRelationshipType($this->getTypes()->getInstitutionTagResourceType())
             ->setReadableByPath();
 
+        $institutionTagCategoryConfig->creationDate
+            ->setReadableByPath();
+
         $institutionTagCategoryConfig->addPostConstructorBehavior(
             new FixedSetBehavior(
                 function (InstitutionTagCategory $institutionTagCategory): array {

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
@@ -55,9 +55,11 @@ class InstitutionTagResourceType extends DplanResourceType
             ->setAliasedPath(Paths::institutionTag()->label)
             ->addPathUpdateBehavior([]);
 
+        $configBuilder->creationDate
+            ->setReadableByPath();
+
         $configBuilder->isUsed
-            ->setReadableByCallable(static fn (InstitutionTag $tag): bool => !$tag->getTaggedInstitutions()->isEmpty()
-            );
+            ->setReadableByCallable(static fn (InstitutionTag $tag): bool => !$tag->getTaggedInstitutions()->isEmpty());
 
         $configBuilder->category
             ->setReadableByPath()


### PR DESCRIPTION
### Ticket
[DPLAN-14634](https://demoseurope.youtrack.cloud/issue/DPLAN-14634/ADO-Issue-22463-Admin-Institutionsliste-Filteroptionen-konnen-nach-Schlagwortkategorien-angepasst-werden)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- instead of displaying the categories and tags in a random order, it seems more intuitive to sort them by creationDate
- while sorting by the user is not possible in the interface, this way we give them the possibility to create their desired order by adjusting the order in which they create categories and tags
- also, in the tag list, after creating a category, it is displayed at the top of the list now, so it's easier to confirm that it has indeed been created

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Link all relevant tickets
