### PR TITLE
refac(DPLAN-15263): update the core to use the new custom dialog

### DIFF
--- a/client/js/components/tags/TagListEditForm.vue
+++ b/client/js/components/tags/TagListEditForm.vue
@@ -71,12 +71,16 @@
             icon="xmark" />
         </button>
       </div>
+      <dp-confirm-dialog
+        ref="confirmDialog"
+        :message="setConfirmMessage()" />
     </div>
   </div>
 </template>
 
 <script>
 import {
+  DpConfirmDialog,
   DpContextualHelp,
   DpIcon,
   DpInput
@@ -88,6 +92,7 @@ export default {
 
   components: {
     AddonWrapper,
+    DpConfirmDialog,
     DpContextualHelp,
     DpIcon,
     DpInput
@@ -128,18 +133,26 @@ export default {
       this.$emit('abort')
     },
 
-    deleteItem () {
-      const { type, attributes, children, id } = this.nodeElement
+    async deleteItem () {
+      const { type, id } = this.nodeElement
+
+      if (this.$refs.confirmDialog?.open) {
+        const isConfirmed = await this.$refs.confirmDialog.open()
+
+        if (isConfirmed) {
+          this.$emit('delete', { id, type })
+        }
+      }
+    },
+
+    setConfirmMessage () {
+      const { type, attributes, children } = this.nodeElement
       const isTagTopic = type === 'TagTopic'
       const topicConfirmMessage = isTagTopic && children?.length === 0 ? 'check.topic.delete' : 'check.topic.delete.tags'
 
-      const confirmMessage = isTagTopic
+      return isTagTopic
         ? Translator.trans(topicConfirmMessage, { topic: attributes.title })
         : Translator.trans('check.tag.delete', { tag: attributes.title })
-
-      if (window.dpconfirm(confirmMessage)) {
-        this.$emit('delete', { id, type })
-      }
     },
 
     editItem () {

--- a/client/js/components/tags/TagListEditForm.vue
+++ b/client/js/components/tags/TagListEditForm.vue
@@ -7,7 +7,7 @@
       v-model="unsavedItem.title" />
     <div
       v-else
-      class="flex-1"
+      class="flex-1 break-words"
       v-text="nodeElement.attributes.title" />
     <div class="text-center w-9">
       <dp-contextual-help
@@ -73,6 +73,7 @@
       </div>
       <dp-confirm-dialog
         ref="confirmDialog"
+        data-cy="removeTagOrTopic"
         :message="setConfirmMessage()" />
     </div>
   </div>


### PR DESCRIPTION
**Ticket:** https://demoseurope.youtrack.cloud/issue/DPLAN-15263/Custom-confirm-Dialog-anstelle-des-nativen-Dialogs-window.confirm

**Description:** Update core to use new DpConfirmDialog, which replaces the native window.confirm functionality, as it is not accessible in certain situations (for example, when a user clicks to close all alert messages). 

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
