### PR TITLE
feat (refs DPLAN-15242): null is a valid return type

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphService.php
@@ -204,12 +204,7 @@ class ParagraphService extends CoreService implements ParagraphServiceInterface
         return $this->convertDateTime($res);
     }
 
-    /**
-     * @param string $ident
-     *
-     * @return Paragraph|null
-     */
-    public function getParaDocumentObject($ident): ?Paragraph
+    public function getParaDocumentObject(string $ident): ?Paragraph
     {
         return $this->paragraphRepository->find($ident);
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ParagraphService.php
@@ -209,7 +209,7 @@ class ParagraphService extends CoreService implements ParagraphServiceInterface
      *
      * @return Paragraph|null
      */
-    public function getParaDocumentObject($ident): Paragraph
+    public function getParaDocumentObject($ident): ?Paragraph
     {
         return $this->paragraphRepository->find($ident);
     }


### PR DESCRIPTION
### Ticket
DPLAN-15242

Null as return is also allowed.
Additionally set string as parameter type and remove now unnecessary docblock

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
