### PR TITLE
bug(refs DPLAN-119521): confirm conditionally

### DIFF
--- a/client/js/components/statement/StatementExportModal.vue
+++ b/client/js/components/statement/StatementExportModal.vue
@@ -216,6 +216,7 @@ export default {
 
     handleExport () {
       const columnTitles = {}
+      const shouldConfirm = ['docx', 'zip'].includes(this.active)
 
       Object.keys(this.docxColumns).forEach(key => {
         const columnTitle = this.docxColumns[key].title
@@ -233,7 +234,8 @@ export default {
       this.$emit('export', {
         route: this.isSingleStatementExport ? this.singleStatementExportPath : this.exportTypes[this.active].exportPath,
         docxHeaders: ['docx', 'zip'].includes(this.active) ? columnTitles : null,
-        fileNameTemplate: this.fileName || null
+        fileNameTemplate: this.fileName || null,
+        shouldConfirm
       })
       this.closeModal()
     },

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -934,9 +934,10 @@ export default {
       }
     },
 
-    showHintAndDoExport ({ route, docxHeaders, fileNameTemplate }) {
-      if (window.dpconfirm(Translator.trans('export.statements.hint'))) {
-        window.location.href = this.exportRoute(route, docxHeaders, fileNameTemplate)
+    showHintAndDoExport ({ route, docxHeaders, fileNameTemplate, shouldConfirm }) {
+      const url = this.exportRoute(route, docxHeaders, fileNameTemplate)
+      if (!shouldConfirm || window.dpconfirm(Translator.trans('export.statements.hint'))) {
+        window.location.href = url
       }
     },
 


### PR DESCRIPTION
### Ticket
DPLAN-11952

Determine if a confirmation dialog should be shown for the export action.
This is required if the selected export type is either 'docx' or 'zip'.
const shouldConfirm = ['docx', 'zip'].includes(this.active);


