### PR TITLE
f_DPLAN-14956 remove STX (start of text) EOT (end of text) special ch…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -959,6 +959,9 @@ class DocxExporter
         }
         try {
             $text = self::replaceTags($text);
+            // remove STX (start of text) EOT (end of text) special chars
+            $text = str_replace([chr(2), chr(3)], '', $text);
+
             Html::addHtml($cell, $text, false);
         } catch (Exception $e) {
             $this->getLogger()->warning('Could not parse HTML in Export', [$e, $text, $e->getTraceAsString()]);

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -352,6 +352,8 @@ class SegmentsExporter
 
     private function addSegmentHtmlCell(Row $row, string $text, CellExportStyle $cellExportStyle): void
     {
+        // remove STX (start of text) EOT (end of text) special chars
+        $text = str_replace([chr(2), chr(3)], '', $text);
         $cell = $row->addCell(
             $cellExportStyle->getWidth(),
             $cellExportStyle->getCellStyle()


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-14956/BOB-SH-ROBOB-Prod-und-Stage-Exporter-Fehler-durch-Sonderzeichen-STX-alle-Produkte-mit-AWT

Description:
original PR pointing to a release-branch: https://github.com/demos-europe/demosplan-core/pull/4399 

remove STX (start of text) EOT (end of text) special chars from STN/Segment texts before exporting them.
Basically from every caller of Html::addHtml instead where just trans keys get passed.
Otherwise Html::addHtml fails on loadXml.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
