### PR TITLE
DPLAN-4237 set NextValidExternalIdForProcedure on stn sync instead ofstrictly setting its source STN value

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/StatementSynchronizer.php
@@ -162,7 +162,12 @@ class StatementSynchronizer
         $newOriginalStatement->setSubmitTypeTranslated($sourceStatement->getSubmitTypeTranslated());
         $newOriginalStatement->setMapFile($sourceStatement->getMapFile());
         $newOriginalStatement->setSubmit($sourceStatement->getSubmitObject()->add(new DateInterval('PT1S')));
-        $newOriginalStatement->setExternId($sourceStatement->getExternId());
+        $newOriginalStatement->setExternId(
+            $this->statementService->getNextValidExternalIdForProcedure(
+                $targetProcedure->getId(),
+                true
+            )
+        );
         $newOriginalStatement->setProcedure($targetProcedure);
         $newOriginalStatement->setOrganisation($sourceStatement->getOrganisation());
         $newOriginalStatement->setManual($sourceStatement->isManual());


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-4237/STN-Nr-wird-doppelt-vergeben

Description:
set NextValidExternalIdForProcedure on stn sync instead ofstrictly setting its source STN value
![image](https://github.com/user-attachments/assets/94fa65bb-76c1-49ac-b0f7-4d1758fe219c)
will become in targetProcedure that already holds a M2 id now
![image](https://github.com/user-attachments/assets/5a923afb-2308-4359-93d7-fd36eb66ac49)


If you couple a procedure with a token obtained by an hearing-agency-procedure and you have your own statements created  within that same procedure before the hearing-agency starts to sync theirs - multiple STNs with the same externalId will be created since we strictly set the externalId of the source Statement.
![image](https://github.com/user-attachments/assets/ba17fa71-edb9-4e25-9f88-9d57a569488b)


I am not certain this issue is the root cause of this ticket - but this hearing-agency sync-feature got introduced before the ticket got created - and that makes it possible at least. 

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
