### PR TITLE
fix(DPLAN-15292): comments are not updated in the UI

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/SegmentCommentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentCommentsList.vue
@@ -98,11 +98,17 @@ export default {
     ]),
 
     comments () {
-      return this.segment?.hasRelationship('comments')
-        ? Object.values(this.segment.rel('comments'))
-          .filter(comment => typeof comment !== 'undefined')
-          .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
-        : []
+      const commentsData = this.segment?.relationships?.comments?.data
+
+      if (!commentsData || commentsData.length === 0) {
+        return []
+      }
+
+      const comments = this.segment.rel('comments') || {}
+
+      return Object.values(comments)
+        .filter(comment => typeof comment !== 'undefined')
+        .sort((a, b) => new Date(b.attributes.creationDate) - new Date(a.attributes.creationDate))
     },
 
     hasComments () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta.vue
@@ -372,7 +372,7 @@ export default {
     window.addEventListener('scroll', this.handleScroll)
   },
 
-  beforeDestroy () {
+  beforeUnmount () {
     window.removeEventListener('scroll', this.handleScroll)
   }
 }

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -78,7 +78,7 @@
           </li>
           <li v-if="hasPermission('feature_read_source_statement_via_api')">
             <dp-flyout :disabled="isDisabledAttachmentFlyout">
-              <template #trigger>
+              <template v-slot:trigger>
                 <span>
                   {{ Translator.trans('attachments') }}
                   <span v-text="attachmentsAndOriginalPdfCount" />
@@ -118,7 +118,7 @@
             <dp-flyout
               ref="metadataFlyout"
               :has-menu="false">
-              <template #trigger>
+              <template v-slot:trigger>
                 <span>
                   {{ Translator.trans('statement.metadata') }}
                   <i
@@ -547,7 +547,6 @@ export default {
     getStatement () {
       const statementFields = [
         'assignee',
-        'availableProcedurePhases',
         'authoredDate',
         'authorName',
         'consentRevoked',
@@ -593,6 +592,10 @@ export default {
         statementFields.push('synchronized')
       }
 
+      if (hasPermission('field_statement_phase')) {
+        statementFields.push('availableProcedurePhases')
+      }
+
       if (hasPermission('area_statement_segmentation')) {
         statementFields.push('segmentDraftList')
       }
@@ -607,7 +610,7 @@ export default {
 
       const allFields = {
         ElementsDetails: [
-          'document',
+          'documents',
           'paragraphs',
           'title'
         ].join(),

--- a/client/js/components/statement/DpClaim.vue
+++ b/client/js/components/statement/DpClaim.vue
@@ -44,7 +44,7 @@ the FB is ready with editing of fragments.
   <button
     class="flex items-center space-inline-xs btn--blank o-link--default"
     :class="{'cursor-pointer' : false === isLoading}"
-    :data-assigned="isAssignedToMe /* needed for checking checked elements*/"
+    :data-assigned="isAssignedToMe ? 'true' : 'false'"
     @click.prevent.stop="updateAssignment"
     data-cy="claimIcon"
     :aria-label="status.text"


### PR DESCRIPTION
### Ticket
[DPLAN-15292](https://demoseurope.youtrack.cloud/issue/DPLAN-15292/Vollbild-Abschnitte-endlose-laden-beim-speichern-von-Kommentare)

**Description:** This PR fixes the main issue where comments are not updated in the UI: register a dependency on the length of the `comments` data array in the computed variable comments so that when the value (`this.segment?.relationships?.comments?.data`) changes, Vues reactivity system triggers a recomputation of the computed property
- fix some lila messages by adjusting parameters in the request 
- fix some vue console warnings

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
