### PR TITLE
chore(refs DPLAN-15169): bump demosplan-ui from v0.4.6 to v0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^9.2.0",
-    "@demos-europe/demosplan-ui": "^0.4.6",
+    "@demos-europe/demosplan-ui": "^0.4.7",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,9 +2584,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:^0.4.6":
-  version: 0.4.6
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.6"
+"@demos-europe/demosplan-ui@npm:^0.4.7":
+  version: 0.4.7
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.7"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2638,7 +2638,7 @@ __metadata:
     vue-multiselect: "npm:^3.1.0"
     vue-omnibox: "npm:^0.3.7"
     vue-sliding-pagination: "npm:^1.3.2"
-  checksum: 10c0/6181728e733735d86aadc082b5bc1800710ea94f460eadca3bf761a1f0497fe1d20c2a8423c58d895516bf9d7518e6d481eda28cf166d21148daed9def8ea7ca
+  checksum: 10c0/322c72d07e644ed4c2c75d97bab511624161188a5dea837331a7b77ef291743ae32be1d94593866c978d7a251ccd07a9e6a9eab5e04e50dc356c8d84b95f0bb3
   languageName: node
   linkType: hard
 
@@ -14015,7 +14015,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^9.2.0"
-    "@demos-europe/demosplan-ui": "npm:^0.4.6"
+    "@demos-europe/demosplan-ui": "npm:^0.4.7"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"


### PR DESCRIPTION
### Ticket
[DPLAN-15169](https://demoseurope.youtrack.cloud/issue/DPLAN-15169/Nicht-moglich-um-ein-Bild-zu-einem-Kapitel-zu-hinzufugen)

Contains a fix for the image upload in DpEditor.

### Linked PRs
- [ ] https://github.com/demos-europe/demosplan-core/pull/4475

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
