### PR TITLE
f DPLAN-14978 : adjust condition to enable and show automatically procedure phase change area

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -13,7 +13,7 @@
       :id="checkboxId"
       v-model="autoSwitchPhase"
       :data-cy="`autoSwitchPhase:${checkboxId}`"
-      :disabled="hasPermission('feature_auto_switch_to_procedure_end_phase') && isParticipationPhaseSelected"
+      :disabled="!hasPermission('feature_auto_switch_to_procedure_end_phase') || (hasPermission('feature_auto_switch_to_procedure_end_phase') && !isParticipationPhaseSelected)"
       :label="{
         text: Translator.trans('procedure.public.phase.autoswitch')
       }"
@@ -23,7 +23,7 @@
       name="slide-fade"
       mode="out-in">
       <div
-        v-if="!hasPermission('feature_auto_switch_to_procedure_end_phase') || (hasPermission('feature_auto_switch_to_procedure_end_phase') && !isParticipationPhaseSelected)"
+        v-if="hasPermission('feature_auto_switch_to_procedure_end_phase') && isParticipationPhaseSelected"
         class="layout u-mt-0_25 u-pl">
         <dp-select
           class="layout__item u-1-of-3 u-1-of-1-lap-down"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-14978


Description: adjust condition to enable and show automatically procedure phase change area :
this area is displayed even if the permission is not enabled which is confusing. It has to be showed only when the relevant permission is enabled and when a participation phase is selected. When the permission is not enabled this area should be desabled .

Delete the checkbox if it doesn't apply/isn't necessary. -->


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

