### PR TITLE
feature (ref: 14941): Add abbitMq Parameter to parameters default

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -427,6 +427,8 @@ parameters:
     # try to create procedures from the messages
     enable_xta_communication: false
 
+    enable_rabbitmq_communication: false
+
 
     ## Robobsh
     geo_wfs_statement_linien: ''

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -427,6 +427,7 @@ parameters:
     # try to create procedures from the messages
     enable_xta_communication: false
 
+    # Enable communication to RabbitMQ through the XBeteiligung Addon
     enable_rabbitmq_communication: false
 
 


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-14941/ADO-5545-Konfiguration-DiPlanBeteiligung-zum-RabbitMQ-Nachrichtenaustausch-mit-DiPlanCockpit


Description: Add rabbitMQ Parameter from XBeteiligung Addon to parameter default. Parameters.yml should be updated with true value in diplanbau.

