### PR TITLE
use meaningful data-cy names instead of loop values

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -19861,21 +19861,21 @@
         },
         {
             "name": "goetas-webservices/xsd2php",
-            "version": "0.4.13",
+            "version": "0.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/goetas-webservices/xsd2php.git",
-                "reference": "95db4b604bab8a893e59a403474e87430ef9972b"
+                "reference": "1c4d79e4572beaf4a786d16be690c6b18d575deb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/goetas-webservices/xsd2php/zipball/95db4b604bab8a893e59a403474e87430ef9972b",
-                "reference": "95db4b604bab8a893e59a403474e87430ef9972b",
+                "url": "https://api.github.com/repos/goetas-webservices/xsd2php/zipball/1c4d79e4572beaf4a786d16be690c6b18d575deb",
+                "reference": "1c4d79e4572beaf4a786d16be690c6b18d575deb",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^2.0",
-                "goetas-webservices/xsd-reader": "^0.3.7 | ^0.4.1",
+                "goetas-webservices/xsd-reader": "^0.4.7",
                 "laminas/laminas-code": "^3.3.2|^4.0",
                 "php": ">=7.2|^8.0",
                 "psr/log": "^1.0 | ^2.0 | ^3.0",
@@ -19926,7 +19926,7 @@
             ],
             "support": {
                 "issues": "https://github.com/goetas-webservices/xsd2php/issues",
-                "source": "https://github.com/goetas-webservices/xsd2php/tree/0.4.13"
+                "source": "https://github.com/goetas-webservices/xsd2php/tree/0.4.14"
             },
             "funding": [
                 {
@@ -19942,7 +19942,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-03-22T12:45:50+00:00"
+            "time": "2025-03-13T19:59:00+00:00"
         },
         {
             "name": "liip/functional-test-bundle",

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/includes/assessment_table_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/includes/assessment_table_pageheader.html.twig
@@ -24,20 +24,21 @@
             label: 'considerationtable',
             feature: 'area_admin_assessmenttable',
             key: 'assessment_table',
-            datacy: 'assessmentTable'
+            datacy: 'assessmentTable:view'
         },
         {
             href: path('DemosPlan_statement_orga_list', {'procedureId': procedureId}),
             label: 'statements.collected.list',
             feature: 'area_statement_data_input_orga',
-            key: 'collected_list'
+            key: 'collected_list',
+            datacy: 'assessmentTable:list'
         },
         {
             href: path('dplan_assessmenttable_view_original_table', {'procedureId': procedureId, 'filterHash': originalFilterHash}) ~ statement_original_hash|default,
             label: 'statements.original',
             feature: 'area_admin_assessmenttable',
             key: 'assessment_table_original',
-            datacy: 'assessmentTableOriginal'
+            datacy: 'assessmentTable:viewOriginal'
         },
         {
             href: path('DemosPlan_statement_new_submitted', {'procedureId': procedureId}),
@@ -45,7 +46,7 @@
             feature: 'feature_statement_data_input_orga',
             icon: 'fa-plus',
             key: 'new_statement',
-            datacy: 'createStatement'
+            datacy: 'assessmentTable:createStatement'
         }
     ],
     assessment_table_back: [

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement.html.twig
@@ -25,6 +25,7 @@
         {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
             heading: heading ~ ' ' ~ externId|default,
             subnav: [{
+                datacy: 'assessmentStatement:saveChanges',
                 href: '#',
                 id: 'statementHistory',
                 label: 'history',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_pageheader.html.twig
@@ -74,7 +74,7 @@
                 <li class="inline-block {{ loop.last ?: 'u-mr-0_5' }}">
                     <a
                         class="{{ item.current|default == true  ? 'o-link--active' : 'o-link--default' }} whitespace-nowrap"
-                        :data-cy="`pageHeader:item:{{ loop.index }}`"
+                        :data-cy="`pageHeader:item:{{ item.datacy }}`"
                         href="{{ item.href }}"
                         {% if item.datacy|default != '' %}data-cy="{{ item.datacy }}"{% endif %}
                         {% if item.id|default != '' %}id="{{ item.id }}"{% endif %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_list_survey_comments.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_list_survey_comments.html.twig
@@ -5,10 +5,12 @@
         heading: 'survey.comments.moderate'|trans,
         subnav: [
             {
+                datacy: 'administrationList:editSurvey',
                 href: path('dplan_survey_edit', { 'procedureId': procedure, 'surveyId': surveyId }),
                 label: 'survey.edit'
             },
             {
+                datacy: 'administrationList:moderateSurveyComments',
                 href: path('dplan_survey_show', { 'procedureId': procedure, 'surveyId': surveyId }),
                 label: 'survey.comments.moderate',
                 current: true

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_new_member_list_mastertoeblist.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_new_member_list_mastertoeblist.html.twig
@@ -13,11 +13,13 @@
     {# Page Header #}
     {% if hasPermission('area_report_mastertoeblist') %}
         {% set subnav = [{
+                datacy: 'administrationNewMemberList:backToList',
                 href: path('DemosPlan_procedure_member_index',{'procedure': procedure}),
                 label: 'invitable_institution.list.back'|trans,
                 icon: 'fa-arrow-circle-left'
             },
             {
+                datacy: 'administrationNewMemberList:report',
                 href: path('DemosPlan_user_mastertoeblist_report', {'procedure': procedure }),
                 label: 'invitable_institution.master.report'|trans,
                 icon: 'fa-bell'

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_survey_form.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_survey_form.html.twig
@@ -5,11 +5,13 @@
         heading: (surveyId is defined ? 'survey.edit' : 'survey.new')|trans,
         subnav: surveyId is defined ? [
             {
+                datacy: 'administrationSurveyForm:edit',
                 href: path('dplan_survey_edit', { 'procedureId': procedure, 'surveyId': surveyId }),
                 label: 'survey.edit',
                 current: true
             },
             {
+                datacy: 'administrationSurveyForm:moderateComments',
                 href: path('dplan_survey_show', { 'procedureId': procedure, 'surveyId': surveyId }),
                 label: 'survey.comments.moderate'
             }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/administration_publicagency_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/includes/administration_publicagency_pageheader.html.twig
@@ -12,12 +12,14 @@
 
 {% set subnav = [
     {
+        datacy: 'administrationPublicagency:administer',
         current: 'publicagency_registered' == highlighted|default,
         href: path('DemosPlan_procedure_member_index', {'procedure': procedureId}),
         label: 'invitable_institution.administer',
         feature: 'area_admin_invitable_institution'
     },
     {
+        datacy: 'administrationPublicagency:inviteUnregistered',
         current: 'publicagency_unregistered' == highlighted|default,
         href: path('DemosPlan_invite_unregistered_public_agency_list', {'procedureId': procedureId}),
         label: 'invitable_institution.unregistered.invite',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/DemosPlanAssessment/cluster_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/DemosPlanAssessment/cluster_detail.html.twig
@@ -15,6 +15,7 @@
         {% include '@DemosPlanCore/DemosPlanCore/includes/base_pageheader.html.twig' with {
             heading: 'statement.cluster'|trans ~ ' ' ~ statement.externId|default,
             subnav: [{
+                datacy: 'clusterDetail:saveChanges',
                 href: '#',
                 id: 'groupHistory',
                 label: 'history',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_original_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_original_statements.html.twig
@@ -14,15 +14,15 @@
             {
                 href: path('dplan_procedure_statement_list', { procedureId: procedureId }),
                 label: 'statements'|trans,
-                datacy: 'listStatements:statementList',
+                datacy: 'listOriginalStatements:list',
                 feature: 'area_admin_original_statement_list'
             },
             {
-            href: path(path, { procedureId: procedureId }),
-            label:  'statement.new'|trans,
-            datacy: 'createStatement',
-            icon: 'fa-plus',
-            feature: permission
+                href: path(path, { procedureId: procedureId }),
+                label:  'statement.new'|trans,
+                datacy: 'listOriginalStatements:createStatement',
+                icon: 'fa-plus',
+                feature: permission
             }
         ]|filter(item => hasPermission(item.feature)),
         flush: true

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -20,7 +20,7 @@
                 {
                     href: path(path, { procedureId: procedureId }),
                     label:  'statement.new'|trans,
-                    datacy: 'createStatement',
+                    datacy: 'listStatements:createStatement',
                     icon: 'fa-plus',
                     feature: permission
                 }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/includes/mastertoeblist_pageheader.html.twig
@@ -8,12 +8,14 @@
 
 {% set subnav = [
     {
+        datacy: 'mastertoeblist',
         current: 'mastertoeblist' == highlighted|default,
         href: path('DemosPlan_user_mastertoeblist'),
         label: 'invitable_institution.master',
         feature: 'area_manage_mastertoeblist'
     },
     {
+        datacy: 'mastertoeblist:report',
         current: 'mastertoeblist_report' == highlighted|default,
         href: path('DemosPlan_user_mastertoeblist_report'),
         label: 'invitable_institution.master.report'|trans,
@@ -21,6 +23,7 @@
         icon: 'fa-bell'
     },
     {
+        datacy: 'mastertoeblist:merge',
         current: 'mastertoeblist_merge' == highlighted|default,
         href: path('DemosPlan_user_mastertoeblist_merge'),
         label: 'invitable_institution.master.merge'|trans,


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-12672/DiplanROG-neue-Stellungnahme-Hook-zurucksetzen

**Description:** This PR updates `data-cy` values:  ad to each each `subnav` item a data-cy attribute, to use it for testing purposes.

**Changes to the existing hooks (testers have been informed):**
createStatement --> listStatements:createStatement
listStatements:statementList --> listOriginalStatements:list
statement.new --> listOriginalStatements:createStatement

**Assessment table:**
assessmentTable --> assessmentTable:view
assessmentTableOriginal --> assessmentTable:viewOriginal
createStatement --> ssessmentTable:createStatement


- [ ] Create/Update tests
- [ ] Update documentation
- [x] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
