### PR TITLE
refac(DPLAN-12672): adjust base page header hook

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_pageheader.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/includes/base_pageheader.html.twig
@@ -74,7 +74,7 @@
                 <li class="inline-block {{ loop.last ?: 'u-mr-0_5' }}">
                     <a
                         class="{{ item.current|default == true  ? 'o-link--active' : 'o-link--default' }} whitespace-nowrap"
-                        :data-cy="`pageHeader:item:{{ item.datacy }}`"
+                        :data-cy="`pageHeader:{{ item.datacy }}`"
                         href="{{ item.href }}"
                         {% if item.datacy|default != '' %}data-cy="{{ item.datacy }}"{% endif %}
                         {% if item.id|default != '' %}id="{{ item.id }}"{% endif %}


### PR DESCRIPTION
### Ticket
[DPLAN-12672](https://demoseurope.youtrack.cloud/issue/DPLAN-12672/DiplanROG-neue-Stellungnahme-Hook-zurucksetzen)

**Description:** Adjust the page header hook by removing the redundant ':item' segment.

- [ ] Create/Update tests
- [ ] Update documentation
- [x] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
