### PR TITLE
f_DPLAN-14956 remove STX (start of text) special chars from STN/Segment texts before exporting them.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -1558,7 +1558,6 @@ class DocxExporter
                 $cell2 = $assessmentTable->addCell($styles['cellWidth'], $cellTop);
                 // T6679:
                 $statementText = $this->editorService->handleObscureTags($statement->getText(), $anonym);
-                $statementText = str_replace(chr(2), '', $statementText);
                 $this->addHtml($cell2, $statementText, $styles);
                 $cell3 = $assessmentTable->addCell($styles['cellWidth'], $cellTop);
                 if (true === $permissions->hasPermission(

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -960,7 +960,7 @@ class DocxExporter
 
     /**
      * Used for non original statement and more?!
-     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used.
+     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used. - which calls this method
      *
      * @param Cell    $cell
      * @param string  $text
@@ -975,6 +975,9 @@ class DocxExporter
         }
         try {
             $text = self::replaceTags($text);
+            // remove STX (start of text) special chars
+            $text = str_replace(chr(2), '', $text);
+
             Html::addHtml($cell, $text, false);
         } catch (Exception $e) {
             $this->getLogger()->warning('Could not parse HTML in Export', [$e, $text, $e->getTraceAsString()]);
@@ -1555,6 +1558,7 @@ class DocxExporter
                 $cell2 = $assessmentTable->addCell($styles['cellWidth'], $cellTop);
                 // T6679:
                 $statementText = $this->editorService->handleObscureTags($statement->getText(), $anonym);
+                $statementText = str_replace(chr(2), '', $statementText);
                 $this->addHtml($cell2, $statementText, $styles);
                 $cell3 = $assessmentTable->addCell($styles['cellWidth'], $cellTop);
                 if (true === $permissions->hasPermission(

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -975,8 +975,8 @@ class DocxExporter
         }
         try {
             $text = self::replaceTags($text);
-            // remove STX (start of text) special chars
-            $text = str_replace(chr(2), '', $text);
+            // remove STX (start of text) EOT (end of text) special chars
+            $text = str_replace([chr(2), chr(3)], '', $text);
 
             Html::addHtml($cell, $text, false);
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -960,7 +960,7 @@ class DocxExporter
 
     /**
      * Used for non original statement and more?!
-     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used. - which calls this method.
+     * For OriginalStatements AssessmentTableServiceOutput::addHtml is used.
      *
      * @param Cell    $cell
      * @param string  $text

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -309,6 +309,7 @@ class SegmentsExporter
 
     private function addSegmentHtmlCell(Row $row, string $text, CellExportStyle $cellExportStyle): void
     {
+        $text = str_replace(chr(2), '', $text);
         $cell = $row->addCell(
             $cellExportStyle->getWidth(),
             $cellExportStyle->getCellStyle()

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -309,7 +309,8 @@ class SegmentsExporter
 
     private function addSegmentHtmlCell(Row $row, string $text, CellExportStyle $cellExportStyle): void
     {
-        $text = str_replace(chr(2), '', $text);
+        // remove STX (start of text) EOT (end of text) special chars
+        $text = str_replace([chr(2), chr(3)], '', $text);
         $cell = $row->addCell(
             $cellExportStyle->getWidth(),
             $cellExportStyle->getCellStyle()


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-14956/BOB-SH-ROBOB-Prod-und-Stage-Exporter-Fehler-durch-Sonderzeichen-STX-alle-Produkte-mit-AWT

Description:
remove STX (start of text) EOT (end of text) special chars from STN/Segment texts before exporting them.
Basically from every caller of Html::addHtml instead where just trans keys get passed.
Otherwise Html::addHtml fails on loadXml.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
