### PR TITLE
fix(DPLAN-15055): display a confirm message before deleting a Tag/Topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 - Institution tag management: Add search field and filters to institution list
 - Procedure basic settings: Move procedure location up under the "internal" section
+- TagsListEditForm: add a confirmation message before deleting the Tag or Topic
 
 ### Further changes
 - Segments list: Use DpSearchField for custom search

--- a/client/js/components/tags/TagListEditForm.vue
+++ b/client/js/components/tags/TagListEditForm.vue
@@ -136,7 +136,17 @@ export default {
     },
 
     deleteItem () {
-      this.$emit('delete', { id: this.nodeElement.id, type: this.nodeElement.type })
+      const { type, attributes, children, id } = this.nodeElement
+      const isTagTopic = type === 'TagTopic'
+      const topicConfirmMessage = isTagTopic && children?.length === 0 ? 'check.topic.delete' : 'check.topic.delete.tags'
+
+      const confirmMessage = isTagTopic
+        ? Translator.trans(topicConfirmMessage, { topic: attributes.title })
+        : Translator.trans('check.tag.delete', { tag: attributes.title })
+
+      if (window.dpconfirm(confirmMessage)) {
+        this.$emit('delete', { id, type })
+      }
     },
 
     editItem () {

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -436,7 +436,7 @@ check.survey.comment.disapprove: "Sind Sie sicher, dass Sie die Veröffentlichun
 check.tag.delete: "Sind Sie sicher, dass Sie das Schlagwort \"{tag}\" löschen möchten?"
 check.tag_is_used.delete: "Sind Sie sicher, dass Sie das Schlagwort löschen möchten? Es ist aktuell an mindestens eine Institution vergeben. Wenn Sie das Schlagwort löschen, wird es von den Institutionen entfernt."
 check.topic.delete.tags: "Sind Sie sicher, daß Sie das Thema \"{topic}\" und alle zugeordneten Schlagworte löschen möchten?"
-check.topic.delete: "Sind Sie sicher, daß Sie das Thema und alle Beiträge dazu löschen möchten?"
+check.topic.delete: "Sind Sie sicher, daß Sie das Thema \"{topic}\" löschen möchten?"
 check.user.delete: |
     {count, plural,
         =1 { Sind Sie sicher, dass Sie diese*n Nutzer*in löschen möchten? }


### PR DESCRIPTION
### Ticket
[DPLAN-15055
](https://demoseurope.youtrack.cloud/agiles/141-245/current?issue=DPLAN-15055)

**Description:** This PR improves the UX and adds a confirmation message before deleting a Tag/Topic.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
