### PR TITLE
Bug(refs DPLAN-15149) faq item delete

### DIFF
--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -257,7 +257,7 @@ export default {
           })
         }
 
-        this.queue.push(deleteAction())
+        this.queue.push(deleteAction)
       }
     }
   }


### PR DESCRIPTION
### Ticket
DPLAN-15149
or
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/XXXXX

The deleteFaqItem method was updated to push the deleteAction function into the queue to ensure reactivity.

### How to review/test
delete an item from faq category

### PR Checklist

- [x ] Run `yarn lint`
- [x ] Move the tickets on the board accordingly
