### PR TITLE
feat(DPLAN-15376):  display user information (such as department or role) for a newly added user

### DIFF
--- a/client/js/components/user/DpCreateItem.vue
+++ b/client/js/components/user/DpCreateItem.vue
@@ -50,7 +50,7 @@
 <script>
 import { DpAccordion, DpButtonRow, dpValidateMixin } from '@demos-europe/demosplan-ui'
 import { defineAsyncComponent } from 'vue'
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 
 export default {
   name: 'DpCreateItem',
@@ -215,6 +215,14 @@ export default {
       createUser: 'create'
     }),
 
+    ...mapMutations('AdministratableUser', {
+      updateAdministratableUser: 'setItem'
+    }),
+
+    ...mapMutations('Orga', {
+      updateOrga: 'setItem'
+    }),
+
     changeTypeToPascalCase (payload) {
       const newPayload = {
         ...payload,
@@ -266,7 +274,11 @@ export default {
       if (this.entity === 'user') {
         if (this.dpValidate.newUserForm) {
           this.createUser(this.itemResource)
-            .then(() => {
+            .then(response => {
+              const { type: userType, relationships = {} } = this.itemResource
+              const newUser = Object.values(response.data[userType])[0]
+              const payload = { ...newUser, relationships }
+              this.updateAdministratableUser({ ...payload, id: newUser.id })
               this.reset()
               dplan.notify.notify('confirm', Translator.trans('confirm.user.created'))
             })

--- a/client/js/components/user/DpCreateItem.vue
+++ b/client/js/components/user/DpCreateItem.vue
@@ -219,10 +219,6 @@ export default {
       updateAdministratableUser: 'setItem'
     }),
 
-    ...mapMutations('Orga', {
-      updateOrga: 'setItem'
-    }),
-
     changeTypeToPascalCase (payload) {
       const newPayload = {
         ...payload,

--- a/client/js/components/user/DpUserList/DpUserFormFields.vue
+++ b/client/js/components/user/DpUserList/DpUserFormFields.vue
@@ -289,6 +289,15 @@ export default {
     }
   },
 
+  watch: {
+    user: {
+      handler () {
+        this.localUser = JSON.parse(JSON.stringify(this.user))
+      },
+      deep: true
+    }
+  },
+
   methods: {
     ...mapMutations('Orga', ['setItem']),
 

--- a/client/js/components/user/DpUserList/DpUserListItem.vue
+++ b/client/js/components/user/DpUserList/DpUserListItem.vue
@@ -38,7 +38,7 @@
             data-cy="editItemToggle"
             class="layout">
             <div class="layout__item u-1-of-1 weight--bold u-mb-0_5 o-hellip--nowrap">
-              {{ initialUser.attributes.firstname }} {{ initialUser.attributes.lastname }}
+              {{ user.attributes.firstname }} {{ user.attributes.lastname }}
             </div>
             <div
               class="u-1-of-2 layout__item"
@@ -166,11 +166,6 @@ export default {
   },
 
   computed: {
-    ...mapState('AdministratableUser', {
-      initialUser (state) {
-        return state.initial[this.user.id]
-      }
-    }),
     ...mapState('Role', {
       roles: 'items'
     }),
@@ -180,21 +175,21 @@ export default {
     },
 
     hasDepartment () {
-      return this.initialUser.hasRelationship('department')
+      return this.user.hasRelationship('department')
     },
 
     hasOrga () {
-      return this.initialUser.hasRelationship('orga') && typeof this.initialUser.relationships.orga !== 'undefined' && this.initialUser.relationships.orga !== null
+      return this.user.hasRelationship('orga') && typeof this.user.relationships.orga !== 'undefined' && this.user.relationships.orga !== null
     },
 
     hasRoles () {
-      return this.initialUser.hasRelationship('roles')
+      return this.user.hasRelationship('roles')
     },
 
     // Check if user name, roles, organisation or department match the entered search string
     isInFilter () {
       return (this.filterValue === '' ||
-        this.initialUser.attributes.fullName.toLowerCase().includes(this.filterValue.toLowerCase()) ||
+        this.user.attributes.fullName.toLowerCase().includes(this.filterValue.toLowerCase()) ||
         /*
          * For now, we don't want to filter by email, because email is not displayed in closed user item - this might confuse users
          * this.user.attributes.email.toLowerCase().includes(this.filterValue.toLowerCase()) ||
@@ -210,15 +205,15 @@ export default {
     },
 
     userDepartment () {
-      return this.hasDepartment ? this.initialUser.relationships.department.get() : null
+      return this.hasDepartment ? this.user.relationships.department.get() : null
     },
 
     userOrga () {
-      return this.hasOrga ? this.initialUser.relationships.orga.get() : null
+      return this.hasOrga ? this.user.relationships.orga.get() : null
     },
 
     userRoles () {
-      return this.hasRoles ? this.initialUser.relationships.roles.list() : null
+      return this.hasRoles ? this.user.relationships.roles.list() : null
     },
 
     userRolesNames () {


### PR DESCRIPTION
### Ticket
[DPLAN-15376](https://demoseurope.youtrack.cloud/issue/DPLAN-15376/User-hinzufugen-Wenn-man-zuerst-Institution-Abteilung-und-Rolle-wahlt-wird-die-Rolle-nur-nach-Seitenrefresh-angezeigt-und-Form)

**Description:** This PR fixes an issue where the user information (such as department or role) for a newly added user was displayed only after the page reload.

- DpCreateItem: after creating a new user, update the store with the new user and its relationship
- DpUserFormFields: since `localUser` was added in the created hook, the actual data with its relationships was not available. A watcher on user was added to detect updates
- DpUserListItem: it seems that calling `state.initial[this.user.id]` from the state is redundant, as `DpUserListItem` already receives an actual user via props

### How to review/test

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
