### PR TITLE
fix(refs DPLAN-15169): enable vue 3 render function api

### DIFF
--- a/client/js/InitVue.js
+++ b/client/js/InitVue.js
@@ -31,11 +31,16 @@ import loadSentry from './loadSentry'
 import NotificationStoreAdapter from '@DpJs/store/core/NotificationStoreAdapter'
 import NotifyContainer from '@DpJs/components/shared/NotifyContainer'
 import RegisterFlyout from '@DpJs/components/user/RegisterFlyout'
+import { configureCompat } from '@vue/compat'
 
 function initialize (components = {}, storeModules = {}, apiStoreModules = [], presetStoreModules = {}) {
   bootstrap()
 
   return initStore(storeModules, apiStoreModules, presetStoreModules).then(store => {
+    configureCompat({
+      RENDER_FUNCTION: false
+    })
+
     const app = createApp({
       mounted () {
         window.dplan.notify = new NotificationStoreAdapter(this.$store)


### PR DESCRIPTION
### Ticket
[DPLAN-15169](https://demoseurope.youtrack.cloud/issue/DPLAN-15169/Nicht-moglich-um-ein-Bild-zu-einem-Kapitel-zu-hinzufugen)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This is needed to make tiptap/vue3 NodeViewWrapper work (used in demosplan-ui/DpResizableImage), which uses the new api.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Login as FPA
- Go to Verfahren > Planungsdokumente und Planzeichnung
- Edit an existing category or create one first
- In the edit view, scroll down and click the "create new chapter" button
- In the new view, try to upload a picture to the editor - this should work without errors

### Linked PRs (optional)
- [x] https://github.com/demos-europe/demosplan-ui/pull/1217

### Tasks 
- [x] Merge https://github.com/demos-europe/demosplan-ui/pull/1217
- [x] Release new demosplan-ui version
- [x] Use new demosplan-ui version in demosplan-core https://github.com/demos-europe/demosplan-core/pull/4483
- [ ] Merge this PR

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
