### PR TITLE
chore(refs DPLAN-14634, #AB22463): bump demosplan-ui from v0.3.47 to v0.3.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:scss": "stylelint {demosplan/DemosPlanCoreBundle/Resources/client/scss,projects}/**/*.scss"
   },
   "dependencies": {
-    "@demos-europe/demosplan-ui": "^0.3.47",
+    "@demos-europe/demosplan-ui": "^0.3.48",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,9 +2430,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:^0.3.47":
-  version: 0.3.47
-  resolution: "@demos-europe/demosplan-ui@npm:0.3.47"
+"@demos-europe/demosplan-ui@npm:^0.3.48":
+  version: 0.3.48
+  resolution: "@demos-europe/demosplan-ui@npm:0.3.48"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2507,7 +2507,7 @@ __metadata:
       optional: true
     prosemirror-view:
       optional: true
-  checksum: 10c0/8bdfb33eb55df8443950a28c062814b8c148ea3af698e84aecf65913227c5b65b52241cf825033e4d695ee77e1d8ebc55ab0f69ef645c0d19f99c8f5ab87fdaa
+  checksum: 10c0/356215567e4cda45ec905a452132267113147b8217a847f52db34fcc5ea425573269cba3065a93d1a165c9a0aa32c41dee1e326e53563e6514dd0ba2fb1b6629
   languageName: node
   linkType: hard
 
@@ -13318,7 +13318,7 @@ __metadata:
     "@babel/plugin-transform-runtime": "npm:^7.25.9"
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
-    "@demos-europe/demosplan-ui": "npm:^0.3.47"
+    "@demos-europe/demosplan-ui": "npm:^0.3.48"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"


### PR DESCRIPTION
<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

changes in demosplan-ui:
- ariaLabel prop can now be passed to DpFlyout if the flyout trigger is only an icon
- icon 'faders' has been added
- primary and secondary button in DpButtonRow can be disabled separately
- translations can be passed to DpPager via prop labelTexts
- several small layout fixes

