### PR TITLE
feat (refs DPLAN-14783): add test to cover update via api 2.0

### DIFF
--- a/config/packages/zenstruck_foundry.yaml
+++ b/config/packages/zenstruck_foundry.yaml
@@ -1,6 +1,9 @@
 when@dev: &dev
     # See full configuration: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#full-default-bundle-configuration
     zenstruck_foundry:
+        database_resetter:
+            orm:
+                reset_mode: schema # enables resetting with migrations
         # Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh)
         auto_refresh_proxies: true
         faker:

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/CustomerFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/CustomerFactory.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
 use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\RepositoryProxy;
 
@@ -35,7 +36,7 @@ use Zenstruck\Foundry\RepositoryProxy;
  * @method static Customer[]|Proxy[]                 randomRange(int $min, int $max, array $attributes = [])
  * @method static Customer[]|Proxy[]                 randomSet(int $number, array $attributes = [])
  */
-final class CustomerFactory extends ModelFactory
+final class CustomerFactory extends PersistentProxyObjectFactory
 {
     public function __construct()
     {
@@ -43,9 +44,18 @@ final class CustomerFactory extends ModelFactory
     }
 
     /**
-     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function getDefaults(): array
+    protected function initialize(): self
+    {
+        return $this;
+    }
+    public static function class(): string
+    {
+        return Customer::class;
+    }
+
+    protected function defaults(): array|callable
     {
         return [
             'accessibilityExplanation'            => self::faker()->text(),
@@ -61,18 +71,6 @@ final class CustomerFactory extends ModelFactory
             'termsOfUse'                          => self::faker()->text(65535),
             'xplanning'                           => self::faker()->text(65535),
         ];
-    }
 
-    /**
-     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
-     */
-    protected function initialize(): self
-    {
-        return $this;
-    }
-
-    protected static function getClass(): string
-    {
-        return Customer::class;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/RoleFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/RoleFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\Role;
+use demosplan\DemosPlanCoreBundle\Repository\RoleRepository;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;
+
+/**
+ * @extends PersistentProxyObjectFactory<Role>
+ *
+ * @method        Role|Proxy                              create(array|callable $attributes = [])
+ * @method static Role|Proxy                              createOne(array $attributes = [])
+ * @method static Role|Proxy                              find(object|array|mixed $criteria)
+ * @method static Role|Proxy                              findOrCreate(array $attributes)
+ * @method static Role|Proxy                              first(string $sortedField = 'id')
+ * @method static Role|Proxy                              last(string $sortedField = 'id')
+ * @method static Role|Proxy                              random(array $attributes = [])
+ * @method static Role|Proxy                              randomOrCreate(array $attributes = [])
+ * @method static RoleRepository|ProxyRepositoryDecorator repository()
+ * @method static Role[]|Proxy[]                          all()
+ * @method static Role[]|Proxy[]                          createMany(int $number, array|callable $attributes = [])
+ * @method static Role[]|Proxy[]                          createSequence(iterable|callable $sequence)
+ * @method static Role[]|Proxy[]                          findBy(array $attributes)
+ * @method static Role[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
+ * @method static Role[]|Proxy[]                          randomSet(int $number, array $attributes = [])
+ *
+ */
+final class RoleFactory extends PersistentProxyObjectFactory
+{
+
+
+    public static function class(): string
+    {
+        return Role::class;
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     *
+     * @todo add your default values here
+     */
+    protected function defaults(): array|callable
+    {
+        return [
+            'code' => self::faker()->text(6),
+            'groupCode' => self::faker()->text(6),
+            'groupName' => self::faker()->text(60),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this
+            // ->afterInstantiate(function(Role $role): void {})
+        ;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/UserFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/UserFactory.php
@@ -35,22 +35,6 @@ use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;
  * @method static User[]|Proxy[]                          findBy(array $attributes)
  * @method static User[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
  * @method static User[]|Proxy[]                          randomSet(int $number, array $attributes = [])
- *
- * @phpstan-method        User&Proxy<User> create(array|callable $attributes = [])
- * @phpstan-method static User&Proxy<User> createOne(array $attributes = [])
- * @phpstan-method static User&Proxy<User> find(object|array|mixed $criteria)
- * @phpstan-method static User&Proxy<User> findOrCreate(array $attributes)
- * @phpstan-method static User&Proxy<User> first(string $sortedField = 'id')
- * @phpstan-method static User&Proxy<User> last(string $sortedField = 'id')
- * @phpstan-method static User&Proxy<User> random(array $attributes = [])
- * @phpstan-method static User&Proxy<User> randomOrCreate(array $attributes = [])
- * @phpstan-method static ProxyRepositoryDecorator<User, EntityRepository> repository()
- * @phpstan-method static list<User&Proxy<User>> all()
- * @phpstan-method static list<User&Proxy<User>> createMany(int $number, array|callable $attributes = [])
- * @phpstan-method static list<User&Proxy<User>> createSequence(iterable|callable $sequence)
- * @phpstan-method static list<User&Proxy<User>> findBy(array $attributes)
- * @phpstan-method static list<User&Proxy<User>> randomRange(int $min, int $max, array $attributes = [])
- * @phpstan-method static list<User&Proxy<User>> randomSet(int $number, array $attributes = [])
  */
 final class UserFactory extends PersistentProxyObjectFactory
 {
@@ -64,6 +48,7 @@ final class UserFactory extends PersistentProxyObjectFactory
      */
     protected function defaults(): array|callable
     {
+        $email = self::faker()->email();
         return [
             'authCodeEmailEnabled'       => self::faker()->boolean(),
             'createdDate'                => self::faker()->dateTime(),
@@ -71,6 +56,11 @@ final class UserFactory extends PersistentProxyObjectFactory
             'modifiedDate'               => self::faker()->dateTime(),
             'providedByIdentityProvider' => self::faker()->boolean(),
             'totpEnabled'                => self::faker()->boolean(),
+            'firstname'                  => self::faker()->firstName(),
+            'lastname'                   => self::faker()->lastName(),
+            'email'                      => $email,
+            'password'                   => self::faker()->password(),
+            'login'                      => $email,
         ];
     }
 

--- a/tests/backend/base/AbstractApiTest.php
+++ b/tests/backend/base/AbstractApiTest.php
@@ -42,14 +42,7 @@ abstract class AbstractApiTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::ensureKernelShutdown();
-        // the createClient() method cannot be used when kernel is booted
-        $this->client = static::createClient();
-        $serverParameters = $this->getServerParameters();
-        $this->client->setServerParameters($serverParameters);
-
-        $this->router = $this->getContainer()->get(RouterInterface::class);
-        $this->tokenManager = $this->getContainer()->get(JWTTokenManagerInterface::class);
+        $this->setUpHttpClient();
     }
 
     /**
@@ -60,7 +53,7 @@ abstract class AbstractApiTest extends FunctionalTestCase
         $token = $this->tokenManager->create($user);
         $userToken = new JWTUserToken($user->getDplanRolesArray(), $user, $token);
         $this->tokenStorage->setToken($userToken);
-
+        $this->client->setServerParameter(SetHttpTestPermissionsListener::X_DPLAN_TEST_USER_ID, $user->getId());
         return $token;
     }
 
@@ -102,4 +95,16 @@ abstract class AbstractApiTest extends FunctionalTestCase
     }
 
     abstract protected function getServerParameters(): array;
+
+    public function setUpHttpClient(): void
+    {
+        static::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+        $serverParameters = $this->getServerParameters();
+        $this->client->setServerParameters($serverParameters);
+
+        $this->router = $this->getContainer()->get(RouterInterface::class);
+        $this->tokenManager = $this->getContainer()->get(JWTTokenManagerInterface::class);
+    }
 }

--- a/tests/backend/core/JsonApi/Functional/ElementResourceTypeTest.php
+++ b/tests/backend/core/JsonApi/Functional/ElementResourceTypeTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\Core\JsonApi\Functional;
+
+
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Document\ElementsFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\RoleFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\Role;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\PlanningDocumentCategoryResourceType;
+use Tests\Base\JsonApiTest;
+
+class ElementResourceTypeTest extends JsonApiTest
+{
+
+    private \demosplan\DemosPlanCoreBundle\Entity\User\User|\Zenstruck\Foundry\Persistence\Proxy $user;
+    private Role|\Zenstruck\Foundry\Persistence\Proxy $role;
+    private $customer;
+
+    public function testCreate(): void
+    {
+    }
+
+
+    public function testCreateReportOnUpdate(): void
+    {
+        $this->setUpHttpClient();
+        $this->user = UserFactory::createOne();
+        $this->customer = CustomerFactory::createOne();
+        $this->role = RoleFactory::createOne([
+            'name' => Role::PLANNING_AGENCY_ADMIN,
+            'code' => Role::PLANNING_AGENCY_ADMIN,
+            'groupCode' => Role::GLAUTH,
+            'groupName' => Role::GLAUTH,
+            ]);
+        $this->user->setDplanroles([$this->role->_real()]);     $this->user->_save();
+        $this->user->setCurrentCustomer($this->customer->_real());     $this->user->_save();
+        $this->tokenStorage = $this->getContainer()->get('security.token_storage');
+        $this->logIn($this->user->_real());
+
+        $this->enablePermissions(['feature_admin_element_edit', 'feature_json_api_update', 'area_admin_single_document']);
+        $testElement = ElementsFactory::createOne()->_enableAutoRefresh();
+
+        static::assertInstanceOf(Elements::class, $this->find(Elements::class, $testElement->getId()));
+
+        $testElement = $testElement->_real();
+        /** @var Elements $testElement */
+        $enabledBeforeUpdate = $testElement->getEnabled();
+        $user = $this->user->_real();
+
+        $result = $this->executeUpdateRequest(
+            PlanningDocumentCategoryResourceType::getName(),
+            $testElement->getId(),
+            $user,
+            [
+                'data' => [
+                    'id'         => $testElement->getId(),
+                    'type'       => PlanningDocumentCategoryResourceType::getName(),
+                    'attributes' => [
+                        'enabled' => !$enabledBeforeUpdate,
+                    ],
+                ],
+            ],
+            $testElement->getProcedure(),
+            204
+        );
+
+        self::assertNull($result);
+        $relatedReports = $this->getEntries(ReportEntry::class,
+            [
+                'group'           => 'element',
+                'category'        => ReportEntry::CATEGORY_UPDATE,
+                'identifierType'  => 'procedure',
+                'identifier'      => $testElement->getProcedure()->getId(),
+            ]
+        );
+
+        $updatedElement = $this->find(Elements::class, $testElement->getId());
+
+        static::assertCount(1, $relatedReports);
+        $relatedReport = $relatedReports[0];
+        static::assertInstanceOf(ReportEntry::class, $relatedReport);
+        $messageArray = $relatedReport->getMessageDecoded(false);
+
+        $this->assertElementReportEntryMessageKeys($messageArray);
+        $this->assertElementReportEntryMessageValues($updatedElement, $messageArray);
+    }
+}


### PR DESCRIPTION
 with all the necessary enhancements to be able to test api 2.0 calls

### Ticket
DPLAN-14783

including  all the necessary enhancements to be able to test api 2.0 calls

### How to review/test
I do not manage to have a "stable workable" test in my local environment.
I'm not sure what is the course of this, but in case of executing the test with freshly cleared cache and using the debugger on execution of the test, it works.
So if you want to reproduce this locally, you have to first clear the cache and then execute the test in debugging mode.

But, that is why we decide to create an PR: Hopefully the automatically execution of the test will just works and the unpredictable behavior will not appear in a different environment.

- [x] Link all relevant tickets
