### PR TITLE
fix(DPLAN-15097): sidemenu layout issue

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_sidemenu.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_sidemenu.scss
@@ -47,9 +47,7 @@
         & > li {
             & > a {
                 display: block;
-                padding: {
-                    inset: $inuit-base-spacing-unit--small $inuit-base-spacing-unit $inuit-base-spacing-unit--small $inuit-base-spacing-unit;
-                }
+                padding: $inuit-base-spacing-unit--small $inuit-base-spacing-unit $inuit-base-spacing-unit--small $inuit-base-spacing-unit;
             }
 
             &.current_ancestor,


### PR DESCRIPTION
### Ticket
[DPLAN-15097](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15097)

**Description:** This PR solves the issue with the layout by sidemenu: using 'inset' inside the 'padding' was incorrect, so removed inset and use spacing direct with padding.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
