### PR TITLE
chore: lower stdout noise in maintenance command, improve logging

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
@@ -132,7 +132,7 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
         ProcedureRepository $procedureRepository,
         private readonly ProcedureService $procedureService,
         StatementService $statementService,
-        $name = null
+        $name = null,
     ) {
         parent::__construct($name);
 
@@ -335,7 +335,6 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
         $this->logger->info('Finished Addon Maintenance.');
     }
 
-
     /**
      * Get postalcode, gemeindekennzahl etc for procedures in queue.
      * - First we need to transform the coordinate, because it's using a different system.
@@ -486,12 +485,11 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
         // Success notice
         if ($internalProcedureCounter > 0 || $externalProcedureCounter > 0) {
             $switchedStr = 'Switched phases of ';
-            $this->logger->info($switchedStr .$internalProcedureCounter.' internal/public agency procedures.');
-            $this->logger->info($switchedStr .$externalProcedureCounter.' external/citizen procedures.');
-            $output->writeln($switchedStr .$internalProcedureCounter.' internal/public agency procedures.');
-            $output->writeln($switchedStr .$externalProcedureCounter.' external/citizen procedures.');
+            $this->logger->info($switchedStr.$internalProcedureCounter.' internal/public agency procedures.');
+            $this->logger->info($switchedStr.$externalProcedureCounter.' external/citizen procedures.');
+            $output->writeln($switchedStr.$internalProcedureCounter.' internal/public agency procedures.');
+            $output->writeln($switchedStr.$externalProcedureCounter.' external/citizen procedures.');
         }
-
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -163,11 +163,13 @@ class FileController extends BaseController
     private function getStreamedResponse(FileInfo $file): StreamedResponse
     {
         // check whether file exists using Default storage
+        $this->logger->debug('Default storage: ', [$this->defaultStorage::class]);
         if ($this->defaultStorage->fileExists($file->getAbsolutePath())) {
             $storage = $this->defaultStorage;
         }
         // as a fallback check whether file exists using Local storage
         elseif ($this->localStorage->fileExists($file->getAbsolutePath())) {
+            $this->logger->info('Found file in fallback local storage only');
             $storage = $this->localStorage;
         } else {
             $this->getLogger()->info('Could not find file', [$file->getAbsolutePath()]);


### PR DESCRIPTION
The maintenance service is quite noisy on stdout. Only show the execution and changes and log more

### How to review/test
run bin/project dplan:maintenance

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
