### PR TITLE
F dplan 15329 adjust statement confirm mail

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
@@ -358,7 +358,6 @@ class StatementSubmissionNotifier
      *
      * @param string $statementText
      * @param string $recipient
-     * @param mixed  $number
      *
      * @throws Throwable
      * @throws LoaderError
@@ -370,7 +369,7 @@ class StatementSubmissionNotifier
         $recipient,
         ?Statement $submittedStatement = null,
         $number = null,
-        GdprConsentRevokeToken $gdprConsentRevokeToken = null
+        ?GdprConsentRevokeToken $gdprConsentRevokeToken = null
     ): void {
         $mailTemplateVars = [];
         $vars = [];

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
@@ -399,6 +399,7 @@ class StatementSubmissionNotifier
         $mailTemplateVars['signature'] = [
             'nameLegal'                 => $orga->getName(),
             'street'                    => $orga->getStreet(),
+            'houseNumber'               => $orga->getHouseNumber(),
             'postalcode'                => $orga->getPostalcode(),
             'city'                      => $orga->getCity(),
             'email'                     => $from,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/new_statement_confirm_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/new_statement_confirm_email.html.twig
@@ -44,10 +44,14 @@ Mit freundlichem Gruß
 {% if signature.nameLegal is defined %}
 {{ signature.nameLegal }}
 {% endif %}
-{% if signature.street is defined %}
+{% if signature.street is defined and signature.houseNumber is defined %}
+{{ signature.street ~ ' ' ~ signature.houseNumber }}
+{% elseif signature.street is defined %}
 {{ signature.street }}
+{% elseif signature.houseNumber is defined %}
+{{ signature.houseNumber }}
 {% endif %}
-{{ signature.city|default('') }} {{ signature.postalcode|default('') }}
+{{ signature.postalcode|default('') }} {{ signature.city|default('') }}
 {% if signature.email is defined %}
 {{ signature.email }}
 {% endif %}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15329/BLP-Adressdaten-in-Einreichungsbestatigungsemail-falsch


Description: 
adjust statement confirm mail:
 - add house number in the template
 - adjust street and postalcode order


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

