### PR TITLE
fix(refs DPLAN-15170, #AB22463): persist flyout and filter option selection

### DIFF
--- a/client/js/components/procedure/SegmentsList/FilterFlyout.vue
+++ b/client/js/components/procedure/SegmentsList/FilterFlyout.vue
@@ -538,6 +538,12 @@ export default {
       const isInitialWithQuery = true
 
       this.requestFilterOptions(isInitialWithQuery)
+
+      if (this.itemsSelected) {
+        const selectedIds = this.itemsSelected.map(item => item.id)
+        this.appliedQuery = selectedIds
+        this.currentQuery = selectedIds
+      }
     }
   }
 }

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -640,7 +640,7 @@ export default {
     getInitiallySelectedFilterCategoriesFromLocalStorage () {
       const selectedFilterCategories = localStorage.getItem('visibleFilterFlyouts')
 
-      return selectedFilterCategories ? JSON.parse(selectedFilterCategories) : []
+      return selectedFilterCategories ? JSON.parse(selectedFilterCategories) : null
     },
 
     getTagById (tagId) {
@@ -727,15 +727,14 @@ export default {
         Object.values(selectedFilterOptions).forEach(option => {
           this.$set(this.appliedFilterQuery, option.condition.value, option)
         })
+      } else if (isReset) {
+        const filtersWithConditions = Object.fromEntries(
+          Object.entries(this.filterQuery).filter(([key, value]) => value.condition)
+        )
+
+        this.appliedFilterQuery = Object.keys(filtersWithConditions).length ? filtersWithConditions : {}
       } else {
-        if (isReset) {
-          const filtersWithConditions = Object.fromEntries(
-            Object.entries(this.filterQuery).filter(([key, value]) => value.condition)
-          )
-          this.appliedFilterQuery = Object.keys(filtersWithConditions).length ? filtersWithConditions : {}
-        } else {
-          this.appliedFilterQuery = selectedFilterOptions
-        }
+        this.appliedFilterQuery = selectedFilterOptions
       }
     },
 
@@ -820,11 +819,8 @@ export default {
 
     setInitiallySelectedFilterCategories () {
       const selectedFilterCategoriesInStorage = this.getInitiallySelectedFilterCategoriesFromLocalStorage()
-      this.initiallySelectedFilterCategories = selectedFilterCategoriesInStorage.length ? selectedFilterCategoriesInStorage : this.initiallySelectedColumns
 
-      if (selectedFilterCategoriesInStorage.length === 0) {
-        localStorage.setItem('visibleFilterFlyouts', JSON.stringify(this.initiallySelectedFilterCategories))
-      }
+      this.initiallySelectedFilterCategories = selectedFilterCategoriesInStorage !== null ? selectedFilterCategoriesInStorage : this.initiallySelectedColumns
     },
 
     toggleAllSelectedFilterCategories () {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -632,6 +632,12 @@ export default {
       return filterQueryInStorage && filterQueryInStorage !== 'undefined' ? JSON.parse(filterQueryInStorage) : {}
     },
 
+    getInitiallySelectedFilterCategoriesFromLocalStorage () {
+      const selectedFilterCategories = localStorage.getItem('visibleFilterFlyouts')
+
+      return selectedFilterCategories ? JSON.parse(selectedFilterCategories) : []
+    },
+
     getTagById (tagId) {
       return this.tagList.find(el => el.id === tagId) ?? null
     },
@@ -643,11 +649,8 @@ export default {
     },
 
     handleChange (filterCategoryName, isSelected) {
-      if (isSelected) {
-        this.currentlySelectedFilterCategories.push(filterCategoryName)
-      } else {
-        this.currentlySelectedFilterCategories = this.currentlySelectedFilterCategories.filter(category => category !== filterCategoryName)
-      }
+      this.updateCurrentlySelectedFilterCategories(filterCategoryName, isSelected)
+      this.setSelectedFilterCategoriesInLocalStorage(this.currentlySelectedFilterCategories)
     },
 
     handleReset () {
@@ -798,14 +801,36 @@ export default {
         .map(category => category.attributes.name)
     },
 
+    setSelectedFilterCategoriesInLocalStorage (selectedFilterCategories) {
+      localStorage.setItem('visibleFilterFlyouts', JSON.stringify(selectedFilterCategories))
+    },
+
     setInitiallySelectedFilterCategories () {
-      this.initiallySelectedFilterCategories = this.initiallySelectedColumns
+      const selectedFilterCategoriesInStorage = this.getInitiallySelectedFilterCategoriesFromLocalStorage()
+      this.initiallySelectedFilterCategories = selectedFilterCategoriesInStorage.length ? selectedFilterCategoriesInStorage : this.initiallySelectedColumns
+
+      if (selectedFilterCategoriesInStorage.length === 0) {
+        localStorage.setItem('visibleFilterFlyouts', JSON.stringify(this.initiallySelectedFilterCategories))
+      }
     },
 
     toggleAllSelectedFilterCategories () {
       const allSelected = this.currentlySelectedFilterCategories.length === Object.keys(this.allFilterCategories).length
 
       this.currentlySelectedFilterCategories = allSelected ? [] : Object.values(this.allFilterCategories).map(filter => filter.label)
+    },
+
+    /**
+     * Adds or removes a single fliterCategory to/from currentlySelectedFilterCategories
+     * @param filterCategoryName {String}
+     * @param isSelected {Boolean}
+     */
+    updateCurrentlySelectedFilterCategories (filterCategoryName, isSelected) {
+      if (isSelected) {
+        this.currentlySelectedFilterCategories.push(filterCategoryName)
+      } else {
+        this.currentlySelectedFilterCategories = this.currentlySelectedFilterCategories.filter(category => category !== filterCategoryName)
+      }
     }
   },
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -826,7 +826,7 @@ export default {
     toggleAllSelectedFilterCategories () {
       const allSelected = this.currentlySelectedFilterCategories.length === Object.keys(this.allFilterCategories).length
       const selectedFilterOptions = Object.values(this.appliedFilterQuery)
-      let categoriesWithSelectedOptions = []
+      const categoriesWithSelectedOptions = []
 
       selectedFilterOptions.forEach(option => {
         const categoryId = option.condition.memberOf.replace('_group', '')


### PR DESCRIPTION
### Ticket
[DPLAN-15170](https://demoseurope.youtrack.cloud/issue/DPLAN-15170)

- after reloading the page, the selection of filter flyouts made by the user via the 'more filters' flyout is still visible
- filter options from those flyouts that are applied will remain applied after reloading the page
- if filter options from a filter flyout are selected and applied, that filter flyout cannot be hidden via the 'more filters' flyout, since it would not be clear which filters are applied. instead, the checkbox is disabled. also, the count of selected options is now displayed in the 'more filters' flyout behind each category label.

### PR Checklist

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
