### PR TITLE
chore: provide a command to list known files

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/FilesListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FilesListCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command;
+
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class FilesListCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:files:list';
+
+    protected static $defaultDescription = 'List files known to flysystem. Supports "local" and "s3" storage';
+
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly FilesystemOperator $s3Storage,
+        private readonly FilesystemOperator $localStorage,
+        ?string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('storage', InputArgument::REQUIRED, 'Storage to list');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output = new SymfonyStyle($input, $output);
+
+        $storage = $input->getArgument('storage');
+
+        $output->note('List files for adapter '.$storage);
+        // keep this simple as long as we only have two storage options
+        $storageOperator = 'local' === $storage ? $this->localStorage : $this->s3Storage;
+
+        $filesTotal = 0;
+        try {
+            $files = $storageOperator->listContents('/', true);
+            foreach ($files as $file) {
+                // only files could be moved via flysystem
+                if ($file->isDir()) {
+                    continue;
+                }
+                $output->writeln($file->path());
+                ++$filesTotal;
+
+                try {
+                    if (!$storageOperator->fileExists($file->path())) {
+                        $output->warning(sprintf('%s does not exist: %s ', $file->type(), $file->path()));
+                    }
+                } catch (FilesystemException $e) {
+                    $output->error('Could not read file '.$file->path().' '.$e->getMessage());
+                }
+            }
+        } catch (FilesystemException $e) {
+            $output->error('Could not list files in storage storage '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $output->info(sprintf('Number of files: %d', $filesTotal));
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
### Ticket
DPLAN-3415

This command lists all files known to the given adapter local or s3. Handy for debugging

### How to review/test
run bin/project dplan:files:list local|s3

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
