### PR TITLE
fix(DPLAN-12013): add the isTopicalTag box to the split statement view

### DIFF
--- a/client/js/components/statement/splitStatement/DpCreateTag.vue
+++ b/client/js/components/statement/splitStatement/DpCreateTag.vue
@@ -55,6 +55,13 @@
       v-model="tagTopic.title"
       required />
 
+    <addon-wrapper
+      class="block mb-4"
+      hook-name="tag.create.form"
+      :addon-props="{
+        hasInlineNotification: false
+      }" />
+
     <dp-button-row
       align="left"
       primary
@@ -66,6 +73,7 @@
 </template>
 
 <script>
+import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import {
   DpButtonRow,
   DpInput,
@@ -80,6 +88,7 @@ export default {
   name: 'DpCreateTag',
 
   components: {
+    AddonWrapper,
     DpButtonRow,
     DpInput,
     DpLabel,
@@ -254,6 +263,7 @@ export default {
                     }
                   }
                   this.updateTags(tagResource)
+                  this.$root.$emit('tag:created', tagResource.id)
                 })
                 .catch(() => {
                   // Reset tags in store
@@ -271,6 +281,7 @@ export default {
             .then((response) => {
               const updatedAvailableTag = response.data.data
               this.updateTags(updatedAvailableTag)
+              this.$root.$emit('tag:created', updatedAvailableTag.id)
             })
             .catch(() => {
               // Reset tags in store


### PR DESCRIPTION
**Ticket:**
https://demoseurope.youtrack.cloud/issue/DPLAN-12013/5-5-Als-FachplanerIn-mochte-ich-von-der-KI-nur-bestimmte-Schlagworte-bzw.-Schlagworte-aus-bestimmten-Kategorien-vorgeschlagen


**Description:** This PR adds the isTopicalTag box to the split statement view. Since the sidebar menu is narrow, the notification was better to place in a tooltip:

![image](https://github.com/user-attachments/assets/9d244c25-7f35-491d-aab3-975d0269ddd1)

Additional PR with some adjustments is provided in the addon.

