### PR TITLE
f DPLAN-15354 keep customer ID after the soft delete procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -910,7 +910,6 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
             foreach ($procedureIds as $procedureId) {
                 $data = [
                     'ident'    => $procedureId,
-                    'customer' => null,
                     'deleted'  => true,
                 ];
 

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -563,7 +563,6 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
         }
         if (array_key_exists('deleted', $data)) {
             $procedure->setDeleted($data['deleted']);
-            $procedure->setCustomer(null);
             $procedure->setProcedureCategories([]);
             $procedure->setDeletedDate(Carbon::now());
         }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15354/Customer-ID-nach-dem-Soft-Delete-Verfahren-behalten

Description: Keep customer ID after the soft delete procedure

### How to review/test
 - delete a procedure
 - check in the DB if the deleted procedure still has its customer Id

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly



