### PR TITLE
fix(DPLAN-12263): the item was still displaying in the list after deleting it

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -945,8 +945,8 @@ export default {
       if (window.confirm(Translator.trans('check.statement.delete'))) {
         this.deleteStatement(id)
           .then(response => checkResponse(response, {
-              200: { type: 'confirm', text: 'confirm.statement.deleted' },
-              204: { type: 'confirm', text: 'confirm.statement.deleted' }
+            200: { type: 'confirm', text: 'confirm.statement.deleted' },
+            204: { type: 'confirm', text: 'confirm.statement.deleted' }
           }))
           .then(() => {
             this.getItemsByPage(this.pagination.currentPage)

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -663,7 +663,6 @@ export default {
       if (assigneeId !== this.currentUserId) {
         this.claimStatement(statementId)
       } else {
-        console.log('unclaim')
         this.unclaimStatement(statementId)
       }
     },
@@ -945,10 +944,13 @@ export default {
     triggerStatementDeletion (id) {
       if (window.confirm(Translator.trans('check.statement.delete'))) {
         this.deleteStatement(id)
-          .then(response => checkResponse(response, {
-            200: { type: 'confirm', text: 'confirm.statement.deleted' },
-            204: { type: 'confirm', text: 'confirm.statement.deleted' }
-          }))
+          .then(response => {
+            this.getItemsByPage(this.pagination.currentPage)
+            checkResponse(response, {
+              200: { type: 'confirm', text: 'confirm.statement.deleted' },
+              204: { type: 'confirm', text: 'confirm.statement.deleted' }
+            })
+          })
       }
     },
 

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -944,12 +944,12 @@ export default {
     triggerStatementDeletion (id) {
       if (window.confirm(Translator.trans('check.statement.delete'))) {
         this.deleteStatement(id)
-          .then(response => {
-            this.getItemsByPage(this.pagination.currentPage)
-            checkResponse(response, {
+          .then(response => checkResponse(response, {
               200: { type: 'confirm', text: 'confirm.statement.deleted' },
               204: { type: 'confirm', text: 'confirm.statement.deleted' }
-            })
+          }))
+          .then(() => {
+            this.getItemsByPage(this.pagination.currentPage)
           })
       }
     },


### PR DESCRIPTION
### Ticket
[DPLAN-12263](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-12263)

**Description:** This PR fixes an issue where the item was still displaying in the list after deleting it. 

The problem is related to reactivity: the `statementsObject` varible updates properly, but the computed value `items()` that transforms the `statementsObject` does not detect the change. I tried different ways to trigger the reactivity, but there were always some problems. The only solution without issues was to fetch the items by page after the delete action.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
