### PR TITLE
fix(refs DPLAN-15179): reset filters in localStorage

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -668,6 +668,10 @@ export default {
         })
     },
 
+    resetFilterQueryInLocalStorage () {
+      localStorage.setItem('filterQuery', JSON.stringify({}))
+    },
+
     resetQuery () {
       this.searchTerm = ''
       Object.keys(this.allFilterCategories).forEach((filterCategoryId, idx) => {
@@ -690,6 +694,8 @@ export default {
           }
         }
       })
+
+      this.resetFilterQueryInLocalStorage()
       this.appliedFilterQuery = []
       this.getInstitutionsByPage(1)
     },

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -232,6 +232,7 @@ export default {
   mixins: [tableScrollbarMixin],
 
   props: {
+    // Array when empty, object when not empty
     initialFilter: {
       type: [Object, Array],
       default: () => ({})
@@ -246,6 +247,7 @@ export default {
 
   data () {
     return {
+      // Array when empty, object when not empty
       appliedFilterQuery: this.initialFilter,
       currentlySelectedColumns: [],
       currentlySelectedFilterCategories: [],
@@ -360,8 +362,9 @@ export default {
 
     queryIds () {
       let ids = []
+      const isFilterApplied = !Array.isArray(this.appliedFilterQuery) && Object.keys(this.appliedFilterQuery).length > 0
 
-      if (!Array.isArray(this.appliedFilterQuery) && Object.values(this.appliedFilterQuery).length > 0) {
+      if (isFilterApplied) {
         ids = Object.values(this.appliedFilterQuery).map(el => el.condition.value)
       }
 
@@ -704,10 +707,12 @@ export default {
      * }
      */
     setAppliedFilterQuery (filter) {
-      const selectedFilterOptions = Object.values(filter).filter(el => el.condition)
+      // Remove groups from filter
+      const selectedFilterOptions = Object.fromEntries(Object.entries(filter).filter(([_key, value]) => value.condition))
       const isReset = Object.keys(selectedFilterOptions).length === 0
+      const isAppliedFilterQueryEmpty = Array.isArray(this.appliedFilterQuery) && this.appliedFilterQuery.length === 0
 
-      if (!isReset && !Array.isArray(this.appliedFilterQuery) && Object.keys(this.appliedFilterQuery).length === 0) {
+      if (!isReset && isAppliedFilterQueryEmpty) {
         Object.values(selectedFilterOptions).forEach(option => {
           this.$set(this.appliedFilterQuery, option.condition.value, option)
         })

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -232,12 +232,6 @@ export default {
   mixins: [tableScrollbarMixin],
 
   props: {
-    // Array when empty, object when not empty
-    initialFilter: {
-      type: [Object, Array],
-      default: () => ({})
-    },
-
     isActive: {
       type: Boolean,
       required: false,
@@ -247,8 +241,7 @@ export default {
 
   data () {
     return {
-      // Array when empty, object when not empty
-      appliedFilterQuery: this.initialFilter,
+      appliedFilterQuery: {},
       currentlySelectedColumns: [],
       currentlySelectedFilterCategories: [],
       editingInstitutionId: null,
@@ -326,7 +319,7 @@ export default {
     },
 
     isQueryApplied () {
-      const isFilterApplied = !Array.isArray(this.appliedFilterQuery) && Object.keys(this.appliedFilterQuery).length > 0
+      const isFilterApplied = Object.keys(this.appliedFilterQuery).length > 0
       const isSearchApplied = this.searchTerm !== ''
 
       return isFilterApplied || isSearchApplied
@@ -362,7 +355,7 @@ export default {
 
     queryIds () {
       let ids = []
-      const isFilterApplied = !Array.isArray(this.appliedFilterQuery) && Object.keys(this.appliedFilterQuery).length > 0
+      const isFilterApplied = Object.keys(this.appliedFilterQuery).length > 0
 
       if (isFilterApplied) {
         ids = Object.values(this.appliedFilterQuery).map(el => el.condition.value)
@@ -696,7 +689,7 @@ export default {
       })
 
       this.resetFilterQueryInLocalStorage()
-      this.appliedFilterQuery = []
+      this.appliedFilterQuery = {}
       this.getInstitutionsByPage(1)
     },
 
@@ -716,7 +709,7 @@ export default {
       // Remove groups from filter
       const selectedFilterOptions = Object.fromEntries(Object.entries(filter).filter(([_key, value]) => value.condition))
       const isReset = Object.keys(selectedFilterOptions).length === 0
-      const isAppliedFilterQueryEmpty = Array.isArray(this.appliedFilterQuery) && this.appliedFilterQuery.length === 0
+      const isAppliedFilterQueryEmpty = Object.keys(this.appliedFilterQuery).length === 0
 
       if (!isReset && isAppliedFilterQueryEmpty) {
         Object.values(selectedFilterOptions).forEach(option => {
@@ -727,7 +720,7 @@ export default {
           const filtersWithConditions = Object.fromEntries(
             Object.entries(this.filterQuery).filter(([key, value]) => value.condition)
           )
-          this.appliedFilterQuery = Object.keys(filtersWithConditions).length ? filtersWithConditions : []
+          this.appliedFilterQuery = Object.keys(filtersWithConditions).length ? filtersWithConditions : {}
         } else {
           this.appliedFilterQuery = selectedFilterOptions
         }


### PR DESCRIPTION
### Ticket
[DPLAN-15179](https://demoseurope.youtrack.cloud/issue/DPLAN-15179/Filter-konnen-nicht-zuruckgesetzt-werden-Institutionen-verschlagworten)

- reset button is no longer disabled when filters are applied; this was fixed by ensuring that `appliedFilterQuery` is an array only when empty, and an object when not empty
- on reset, applied filters are also removed from storage, so when reloading the page, filters are not re-applied

### How to review/test

- login as customer admin
- go to "Institutionen verschlagworten"
- filter the list and try to reset the applied filters - it should now work without problems and list should remain unfiltered after reloading the page

### PR Checklist

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
