### PR TITLE
bug(refs DPLAN-15148): Add spacing for inline notifications

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_list_masters.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_list_masters.html.twig
@@ -82,10 +82,12 @@
                 </tbody>
             </table>
         {% else %}
-            {{ uiComponent('inline-notification', {
-                message: 'blueprints.none'|trans,
-                type: 'info'
-            }) }}
+            <div class="mt-3">
+                {{ uiComponent('inline-notification', {
+                    message: 'blueprints.none'|trans,
+                    type: 'info'
+                }) }}
+            </div>
         {% endif %}
     </form>
 {% endblock %}

--- a/templates/bundles/DemosPlanCoreBundle/UI/inline-notification.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/UI/inline-notification.html.twig
@@ -15,7 +15,7 @@ type {String}:    Error level (may be 'info', 'warning', 'error' or 'success'). 
 {% set type = type|default('info') %}
 
 <div class="flash flash-{{ type }}">
-    <i class="fa {{ iconClasses[type] }}" aria-hidden="true"></i>
+    <i class="fa {{ iconClasses[type] }} mr-1" aria-hidden="true"></i>
     <p class="inline-block u-mb-0">
         {{ message|wysiwyg }}
     </p>


### PR DESCRIPTION
### Ticket
DPLAN-15148

Add some spacing between icon and text for inline notifications. Also add top spacing between button and notification. 

### How to review/test
Login Mandantenadmin -> Blaupausen -> check spacing of the notification if there are no blue prints. 


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
