### PR TITLE
F dplan 14783 extend report entries (4383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - **Patch Version**: Incremented for bug fixes.
 
 ## UNRELEASED
+- Create report entries on create, update, deletion of an element, paragraph , singleDocument, mapDrawing or mapDrawing-explanation
+- Enable to send Statement final notice using RpcRequest and Vue.js
+- Add the possibility to export synopsis without personal data.
+
 ## v2.26.0 (2025-02-25)
 - Allow flag on external links to indicate this URL should only be shown for user(roles) with a specific permission
 - Extend safelist for purge css to include all plyr classes
@@ -20,6 +24,7 @@
 - Rework Tags-Lists: Now works with APi2.0 and is extendable by addons.
 - Enable the DELETE method for the AdministratableUser resource type
 - TagsList: trigger an update request only when the title is modified
+- DpCreateTag: Ensure the new tag retains its relationship to the Topic after creation
 
 ## 2.20.0
 

--- a/client/js/bundles/report/list.js
+++ b/client/js/bundles/report/list.js
@@ -18,7 +18,18 @@ import { initialize } from '@DpJs/InitVue'
 const stores = {}
 const components = { DpReportListing }
 
-const presetModules = ['general', 'public_phase', 'invitations', 'register_invitations', 'final_mails', 'statements']
+const presetModules = [
+    'general',
+    'public_phase',
+    'invitations',
+    'register_invitations',
+    'final_mails',
+    'statements',
+    'elements',
+    'single_documents',
+    'paragraphs',
+    'drawings'
+]
   .filter(name => hasPermission('feature_procedure_report_' + name))
   .map(name => {
     const camelName = name.replace(/_([a-z])/g, (match, p1) => p1.toUpperCase())

--- a/client/js/components/report/DpReportGroup.vue
+++ b/client/js/components/report/DpReportGroup.vue
@@ -32,7 +32,9 @@
       </dp-data-table>
 
       <div class="layout u-mv-0_5">
-        <div class="layout__item u-1-of-2">
+        <div
+          v-if="totalPages > 1"
+          class="layout__item u-1-of-2">
           <dp-sliding-pagination
             :current="currentPage"
             :total="totalPages"

--- a/client/js/components/report/DpReportListing.vue
+++ b/client/js/components/report/DpReportListing.vue
@@ -91,6 +91,50 @@
       :total-pages="statementsTotalPages"
       :is-loading="statementsLoading"
       @page-change="handlePageChange('statements', $event)" />
+
+    <dp-report-group
+      v-if="hasPermission('feature_procedure_report_elements')"
+      group="elements"
+      group-label="plandocument.and.drawing.categories"
+      content-label="category"
+      :items="elementsItems"
+      :current-page="elementsCurrentPage"
+      :total-pages="elementsTotalPages"
+      :is-loading="elementsLoading"
+      @page-change="handlePageChange('elements', $event)" />
+
+    <dp-report-group
+      v-if="hasPermission('feature_procedure_report_single_documents')"
+      group="singleDocuments"
+      group-label="plandocument.and.drawing.documents"
+      content-label="plandocument"
+      :items="singleDocumentsItems"
+      :current-page="singleDocumentsCurrentPage"
+      :total-pages="singleDocumentsTotalPages"
+      :is-loading="singleDocumentsLoading"
+      @page-change="handlePageChange('singleDocuments', $event)" />
+
+    <dp-report-group
+      v-if="hasPermission('feature_procedure_report_paragraphs')"
+      group="paragraphs"
+      group-label="plandocument.and.drawing.paragraphs"
+      content-label="paragraph"
+      :items="paragraphsItems"
+      :current-page="paragraphsCurrentPage"
+      :total-pages="paragraphsTotalPages"
+      :is-loading="paragraphsLoading"
+      @page-change="handlePageChange('paragraphs', $event)"/>
+
+    <dp-report-group
+      v-if="hasPermission('feature_procedure_report_drawings')"
+      group="drawings"
+      group-label="plandocument.and.drawing.drawings"
+      content-label="drawing"
+      :items="drawingsItems"
+      :current-page="drawingsCurrentPage"
+      :total-pages="drawingsTotalPages"
+      :is-loading="drawingsLoading"
+      @page-change="handlePageChange('drawings', $event)"/>
   </div>
 </template>
 
@@ -157,6 +201,30 @@ export default {
       statementsCurrentPage: 'currentPage',
       statementsTotalPages: 'totalPages',
       statementsLoading: 'loading'
+    }),
+    ...mapState('report/elements', {
+      elementsItems: 'items',
+      elementsCurrentPage: 'currentPage',
+      elementsTotalPages: 'totalPages',
+      elementsLoading: 'loading'
+    }),
+    ...mapState('report/singleDocuments', {
+      singleDocumentsItems: 'items',
+      singleDocumentsCurrentPage: 'currentPage',
+      singleDocumentsTotalPages: 'totalPages',
+      singleDocumentsLoading: 'loading'
+    }),
+    ...mapState('report/paragraphs', {
+      paragraphsItems: 'items',
+      paragraphsCurrentPage: 'currentPage',
+      paragraphsTotalPages: 'totalPages',
+      paragraphsLoading: 'loading'
+    }),
+    ...mapState('report/drawings', {
+      drawingsItems: 'items',
+      drawingsCurrentPage: 'currentPage',
+      drawingsTotalPages: 'totalPages',
+      drawingsLoading: 'loading'
     })
   },
 
@@ -167,7 +235,11 @@ export default {
       listInvitations: 'report/invitations/list',
       listRegisterInvitations: 'report/registerInvitations/list',
       listFinalMails: 'report/finalMails/list',
-      listStatements: 'report/statements/list'
+      listStatements: 'report/statements/list',
+      listElements: 'report/elements/list',
+      listSingleDocuments: 'report/singleDocuments/list',
+      listParagraphs: 'report/paragraphs/list',
+      listDrawings: 'report/drawings/list'
     }),
 
     handlePageChange (group, page) {
@@ -194,7 +266,12 @@ export default {
       'invitations',
       'register_invitations',
       'final_mails',
-      'statements']
+      'statements',
+      'elements',
+      'single_documents',
+      'paragraphs',
+      'drawings'
+    ]
       .filter(groupName => {
         /*
          * This returns one of those permissions:
@@ -203,6 +280,10 @@ export default {
          * - feature_procedure_report_register_invitations
          * - feature_procedure_report_final_mails
          * - feature_procedure_report_statements
+         * - feature_procedure_report_elements
+         * - feature_procedure_report_single_documents
+         * - feature_procedure_report_paragraphs
+         * - feature_procedure_report_drawings
          */
         return hasPermission('feature_procedure_report_' + groupName)
       })

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1657,36 +1657,56 @@ feature_procedure_preview:
     label: 'Show preview of precedures'
     loginRequired: true
     parent: area_main_procedures
+feature_procedure_report_elements:
+    description: 'Enables ''elements'' section in protocol (report).'
+    expose: true
+    label: 'Show the elements procedure reports'
+    loginRequired: true
 feature_procedure_report_final_mails:
-    description: 'Enables ''final mail'' section in Protokoll (report).'
+    description: 'Enables ''final mail'' section in protocol (report).'
     expose: true
     label: 'Show the final mail procedure reports'
-    loginRequired: false
+    loginRequired: true
 feature_procedure_report_general:
-    description: 'Enables ''general'' section in Protokoll (report).'
+    description: 'Enables ''general'' section in protocol (report).'
     expose: true
     label: 'Show the general procedure reports'
-    loginRequired: false
+    loginRequired: true
 feature_procedure_report_invitations:
-    description: 'Enables ''invitations'' section in Protokoll (report).'
+    description: 'Enables ''invitations'' section in protocol (report).'
     expose: true
     label: 'Show the invitations procedure reports'
-    loginRequired: false
+    loginRequired: true
+feature_procedure_report_drawings:
+    description: 'Enables ''drawings'' section in protocol (report).'
+    expose: true
+    label: 'Show the drawings procedure reports'
+    loginRequired: true
+feature_procedure_report_paragraphs:
+    description: 'Enables ''paragraphs'' section in protocol (report).'
+    expose: true
+    label: 'Show the paragraphs procedure reports'
+    loginRequired: true
 feature_procedure_report_public_phase:
-    description: 'Enables ''public phase'' section in Protokoll (report).'
+    description: 'Enables ''public phase'' section in protocol (report).'
     expose: true
     label: 'Show the public phase procedure reports'
-    loginRequired: false
+    loginRequired: true
 feature_procedure_report_register_invitations:
-    description: 'Enables ''register invitations'' section in Protokoll (report).'
+    description: 'Enables ''register invitations'' section in protocol (report).'
     expose: true
     label: 'Show the register invitations procedure reports'
+    loginRequired: true
+feature_procedure_report_single_documents:
+    description: 'Enables ''single documents'' section in protocol (report).'
+    expose: true
+    label: 'Show the single documents procedure reports'
     loginRequired: false
 feature_procedure_report_statements:
-    description: 'Enables ''statements'' section in Protokoll (report).'
+    description: 'Enables ''statements'' section in protocol (report).'
     expose: true
     label: 'Show the statement procedure reports'
-    loginRequired: false
+    loginRequired: true
 feature_procedure_require_location:
     description: 'Require location of procedure on the map.'
     expose: true

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -455,7 +455,10 @@ class DemosPlanDocumentController extends BaseController
      *
      * @throws Exception
      */
-    #[Route(name: 'DemosPlan_singledocument_administration_new', path: '/verfahren/{procedure}/verwalten/planunterlagen/dokument/{elementId}/neu/{category}')]
+    #[Route(
+        name: 'DemosPlan_singledocument_administration_new',
+        path: '/verfahren/{procedure}/verwalten/planunterlagen/dokument/{elementId}/neu/{category}'
+    )]
     public function singleDocumentAdminNewAction(
         Breadcrumb $breadcrumb,
         FileUploadService $fileUploadService,
@@ -890,7 +893,7 @@ class DemosPlanDocumentController extends BaseController
 
         try {
             $documentlistPager->setMaxPerPage((int) $request->get('r_limit', 3));
-            $documentlistPager->setCurrentPage((int)$currentPage);
+            $documentlistPager->setCurrentPage((int) $currentPage);
         } catch (Exception $e) {
             $this->getLogger()->warning('Could not set paginate: ', [$e]);
 
@@ -1033,7 +1036,11 @@ class DemosPlanDocumentController extends BaseController
      *
      * @throws Exception
      */
-    #[Route(name: 'DemosPlan_elements_administration_edit', path: '/verfahren/{procedure}/verwalten/planunterlagen/{elementId}/edit', options: ['expose' => true])]
+    #[Route(
+        name: 'DemosPlan_elements_administration_edit',
+        path: '/verfahren/{procedure}/verwalten/planunterlagen/{elementId}/edit',
+        options: ['expose' => true]
+    )]
     public function elementAdminEditAction(
         Breadcrumb $breadcrumb,
         CurrentProcedureService $currentProcedureService,
@@ -1054,20 +1061,16 @@ class DemosPlanDocumentController extends BaseController
         $requestPost = $request->request->all();
 
         if (!empty($requestPost['r_action']) && 'singledocumentdelete' === $requestPost['r_action'] && array_key_exists('document_delete', $requestPost)) {
-            // Storage Formulardaten übergeben
             $storageResult = $singleDocumentService->deleteSingleDocument($requestPost['document_delete']);
             if (true === $storageResult) {
-                // Erfolgsmeldung
                 $this->getMessageBag()->add('confirm', 'confirm.plandocument.deleted');
             }
         }
 
         if (!empty($requestPost['r_action']) && 'saveSort' === $requestPost['r_action'] && array_key_exists('r_sorting', $requestPost)) {
-            // Storage Formulardaten übergeben
             $sortArray = explode(', ', (string) $requestPost['r_sorting']);
             $storageResult = $singleDocumentService->sortDocuments($sortArray);
             if ($storageResult) {
-                // Erfolgsmeldung
                 $this->getMessageBag()->add('confirm', 'confirm.plandocument.sorted');
             }
         }
@@ -1075,7 +1078,6 @@ class DemosPlanDocumentController extends BaseController
         if (!empty($requestPost['r_action']) && 'elementedit' === $requestPost['r_action']) {
             $inData = $this->prepareIncomingData($request, 'elementedit');
 
-            // Storage Formulardaten übergeben
             if (null !== $inData) {
                 $inData['r_picture'] = $fileUploadService->prepareFilesUpload($request);
 
@@ -1094,7 +1096,6 @@ class DemosPlanDocumentController extends BaseController
                     return $this->redirectToRoute('DemosPlan_element_administration', compact('procedure'));
                 } else {
                     $storageResult = $elementHandler->administrationElementEditHandler($procedure, $inData);
-                    // Wenn Storage erfolgreich: Erfolgsmeldung
                     if (array_key_exists('ident', $storageResult) && !array_key_exists('mandatoryfieldwarning', $storageResult)) {
                         $this->getMessageBag()->add('confirm', 'confirm.plandocument.category.saved');
                     }

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -183,13 +183,14 @@ class DemosPlanProcedureController extends BaseController
      *
      * @DplanPermissions("area_demosplan")
      *
-     * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
     #[Route(path: '/plan/{slug}', name: 'core_procedure_slug')]
-    public function procedureSlugAction(CurrentUserInterface $currentUser, ProcedureServiceOutput $procedureOutput, string $slug = '')
-    {
+    public function procedureSlugAction(
+        CurrentUserInterface $currentUser,
+        ProcedureServiceOutput $procedureOutput,
+        string $slug = '',
+    ): RedirectResponse|Response {
         try {
             $slugify = new Slugify();
             $slug = $slugify->slugify($slug);

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
@@ -15,12 +15,16 @@ use DemosEurope\DemosplanAddon\Controller\APIController;
 use DemosEurope\DemosplanAddon\Response\APIResponse;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Logic\JsonApiPaginationParser;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\ElementReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\FinalMailReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\GeneralReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\InvitationReportEntryResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\ParagraphReportEntryResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\PlanDrawChangeReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\PublicPhaseReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\RegisterInvitationReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\ReportEntryResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\SingleDocumentReportEntryResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementReportEntryResourceType;
 use EDT\JsonApi\RequestHandling\PaginatorFactory;
 use Exception;
@@ -44,7 +48,13 @@ class DemosPlanReportAPIController extends APIController
      *
      * @param string $group
      */
-    #[Route(path: '/api/1.0/reports/{procedureId}/{group}', methods: ['GET'], name: 'dplan_api_report_procedure_list', defaults: ['group' => null], options: ['expose' => true])]
+    #[Route(
+        path: '/api/1.0/reports/{procedureId}/{group}',
+        methods: ['GET'],
+        name: 'dplan_api_report_procedure_list',
+        defaults: ['group' => null],
+        options: ['expose' => true]
+    )]
     public function listProcedureReportsAction(
         JsonApiPaginationParser $paginationParser,
         PaginatorFactory $paginatorFactory,
@@ -53,6 +63,10 @@ class DemosPlanReportAPIController extends APIController
     ): APIResponse {
         $resourceTypeName = match ($group) {
             'general'             => GeneralReportEntryResourceType::getName(),
+            'drawings'            => PlanDrawChangeReportEntryResourceType::getName(),
+            'elements'            => ElementReportEntryResourceType::getName(),
+            'paragraphs'          => ParagraphReportEntryResourceType::getName(),
+            'singleDocuments'     => SingleDocumentReportEntryResourceType::getName(),
             'statements'          => StatementReportEntryResourceType::getName(),
             'publicPhase'         => PublicPhaseReportEntryResourceType::getName(),
             'invitations'         => InvitationReportEntryResourceType::getName(),

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -59,18 +59,21 @@ class DemosPlanReportController extends BaseController
      *
      * @DplanPermissions({"area_admin_protocol", "feature_export_protocol"})
      *
-     * @param string $procedureId
-     *
      * @throws Exception
      */
-    #[Route(name: 'dplan_export_report', path: '/report/export/{procedureId}', methods: ['GET'], options: ['expose' => true])]
+    #[Route(
+        name: 'dplan_export_report',
+        path: '/report/export/{procedureId}',
+        methods: ['GET'],
+        options: ['expose' => true]
+    )]
     public function exportProcedureReportAction(
         ExportReportService $reportService,
         ParameterBagInterface $parameterBag,
         NameGenerator $nameGenerator,
         PermissionsInterface $permissions,
         ProcedureHandler $procedureHandler,
-        $procedureId,
+        string $procedureId,
     ): Response {
         $slugify = new Slugify();
         $procedure = $procedureHandler->getProcedureWithCertainty($procedureId);
@@ -88,7 +91,7 @@ class DemosPlanReportController extends BaseController
         $response = new StreamedResponse(
             static function () use ($procedureId, $reportMeta, $reportService, $permissions) {
                 $reportInfo = $reportService->getReportInfo($procedureId, $permissions);
-                $pdfReport = $reportService->generateProcedureReport($reportInfo, $reportMeta);
+                $pdfReport = $reportService->generateProcedureReport($procedureId, $reportInfo, $reportMeta);
                 $pdfReport->save('php://output');
             }
         );

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
@@ -18,6 +18,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -552,6 +553,23 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
     }
 
     /**
+     * @return array<>|string
+     */
+    public function getOrganisationNames($asString): array|string
+    {
+        $organisations = collect($this->getOrganisations())->map(
+            function ($item) {
+                return $item->getName();
+            })->sort();
+
+        if ($asString) {
+            return $organisations->implode(', ');
+        }
+
+        return $organisations->toArray();
+    }
+
+    /**
      * @param Collection<int, Orga> $organisations
      */
     public function setOrganisations(Collection $organisations): void
@@ -627,5 +645,20 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
     public function setPermission(string $permission): void
     {
         $this->permission = '' === $permission ? null : $permission;
+    }
+
+    public function getFileInfo(): FileInfo
+    {
+        $fileStringParts = explode(':', $this->getFile());
+
+        return new FileInfo(
+            $fileStringParts[1] ?? '',
+            $fileStringParts[0] ?? '',
+            (int)($fileStringParts[2] ?? ''),
+            $fileStringParts[3] ?? '',
+            'missing',
+            'missing',
+            $this->procedure
+        );
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/SingleDocument.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/SingleDocument.php
@@ -17,6 +17,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\SingleDocumentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\SingleDocumentVersionInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
+use demosplan\DemosPlanCoreBundle\ValueObject\FileInfo;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -446,5 +447,41 @@ class SingleDocument extends CoreEntity implements SingleDocumentInterface, Uuid
     public function getDeleteDate(): DateTime
     {
         return $this->deleteDate;
+    }
+
+    /**
+     *  If there is no file info in the SingleDocument object, returns an associative array keeping its keys
+     *  ['name','hash', 'size', 'mimeType'] but with empty values.
+     *
+     * @return array<string, string>
+     */
+    public function getSingleDocumentInfo(): array
+    {
+        $fileInfo = ['name' => '', 'hash' => '', 'size' => '', 'mimeType' => ''];
+
+        $documentStringParts = explode(':', $this->getDocument());
+        if (count($documentStringParts) >= 4) {
+            $fileInfo['name'] = $documentStringParts[0];
+            $fileInfo['hash'] = $documentStringParts[1];
+            $fileInfo['size'] = $documentStringParts[2];
+            $fileInfo['mimeType'] = $documentStringParts[3];
+        }
+
+        return $fileInfo;
+    }
+
+    public function getFileInfo(): FileInfo
+    {
+        $fileStringParts = explode(':', $this->getDocument());
+
+        return new FileInfo(
+            $fileStringParts[1] ?? '',
+            $fileStringParts[0] ?? '',
+            (int)($fileStringParts[2] ?? ''),
+            $fileStringParts[3] ?? '',
+            'missing',
+            'missing',
+            $this->procedure
+        );
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
@@ -39,6 +39,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ReportEntry extends CoreEntity implements UuidEntityInterface, ReportEntryInterface
 {
     final public const GROUP_PROCEDURE = 'procedure';
+    final public const GROUP_SINGLE_DOCUMENT = 'singleDocument';
+    final public const GROUP_PLAN_DRAW = 'planDraw';
+    final public const GROUP_PARAGRAPH = 'paragraph';
+    final public const GROUP_ELEMENT = 'element';
     final public const GROUP_STATEMENT = 'statement';
     final public const GROUP_MASTER_PUBLIC_AGENCY = 'mastertoeb';
     final public const GROUP_ORGA = 'orga';
@@ -46,6 +50,7 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface, ReportEntry
     final public const CATEGORY_ADD = 'add';
     final public const CATEGORY_ANONYMIZE_META = 'anonymizeMeta';
     final public const CATEGORY_ANONYMIZE_TEXT = 'anonymizeText';
+    final public const CATEGORY_CHANGE = 'change';
     final public const CATEGORY_CHANGE_PHASES = 'changePhases';
     final public const CATEGORY_COPY = 'copy';
     final public const CATEGORY_DELETE = 'delete';

--- a/demosplan/DemosPlanCoreBundle/Event/CreateReportEntryEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/CreateReportEntryEvent.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+
+namespace demosplan\DemosPlanCoreBundle\Event;
+
+
+use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use function PHPUnit\Framework\assertContains;
+
+class CreateReportEntryEvent extends DPlanEvent
+{
+    public function __construct(
+        protected readonly CoreEntity $entity,
+        protected readonly string $category,
+    ) {
+        assertContains($category, [ReportEntry::CATEGORY_ADD, ReportEntry::CATEGORY_UPDATE, ReportEntry::CATEGORY_DELETE]);
+    }
+
+    public function getEntity(): CoreEntity
+    {
+        return $this->entity;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ReportSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ReportSubscriber.php
@@ -10,11 +10,27 @@
 
 namespace demosplan\DemosPlanCoreBundle\EventSubscriber;
 
+use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Exception\JsonException;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Paragraph;
+use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Event\CreateReportEntryEvent;
 use demosplan\DemosPlanCoreBundle\Event\Procedure\ProcedureEditedEvent;
 use demosplan\DemosPlanCoreBundle\Event\StatementAnonymizeRpcEvent;
+use demosplan\DemosPlanCoreBundle\Logic\Report\ElementReportEntryFactory;
+use demosplan\DemosPlanCoreBundle\Logic\Report\ParagraphReportEntryFactory;
+use demosplan\DemosPlanCoreBundle\Logic\Report\PlanDrawReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ProcedureReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
+use demosplan\DemosPlanCoreBundle\Logic\Report\SingleDocumentReportEntryFactory;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use EDT\JsonApi\Event\AfterCreationEvent;
+use EDT\JsonApi\Event\AfterDeletionEvent;
+use EDT\JsonApi\Event\AfterUpdateEvent;
 use Exception;
 
 class ReportSubscriber extends BaseEventSubscriber
@@ -26,6 +42,10 @@ class ReportSubscriber extends BaseEventSubscriber
 
     public function __construct(
         private readonly ProcedureReportEntryFactory $procedureReportEntryFactory,
+        private readonly ElementReportEntryFactory $elementReportEntryFactory,
+        private readonly SingleDocumentReportEntryFactory $singleDocumentReportEntryFactory,
+        private readonly ParagraphReportEntryFactory $paragraphReportEntryFactory,
+        private readonly PlanDrawReportEntryFactory $planDrawReportEntryFactory,
         ReportService $reportService
     ) {
         $this->reportService = $reportService;
@@ -37,8 +57,12 @@ class ReportSubscriber extends BaseEventSubscriber
     public static function getSubscribedEvents(): array
     {
         return [
-            ProcedureEditedEvent::class       => ['onEditProcedure'],
-            StatementAnonymizeRpcEvent::class => ['onStatementAnonymizeRpc'],
+            CreateReportEntryEvent::class       => ['createReportEntry'],
+            AfterUpdateEvent::class             => ['afterCreateUpdateOrDelete'],
+            AfterDeletionEvent::class           => ['afterCreateUpdateOrDelete'],
+            AfterCreationEvent::class           => ['afterCreateUpdateOrDelete'],
+            ProcedureEditedEvent::class         => ['onEditProcedure'],
+            StatementAnonymizeRpcEvent::class   => ['onStatementAnonymizeRpc'],
         ];
     }
 
@@ -54,26 +78,121 @@ class ReportSubscriber extends BaseEventSubscriber
             /** @var User $user */
             $user = $event->getUser();
 
-            if (!isset($inData['r_externalDesc'])) {
-                return;
+            if (isset($inData['r_externalDesc'])) {
+                // speichere ggf. eine Änderung des Planungsanlasses im Report
+                $newExternalDesc = str_replace(["\r\n", "\r", "\n"], '<br />', (string) $inData['r_externalDesc']);
+                if ($currentProcedure['externalDesc'] !== $newExternalDesc) {
+                    $report = $this->procedureReportEntryFactory->createDescriptionUpdateEntry(
+                        $procedureId,
+                        $inData['r_externalDesc'],
+                        $user
+                    );
+                    $this->reportService->persistAndFlushReportEntries($report);
+                }
             }
-            // speichere ggf. eine Änderung des Planungsanlasses im Report
-            $newExternalDesc = str_replace(["\r\n", "\r", "\n"], '<br />', (string) $inData['r_externalDesc']);
-            if ($currentProcedure['externalDesc'] !== $newExternalDesc) {
-                $report = $this->procedureReportEntryFactory->createDescriptionUpdateEntry(
-                    $procedureId,
-                    $inData['r_externalDesc'],
-                    $user
-                );
-                $this->reportService->persistAndFlushReportEntries($report);
-            }
+
+            $this->createPlanDrawReportOnDemand($event);
+
         } catch (Exception $e) {
             $this->getLogger()->error('Add Report failed ', [$e]);
+        }
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws JsonException
+     */
+    private function createPlanDrawReportOnDemand(ProcedureEditedEvent $event): void
+    {
+        $originPlanPDF = $event->getOriginalProcedureArray()['planPDF'] ?? null;
+        $originPlanDrawPDF = $event->getOriginalProcedureArray()['planDrawPDF'] ?? null;
+
+        $incomingPlanPDF = $event->getInData()['planPDF'] ?? null;
+        $incomingPlanDrawPDF = $event->getInData()['planDrawPDF'] ?? null;
+
+
+        if ((null !== $originPlanPDF && null !== $incomingPlanPDF)
+            ||(null !== $originPlanDrawPDF && null !== $incomingPlanDrawPDF))
+        {
+            $report = $this->planDrawReportEntryFactory->createPlanDrawEntry(
+                $event->getProcedureId(),
+                $originPlanPDF,
+                $incomingPlanPDF,
+                $originPlanDrawPDF,
+                $incomingPlanDrawPDF
+            );
+
+            $this->reportService->persistAndFlushReportEntries($report);
         }
     }
 
     public function onStatementAnonymizeRpc(StatementAnonymizeRpcEvent $event): void
     {
         $this->reportService->addReportsOnStatementAnonymization($event);
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function createReportEntry(CreateReportEntryEvent $event): void
+    {
+        $this->dynamicCreateReportEntry($event->getEntity(), $event->getCategory());
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    public function afterCreateUpdateOrDelete(AfterDeletionEvent|AfterCreationEvent|AfterUpdateEvent $event): void
+    {
+        $reportCategory = match (true) {
+            $event instanceof AfterCreationEvent => ReportEntry::CATEGORY_ADD,
+            $event instanceof AfterUpdateEvent => ReportEntry::CATEGORY_UPDATE,
+            $event instanceof AfterDeletionEvent => ReportEntry::CATEGORY_DELETE,
+            default => 'unknown',
+        };
+        //fixme: in case of AfterDeletionEvent there is no entity, only the entityIdentifier!
+        //fixme: not implemented yet: AfterDeletionEvent does not have an entity, only an getEntityIdentifier
+        // this needs to be handled in case of deletion of one of these three entities, via ResourceTypes.
+//        if ($event->getEntity() instanceof Elements
+//            || $event->getEntity() instanceof SingleDocument
+//            || $event->getEntity() instanceof Paragraph) {
+//            $this->dynamicCreateReportEntry($event->getEntity(), $reportCategory);
+//        }
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    private function dynamicCreateReportEntry(Elements|Paragraph|SingleDocument $entity, string $category): void
+    {
+        $date = match ($category) {
+            ReportEntry::CATEGORY_ADD => $entity->getCreateDate()->getTimestamp(),
+            ReportEntry::CATEGORY_UPDATE => $entity->getModifyDate()->getTimestamp(),
+            default => Carbon::now()->getTimestamp(),
+        };
+
+        $report = match (true) {
+            $entity instanceof Elements => $this->elementReportEntryFactory->createElementEntry(
+                $entity,
+                $category,
+                $date
+            ),
+            $entity instanceof SingleDocument => $this->singleDocumentReportEntryFactory->createSingleDocumentEntry(
+                $entity,
+                $category,
+                $date
+            ),
+            $entity instanceof Paragraph => $this->paragraphReportEntryFactory->createParagraphEntry(
+                $entity,
+                $category,
+                $date
+            ),
+        };
+
+        $this->reportService->persistAndFlushReportEntries($report);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/ReportSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/ReportSubscriber.php
@@ -153,14 +153,18 @@ class ReportSubscriber extends BaseEventSubscriber
             $event instanceof AfterDeletionEvent => ReportEntry::CATEGORY_DELETE,
             default => 'unknown',
         };
-        //fixme: in case of AfterDeletionEvent there is no entity, only the entityIdentifier!
-        //fixme: not implemented yet: AfterDeletionEvent does not have an entity, only an getEntityIdentifier
-        // this needs to be handled in case of deletion of one of these three entities, via ResourceTypes.
-//        if ($event->getEntity() instanceof Elements
-//            || $event->getEntity() instanceof SingleDocument
-//            || $event->getEntity() instanceof Paragraph) {
-//            $this->dynamicCreateReportEntry($event->getEntity(), $reportCategory);
-//        }
+
+        //not implemented yet:
+        // In case of AfterDeletionEvent there is no entity, only the entityIdentifier!
+        if ('unknown' === $reportCategory || ReportEntry::CATEGORY_DELETE === $reportCategory) {
+            return;
+        }
+
+        if ($event->getEntity() instanceof Elements
+            || $event->getEntity() instanceof SingleDocument
+            || $event->getEntity() instanceof Paragraph) {
+            $this->dynamicCreateReportEntry($event->getEntity(), $reportCategory);
+        }
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -744,7 +744,7 @@ class ExportService
             Settings::setPdfRendererPath($this->rendererPath);
             Settings::setPdfRendererName($this->rendererName);
             $reportInfo = $this->exportReportService->getReportInfo($procedureId, $this->permissions);
-            $pdfReport = $this->exportReportService->generateProcedureReport($reportInfo, $reportMeta);
+            $pdfReport = $this->exportReportService->generateProcedureReport($procedureId, $reportInfo, $reportMeta);
             $this->zipExportService->addWriterToZipStream(
                 $pdfReport,
                 $procedureName.'/Verfahrensprotokoll.pdf',

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ElementReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ElementReportEntryFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Report;
+
+use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
+
+class ElementReportEntryFactory extends AbstractReportEntryFactory
+{
+    private function createMessageData(Elements $element): array
+    {
+        return [
+            'id'                    => $element->getId(),
+            'title'                 => $element->getTitle(),
+            'text'                  => $element->getText(),
+            'category'              => $element->getCategory(), // eg. file, e_unterlagen, arbeitskreis, informationen,...
+            'fileName'              => $element->getFileInfo()->getFileName(), // Planungsdokument als Datei
+            'parentCategory'        => $element->getParent()?->getCategory(), // eg map, file, statement, paragraph, ..
+            'parentTitle'           => $element->getParent()?->getTitle(), // eg Fehlanzeige, Begründung, Ergänzende Unterlagen, Planzeichnung
+            'enabled'               => $element->getEnabled(),
+            'organisations'         => $element->getOrganisationNames(true),
+            'keyOfInternalPhase'    => $element->getProcedure()->getPhase(),
+            'keyOfEternalPhase'     => $element->getProcedure()->getPublicParticipationPhase(),
+            //The translation of the time the report is created is the important one, not the key
+            'nameOfInternalPhase'   => $element->getProcedure()->getPhaseName(),
+            'nameOfExternalPhase'   => $element->getProcedure()->getPublicParticipationPhaseName(),
+        ];
+    }
+
+    public function createElementEntry(Elements $element, string $reportCategory, int $date = null): ReportEntry
+    {
+        $data = $this->createMessageData($element);
+        $data['date'] = null === $date ? Carbon::now()->getTimestamp() : $date;
+        $reportEntry = $this->createReportEntry();
+        $reportEntry->setUser($this->getCurrentUser());
+        $reportEntry->setGroup(ReportEntry::GROUP_ELEMENT);
+        $reportEntry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_PROCEDURE);
+        $reportEntry->setIdentifier($element->getProcedure()->getId());
+        $reportEntry->setMessage(Json::encode($data, JSON_UNESCAPED_UNICODE));
+        $reportEntry->setCategory($reportCategory);
+
+        return $reportEntry;
+    }
+
+    protected function createReportEntry(): ReportEntry
+    {
+        $reportEntry = parent::createReportEntry();
+        $reportEntry->setGroup(ReportEntry::GROUP_ELEMENT);
+
+        return $reportEntry;
+    }
+
+    private function getCurrentUser(): User
+    {
+        try {
+            $currentUser = $this->currentUserProvider->getUser();
+        } catch (UserNotFoundException) {
+            $currentUser = new AnonymousUser();
+        }
+
+        return $currentUser;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ParagraphReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ParagraphReportEntryFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Report;
+
+use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Paragraph;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
+
+class ParagraphReportEntryFactory extends AbstractReportEntryFactory
+{
+    private function createMessageData(Paragraph $paragraph): array
+    {
+        return [
+            'id'                        => $paragraph->getId(),
+            'title'                     => $paragraph->getTitle(),
+            'text'                      => $paragraph->getText(),
+            'category'                  => $paragraph->getCategory(), // eg. file, e_unterlagen, arbeitskreis, informationen,...
+            'relatedElementCategory'    => $paragraph->getElement()->getCategory(), // eg map, file, statement, paragraph, ..
+            'relatedElementTitle'       => $paragraph->getElement()->getTitle(), // eg Fehlanzeige, Begründung, Ergänzende Unterlagen, Planzeichnung
+            'visible'                   => $paragraph->getVisible(),
+            'keyOfInternalPhase'        => $paragraph->getProcedure()->getPhase(),
+            'keyOfEternalPhase'         => $paragraph->getProcedure()->getPublicParticipationPhase(),
+            //The translation of the time the report is created is the important one, not the key
+            'nameOfInternalPhase'       => $paragraph->getProcedure()->getPhaseName(),
+            'nameOfExternalPhase'       => $paragraph->getProcedure()->getPublicParticipationPhaseName(),
+        ];
+    }
+
+    public function createParagraphEntry(
+        Paragraph $paragraph,
+        string $reportCategory,
+        int $date = null
+    ): ReportEntry {
+        $data = $this->createMessageData($paragraph);
+        $data['date'] = null === $date ? Carbon::now()->getTimestamp() : $date;
+        $reportEntry = $this->createReportEntry();
+        $reportEntry->setUser($this->getCurrentUser());
+        $reportEntry->setGroup(ReportEntry::GROUP_PARAGRAPH);
+        $reportEntry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_PROCEDURE);
+        $reportEntry->setIdentifier($paragraph->getProcedure()->getId());
+        $reportEntry->setMessage(Json::encode($data, JSON_UNESCAPED_UNICODE));
+        $reportEntry->setCategory($reportCategory);
+
+        return $reportEntry;
+    }
+
+    protected function createReportEntry(): ReportEntry
+    {
+        $reportEntry = parent::createReportEntry();
+        $reportEntry->setGroup(ReportEntry::GROUP_PARAGRAPH);
+
+        return $reportEntry;
+    }
+
+    private function getCurrentUser(): User
+    {
+        try {
+            $currentUser = $this->currentUserProvider->getUser();
+        } catch (UserNotFoundException) {
+            $currentUser = new AnonymousUser();
+        }
+
+        return $currentUser;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/PlanDrawReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/PlanDrawReportEntryFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Report;
+
+use DemosEurope\DemosplanAddon\Exception\JsonException;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
+use function PHPUnit\Framework\assertNotNull;
+
+class PlanDrawReportEntryFactory extends AbstractReportEntryFactory
+{
+    /**
+     * @throws JsonException
+     */
+    private function createPlanDrawReportEntry(string $procedureId, array $data): ReportEntry
+    {
+        $entry = $this->createReportEntry();
+        $entry->setUser($this->getCurrentUser());
+        $entry->setGroup(ReportEntry::GROUP_PLAN_DRAW);
+        $entry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_PROCEDURE);
+        $entry->setIdentifier($procedureId);
+        $entry->setMessage(Json::encode($data, JSON_UNESCAPED_UNICODE));
+
+        return $entry;
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createPlanDrawEntry(
+        string $procedureId,
+        string $oldPlanPDF,
+        string $newPlanPDF,
+        string $oldPlanDrawPDF,
+        string $newPlanDrawPDF,
+    ): ReportEntry {
+        $messageData = null;
+
+        if (0 !== strcmp($oldPlanPDF, $newPlanPDF)) {
+            $messageData['planDrawFile']['old'] = $oldPlanPDF;
+            $messageData['planDrawFile']['new'] = $newPlanPDF;
+        }
+
+        if (0 !== strcmp($oldPlanDrawPDF, $newPlanDrawPDF)) {
+            $messageData['planDrawingExplanation']['old'] = $oldPlanDrawPDF;
+            $messageData['planDrawingExplanation']['new'] = $newPlanDrawPDF;
+        }
+
+        assertNotNull($messageData);
+
+        $reportEntry = $this->createPlanDrawReportEntry($procedureId, $messageData);
+        $reportEntry->setCategory(ReportEntry::CATEGORY_CHANGE);
+
+        return $reportEntry;
+    }
+
+    protected function createReportEntry(): ReportEntry
+    {
+        $reportEntry = parent::createReportEntry();
+        $reportEntry->setGroup(ReportEntry::GROUP_PLAN_DRAW);
+
+        return $reportEntry;
+    }
+
+    private function getCurrentUser(): User
+    {
+        try {
+            $currentUser = $this->currentUserProvider->getUser();
+        } catch (UserNotFoundException) {
+            $currentUser = new AnonymousUser();
+        }
+
+        return $currentUser;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/ProcedureReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/ProcedureReportEntryFactory.php
@@ -27,8 +27,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProcedureReportEntryFactory extends AbstractReportEntryFactory
 {
-    public function __construct(CurrentUserInterface $currentUserProvider, CustomerService $currentCustomerProvider, private readonly TranslatorInterface $translator)
-    {
+    public function __construct(
+        CurrentUserInterface $currentUserProvider,
+        CustomerService $currentCustomerProvider,
+        private readonly TranslatorInterface $translator,
+    ) {
         parent::__construct($currentUserProvider, $currentCustomerProvider);
     }
 
@@ -37,7 +40,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
         array $ccAddresses,
         string $procedureId,
         string $phase,
-        string $mailSubject
+        string $mailSubject,
     ): ReportEntry {
         $data = [
             'recipients'  => $recipients,
@@ -61,7 +64,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
         array $recipientsWithEmail,
         string $procedureId,
         string $phase,
-        string $mailSubject
+        string $mailSubject,
     ): ReportEntry {
         $data = [
             'recipients'  => $recipientsWithEmail,
@@ -82,7 +85,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
 
     public function createProcedureCreationEntry(
         array $data,
-        Procedure $procedure
+        Procedure $procedure,
     ): ReportEntry {
         $entry = $this->createReportEntry();
         $entry->setUser($this->getCurrentUser());
@@ -120,7 +123,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
     public function createPhaseChangeEntry(
         Procedure $procedure,
         array $data,
-        User|string $user
+        User|string $user,
     ): ReportEntry {
         $entry = $this->createReportEntry();
         $entry->setCategory(ReportEntry::CATEGORY_CHANGE_PHASES);
@@ -143,7 +146,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
     public function createTargetProcedureCoupleEntry(
         string $procedureIdToCreateTheReportEntryFor,
         Procedure $coupledProcedure,
-        User $user
+        User $user,
     ): ReportEntry {
         $messageData = [];
         $messageData['sourceProcedure'] = $coupledProcedure->getName();
@@ -156,7 +159,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
      */
     public function createSourceProcedureCoupleEntry(
         string $procedureIdToCreateTheReportEntryFor,
-        Procedure $coupledProcedure
+        Procedure $coupledProcedure,
     ): ReportEntry {
         $messageData = [];
         $messageData['targetProcedure'] = $coupledProcedure->getName();
@@ -171,7 +174,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
         string $procedureIdToCreateTheReportEntryFor,
         Procedure $coupledProcedure,
         ?User $user,
-        array $messageData
+        array $messageData,
     ): ReportEntry {
         $messageData['relatedInstitutionName'] = $coupledProcedure->getOrgaName();
 
@@ -190,7 +193,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
 
     public function createUpdateEntry(
         Procedure $procedure,
-        array $data
+        array $data,
     ): ReportEntry {
         $entry = $this->createReportEntry();
         $entry->setCategory(ReportEntry::CATEGORY_UPDATE);
@@ -219,7 +222,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
     public function createDescriptionUpdateEntry(
         string $procedureId,
         $externalDescription,
-        User $user
+        User $user,
     ): ReportEntry {
         $message = [
             'ident'        => $procedureId,
@@ -242,7 +245,7 @@ class ProcedureReportEntryFactory extends AbstractReportEntryFactory
         string $procedureId,
         User $fromUser,
         PreparationMailVO $preparationMail,
-        $statementMailAddresses
+        $statementMailAddresses,
     ): ReportEntry {
         $message = [
             'procedureId'   => $procedureId,

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/SingleDocumentReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/SingleDocumentReportEntryFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Report;
+
+use Carbon\Carbon;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
+
+class SingleDocumentReportEntryFactory extends AbstractReportEntryFactory
+{
+    private function createMessageData(SingleDocument $singleDocument): array
+    {
+        return [
+            'id'                        => $singleDocument->getId(),
+            'title'                     => $singleDocument->getTitle(),
+            'text'                      => $singleDocument->getText(),
+            'category'                  => $singleDocument->getCategory(), // eg. file, e_unterlagen, arbeitskreis, informationen,...
+            'fileName'               => $singleDocument->getFileInfo()->getFileName(),
+            'relatedElementCategory'    => $singleDocument->getElement()->getCategory(), // eg map, file, statement, paragraph, ..
+            'relatedElementTitle'       => $singleDocument->getElement()->getTitle(), // eg Fehlanzeige, Begründung, Ergänzende Unterlagen, Planzeichnung
+            'visible'                   => $singleDocument->getVisible(),
+            'statement_enabled'         => $singleDocument->isStatementEnabled(),
+            'keyOfInternalPhase'        => $singleDocument->getProcedure()->getPhase(),
+            'keyOfEternalPhase'         => $singleDocument->getProcedure()->getPublicParticipationPhase(),
+            //The translation of the time the report is created is the important one, not the key
+            'nameOfInternalPhase'       => $singleDocument->getProcedure()->getPhaseName(),
+            'nameOfExternalPhase'       => $singleDocument->getProcedure()->getPublicParticipationPhaseName(),
+        ];
+    }
+
+    public function createSingleDocumentEntry(
+        SingleDocument $singleDocument,
+        string $reportCategory,
+        int $date = null
+    ): ReportEntry {
+        $data = $this->createMessageData($singleDocument);
+        $data['date'] = null === $date ? Carbon::now()->getTimestamp() : $date;
+        $reportEntry = $this->createReportEntry();
+        $reportEntry->setUser($this->getCurrentUser());
+        $reportEntry->setGroup(ReportEntry::GROUP_SINGLE_DOCUMENT);
+        $reportEntry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_PROCEDURE);
+        $reportEntry->setIdentifier($singleDocument->getProcedure()->getId());
+        $reportEntry->setMessage(Json::encode($data, JSON_UNESCAPED_UNICODE));
+        $reportEntry->setCategory($reportCategory);
+
+        return $reportEntry;
+    }
+
+    protected function createReportEntry(): ReportEntry
+    {
+        $reportEntry = parent::createReportEntry();
+        $reportEntry->setGroup(ReportEntry::GROUP_SINGLE_DOCUMENT);
+
+        return $reportEntry;
+    }
+
+    private function getCurrentUser(): User
+    {
+        try {
+            $currentUser = $this->currentUserProvider->getUser();
+        } catch (UserNotFoundException) {
+            $currentUser = new AnonymousUser();
+        }
+
+        return $currentUser;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Repository/ElementsRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ElementsRepository.php
@@ -47,7 +47,7 @@ class ElementsRepository extends CoreRepository implements ArrayInterface, Objec
         PermissionsInterface $permissions,
         Reindexer $reindexer,
         SortMethodFactory $sortMethodFactory,
-        string $entityClass = Elements::class
+        string $entityClass = Elements::class,
     ) {
         parent::__construct($dqlConditionFactory, $registry, $reindexer, $sortMethodFactory, $entityClass);
 
@@ -195,11 +195,9 @@ class ElementsRepository extends CoreRepository implements ArrayInterface, Objec
      *
      * @param string $id
      *
-     * @return Elements|mixed
-     *
      * @throws Exception
      */
-    public function update($id, array $data)
+    public function update($id, array $data): Elements
     {
         try {
             $em = $this->getEntityManager();

--- a/demosplan/DemosPlanCoreBundle/Repository/SingleDocumentRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/SingleDocumentRepository.php
@@ -29,11 +29,9 @@ class SingleDocumentRepository extends CoreRepository implements ArrayInterface
     /**
      * Add single document entry.
      *
-     * @return SingleDocument
-     *
      * @throws Exception
      */
-    public function add(array $data)
+    public function add(array $data): SingleDocument
     {
         try {
             $em = $this->getEntityManager();

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ElementReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ElementReportEntryResourceType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
+
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+
+final class ElementReportEntryResourceType extends ReportEntryResourceType
+{
+    public static function getName(): string
+    {
+        return 'ElementReport';
+    }
+
+    protected function getGroups(): array
+    {
+        return [ReportEntry::GROUP_ELEMENT];
+    }
+
+    protected function getCategories(): array
+    {
+        return [
+            ReportEntry::CATEGORY_ADD,
+            ReportEntry::CATEGORY_UPDATE,
+            ReportEntry::CATEGORY_DELETE,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ParagraphReportEntryResourceType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
+
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+
+final class ParagraphReportEntryResourceType extends ReportEntryResourceType
+{
+    public static function getName(): string
+    {
+        return 'ParagraphReport';
+    }
+
+    protected function getGroups(): array
+    {
+        return [ReportEntry::GROUP_PARAGRAPH];
+    }
+
+    protected function getCategories(): array
+    {
+        return [
+            ReportEntry::CATEGORY_ADD,
+            ReportEntry::CATEGORY_UPDATE,
+            ReportEntry::CATEGORY_DELETE,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanDrawChangeReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/PlanDrawChangeReportEntryResourceType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
+
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+
+final class PlanDrawChangeReportEntryResourceType extends ReportEntryResourceType
+{
+    public static function getName(): string
+    {
+        return 'PlanDrawReport';
+    }
+
+    protected function getGroups(): array
+    {
+        return [ReportEntry::GROUP_PLAN_DRAW];
+    }
+
+    protected function getCategories(): array
+    {
+        return [
+            ReportEntry::CATEGORY_CHANGE,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentReportEntryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentReportEntryResourceType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
+
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+
+final class SingleDocumentReportEntryResourceType extends ReportEntryResourceType
+{
+    public static function getName(): string
+    {
+        return 'SingleDocumentReport';
+    }
+
+    protected function getGroups(): array
+    {
+        return [ReportEntry::GROUP_SINGLE_DOCUMENT];
+    }
+
+    protected function getCategories(): array
+    {
+        return [
+            ReportEntry::CATEGORY_ADD,
+            ReportEntry::CATEGORY_UPDATE,
+            ReportEntry::CATEGORY_DELETE,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
@@ -81,7 +81,7 @@ final class SingleDocumentResourceType extends DplanResourceType
                 $this->createAttribute($this->title)
                     ->readable(true)->filterable()->sortable(),
                 $this->createAttribute($this->fileInfo)
-                    ->readable(true, fn (SingleDocument $document): array => $this->singleDocumentService->getSingleDocumentInfo($document)),
+                    ->readable(true, fn (SingleDocument $document): array => $document->getSingleDocumentInfo()),
                 $this->createAttribute($this->index)->readable(true)->aliasedPath($this->order),
             ]);
         }

--- a/tests/backend/core/Document/Functional/ElementsServiceTest.php
+++ b/tests/backend/core/Document/Functional/ElementsServiceTest.php
@@ -338,10 +338,10 @@ class ElementsServiceTest extends FunctionalTestCase
 
     public function testDeleteElement()
     {
-        $data = [$this->fixtures->getReference('testElement5')];
+        $elementId = $this->fixtures->getReference('testElement5')->getId();
 
         $entriesBefore = $this->countEntries(Elements::class);
-        $result = $this->sut->deleteElement($data);
+        $result = $this->sut->deleteElement($elementId);
         static::assertTrue($result); // has to be true but is null
         static::assertEquals($entriesBefore - 1, $this->countEntries(Elements::class));
     }

--- a/tests/backend/core/Document/Functional/ParagraphServiceTest.php
+++ b/tests/backend/core/Document/Functional/ParagraphServiceTest.php
@@ -260,14 +260,14 @@ class ParagraphServiceTest extends FunctionalTestCase
         static::assertEquals($referenceDocument->getPId(), $result['pId']);
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $paragraph = [
             'pId'       => $this->fixtures->getReference('testProcedure')->getId(),
-            'elementId' => 'f9b1e7e3-7936-4edb-8b12-d6c42e1f349f',
+            'elementId' => $this->fixtures->getReference('testReasonElement')->getId(),
             'category'  => 'begruendung',
-            'title'     => '',
-            'text'      => '',
+            'title'     => ',my test title',
+            'text'      => 'my test text',
             'order'     => 0,
             'deleted'   => false,
             'visible'   => 1,

--- a/tests/backend/core/Document/Unit/DocumentBundleImporterTest.php
+++ b/tests/backend/core/Document/Unit/DocumentBundleImporterTest.php
@@ -27,6 +27,7 @@ use OldSound\RabbitMqBundle\RabbitMq\RpcClient;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Tests\Base\FunctionalTestCase;
 
 /**
@@ -61,6 +62,7 @@ class DocumentBundleImporterTest extends FunctionalTestCase
             self::$container->get(PdfCreatorInterface::class),
             self::$container->get(RouterInterface::class),
             self::$container->get(RpcClient::class),
+            self::$container->get(EventDispatcherInterface::class),
         );
     }
 

--- a/tests/backend/core/Procedure/Functional/BoilerplateServiceTest.php
+++ b/tests/backend/core/Procedure/Functional/BoilerplateServiceTest.php
@@ -12,6 +12,7 @@ namespace Tests\Core\Procedure\Functional;
 
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\BoilerplateGroup;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\DateHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use Exception;
@@ -322,5 +323,35 @@ class BoilerplateServiceTest extends FunctionalTestCase
             $boilerplates = $this->getEntries(Boilerplate::class, ['ident' => $id]);
             static::assertCount(1, $boilerplates);
         }
+    }
+
+    public function testBoilerplateCategoryCascade()
+    {
+        /** @var BoilerplateCategory $category */
+        $category = $this->fixtures->getReference('testBoilerplateEmptyCategory');
+
+        /** @var Procedure $blueprintWithBoilerplates */
+        $blueprintWithBoilerplates = $this->getReference('testmasterProcedureWithBoilerplates');
+
+        $boilerplate = new Boilerplate();
+        $boilerplate->setTitle('Cascade Test');
+        $boilerplate->setText('This is a test for cascade delete.');
+        $boilerplate->setProcedure($blueprintWithBoilerplates);
+        $boilerplate->addBoilerplateCategory($category);
+
+        $this->getEntityManager()->persist($boilerplate);
+        $this->getEntityManager()->flush();
+
+        // Ensure the boilerplate is associated with the category
+        static::assertContains($boilerplate, $category->getBoilerplates());
+
+        // Delete the category and check if the boilerplate is also deleted
+        $this->sut->deleteBoilerplate($boilerplate->getId());
+
+        $deletedCategory = $this->getEntries(BoilerplateCategory::class, ['id' => $category->getId()]);
+        $deletedBoilerplate = $this->getEntries(Boilerplate::class, ['ident' => $boilerplate->getId()]);
+
+        static::assertCount(0, $deletedCategory);
+        static::assertCount(0, $deletedBoilerplate);
     }
 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1701,6 +1701,7 @@ file.pdf.explanation: "Sie können an dieser Stelle Dateien des Typs PDF hochlad
 file.delete: "Datei löschen"
 file.download: "Anhang herunterladen"
 file.reference: "Dateibezug"
+file.related: "dokumentbezogen"
 file.upload.docx: ".docx hochladen"
 file.upload.pdf: ".pdf hochladen"
 file.upload.pdf.zip.mp4: ".pdf, .zip oder .mp4 hochladen"
@@ -2444,6 +2445,7 @@ paragraph.notavailable: "Kapitelbezug nicht verfügbar"
 paragraph.parent.none: "oberste Ebene"
 paragraph.parent: "Übergeordnetes Kapitel"
 paragraph.reference: "Kapitelbezug"
+paragraph.related: "kapitelbezogen"
 paragraph.file: "Planungsdokument als Datei"
 paragraph.text: "Text des Kapitels"
 paragraph.title: "Absatz"
@@ -2527,6 +2529,10 @@ places.edit.infoProcedureTemplate: "Die Anpassungen werden in die auswählbaren 
 plandocument: "Planungsdokument"
 plandocument.add: "Planungsdokument hinzufügen"
 plandocument.and.drawing: 'Planungsdokumente und Planzeichnung'
+plandocument.and.drawing.categories: "Planungsdokumente - Kategorien"
+plandocument.and.drawing.documents: "Planungsdokumente - Dokumente"
+plandocument.and.drawing.drawings: "Planzeichnung"
+plandocument.and.drawing.paragraphs: "Planungsdokumente - Kapitel"
 plandocument.and.chapter: "Planungsdokument und -kapitel"
 plandocument.edit: "Planungsdokument bearbeiten"
 plandocument.file.attach: "Planungsdokument als Datei anhängen"
@@ -2948,6 +2954,85 @@ remove: "Entfernen"
 remove.from.list: "Aus Liste entfernen"
 rename: "umbenennen"
 replied.to: "Erwidert"
+report.add.element: |
+    Eine Kategorie wurde hinzugefügt:<br />
+    Titel: "{title}"<br />
+    Text: "{text}"<br />
+    Kategorietyp: {category}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Berechtigte Institutionen: {organisations} <br />
+    Veröffentlicht: {enabled}
+report.update.element: |
+    Eine Kategorie wurde geändert zu:<br />
+    Titel: "{title}"<br />
+    Text: "{text}"<br />
+    Kategorietyp: {category}<br />
+    Planungsdokument als Datei: {fileName}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Berechtigte Institutionen: {organisations} <br />
+    Veröffentlicht: {enabled}
+report.delete.element: |
+    Die Kategorie "{title}" ({category}) wurde gelöscht.<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+report.add.paragraph: |
+    Eine Kapitel wurde hinzugefügt:<br />
+    Titel: "{title}"<br />
+    Text: "{text}"<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Sichtbar: {visible}
+report.update.paragraph: |
+    Eine Kapitel wurde geändert zu:<br />
+    Titel: "{title}"<br />
+    Text: "{text}"<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Sichtbar: {visible}
+report.delete.paragraph: |
+    Das Kapitel "{title}" wurde gelöscht.<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+report.add.singleDocument: |
+    Eine Planungsdokument wurde hinzugefügt:<br />
+    Titel: "{title}"<br />
+    Datei: {fileName}<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Sichtbar: {visible}<br />
+    Stellungnahme möglich: {statement_enabled}
+report.update.singleDocument: |
+    Eine Planungsdokument wurde geändert zu:<br />
+    Titel: "{title}"<br />
+    Datei: {fileName}<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+    Sichtbar: {visible}<br />
+    Stellungnahme möglich: {statement_enabled}
+report.delete.singleDocument:  |
+    Das Planungsdokument "{title}" wurde gelöscht.<br />
+    Kategorie: {relatedElementTitle}<br />
+    Verfahrensschritt: {nameOfInternalPhase}<br />
+    Öffentlicher Verfahrensschritt: {nameOfExternalPhase}<br />
+report.create.planDrawingFile: |
+    Die Planzeichnung "{fileName}" wurde hinzugefügt.
+report.delete.planDrawingFile: |
+    Die Planzeichnung "{fileName}" wurde gelöscht.
+report.update.planDrawingFile: |
+    Die Planzeichnung wurde geändert von "{oldFileName}" zu "{newFileName}".
+report.create.planDrawingExplanation: |
+    Die Planzeichenerklärung "{fileName}" wurde hinzugefügt.
+report.delete.planDrawingExplanation: |
+    Die Planzeichenerklärung "{fileName}" wurde gelöscht.
+report.update.planDrawingExplanation: |
+    Die Planzeichenerklärung wurde geändert von "{oldFileName}" zu "{newFileName}".
 request: "Ihre Anfrage"
 requested: "angefragt"
 reset: "Zurücksetzen"
@@ -3947,6 +4032,7 @@ unsaved.changes: "Ungespeicherte Änderungen"
 unselect: "Auswahl aufheben"
 unselect.entity.first: "Aktuelle Auswahl aufheben, um {entity} auszuwählen"
 unpublished.statements.if.participation.ends: "nicht eingereichten Stellungnahmen, wenn die Beteiligung in einem Verfahren endet"
+unrestricted: "Uneingeschränkt"
 update: "Aktualisierung"
 upload: "Hochladen"
 upload.again: "Erneut hochladen"


### PR DESCRIPTION
### Ticket
DPLAN-14783

This is a "re-merge-PR"
This changes are already reviewed and merged with https://github.com/demos-europe/demosplan-core/pull/4383
To be able to merge all the related changes to release_diplanbau, this PR is needed.

The squashed merge message is:

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

* feat (refs DPLAN-14783): WIP: Enhance PDF-Export of report with procedure url. minor formatting and typing
* feat (refs DPLAN-14783): Add new group of report entries to cover reports of documents Group "documents" covers singledocuments, paragraphs, files and map as well
* feat (refs DPLAN-14783): minor formatting & typing
* feat (refs DPLAN-14783): create Factory to generate documents report entries
* feat (refs DPLAN-14783): Distinguish between element, singledoc and paragaph in the reports seems to be necessary
* feat (refs DPLAN-14783): relocate method to be able to used directly from object in preparation of creating a report entry
* feat (refs DPLAN-14783): Add additional information to create, update, delete - report of a single document
* feat (refs DPLAN-14783): Create report on create, update, delete of an Element
* feat (refs DPLAN-14783): Create report on create, update, delete of a Paragraph
* feat (refs DPLAN-14783): Add reports for missed creation of singledocuments and elements
* style: Apply php-cs-fixer
* feat (refs DPLAN-14783): add missing groups / use new groups for report entries
* feat (refs DPLAN-14783): Add simple report messages for create, update, delete of paragraph, element, singleDocument
* style: Apply php-cs-fixer
* feat (refs DPLAN-14783): Store report of file on element (which can be added directly) bring naming of keys into line
* style: Apply php-cs-fixer
* feat(refs DPLAN-14783): Add permissions for report entries
* feat (refs DPLAN-14783): Fix keys of messages
* style: Apply php-cs-fixer
* feat (refs DPLAN-14783): shorten text of entries of reports and improve readability by extract logic into methods
* feat (refs DPLAN-14783): adjust format in protocol to improve readability in UI
* feat (refs DPLAN-14783): improve readability by extracting logic and adjust format of report entry output
* feat (refs DPLAN-14783): text of singledocument always seems to be empty
* feat (refs DPLAN-14783): improve readability by relocating method
* feat (refs DPLAN-14783): improve readability by bringing key into line with other reports
* feat (refs DPLAN-14783): Improve performance by removing unnecessary constructor
* feat (refs DPLAN-14783): create reportEntry on creation, deletion and update of plandrawpdf and planpdf
* feat (refs DPLAN-14783): create reportEntry on creation, deletion and update of plandrawpdf and planpdf
* feat (refs DPLAN-14783): add map-drawing to protocol extract some logic into own methods to improve the readability
* feat (refs DPLAN-14783): add and enable permission for new report entries major: make all of the reports login required=true
* feat (refs DPLAN-14783): fix wrong key of array to avoid empty report entry
* feat (refs DPLAN-14783) add needed translation keys
* feat (refs DPLAN-14783): improve readability of report-export by using breaks which will interpreted by export logic
* feat (refs DPLAN-14783): Enable new sections of report in report-export
* feat (refs DPLAN-14783): Use existing FileInfo Object instead of array as return-type to improve DX
* feat (refs DPLAN-14783): fix create of new fileinfo
* feat (refs DPLAN-14783): fix message of report of deletion of an element minor:  adjust report messages of element
* feat (refs DPLAN-14783): fix wrong array keys and handle restricted organisations
* feat (refs DPLAN-14783): enhance report message to include restricted organisations
* feat (refs DPLAN-14783): fix translation of categories in report-entries
* feat (refs DPLAN-14783): remove unnecessary category of singledocument report entry
* feat (refs DPLAN-14783): fix: use correct transkey for case of creation
* feat (refs DPLAN-14783): remove unnecessary category of singledocument report entry
* feat (refs DPLAN-14783): reduce code duplication by reusing logic and dynamic method for creation of singledocument report entry
* feat (refs DPLAN-14783): reduce code duplication by reusing logic and dynamic method for creation of paragraph report entry
* feat (refs DPLAN-14783): reduce code duplication by reusing logic and dynamic method for creation of element report entry
- minor formatting
- typing
* feat (refs DPLAN-14783): change missing call of createParagraphCreateEntry() to createParagraphEntry()
* feat (refs DPLAN-14783): Cover update/deletion/creation of elements, singleDocument or Paragraph via resourceTypes by using EDTEvents
* feat (refs DPLAN-14783): Add changelog
* feat (refs DPLAN-14783): Using event to trigger creation of report for more loose coupling
* feat (refs DPLAN-14783): merge methods into one because missing advantage of two separate methods and to improve readability
* feat (refs DPLAN-14783): merge methods into one because missing advantage of two separate methods and to improve readability
* feat (refs DPLAN-14783): For Paragaph, SingleDocument and Element: dispatching events instead of direct service call to trigger creation of report for more loose coupling
* feat (refs DPLAN-14783): minor cleanup
* feat (refs DPLAN-14783): Cover update/deletion/creation of planDraw and planDrawPDF via resourceTypes by using Event
* feat (refs DPLAN-14783): Fix test
* feat (refs DPLAN-14783): avoid empty report entries by ensuring filled message data
* feat (refs DPLAN-14783): Fix not existing element reference on test of adding a paragraph
* feat (refs DPLAN-14783): If existing add (and render) the name of a pdf of a paragraph to report entry
* feat (refs DPLAN-14783): Fit A3 of related US by
- adjusting/enhancing stored data on writing reportEntry
- adjusting/enhancing report output message
* feat (refs DPLAN-14783): cleanup: removed unused injections
* feat (refs DPLAN-14783): Fix test
* feat (refs DPLAN-14783): Remove unused and unsolved issue of missing entity in AfterDeletionEvent
* feat (refs DPLAN-14783): use match() instead of switch() to improve readability and type-security
* feat (refs DPLAN-14783): reduce code-duplication to improve maintainability
* feat (refs DPLAN-14783): try to fix test by add missing procedurerelation
* fix DPLAN-14783: Fix unrelated test
* feat (refs DPLAN-14783): reduce code-duplication to fit requirements of CI/sonarcloud. ---------

(cherry picked from commit 2036b1cede41da5f0d8380b8ba6410013f37b267)