### PR TITLE
b(refs-DPLAN-13110) delete obscure option in new statement 

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
@@ -522,7 +522,6 @@
                             data-cy="submitterForm:statementText"
                             required
                             :toolbar-items="{
-                                obscure: hasPermission('feature_obscure_text'),
                                 mark: true,
                                 strikethrough: true
                             }"


### PR DESCRIPTION
### Ticket
DPLAN-15298

Deleted obscure option in DpEditor in NewStatement component since it should just be available in segements. 


### How to review/test
Create new stn and take a look at the icons

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/4421

