### PR TITLE
f DPLAN- 15167 remove duplicated line

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsExporter.php
@@ -215,7 +215,6 @@ class SegmentsExporter
         );
 
         $this->addSegmentCell($row5, '', $this->styles['statementInfoEmptyCell']);
-        $this->addSegmentCell($row5, '', $this->styles['statementInfoEmptyCell']);
         $this->addSegmentCell($row5, '', $this->styles['statementInfoTextCell']);
 
         $row6 = $table->addRow();


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15167/DEGES-Westendbrucke-Verfassungsdatum-bei-DOCX-Exporten-mittig-statt-rechtsbundig


Description: remove duplicated line


Delete the checkbox if it doesn't apply/isn't necessary. -->

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
