### PR TITLE
DPLAN-15064 fix placement of setter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/TagTopicRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/TagTopicRepository.php
@@ -189,8 +189,8 @@ class TagTopicRepository extends CoreRepository implements ObjectInterface
                     }
 
                     $this->getEntityManager()->persist($newTopic);
+                    $newProcedure->addTagTopic($newTopic);
                 }
-                $newProcedure->addTagTopic($newTopic);
             }
 
             $this->getEntityManager()->flush();


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15064/Nutzung-einer-Blaupause-mit-thematischen-Schlagworten-funktioniert-nicht

Description:
The setter should be inside the loop instead outside to set all topics and tags instead only the last one

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
