### PR TITLE
fix DPLAN-15092 Use $pathStartResourceType as this buildConditions me…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -154,7 +154,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                 ? $this->conditionFactory->false()
                 : $this->conditionFactory->propertyHasAnyOfValues($allowedProcedureIds, $pathStartResourceType->procedure->id),
             // filter out segments
-            $this->conditionFactory->propertyIsNull($this->parentStatementOfSegment),
+            $this->conditionFactory->propertyIsNull($pathStartResourceType->parentStatementOfSegment),
         ];
         if (!$allowOriginals) {
             // Normally the path to the relationship would suffice for a NULL check, but the ES


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-15092/Nach-aufteilen-von-einer-STN-via-Beteiligungsimport-Navigierung-zur-Abschnitte-schlagt-Fehl-keine-Abschnitte-obwohl-zwei-da-sein

Use the parameter on the buildConditions of the StatementSegment

### How to review/test
- Go to Verfahren > Click on Abschnitte
- No error should happen
