### PR TITLE
f DPLAN-15195 allow master customer user to get and edit procedure te…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -56,6 +56,7 @@ class User implements AddonUserInterface, TotpTwoFactorInterface, EmailTwoFactor
     public const HEARING_AUTHORITY_ROLES = [RoleInterface::HEARING_AUTHORITY_ADMIN, RoleInterface::HEARING_AUTHORITY_WORKER];
     public const PLANNING_AGENCY_ROLES = [RoleInterface::PLANNING_AGENCY_ADMIN, RoleInterface::PLANNING_AGENCY_WORKER];
     public const PUBLIC_AGENCY_ROLES = [RoleInterface::PUBLIC_AGENCY_COORDINATION, RoleInterface::PUBLIC_AGENCY_WORKER];
+    public const CUSTOMER_MASTER_USER_ROLE = [RoleInterface::CUSTOMER_MASTER_USER];
     /**
      * @var string|null
      *

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -114,6 +114,7 @@ class OwnsProcedureConditionFactory
         $relevantRoles = [
             ...User::PLANNING_AGENCY_ROLES,
             ...User::HEARING_AUTHORITY_ROLES,
+            ...User::CUSTOMER_MASTER_USER_ROLE
         ];
 
         if ($this->userOrProcedure instanceof User) {


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15195/ADO-Issue-25324-Integration-Beteiligung-Bauleitplanung-2025.3.1-Mandantenadministration-kann-keine-Blaupausen-anlegen


Description: the master customer user role can already create procedure template but it should be able to get and edit the procedure template list too.

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

