### PR TITLE
f DPLAN-15186 get only accepted planning offices

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/OrgaRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/OrgaRepository.php
@@ -77,6 +77,8 @@ class OrgaRepository extends SluggedRepository implements ArrayInterface
             ->setParameter('planningOfficeOrgaTypeName', OrgaType::PLANNING_AGENCY)
             ->andWhere('relation_customer_orga_orga_type.customer = :customer')
             ->setParameter('customer', $customer)
+            ->andWhere('relation_customer_orga_orga_type.status = :status')
+            ->setParameter('status', OrgaStatusInCustomer::STATUS_ACCEPTED)
             ->getQuery();
 
         $orgaResult = $query->getResult();


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15186/Noch-nicht-freigegebenen-Planungsburos-durfen-fur-Verfahren-berechtigt-werden


Description: get only accepted planning offices


Delete the checkbox if it doesn't apply/isn't necessary.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
