### PR TITLE
chore: bump demosplan-ui from 0.4.8 to 0.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^9.2.0",
-    "@demos-europe/demosplan-ui": "0.4.8",
+    "@demos-europe/demosplan-ui": "0.4.9",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,9 +2025,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.8":
-  version: 0.4.8
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.8"
+"@demos-europe/demosplan-ui@npm:0.4.9":
+  version: 0.4.9
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.9"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2079,7 +2079,7 @@ __metadata:
     vue-multiselect: "npm:^3.1.0"
     vue-omnibox: "npm:^0.3.7"
     vue-sliding-pagination: "npm:^1.3.2"
-  checksum: 10c0/41dbd20a0cd29d5b964baca4bcfe0be1cb4e5ecdab7d6208b9f2cad02b52048cd217bf8bc084180475a9fea3349182d2584fbbe98528c1ee7c69f347bfd0edc5
+  checksum: 10c0/d89ead6ab1336248daad0625de4ec5063626d23f2dbe58ce5f93e25e630ba5f12c2a16f42483534481f6e78e90dc32109865ddd72d3f74a101d8c49bb8faaa5a
   languageName: node
   linkType: hard
 
@@ -12385,7 +12385,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^9.2.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.8"
+    "@demos-europe/demosplan-ui": "npm:0.4.9"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"


### PR DESCRIPTION
The new version contains a fix for DpTreeList so that the toggle is not displayed if the list is empty.

