### PR TITLE
DPLAN-DS31 filter deleted single and paradocs when retrieved via resourceTypes

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphResourceType.php
@@ -21,6 +21,7 @@ use EDT\PathBuilding\End;
  *
  * @property-read End $title
  * @property-read PlanningDocumentCategoryResourceType $element
+ * @property-read End $deleted
  */
 final class ParagraphResourceType extends DplanResourceType
 {
@@ -51,7 +52,7 @@ final class ParagraphResourceType extends DplanResourceType
 
     protected function getAccessConditions(): array
     {
-        return [];
+        return [$this->conditionFactory->propertyHasValue(false, $this->deleted)];
     }
 
     protected function getProperties(): array

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
@@ -28,6 +28,7 @@ use EDT\PathBuilding\End;
  * @property-read End $order
  * @property-read End $index
  * @property-read End $fileInfo improve T22479
+ * @property-read End $deleted
  */
 final class SingleDocumentResourceType extends DplanResourceType
 {
@@ -62,11 +63,14 @@ final class SingleDocumentResourceType extends DplanResourceType
 
     protected function getAccessConditions(): array
     {
+        //SingleDocuments get soft-deleted only if a statement references it SingleDocumentRepository::delete
+        $accessConditions = [$this->conditionFactory->propertyHasValue(false, $this->deleted)];
         if ($this->currentUser->hasPermission('area_admin_single_document')) {
-            return [];
+            return $accessConditions;
         }
+        $accessConditions[] = $this->conditionFactory->propertyHasValue(true, $this->visible);
 
-        return [$this->conditionFactory->propertyHasValue(true, $this->visible)];
+        return $accessConditions;
     }
 
     protected function getProperties(): array


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/tickets/DS-31/Evtl.-Bug-in-den-Planunterlagendarstellungen?backToIssues

Description:
filter deleted single and paradocs when retrieved via resourceTypes

### How to review/test
delete a single-doc from an element after referencing it in a statement - this will lead to a soft-deletion.
Those ones were not filtered out correctly before but are now.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
