### PR TITLE
bug(refs DPLAN-14953): Sanitize statement text

### DIFF
--- a/client/js/components/shared/TextContentRenderer.vue
+++ b/client/js/components/shared/TextContentRenderer.vue
@@ -1,5 +1,6 @@
 <script>
 import { DpLoading } from '@demos-europe/demosplan-ui'
+import DomPurify from 'dompurify'
 
 export default {
   name: 'TextContentRenderer',
@@ -41,8 +42,10 @@ export default {
    * @return {*}
    */
   render (h, context) {
+    const sanitizedText = DomPurify.sanitize(context.props.text)
+
     const immediateComponent = {
-      template: `<div class='text-wrapper w-fit' data-cy='textWrapper'>${context.props.text}</div>`,
+      template: `<div class='text-wrapper w-fit' data-cy='textWrapper'>${sanitizedText}</div>`,
       data () {
         return context.props.data
       }


### PR DESCRIPTION
### Ticket
DPLAN-14953


We should sanitize the statement text before rendering it to avoid Cross Site Scripting.

### How to review/test
Login as Datenerfasser -> Verwalten -> Verfahren -> Import xlsx file from the ticket as Abschnitte -> Go to the imported statement -> Click on Mehr anzeigen on the statement text -> Text should be shown and no errors in console


