### PR TITLE
Fix(dplan 15119): segment location map issue by saving relation

### DIFF
--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -7,12 +7,12 @@
  * All rights reserved
  */
 
+import { api1_0Routes, generateApi2_0Routes } from './VuexApiRoutes'
 import { checkResponse, handleResponseMessages, hasOwnProp } from '@demos-europe/demosplan-ui'
 import { initJsonApiPlugin, prepareModuleHashMap, StaticRouter } from '@efrane/vuex-json-api'
 import notify from './Notify'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { api1_0Routes, generateApi2_0Routes } from './VuexApiRoutes'
 
 function registerPresetModules (store, presetStoreModules) {
   if (Object.keys(presetStoreModules).length > 0) {
@@ -64,18 +64,19 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
         plugins: [
           initJsonApiPlugin({
             apiModules: apiStoreModules,
-            router: router,
-            baseUrl: baseUrl,
+            router,
+            baseUrl,
             headers: {
               'X-JWT-Authorization': 'Bearer ' + dplan.jwtToken,
-              'X-Demosplan-Procedure-Id': dplan.procedureId
+              'X-Demosplan-Procedure-Id': dplan.procedureId,
+              'X-CSRF-Token': dplan.csrfToken
             },
             successCallbacks: [
               async (success) => {
                 // If the response body is empty, contentType will be null
                 const contentType = success.headers.get('Content-Type')
 
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.includes('json')) {
                   const response = await success.json()
 
                   const meta = response.data?.meta
@@ -96,7 +97,7 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
                 // If the response body is empty, contentType will be null
                 const contentType = error.headers.get('Content-Type')
 
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.includes('json')) {
                   const response = await error.json()
 
                   const meta = response.data?.meta

--- a/client/js/store/core/initStore.js
+++ b/client/js/store/core/initStore.js
@@ -72,31 +72,45 @@ function initStore (storeModules, apiStoreModules, presetStoreModules) {
             },
             successCallbacks: [
               async (success) => {
-                const response = await success.json()
+                // If the response body is empty, contentType will be null
+                const contentType = success.headers.get('Content-Type')
 
-                const meta = response.data?.meta
-                  ? response.data.meta
-                  : response.meta || null
-                if (meta?.messages) {
-                  handleResponseMessages(meta)
+                if (contentType && contentType.includes('application/json')) {
+                  const response = await success.json()
+
+                  const meta = response.data?.meta
+                    ? response.data.meta
+                    : response.meta || null
+                  if (meta?.messages) {
+                    handleResponseMessages(meta)
+                  }
+
+                  return Promise.resolve(response)
                 }
 
-                return Promise.resolve(response)
+                return Promise.resolve(success)
               }
             ],
             errorCallbacks: [
               async (error) => {
-                const response = await error.json()
+                // If the response body is empty, contentType will be null
+                const contentType = error.headers.get('Content-Type')
 
-                const meta = response.data?.meta
-                  ? response.data.meta
-                  : response.meta || null
+                if (contentType && contentType.includes('application/json')) {
+                  const response = await error.json()
 
-                if (meta?.messages) {
-                  handleResponseMessages(meta)
+                  const meta = response.data?.meta
+                    ? response.data.meta
+                    : response.meta || null
+
+                  if (meta?.messages) {
+                    handleResponseMessages(meta)
+                  }
+
+                  return Promise.reject(response)
                 }
 
-                return Promise.reject(response)
+                return Promise.reject(error)
               }
             ]
           }),


### PR DESCRIPTION
### Ticket
[DPLAN-XXXXX](https://demoseurope.youtrack.cloud/issue/DPLAN-15119/Ortsbezug-kann-nicht-gespeichert-werden-Erwiderung-verfassen)

**Description:** Cherry-pick from main a commit that solves an issue; adjust content type check in the success callback and use the more general "json" instead of "application/json"

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
