### PR TITLE
feat(refs dplan 15328): make submitter data always editable

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1132,14 +1132,6 @@ class StatementService extends CoreService implements StatementServiceInterface
                 $this->getLogger()->warning('Trying to update a locked by assignment statement.');
             }
 
-            // there are fields, which are only allowed to modify on a manual statement?
-            $hasManualStatementUpdateFields = $this->hasManualStatementUpdateFields($updatedStatement, $currentStatementObject);
-            $updateForbidden = !$hasManualStatementUpdateFields;
-            if ($updateForbidden) {
-                $this->messageBag->add('warning', 'warning.deny.update.manual.statement');
-                $this->getLogger()->warning('Trying to update manualStatementUpdateFields on a normal statement.');
-            }
-
             // is a original statement?
             $lockedByOriginal = false;
             $isOriginal = $currentStatementObject->isOriginal();
@@ -1157,7 +1149,6 @@ class StatementService extends CoreService implements StatementServiceInterface
             if (!$lockedByAssignment
                 && !$lockedByAssignmentOfHeadStatement
                 && !$lockedByCluster
-                && !$updateForbidden
                 && !$lockedByOriginal
                 && !$currentStatementObject->isPlaceholder()) {
                 $preUpdatedStatement = clone $currentStatementObject;
@@ -1257,71 +1248,6 @@ class StatementService extends CoreService implements StatementServiceInterface
         }
 
         return $fileHashToFileContainerMapping;
-    }
-
-    /**
-     * Determines if one of the fields which only can be modified on a manual statement, should be updated.
-     *
-     * @param Statement|array $statement        - Statement as array or object
-     * @param Statement       $currentStatement - current unmodified statement object, to compare with incoming update data
-     *
-     * @return bool - true if one of the 'critical' fields should be updated, otherwise false
-     */
-    private function hasManualStatementUpdateFields($statement, Statement $currentStatement): bool
-    {
-        $currentAuthorName = $currentStatement->getAuthorName();
-        $currentSubmitterName = $currentStatement->getSubmitterName();
-        $currentSubmitterEmailAddress = $currentStatement->getSubmitterEmailAddress();
-        $currentDepartmentName = $currentStatement->getMeta()->getOrgaDepartmentName();
-        // orgaName is submitterType:
-        $currentSubmitterType = $currentStatement->getMeta()->getOrgaName();
-        $currentOrgaPostalCode = $currentStatement->getOrgaPostalCode();
-        $currentOrgaCity = $currentStatement->getOrgaCity();
-        $currentOrgaStreet = $currentStatement->getOrgaStreet();
-        $currentOrgaEmail = $currentStatement->getOrgaEmail();
-        $currentAuthoredDateString = $currentStatement->getAuthoredDateString();
-        $currentAuthoredDateTimeStamp = $currentStatement->getAuthoredDate();
-        $currentSubmittedDateString = $currentStatement->getSubmitDateString();
-        $currentSubmittedDateTimeStamp = $currentStatement->getSubmit();
-
-        if (\is_array($statement)) {
-            $statement = \collect($statement);
-            if (
-                ($statement->has('author_name') && $statement->get('author_name') != $currentAuthorName)
-                || ($statement->has('submit_name') && $statement->get('submit_name') != $currentSubmitterName)
-                || ($statement->has('submitterEmailAddress') && $statement->get('submitterEmailAddress') != $currentSubmitterEmailAddress)
-                || ($statement->has('departmentName') && $statement->get('departmentName') != $currentDepartmentName)
-                || ($statement->has('submitterType') && $statement->get('submitterType') != $currentSubmitterType)
-                || ($statement->has('orga_postalcode') && $statement->get('orga_postalcode') != $currentOrgaPostalCode)
-                || ($statement->has('orga_city') && $statement->get('orga_city') != $currentOrgaCity)
-                || ($statement->has('orga_street') && $statement->get('orga_street') != $currentOrgaStreet)
-                || ($statement->has('orga_email') && $statement->get('orga_email') != $currentOrgaEmail)
-                || ($statement->has('authoredDate') && $statement->get('authoredDate') != $currentAuthoredDateString)
-                || ($statement->has('submittedDate') && $statement->get('submittedDate') != $currentSubmittedDateString)
-            ) {
-                return true;
-            }
-        }
-
-        if ($statement instanceof Statement) {
-            if (
-                $statement->getAuthorName() != $currentAuthorName
-                || $statement->getSubmitterName() != $currentSubmitterName
-                || $statement->getMeta()->getOrgaDepartmentName() != $currentDepartmentName
-                || $statement->getMeta()->getOrgaName() != $currentSubmitterType
-                || $statement->getSubmitterEmailAddress() != $currentSubmitterEmailAddress
-                || $statement->getOrgaPostalCode() != $currentOrgaPostalCode
-                || $statement->getOrgaCity() != $currentOrgaCity
-                || $statement->getOrgaStreet() != $currentOrgaStreet
-                || $statement->getOrgaEmail() != $currentOrgaEmail
-                || $statement->getAuthoredDate() != $currentAuthoredDateTimeStamp
-                || $statement->getSubmit() != $currentSubmittedDateTimeStamp
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -3054,10 +3054,10 @@ class StatementService extends CoreService implements StatementServiceInterface
                 $limit = $defaultLimits[0];
             }
 
-            $paginator->setMaxPerPage((int)$limit);
+            $paginator->setMaxPerPage((int) $limit);
             // try to paginate Result, check for validity
             try {
-                $paginator->setCurrentPage((int)$page);
+                $paginator->setCurrentPage((int) $page);
             } catch (NotValidCurrentPageException $e) {
                 $this->logger->info('Received invalid Page for pagination', [$e]);
                 $paginator->setCurrentPage(1);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1134,7 +1134,7 @@ class StatementService extends CoreService implements StatementServiceInterface
 
             // there are fields, which are only allowed to modify on a manual statement?
             $hasManualStatementUpdateFields = $this->hasManualStatementUpdateFields($updatedStatement, $currentStatementObject);
-            $updateForbidden = $hasManualStatementUpdateFields && !$currentStatementObject->isManual();
+            $updateForbidden = !$hasManualStatementUpdateFields;
             if ($updateForbidden) {
                 $this->messageBag->add('warning', 'warning.deny.update.manual.statement');
                 $this->getLogger()->warning('Trying to update manualStatementUpdateFields on a normal statement.');

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -23,6 +23,31 @@
                 {% block submitOrga %}
                     {% if statement.meta.orgaName is defined %}
                         {% set orgaNameClass = 'u-mb-0_25 u-pr-0_5' %}
+                        {% if not readonly %}
+                            {% if statement.isSubmittedByCitizen == false%}
+                                {% set orgaNameValue = statement.meta.orgaName|default %}
+                                {% set labelHint = 'institution.name' %}
+                            {% elseif statement.isSubmittedByCitizen %}
+                                {% if statement.meta.miscData.submitterRole|default == 'publicagency' %}
+                                    {% set orgaNameValue = 'institution'|trans %}
+                                {% else %}
+                                    {% set orgaNameValue = 'role.citizen'|trans %}
+                                {% endif %}
+                                {% set orgaNameDisabled = true %}
+                            {% endif %}
+                        {% else %}
+                            {% if statement.isSubmittedByCitizen == false %}
+                                {% set orgaNameValue = statement.meta.orgaName|default('-') %}
+                                {% set orgaNameDisabled = true %}
+                            {% else %}
+                                {% if statement.meta.miscData.submitterRole|default == 'publicagency' and statement.meta.orgaName == '' %}
+                                    {% set orgaNameValue = 'institution'|trans %}
+                                {% else %}
+                                    {% set orgaNameValue = 'role.citizen'|trans %}
+                                {% endif %}
+                                {% set orgaNameDisabled = true %}
+                            {% endif %}
+                        {% endif %}
                         {% if statement.isSubmittedByCitizen == false%}
                             {% set orgaNameValue = statement.meta.orgaName|default %}
                             {% set labelHint = 'institution.name' %}
@@ -66,8 +91,12 @@
             {% endif %}
 
             {# department #}
+            {# editable only if not readonly #}
             {% if hasPermission('field_statement_meta_orga_department_name') %}
                 {% if statement.isSubmittedByCitizen == false %}
+                    {% if readonly %}
+                        {% set departmentDisabled = true %}
+                    {% endif %}
 
                     {{ uiComponent('form.element', {
                         label: { text: 'department'|trans },
@@ -77,7 +106,7 @@
                         elementSize: 'large',
                         elementStyle: 'inline-block',
                         elementClass: 'u-pl-0_5',
-                        disabled: false,
+                        disabled: departmentDisabled|default(false),
                         attributes: ['data-cy=statementDetail:departmentName']
                     }) }}
                 {% endif %}
@@ -119,8 +148,11 @@
             {% endif %}
 
             {# submitter name #}
+            {# editable only if not readonly #}
             {% if hasPermission('field_statement_meta_submit_name') and formDefinitions.name.enabled == true %}
-
+                {% if readonly %}
+                    {% set submittedAuthorDisabled = true %}
+                {% endif %}
                 <div class="u-1-of-2 inline-block u-pr-0_5">
                     {% block submitted_author_label %}
                         {% if statement.gdprConsent and statement.gdprConsent.consentRevoked %}
@@ -136,7 +168,7 @@
                         {{ uiComponent('form.label', {
                             id: submittedAuthorId,
                             text: 'name'|trans,
-                            disabled: false
+                            disabled: submittedAuthorDisabled|default(false)
                         }) }}
                     {% endblock submitted_author_label %}
 
@@ -184,7 +216,7 @@
                             name: submittedAuthorId,
                             class: submittedAuthorClass|default,
                             value: submittedAuthorValue,
-                            disabled: false,
+                            disabled: submittedAuthorDisabled|default(false),
                             attributes: ['data-cy=statementDetail:' ~ submittedAuthorId]
                         }) }}
                     {% endif %}
@@ -323,13 +355,40 @@
             {% endif %}
 
             {% block address %}
-
+                {# Address block is not shown if it's postalcode is empty #}
+                {# editable if not readonly #}
                 {% if hasPermission('field_statement_meta_address') %}
 
                     {% set streetValue = statement.meta.orgaStreet|default %}
                     {% set houseNumberValue = statement.meta.houseNumber|default %}
                     {% set postalCodeValue = statement.meta.orgaPostalCode|default %}
                     {% set cityValue = statement.meta.orgaCity|default %}
+
+                    {% if readonly %}
+                        {# disable input fields #}
+                        {% set houseNumberDisabled = true %}
+                        {% set streetDisabled = true %}
+                        {% set postalCodeDisabled = true %}
+                        {% set cityDisabled = true %}
+
+                        {# if any of these is empty, set value to '-' #}
+                        {% if statement.meta.orgaStreet|default == '' %}
+                            {% set streetValue = '-' %}
+                        {% endif %}
+
+                        {% if statement.meta.houseNumber|default == '' %}
+                            {% set houseNumberValue = '-' %}
+                        {% endif %}
+
+                        {% if statement.meta.orgaPostalCode|default == '' %}
+                            {% set postalCodeValue = '-' %}
+                        {% endif %}
+
+                        {% if statement.meta.orgaCity|default == '' %}
+                            {% set cityValue = '-' %}
+                        {% endif %}
+                    {% endif %}
+
 
                     <div class="u-1-of-1">
                       {% if hasPermission('field_statement_meta_street') and (formDefinitions.streetAndHouseNumber.enabled == true or formDefinitions.street.enabled == true) %}
@@ -341,7 +400,7 @@
                                 id: 'r_orga_street',
                                 elementClass: 'u-5-of-6 u-pr-0_5',
                                 elementStyle: 'inline-block',
-                                disabled: false,
+                                disabled: streetDisabled|default(false),
                                 attributes: ['data-cy=statementDetail:orgaStreet']
                             }) }}
 
@@ -353,7 +412,7 @@
                                     id: 'r_houseNumber',
                                     elementSize: 'tiny',
                                     elementStyle: 'inline-block',
-                                    disabled: false,
+                                    disabled: houseNumberDisabled|default(false),
                                     attributes: ['data-cy=statementDetail:houseNumber']
                                 }) }}
                             {% endif %}
@@ -368,7 +427,7 @@
                                 id: 'r_orga_postalcode',
                                 elementStyle: 'inline-block',
                                 elementSize: 'tiny',
-                                disabled: false,
+                                disabled: postalCodeDisabled|default(false),
                                 attributes: ['data-cy=statementDetail:orgaPostalcode']
                             }) }}
 
@@ -384,7 +443,7 @@
                                 id: 'r_orga_city',
                                 elementStyle: 'inline-block',
                                 elementClass: cityClasses,
-                                disabled: false,
+                                disabled: cityDisabled|default(false),
                                 attributes: ['data-cy=statementDetail:orgaCity']
                             }) }}
                         </div>
@@ -572,34 +631,51 @@
                 }) }}
 
                 {# Procedure phase
+                   editable if not readonly
                    display internal phases if submitter is not a citizen, otherwise display external phases
                 #}
                 {% if hasPermission('field_statement_phase') %}
                     {% set procedurePhaseOptGroups = {} %}
                     {% set procedurePhaseOptions = {} %}
-                    {% if statement.isSubmittedByCitizen == false and hasPermission('field_show_internal_procedure_phases_in_dropdown') %}
-                        {% set phases = templateVars.internalPhases|default %}
+
+                    {% if readonly %}
+                        {# disable select #}
+                        {% set procedurePhaseSelectDisabled = true %}
+
+                        {# set selected option #}
+                        {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
+                            label: statement.phase,
+                            value: '',
+                            selected: true
+                        }]) %}
+
+                        {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
+
                     {% else %}
-                        {% set phases = templateVars.externalPhases|default %}
-                    {% endif %}
-
-                    {% for phase in phases %}
-                        {% if phase.name == statement.phase %}
-                            {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
-                                label: phase.name,
-                                value: phase.key,
-                                selected: true
-                            }]) %}
+                        {# set all options for optgroups only for edit-mode #}
+                        {% if statement.isSubmittedByCitizen == false and hasPermission('field_show_internal_procedure_phases_in_dropdown') %}
+                            {% set phases = templateVars.internalPhases|default %}
                         {% else %}
-                            {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
-                                label: phase.name,
-                                value: phase.key
-                            }]) %}
+                            {% set phases = templateVars.externalPhases|default %}
                         {% endif %}
-                    {% endfor %}
 
-                    {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
+                        {% for phase in phases %}
+                            {% if phase.name == statement.phase %}
+                                {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
+                                    label: phase.name,
+                                    value: phase.key,
+                                    selected: true
+                                }]) %}
+                            {% else %}
+                                {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
+                                    label: phase.name,
+                                    value: phase.key
+                                }]) %}
+                            {% endif %}
+                        {% endfor %}
 
+                        {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
+                    {% endif %}
                     {{ uiComponent('form.row', {
                         elements: [
                             {
@@ -610,7 +686,7 @@
                                 elementSize: 'large',
                                 elementClass: 'u-pr-0_5',
                                 disabledPlainText: true,
-                                disabled: false,
+                                disabled: procedurePhaseSelectDisabled|default(false),
                                 attributes: ['data-cy=statementDetail:Phase']
                             }
                         ]
@@ -620,8 +696,17 @@
                 {# elements for form.row component are merged into this object: date authored, date submitted and submit type #}
                 {% set authorDateRowElements = {} %}
 
+                {# date submitted - editable if not readonly #}
+                {% if readonly %}
+                    {% set submitDateDisabled = true %}
+                {% endif %}
+
                 {# date authored #}
+                {# editable if not readonly #}
                 {% if statement.meta.authoredDate is defined %}
+                    {% if readonly %}
+                        {% set authoredDateDisabled = true %}
+                    {% endif %}
                     {% if statement.meta.authoredDate|dplanDate() != '' %}
                         {% set authoredDateValue = statement.meta.authoredDate|default()|dplanDate() %}
                     {% elseif statement.meta.authoredDate|dplanDate() == '' and readonly %}
@@ -640,11 +725,11 @@
                             dataCy: 'statementDetail:authoredDate',
                             maxDate: 'now'|date('d.m.Y')
                         },
-                        type: 'text',
+                        type: submitDateDisabled|default(false) ? 'text' : 'datepicker',
                         id: 'r_authored_date',
                         elementSize: 'small',
                         elementStyle: 'inline-block',
-                        disabled: false
+                        disabled: submitDateDisabled|default(false)
                     }]) %}
                 {% endif %}
 
@@ -659,24 +744,37 @@
                         class: 'u-5-of-6 o-form__control-wrapper',
                         dataCy: 'statementDetail:submittedDate'
                     },
-                    type: 'text',
+                    type: submitDateDisabled|default(false) ? 'text' : 'datepicker',
                     id: 'r_submitted_date',
                     elementSize: 'small',
                     elementStyle: 'inline-block',
-                    disabled: false
+                    disabled: submitDateDisabled|default(false)
                 }]) %}
 
                 {# show submit type, if feature is set and value differs from 'system' (-> manual statement) #}
+                {# editable only if not readonly #}
                 {% if hasPermission('field_statement_submit_type') %}
                     {% set submitTypeSelectOptions = {} %}
-                    {% for value, label in getFormOption('statement_submit_types.values', true)|filter(value => value != 'system') %}
-                        {% if value != statement.submitType %}
-                            {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value }]) %}
-                        {% else %}
-                            {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
-                        {% endif %}
-                    {% endfor %}
+                    {% if readonly %}
+                        {% set submitTypeSelectDisabled = true %}
 
+                        {% for value, label in getFormOption('statement_submit_types.values', true) %}
+                            {% if value == statement.submitType %}
+                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
+                            {% endif %}
+                        {% endfor %}
+
+                    {% else %}
+                        {# the default option is skipped in this case, since it is the value for "system" (submitted
+                          by using the platform), which is no valid value for a manual statement #}
+                        {% for value, label in getFormOption('statement_submit_types.values', true)|filter(value => value != 'system') %}
+                            {% if value != statement.submitType %}
+                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value }]) %}
+                            {% else %}
+                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
 
                     {% set authorDateRowElements = authorDateRowElements|merge([{
                         label: { text: 'submit.type'|trans },
@@ -854,7 +952,7 @@
                                     :ignore-last-claimed="true"
                                 ></dp-select-statement-cluster>
                             </label>
-                        {# if not editable #}
+                            {# if not editable #}
                         {% else %}
                             <span class="layout__item u-3-of-4 u-mb-0_75 color--grey">{{ templateVars.table.statement.headStatement|default('statements.group.not.selected'|trans) }}</span>
                         {% endif %}
@@ -870,65 +968,65 @@
 
                     <div class="u-1-of-2 inline-block">
                         {% if statement.element.ident is defined %}
-                                    {{ uiComponent('form.element', {
-                                        label: { text: 'plandocument'|trans },
-                                        control: { value: statement.element.title|default },
-                                        type: 'text',
-                                        id: 'elementTitle',
-                                        elementClass: 'u-mb-0_25',
-                                        disabled: true
-                                    }) }}
-                                    {% if not readonly %}
-                                        {{ uiComponent('form.element', {
-                                            label: { text: 'delete'|trans },
-                                            control: { name: 'r_delete_element', value: '1' },
-                                            type: 'checkbox',
-                                            elementClass: 'u-mb-0_5',
-                                            id: 'r_delete_element',
-                                            attributes: ['data-cy=statementDetail:deleteElement']
-                                        }) }}
-                                    {% endif %}
+                            {{ uiComponent('form.element', {
+                                label: { text: 'plandocument'|trans },
+                                control: { value: statement.element.title|default },
+                                type: 'text',
+                                id: 'elementTitle',
+                                elementClass: 'u-mb-0_25',
+                                disabled: true
+                            }) }}
+                            {% if not readonly %}
+                                {{ uiComponent('form.element', {
+                                    label: { text: 'delete'|trans },
+                                    control: { name: 'r_delete_element', value: '1' },
+                                    type: 'checkbox',
+                                    elementClass: 'u-mb-0_5',
+                                    id: 'r_delete_element',
+                                    attributes: ['data-cy=statementDetail:deleteElement']
+                                }) }}
+                            {% endif %}
 
-                                {% if statement.document.ident is defined and hasPermission('field_procedure_documents')%}
+                            {% if statement.document.ident is defined and hasPermission('field_procedure_documents')%}
+                                {{ uiComponent('form.element', {
+                                    label: { text: 'file'|trans },
+                                    control: { value: statement.document.title|default },
+                                    type: 'text',
+                                    id: 'fileTitle',
+                                    elementClass: 'u-mb-0_25',
+                                    disabled: true
+                                }) }}
+                                {% if not readonly %}
                                     {{ uiComponent('form.element', {
-                                        label: { text: 'file'|trans },
-                                        control: { value: statement.document.title|default },
-                                        type: 'text',
-                                        id: 'fileTitle',
-                                        elementClass: 'u-mb-0_25',
-                                        disabled: true
+                                        label: { text: 'delete'|trans },
+                                        control: { name: 'r_delete_document', value: '1' },
+                                        type: 'checkbox',
+                                        elementClass: 'u-mb-0_5',
+                                        id: 'r_delete_document'
                                     }) }}
-                                    {% if not readonly %}
-                                        {{ uiComponent('form.element', {
-                                            label: { text: 'delete'|trans },
-                                            control: { name: 'r_delete_document', value: '1' },
-                                            type: 'checkbox',
-                                            elementClass: 'u-mb-0_5',
-                                            id: 'r_delete_document'
-                                        }) }}
-                                    {% endif %}
                                 {% endif %}
+                            {% endif %}
 
-                                {% if statement.paragraph.ident is defined and hasPermission('field_procedure_paragraphs') %}
+                            {% if statement.paragraph.ident is defined and hasPermission('field_procedure_paragraphs') %}
+                                {{ uiComponent('form.element', {
+                                    label: { text: 'paragraph'|trans },
+                                    control: { value: statement.paragraph.title|striptags|default },
+                                    type: 'text',
+                                    id: 'paragraphTitle',
+                                    elementClass: 'u-mb-0_25',
+                                    disabled: true
+                                }) }}
+
+                                {% if not readonly %}
                                     {{ uiComponent('form.element', {
-                                        label: { text: 'paragraph'|trans },
-                                        control: { value: statement.paragraph.title|striptags|default },
-                                        type: 'text',
-                                        id: 'paragraphTitle',
-                                        elementClass: 'u-mb-0_25',
-                                        disabled: true
+                                        label: { text: 'delete'|trans },
+                                        control: { name: 'r_delete_paragraph', value: '1' },
+                                        type: 'checkbox',
+                                        elementClass: 'u-mb-0_5',
+                                        id: 'r_delete_paragraph'
                                     }) }}
-
-                                    {% if not readonly %}
-                                        {{ uiComponent('form.element', {
-                                            label: { text: 'delete'|trans },
-                                            control: { name: 'r_delete_paragraph', value: '1' },
-                                            type: 'checkbox',
-                                            elementClass: 'u-mb-0_5',
-                                            id: 'r_delete_paragraph'
-                                        }) }}
-                                    {% endif %}
                                 {% endif %}
+                            {% endif %}
                         {% else %} {# if statement.element.ident is not defined #}
                             {{ uiComponent('form.element', {
                                 label: { text: 'plandocument'|trans },
@@ -1126,14 +1224,14 @@
                         <div class="layout--flush">
                             <div class="layout__item u-1-of-1">
                                 {{
-                                    fileupload(
-                                        "r_fileupload",
-                                        "documents.attach",
-                                        "all",
-                                        "form.button.upload.files",
-                                        20,
-                                        true
-                                    )
+                                fileupload(
+                                    "r_fileupload",
+                                    "documents.attach",
+                                    "all",
+                                    "form.button.upload.files",
+                                    20,
+                                    true
+                                )
                                 }}
                             </div>
                         </div>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -139,9 +139,6 @@
             {# submitter name #}
             {# editable only if manualStatement #}
             {% if hasPermission('field_statement_meta_submit_name') and formDefinitions.name.enabled == true %}
-                {% if not manualStatement or readonly %}
-                    {% set submittedAuthorDisabled = true %}
-                {% endif %}
 
                 <div class="u-1-of-2 inline-block u-pr-0_5">
                     {% block submitted_author_label %}
@@ -158,7 +155,7 @@
                         {{ uiComponent('form.label', {
                             id: submittedAuthorId,
                             text: 'name'|trans,
-                            disabled: submittedAuthorDisabled|default(false)
+                            disabled: false
                         }) }}
                     {% endblock submitted_author_label %}
 
@@ -206,7 +203,7 @@
                             name: submittedAuthorId,
                             class: submittedAuthorClass|default,
                             value: submittedAuthorValue,
-                            disabled: submittedAuthorDisabled|default(false),
+                            disabled: false,
                             attributes: ['data-cy=statementDetail:' ~ submittedAuthorId]
                         }) }}
                     {% endif %}
@@ -234,7 +231,6 @@
                     {% set submitterEmailAddressValue = statement.submitterEmailAddress %}
                 {% elseif readonly and manualStatement or not manualStatement %}
                     {# disable input #}
-                    {% set submitterEmailAddressDisabled = true %}
                     {% if statement.anonymous == true %}
                         {% set submitterEmailAddressValue = 'email.address.notavailable.anonymous'|trans %}
                     {% elseif statement.submitterEmailAddress is defined and statement.submitterEmailAddress|trim is not empty %}
@@ -261,7 +257,7 @@
                     elementSize: 'large',
                     elementStyle: submitterEmailAddressStyle|default,
                     elementClass: submitterEmailAddressClass|default,
-                    disabled: submitterEmailAddressDisabled|default(false),
+                    disabled: false,
                     attributes: ['data-cy=statementDetail:submitterEmailAddress']
                 }) }}
             {% endif %}
@@ -359,9 +355,6 @@
                     {% if (manualStatement and readonly) or not manualStatement %}
                         {# disable input fields #}
                         {% set houseNumberDisabled = true %}
-                        {% set streetDisabled = true %}
-                        {% set postalCodeDisabled = true %}
-                        {% set cityDisabled = true %}
 
                         {# if any of these is empty, set value to '-' #}
                         {% if statement.meta.orgaStreet|default == '' %}
@@ -391,7 +384,7 @@
                                 id: 'r_orga_street',
                                 elementClass: 'u-5-of-6 u-pr-0_5',
                                 elementStyle: 'inline-block',
-                                disabled: streetDisabled|default(false),
+                                disabled: false,
                                 attributes: ['data-cy=statementDetail:orgaStreet']
                             }) }}
 
@@ -403,7 +396,7 @@
                                     id: 'r_houseNumber',
                                     elementSize: 'tiny',
                                     elementStyle: 'inline-block',
-                                    disabled: houseNumberDisabled|default(false),
+                                    disabled: false,
                                     attributes: ['data-cy=statementDetail:houseNumber']
                                 }) }}
                             {% endif %}
@@ -418,7 +411,7 @@
                                 id: 'r_orga_postalcode',
                                 elementStyle: 'inline-block',
                                 elementSize: 'tiny',
-                                disabled: postalCodeDisabled|default(false),
+                                disabled: false,
                                 attributes: ['data-cy=statementDetail:orgaPostalcode']
                             }) }}
 
@@ -434,7 +427,7 @@
                                 id: 'r_orga_city',
                                 elementStyle: 'inline-block',
                                 elementClass: cityClasses,
-                                disabled: cityDisabled|default(false),
+                                disabled: false,
                                 attributes: ['data-cy=statementDetail:orgaCity']
                             }) }}
                         </div>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -192,7 +192,8 @@
             {% endif %}
 
             {# email address #}
-            {% if hasPermission('field_statement_submitter_email_address') and (formDefinitions.emailAddress.enabled == true or formDefinitions.phoneOrEmail.enabled == true) %}
+            {# editable if manual statement #}
+            {% if hasPermission('field_statement_submitter_email_address') and (formDefinitions.emailAddress.enabled == true or formDefinitions.phoneOrEmail.enabled == true) or manualStatement %}
 
                 {# set styling for submitterEmailAddress uiComponent, should be moved to component #}
                 {% set submitterEmailAddressClass = 'u-mb-0_5' %}
@@ -206,7 +207,7 @@
                 {% endif %}
 
                 {# set value for submitterEmailAdress, see T10993#231880 for details about possible values #}
-                {% if not readonly %}
+                {% if manualStatement and not readonly %}
                     {# show email address for manual statements #}
                     {% set submitterEmailAddressValue = statement.submitterEmailAddress %}
                 {% elseif readonly and manualStatement or not manualStatement %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -18,35 +18,21 @@
             <h4 class="font-size-large">{{ "submitter.invitable_institution"|trans }}</h4>
 
             {# Submitted by #}
-            {# editable if manualStatement and orga is institution #}
+            {# editable if orga is institution #}
             {% if hasPermission('field_statement_meta_orga_name') %}
                 {% block submitOrga %}
                     {% if statement.meta.orgaName is defined %}
                         {% set orgaNameClass = 'u-mb-0_25 u-pr-0_5' %}
-                        {% if manualStatement and not readonly %}
-                            {% if statement.isSubmittedByCitizen == false%}
-                                {% set orgaNameValue = statement.meta.orgaName|default %}
-                                {% set labelHint = 'institution.name' %}
-                            {% elseif statement.isSubmittedByCitizen %}
-                                {% if statement.meta.miscData.submitterRole|default == 'publicagency' %}
-                                    {% set orgaNameValue = 'institution'|trans %}
-                                {% else %}
-                                    {% set orgaNameValue = 'role.citizen'|trans %}
-                                {% endif %}
-                                {% set orgaNameDisabled = true %}
-                            {% endif %}
-                        {% elseif not manualStatement or readonly %}
-                            {% if statement.isSubmittedByCitizen == false %}
-                                {% set orgaNameValue = statement.meta.orgaName|default('-') %}
-                                {% set orgaNameDisabled = true %}
+                        {% if statement.isSubmittedByCitizen == false%}
+                            {% set orgaNameValue = statement.meta.orgaName|default %}
+                            {% set labelHint = 'institution.name' %}
+                        {% elseif statement.isSubmittedByCitizen %}
+                            {% if statement.meta.miscData.submitterRole|default == 'publicagency' %}
+                                {% set orgaNameValue = 'institution'|trans %}
                             {% else %}
-                                {% if statement.meta.miscData.submitterRole|default == 'publicagency' and statement.meta.orgaName == '' %}
-                                    {% set orgaNameValue = 'institution'|trans %}
-                                {% else %}
-                                    {% set orgaNameValue = 'role.citizen'|trans %}
-                                {% endif %}
-                                {% set orgaNameDisabled = true %}
+                                {% set orgaNameValue = 'role.citizen'|trans %}
                             {% endif %}
+                            {% set orgaNameDisabled = true %}
                         {% endif %}
 
                         {% if hasPermission('field_statement_meta_orga_department_name') and statement.isSubmittedByCitizen == false %}
@@ -80,12 +66,8 @@
             {% endif %}
 
             {# department #}
-            {# editable only if manual statement #}
             {% if hasPermission('field_statement_meta_orga_department_name') %}
                 {% if statement.isSubmittedByCitizen == false %}
-                    {% if not manualStatement or readonly %}
-                        {% set departmentDisabled = true %}
-                    {% endif %}
 
                     {{ uiComponent('form.element', {
                         label: { text: 'department'|trans },
@@ -95,7 +77,7 @@
                         elementSize: 'large',
                         elementStyle: 'inline-block',
                         elementClass: 'u-pl-0_5',
-                        disabled: departmentDisabled|default(false),
+                        disabled: false,
                         attributes: ['data-cy=statementDetail:departmentName']
                     }) }}
                 {% endif %}
@@ -137,7 +119,6 @@
             {% endif %}
 
             {# submitter name #}
-            {# editable only if manualStatement #}
             {% if hasPermission('field_statement_meta_submit_name') and formDefinitions.name.enabled == true %}
 
                 <div class="u-1-of-2 inline-block u-pr-0_5">
@@ -211,8 +192,7 @@
             {% endif %}
 
             {# email address #}
-            {# editable if manual statement #}
-            {% if hasPermission('field_statement_submitter_email_address') and (formDefinitions.emailAddress.enabled == true or formDefinitions.phoneOrEmail.enabled == true) or manualStatement %}
+            {% if hasPermission('field_statement_submitter_email_address') and (formDefinitions.emailAddress.enabled == true or formDefinitions.phoneOrEmail.enabled == true) %}
 
                 {# set styling for submitterEmailAddress uiComponent, should be moved to component #}
                 {% set submitterEmailAddressClass = 'u-mb-0_5' %}
@@ -226,7 +206,7 @@
                 {% endif %}
 
                 {# set value for submitterEmailAdress, see T10993#231880 for details about possible values #}
-                {% if manualStatement and not readonly %}
+                {% if not readonly %}
                     {# show email address for manual statements #}
                     {% set submitterEmailAddressValue = statement.submitterEmailAddress %}
                 {% elseif readonly and manualStatement or not manualStatement %}
@@ -341,9 +321,6 @@
             {% endif %}
 
             {% block address %}
-                {# Address block is not shown if it's not a manual statement and postalcode is empty or if it's a manual
-                   citizen statement and postalcode is empty #}
-                {# editable if manualStatement #}
 
                 {% if hasPermission('field_statement_meta_address') %}
 
@@ -351,28 +328,6 @@
                     {% set houseNumberValue = statement.meta.houseNumber|default %}
                     {% set postalCodeValue = statement.meta.orgaPostalCode|default %}
                     {% set cityValue = statement.meta.orgaCity|default %}
-
-                    {% if (manualStatement and readonly) or not manualStatement %}
-                        {# disable input fields #}
-                        {% set houseNumberDisabled = true %}
-
-                        {# if any of these is empty, set value to '-' #}
-                        {% if statement.meta.orgaStreet|default == '' %}
-                            {% set streetValue = '-' %}
-                        {% endif %}
-
-                        {% if statement.meta.houseNumber|default == '' %}
-                            {% set houseNumberValue = '-' %}
-                        {% endif %}
-
-                        {% if statement.meta.orgaPostalCode|default == '' %}
-                            {% set postalCodeValue = '-' %}
-                        {% endif %}
-
-                        {% if statement.meta.orgaCity|default == '' %}
-                            {% set cityValue = '-' %}
-                        {% endif %}
-                    {% endif %}
 
                     <div class="u-1-of-1">
                       {% if hasPermission('field_statement_meta_street') and (formDefinitions.streetAndHouseNumber.enabled == true or formDefinitions.street.enabled == true) %}
@@ -615,82 +570,56 @@
                 }) }}
 
                 {# Procedure phase
-                   editable if manualStatement
                    display internal phases if submitter is not a citizen, otherwise display external phases
                 #}
                 {% if hasPermission('field_statement_phase') %}
                     {% set procedurePhaseOptGroups = {} %}
                     {% set procedurePhaseOptions = {} %}
-
-                    {% if not manualStatement or readonly %}
-                        {# disable select #}
-                        {% set procedurePhaseSelectDisabled = true %}
-
-                        {# set selected option #}
-                        {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
-                            label: statement.phase,
-                            value: '',
-                            selected: true
-                        }]) %}
-
-                        {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
-
-                    {% elseif manualStatement and not readonly %}
-                        {# set all options for optgroups only for edit-mode #}
-                        {% if statement.isSubmittedByCitizen == false and hasPermission('field_show_internal_procedure_phases_in_dropdown') %}
-                            {% set phases = templateVars.internalPhases|default %}
-                        {% else %}
-                            {% set phases = templateVars.externalPhases|default %}
-                        {% endif %}
-
-                        {% for phase in phases %}
-                            {% if phase.name == statement.phase %}
-                                {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
-                                    label: phase.name,
-                                    value: phase.key,
-                                    selected: true
-                                }]) %}
-                            {% else %}
-                                {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
-                                    label: phase.name,
-                                    value: phase.key
-                                }]) %}
-                            {% endif %}
-                        {% endfor %}
-
-                        {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
+                    {% if statement.isSubmittedByCitizen == false and hasPermission('field_show_internal_procedure_phases_in_dropdown') %}
+                        {% set phases = templateVars.internalPhases|default %}
+                    {% else %}
+                        {% set phases = templateVars.externalPhases|default %}
                     {% endif %}
-                        {{ uiComponent('form.row', {
-                            elements: [
-                                {
-                                    label: { text: 'procedure.public.phase'|trans },
-                                    control: procedurePhaseControlOptions,
-                                    type: 'select',
-                                    id: 'Phase',
-                                    elementSize: 'large',
-                                    elementClass: 'u-pr-0_5',
-                                    disabledPlainText: true,
-                                    disabled: procedurePhaseSelectDisabled|default(false),
-                                    attributes: ['data-cy=statementDetail:Phase']
-                                }
-                            ]
-                        }) }}
+
+                    {% for phase in phases %}
+                        {% if phase.name == statement.phase %}
+                            {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
+                                label: phase.name,
+                                value: phase.key,
+                                selected: true
+                            }]) %}
+                        {% else %}
+                            {% set procedurePhaseOptions = procedurePhaseOptions|merge([{
+                                label: phase.name,
+                                value: phase.key
+                            }]) %}
+                        {% endif %}
+                    {% endfor %}
+
+                    {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
+
+                    {{ uiComponent('form.row', {
+                        elements: [
+                            {
+                                label: { text: 'procedure.public.phase'|trans },
+                                control: procedurePhaseControlOptions,
+                                type: 'select',
+                                id: 'Phase',
+                                elementSize: 'large',
+                                elementClass: 'u-pr-0_5',
+                                disabledPlainText: true,
+                                disabled: false,
+                                attributes: ['data-cy=statementDetail:Phase']
+                            }
+                        ]
+                    }) }}
                 {% endif %}
 
                 {# elements for form.row component are merged into this object: date authored, date submitted and submit type #}
                 {% set authorDateRowElements = {} %}
 
-                {# date submitted - editable if manualStatement #}
-                {% if not manualStatement or readonly %}
-                    {% set submitDateDisabled = true %}
-                {% endif %}
-
                 {# date authored #}
-                {# editable if manualStatement #}
                 {% if statement.meta.authoredDate is defined %}
-                    {% if not manualStatement or readonly %}
-                        {% set authoredDateDisabled = true %}
-                    {% endif %}
                     {% if statement.meta.authoredDate|dplanDate() != '' %}
                         {% set authoredDateValue = statement.meta.authoredDate|default()|dplanDate() %}
                     {% elseif statement.meta.authoredDate|dplanDate() == '' and readonly %}
@@ -709,11 +638,11 @@
                             dataCy: 'statementDetail:authoredDate',
                             maxDate: 'now'|date('d.m.Y')
                         },
-                        type: submitDateDisabled|default(false) ? 'text' : 'datepicker',
+                        type: 'text',
                         id: 'r_authored_date',
                         elementSize: 'small',
                         elementStyle: 'inline-block',
-                        disabled: submitDateDisabled|default(false)
+                        disabled: false
                     }]) %}
                 {% endif %}
 
@@ -728,37 +657,24 @@
                         class: 'u-5-of-6 o-form__control-wrapper',
                         dataCy: 'statementDetail:submittedDate'
                     },
-                    type: submitDateDisabled|default(false) ? 'text' : 'datepicker',
+                    type: 'text',
                     id: 'r_submitted_date',
                     elementSize: 'small',
                     elementStyle: 'inline-block',
-                    disabled: submitDateDisabled|default(false)
+                    disabled: false
                 }]) %}
 
                 {# show submit type, if feature is set and value differs from 'system' (-> manual statement) #}
-                {# editable only if manualStatement #}
                 {% if hasPermission('field_statement_submit_type') %}
                     {% set submitTypeSelectOptions = {} %}
-                    {% if not manualStatement or readonly %}
-                        {% set submitTypeSelectDisabled = true %}
+                    {% for value, label in getFormOption('statement_submit_types.values', true)|filter(value => value != 'system') %}
+                        {% if value != statement.submitType %}
+                            {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value }]) %}
+                        {% else %}
+                            {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
+                        {% endif %}
+                    {% endfor %}
 
-                        {% for value, label in getFormOption('statement_submit_types.values', true) %}
-                            {% if value == statement.submitType %}
-                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
-                            {% endif %}
-                        {% endfor %}
-
-                    {% elseif manualStatement and not readonly %}
-                        {# the default option is skipped in this case, since it is the value for "system" (submitted
-                          by using the platform), which is no valid value for a manual statement #}
-                        {% for value, label in getFormOption('statement_submit_types.values', true)|filter(value => value != 'system') %}
-                            {% if value != statement.submitType %}
-                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value }]) %}
-                            {% else %}
-                                {% set submitTypeSelectOptions = submitTypeSelectOptions|merge([{ label: label, value: value, selected: true }]) %}
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
 
                     {% set authorDateRowElements = authorDateRowElements|merge([{
                         label: { text: 'submit.type'|trans },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -212,6 +212,7 @@
                     {% set submitterEmailAddressValue = statement.submitterEmailAddress %}
                 {% elseif readonly and manualStatement or not manualStatement %}
                     {# disable input #}
+                    {% set submitterEmailAddressDisabled = true %}
                     {% if statement.anonymous == true %}
                         {% set submitterEmailAddressValue = 'email.address.notavailable.anonymous'|trans %}
                     {% elseif statement.submitterEmailAddress is defined and statement.submitterEmailAddress|trim is not empty %}
@@ -238,7 +239,7 @@
                     elementSize: 'large',
                     elementStyle: submitterEmailAddressStyle|default,
                     elementClass: submitterEmailAddressClass|default,
-                    disabled: false,
+                    disabled: submitterEmailAddressDisabled|default(false),
                     attributes: ['data-cy=statementDetail:submitterEmailAddress']
                 }) }}
             {% endif %}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15328/BLP-Einreicherdaten-in-STN-immer-editierbar-machen


Description: 
- make submitter data always editable : submitter fields in 'assessment_statement_detail_statement_data.html.twig' have to be always editable
- adjust statement update condition : not manual statement can be updated too
- email address will not be editable

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
