### PR TITLE
f_DPLAN-14943 alter statement validation. Do not assert parentStatementOfSegment is Null by default Group

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "cocur/slugify": "^4.0",
         "composer/composer": "^2.8",
         "composer/package-versions-deprecated": "1.11.99.5",
-        "demos-europe/demosplan-addon": "0.47",
+        "demos-europe/demosplan-addon": "0.48",
         "doctrine/annotations": "^2.0",
         "doctrine/common": "^3.2",
         "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d52ae060f66ee3807029e605af3d5771",
+    "content-hash": "3403656b54203c33367fe69050f4b8ab",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1637,16 +1637,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.47",
+            "version": "v0.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "1c445204a71a25b6468da83687bd321d60457091"
+                "reference": "b43984a46a99b57f49464ac5736c335cae653049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/1c445204a71a25b6468da83687bd321d60457091",
-                "reference": "1c445204a71a25b6468da83687bd321d60457091",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/b43984a46a99b57f49464ac5736c335cae653049",
+                "reference": "b43984a46a99b57f49464ac5736c335cae653049",
                 "shasum": ""
             },
             "require": {
@@ -1712,9 +1712,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.47"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.48"
             },
-            "time": "2024-12-19T16:39:42+00:00"
+            "time": "2025-02-13T14:09:50+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -120,7 +120,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      *
      * @ORM\JoinColumn(name="segment_statement_fk", referencedColumnName="_st_id", nullable=true)
      */
-    #[Assert\IsNull()]
+    #[Assert\IsNull(groups:[StatementInterface::BASE_STATEMENT_CLASS_VALIDATION])]
     protected $parentStatementOfSegment;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -120,7 +120,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
      *
      * @ORM\JoinColumn(name="segment_statement_fk", referencedColumnName="_st_id", nullable=true)
      */
-    #[Assert\IsNull(groups:[StatementInterface::BASE_STATEMENT_CLASS_VALIDATION])]
+    #[Assert\IsNull(groups: [StatementInterface::BASE_STATEMENT_CLASS_VALIDATION])]
     protected $parentStatementOfSegment;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic;
 
 use DateInterval;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Entity\EntitySyncLink;
 use demosplan\DemosPlanCoreBundle\Entity\File;
@@ -377,9 +378,10 @@ class StatementSynchronizer
     private function validateStatement(Statement $statement): void
     {
         $statementViolations = $this->validator->validate($statement, null, [
-            Statement::DEFAULT_VALIDATION,
-            Statement::MANUAL_CREATE_VALIDATION,
-            Statement::IMPORT_VALIDATION,
+            StatementInterface::DEFAULT_VALIDATION,
+            StatementInterface::MANUAL_CREATE_VALIDATION,
+            StatementInterface::IMPORT_VALIDATION,
+            StatementInterface::BASE_STATEMENT_CLASS_VALIDATION
         ]);
         if (0 !== $statementViolations->count()) {
             throw ViolationsException::fromConstraintViolationList($statementViolations);

--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -51,7 +51,7 @@ class StatementSynchronizer
         private readonly StatementRepository $statementRepository,
         private readonly StatementService $statementService,
         private readonly TransactionService $transactionService,
-        private readonly ValidatorInterface $validator
+        private readonly ValidatorInterface $validator,
     ) {
     }
 
@@ -141,7 +141,7 @@ class StatementSynchronizer
      */
     private function copyAsOriginalStatement(
         Statement $sourceStatement,
-        Procedure $targetProcedure
+        Procedure $targetProcedure,
     ): array {
         if ($sourceStatement->isOriginal()) {
             throw new InvalidArgumentException('Given statement is an original statement.');
@@ -252,7 +252,7 @@ class StatementSynchronizer
      */
     private function copyFileContainersBetweenStatements(
         Statement $sourceStatement,
-        Statement $newOriginalStatement
+        Statement $newOriginalStatement,
     ): array {
         $sourceFileContainers = $this->statementService->getFileContainersForStatement($sourceStatement->getId());
 
@@ -268,7 +268,7 @@ class StatementSynchronizer
      */
     private function copyFileContainersToStatement(
         array $fileContainers,
-        Statement $targetStatement
+        Statement $targetStatement,
     ): array {
         $fileContainerCopies = [];
         foreach ($fileContainers as $fileContainer) {
@@ -298,7 +298,7 @@ class StatementSynchronizer
      */
     public function cloneFileContainersToStatement(
         array $originalfileContainers,
-        Statement $newStatement
+        Statement $newStatement,
     ): void {
         $fileStrings = [];
         foreach ($originalfileContainers as $oldFileContainer) {
@@ -381,7 +381,7 @@ class StatementSynchronizer
             StatementInterface::DEFAULT_VALIDATION,
             StatementInterface::MANUAL_CREATE_VALIDATION,
             StatementInterface::IMPORT_VALIDATION,
-            StatementInterface::BASE_STATEMENT_CLASS_VALIDATION
+            StatementInterface::BASE_STATEMENT_CLASS_VALIDATION,
         ]);
         if (0 !== $statementViolations->count()) {
             throw ViolationsException::fromConstraintViolationList($statementViolations);

--- a/demosplan/DemosPlanCoreBundle/Validator/StatementValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/StatementValidator.php
@@ -36,9 +36,8 @@ class StatementValidator
         array $validationGroups = [
             ResourceTypeService::VALIDATION_GROUP_DEFAULT,
             StatementInterface::BASE_STATEMENT_CLASS_VALIDATION,
-        ]
-    ): ConstraintViolationListInterface
-    {
+        ],
+    ): ConstraintViolationListInterface {
         return $this->validator->validate($statement, null, $validationGroups);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Validator/StatementValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Validator/StatementValidator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Validator;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Logic\ResourceTypeService;
@@ -30,7 +31,13 @@ class StatementValidator
      * @param Statement|DraftStatement $statement
      * @param string[]                 $validationGroups
      */
-    public function validate($statement, array $validationGroups = [ResourceTypeService::VALIDATION_GROUP_DEFAULT]): ConstraintViolationListInterface
+    public function validate(
+        $statement,
+        array $validationGroups = [
+            ResourceTypeService::VALIDATION_GROUP_DEFAULT,
+            StatementInterface::BASE_STATEMENT_CLASS_VALIDATION,
+        ]
+    ): ConstraintViolationListInterface
     {
         return $this->validator->validate($statement, null, $validationGroups);
     }


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-14943/Kommentar-in-Erwiderung-ladt-unendlich

HowToTest:
Even assignment of Statements did not work via api. should work now

Description:
parentStatementOfSegment should not be asserted by the DEFAULT Group as this group gets used for segments as well.
Therefore a different group was assigned to parentStatementOfSegments.
This group was added to the places where only base statement entities get validated.

bumps demosplan-addon to v0.48 https://github.com/demos-europe/demosplan-addon/pull/136
