### PR TITLE
chore: do not send a not existing hash to the frontend

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/TusUploadEventSubscriber.php
@@ -88,10 +88,10 @@ class TusUploadEventSubscriber implements EventSubscriberInterface
             )->getId();
         } catch (VirusFoundException $e) {
             $this->logger->error('Virus found in File ', [$e]);
-            $fileId = '';
+            $fileId = $fileHash ='';
         } catch (Throwable $e) {
             $this->logger->error('Could not save uploaded File ', [$e]);
-            $fileId = '';
+            $fileId = $fileHash = '';
         }
 
         // we handled the file and can allow tus to have the same file uploaded again


### PR DESCRIPTION
In case of an error or found virus during upload only the id is reset and an invalid hash is sent. We should also remove the temporary hash

### How to review/test
code review might be easiest. At the frontend side you may assess, what happens, when no hash is sent back from the upload file. I could not find any misbehaviour

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
