### PR TITLE
DPLAN-15063 configure the TagTopicResourceType to use the correct relation-paths if used in blueprint vs procedure context.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
@@ -141,9 +141,16 @@ final class TagTopicResourceType extends DplanResourceType
             )
         );
 
-        $configBuilder->procedure
-            ->setRelationshipType($this->resourceTypeStore->getProcedureResourceType())
-            ->setReadableByPath()->setSortable()->setFilterable()->initializable();
+        if ($this->currentProcedureService->getProcedure()->getMaster()) {
+            $configBuilder->procedure
+                ->setRelationshipType($this->resourceTypeStore->getProcedureTemplateResourceType())
+                ->setReadableByPath()->setSortable()->setFilterable()->initializable();
+        }
+        if (!$this->currentProcedureService->getProcedure()->getMaster()) {
+            $configBuilder->procedure
+                ->setRelationshipType($this->resourceTypeStore->getProcedureResourceType())
+                ->setReadableByPath()->setSortable()->setFilterable()->initializable();
+        }
 
         $configBuilder->addConstructorBehavior(
             new FixedConstructorBehavior(
@@ -198,6 +205,7 @@ final class TagTopicResourceType extends DplanResourceType
                     EntityDataInterface $entityData,
                 ): array {
                     try {
+                        $this->messageBag->add('confirm', var_export($entityData, true));
                         // check Procedure relation
                         $procedureIdToSet = ((array) $entityData->getToOneRelationships())['procedure']['id'];
                         Assert::same(


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15063/Schlagwortkategorie-anlegen-in-Blaupause-wirft-Fehler

Description:
configure the TagTopicResourceType to use the correct relation-paths if used in blueprint vs procedure context.

ToDo:
Only if in blueprint context - the file ```TagsCreateForm.vue``` has to set the type to 
```
saveNewTopic () {
      this.createTagTopic({
        type: 'TagTopic',
        attributes: {
          title: this.newTopic.title
        },
        relationships: {
          procedure: {
            data: {
              type: 'ProcedureTemplate',
              id: this.procedureId
            }
          }
        }
      })
```
otherwise it has to stay put.



- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
