### PR TITLE
feat (DPLAN-14868): xlsx export assessmenttable

### DIFF
--- a/client/js/components/statement/assessmentTable/ExportModal.vue
+++ b/client/js/components/statement/assessmentTable/ExportModal.vue
@@ -322,6 +322,7 @@
                 value="topicsAndTags"
                 @change="exportChoice.xlsx.exportType = 'topicsAndTags'" />
               <dp-radio
+                v-if="hasPermission('feature_admin_assessmenttable_export_potential_areas_xlsx')"
                 id="xlsxExportTypePotentialAreas"
                 :checked="exportChoice.xlsx.exportType === 'potentialAreas'"
                 :class="{'mb-1': hasPermission('feature_admin_assessmenttable_export_statement_generic_xlsx')}"

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -574,6 +574,12 @@ feature_admin_assessmenttable_export_docx_condensed:
     label: 'Abwägungstabelle in kompaktem Docx-Format exportieren'
     loginRequired: true
     parent: feature_admin
+feature_admin_assessmenttable_export_potential_areas_xlsx:
+    label: 'Export of potential areas in xlsx format'
+    description: 'Permission to enable the export of potential areas in xlsx format.'
+    expose: true
+    loginRequired: true
+    parent: feature_admin
 feature_admin_assessmenttable_export_statement_generic_xlsx:
     label: 'Enable Excel Export'
     description: 'Permission to enable excel export for statement(s) with all data from assessmenttable.'

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -246,7 +246,7 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
 
         $this->addColumnDefinition($columnsDefinition, 'externId', 'field_statement_extern_id', 'id');
 
-        if ($isStatement) {
+        if ($isStatement && $this->permissions->hasPermission('feature_statement_cluster')) {
             $columnsDefinition[] = $this->createColumnDefinition('name', 'cluster.name');
         }
 


### PR DESCRIPTION
### Ticket
[DPLAN-14868](https://demoseurope.youtrack.cloud/issue/DPLAN-14868/ADO-Issue-23356-Excel-Export-aller-Informationen-aus-Abwagungstabelle)

Enable xlsx export for specific project. Therefore a new permission is needed for "potentialAreas" and a permission check for "cluster.name" to add or remove this field from export.

### How to review/test
code review, test in interface of the specified projects if the export works how intended.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
