### PR TITLE
feat DPLAN-15068 Add template for tag topic import

### DIFF
--- a/client/js/components/tags/TagsImportForm.vue
+++ b/client/js/components/tags/TagsImportForm.vue
@@ -80,10 +80,6 @@ export default {
     availableEntity () {
       return {
         exampleFile: '/files/tag_topics_import_template.csv',
-        label: 'statements.import',
-        key: 'statements',
-        permission: 'feature_statements_import_excel',
-        uploadPath: 'DemosPlan_statement_import'
       }
     },
   },

--- a/client/js/components/tags/TagsImportForm.vue
+++ b/client/js/components/tags/TagsImportForm.vue
@@ -20,6 +20,7 @@
           :text="Translator.trans('tags.import')"
           for="uploadTags"
           :tooltip="Translator.trans('tags.import.help')" />
+        <a download :href="availableEntity.exampleFile" target="_blank">{{ Translator.trans('example.file') }}</a>
         <dp-upload
           id="uploadTags"
           name="r_importCsv"
@@ -73,6 +74,18 @@ export default {
       uploadedCSV: null,
       uploadedFiles: ''
     }
+  },
+
+  computed: {
+    availableEntity () {
+      return {
+        exampleFile: '/files/tag_topics_import_template.csv',
+        label: 'statements.import',
+        key: 'statements',
+        permission: 'feature_statements_import_excel',
+        uploadPath: 'DemosPlan_statement_import'
+      }
+    },
   },
 
   methods: {

--- a/demosplan/DemosPlanCoreBundle/Resources/public/files/tag_topics_import_template.csv
+++ b/demosplan/DemosPlanCoreBundle/Resources/public/files/tag_topics_import_template.csv
@@ -1,0 +1,7 @@
+Thema;Schlagwortname;Textbaustein (ja/nein);Textbausteininhalt
+ Grundtenor der Stellungnahme;Positiv, Zustimmung;ja;Die Stellungnahme wird zur Kenntnis genommen. [wenn eine Planänderung zu dem positiv bewerteten Planteil erfolgt, muss dies allerdings auftauchen]
+ Grundtenor der Stellungnahme;Negativ, Ablehnung / Kritik;nein;
+ Grundtenor der Stellungnahme;Datenkorrektur-Hinweis;nein;
+ Inhaltliche Intention der Stellungnahme;Neuer Flächenwunsch / Flächenerweiterung;nein;
+ Inhaltliche Intention der Stellungnahme;Wunsch Flächen- (teil-) Streichung;nein;
+ Inhaltliche Intention der Stellungnahme;Allgemeine Kritik ohne Flächenbezug;nein;


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-15068/Add-Beispieldatei-fur-Schlagwort

The user should have a template file that describes how to import the tags - topics

### How to review/test
- Go to Verfahren > Schlalwort
- There should be a link called BeispielDatei and when clicking , a csv should be downloaded as a template


