### PR TITLE
chore: use current eslint command to fix reviewdog

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,6 +1,6 @@
 runner:
     eslint:
-        cmd: "node_modules/.bin/eslint -c config/linters/eslintrc.js demosplan client"
+        cmd: "ESLINT_USE_FLAT_CONFIG=false eslint -c eslintrc.js --ext .js,.vue demosplan client"
 
     phpstan:
         cmd: "DEVELOPMENT_CONTAINER=1 php bin/test dplan:phpstan --ci -l1"


### PR DESCRIPTION
Eslint fails during reviewdog run, update the command to match `yarn lint`

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
