### PR TITLE
fix(refs  dplan-14909): Always send assignee and place in pair

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -623,7 +623,7 @@ export default {
         }
       }
 
-      return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
+      dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
         .then(checkResponse)
         .then(() => {
           this.claimLoading = false
@@ -678,9 +678,18 @@ export default {
 
     save () {
       const comments = this.segment.relationships.comments ? { ...this.segment.relationships.comments } : null
+      const rel = this.updateRelationships()
 
-      this.updateRelationships()
-      return this.saveSegmentAction(this.segment.id)
+      const payload = {
+        data: {
+          id: this.segment.id,
+          type: 'StatementSegment',
+          relationships: { assignee: rel.assignee, place: rel.place }
+        }
+      }
+
+      dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
+        .then(checkResponse)
         .then(() => {
           /*
            * @improve - once the vuex-json-api resolves with a response,
@@ -863,9 +872,12 @@ export default {
       }
 
       this.setSegment({ ...updated, id: this.segment.id })
+
+      return relations
     },
 
     updateSegment (key, val) {
+      console.log('updateSegment', key, val)
       const updated = { ...this.segment, ...{ attributes: { ...this.segment.attributes, ...{ [key]: val } } } }
       this.setSegment({ ...updated, id: this.segment.id })
     }

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -678,13 +678,16 @@ export default {
 
     save () {
       const comments = this.segment.relationships.comments ? { ...this.segment.relationships.comments } : null
-      const rel = this.updateRelationships()
+      const { assignee, place } = this.updateRelationships()
 
       const payload = {
         data: {
           id: this.segment.id,
           type: 'StatementSegment',
-          relationships: { assignee: rel.assignee, place: rel.place }
+          relationships: {
+            assignee,
+            place
+          }
         }
       }
 
@@ -877,7 +880,6 @@ export default {
     },
 
     updateSegment (key, val) {
-      console.log('updateSegment', key, val)
       const updated = { ...this.segment, ...{ attributes: { ...this.segment.attributes, ...{ [key]: val } } } }
       this.setSegment({ ...updated, id: this.segment.id })
     }

--- a/client/js/components/report/DpReportListing.vue
+++ b/client/js/components/report/DpReportListing.vue
@@ -16,7 +16,9 @@
     <div
       class="float-right u-mt-0_25"
       v-if="hasPermission('feature_export_protocol')">
-      <a :href="Routing.generate('dplan_export_report', { procedureId })">
+      <a
+        data-cy="exportTriggerPdf"
+        :href="Routing.generate('dplan_export_report', { procedureId })">
         <i
           class="fa fa-share-square"
           aria-hidden="true" />


### PR DESCRIPTION
### Ticket
DPLAN-14909

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

For some reason, sometimes, when both assignee and place changed, only place where send. Because it happens soemtimes, I think it is some sort of race condition between the request and an update of the initial segment. Because I monitored that the initial segment gets updated aswell even though, It should not at that very moment.

To prevent all that, I decided to bypass the vuex-json-api and update the resourcetype "manually".



### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

in the segmentslist, when changing plce and assignee, it always should send both.
Hence the bug appears just randomly, its really hard to test.
