### PR TITLE
chore (refs DPLAN-14978): throw event with unmodified values

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -339,6 +339,14 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
                 // directly update procedure in loop to create report entries
                 // and dispatch events
                 $this->updateProcedureObject($procedure);
+
+                // unfortunately php/doctrine is not able to fetch the unmodified procedure
+                // from the database **before** the update of the modified object in updateProcedureObject,
+                // so we need to dispatch the event here again
+                $this->eventDispatcher->dispatch(
+                    new PostProcedureUpdatedEvent($originalProcedure, $procedure),
+                    PostProcedureUpdatedEventInterface::class
+                );
             }
         }
 


### PR DESCRIPTION
### Ticket
DPLAN-14978

unfortunately php/doctrine is not able to fetch the unmodified procedure from the database **before** the update of the modified object in updateProcedureObject, so we need to dispatch the event again. Moreover during clone the objects that are attached to the entity are not cloned automatically. I tried __clone which did not work, I exprerimented with https://github.com/myclabs/DeepCopy which is quite a nice package, but triggered new problems. Finally I found no other way than to trigger the event again with the original values as well

### How to review/test
code review should be best

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
