### PR TITLE
 chore (refs DPLAN-14978): create report entries and dispatch events 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -1910,11 +1910,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      */
     public function isAutoSwitchOfPublicPhasePossible(Procedure $procedure): bool
     {
-        $procedureSettings = $procedure->getSettings();
-
-        return null !== $procedureSettings->getDesignatedPublicSwitchDate()
-            && null !== $procedureSettings->getDesignatedPublicPhase()
-            && null !== $procedureSettings->getDesignatedPublicEndDate();
+        $participationPhase = $procedure->getPublicParticipationPhaseObject();
+        return null !== $participationPhase->getDesignatedSwitchDate()
+            && null !== $participationPhase->getDesignatedPhase()
+            && null !== $participationPhase->getDesignatedEndDate();
     }
 
     /**
@@ -1924,11 +1923,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
      */
     public function isAutoSwitchOfPhasePossible(Procedure $procedure): bool
     {
-        $procedureSettings = $procedure->getSettings();
-
-        return null !== $procedureSettings->getDesignatedSwitchDate()
-            && null !== $procedureSettings->getDesignatedPhase()
-            && null !== $procedureSettings->getDesignatedEndDate();
+        $institutionPhase = $procedure->getPhaseObject();
+        return null !== $institutionPhase->getDesignatedSwitchDate()
+            && null !== $institutionPhase->getDesignatedPhase()
+            && null !== $institutionPhase->getDesignatedEndDate();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -266,7 +266,6 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
         $entitiesToPersist = [];
 
         foreach ($proceduresToSwitch as $procedure) {
-
             $this->logger->info('Switching phase of procedure '.$procedure->getName().' ('.$procedure->getId().')');
 
             // determine user; needs to be done before the phase change as it is lost afterwards
@@ -1919,6 +1918,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     public function isAutoSwitchOfPublicPhasePossible(Procedure $procedure): bool
     {
         $participationPhase = $procedure->getPublicParticipationPhaseObject();
+
         return null !== $participationPhase->getDesignatedSwitchDate()
             && null !== $participationPhase->getDesignatedPhase()
             && null !== $participationPhase->getDesignatedEndDate();
@@ -1932,6 +1932,7 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
     public function isAutoSwitchOfPhasePossible(Procedure $procedure): bool
     {
         $institutionPhase = $procedure->getPhaseObject();
+
         return null !== $institutionPhase->getDesignatedSwitchDate()
             && null !== $institutionPhase->getDesignatedPhase()
             && null !== $institutionPhase->getDesignatedEndDate();
@@ -1952,10 +1953,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
         if (!$this->isAutoSwitchOfPhasePossible($procedure)) {
             $this->logger->info('Automatic phase switch prevented because of incomplete settings.',
                 [
-                    'id' => $procedure->getId(),
+                    'id'         => $procedure->getId(),
                     'switchDate' => $procedure->getPhaseObject()->getDesignatedSwitchDate(),
-                    'phase' => $procedure->getPhaseObject()->getDesignatedPhase(),
-                    'endDate' => $procedure->getPhaseObject()->getDesignatedEndDate(),
+                    'phase'      => $procedure->getPhaseObject()->getDesignatedPhase(),
+                    'endDate'    => $procedure->getPhaseObject()->getDesignatedEndDate(),
                 ]
             );
 
@@ -2006,10 +2007,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
         if (!$this->isAutoSwitchOfPublicPhasePossible($procedure)) {
             $this->logger->info('Auto switch public phase is not possible',
                 [
-                    'id' => $procedure->getId(),
+                    'id'         => $procedure->getId(),
                     'switchDate' => $procedure->getPhaseObject()->getDesignatedSwitchDate(),
-                    'phase' => $procedure->getPhaseObject()->getDesignatedPhase(),
-                    'endDate' => $procedure->getPhaseObject()->getDesignatedEndDate(),
+                    'phase'      => $procedure->getPhaseObject()->getDesignatedPhase(),
+                    'endDate'    => $procedure->getPhaseObject()->getDesignatedEndDate(),
                 ]
             );
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -329,7 +329,9 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
             }
 
             if ($internalPhaseSwitched || $externalPhaseSwitched) {
-                $entitiesToPersist[] = $procedure;
+                // directly update procedure in loop to create report entries
+                // and dispatch events
+                $this->updateProcedureObject($procedure);
             }
         }
 


### PR DESCRIPTION
### Ticket
DPLAN-14978

During automatic phase change via maintenance command the event was not dispatched and no report entries written. Main change is 2e508f3b91cb8df1be6748a3fbe6da2364123b81, the other changes only add logging and ease access to the phase object


### How to review/test
Trigger automatic phase change via maintenance service, phases should still change

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
