### PR TITLE
DPLAN-15259  bump addon auto-install versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "cocur/slugify": "^4.0",
     "composer/composer": "^2.8",
     "composer/package-versions-deprecated": "1.11.99.5",
-    "demos-europe/demosplan-addon": "0.50",
+    "demos-europe/demosplan-addon": "0.51",
     "doctrine/annotations": "^2.0",
     "doctrine/common": "^3.2",
     "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0faa2c3881008291ff4085c8f6559a8",
+    "content-hash": "390f661b3332fa218156e5afabb58f4b",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1637,16 +1637,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.50",
+            "version": "v0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "8df8cf14cfb856cbb012e83aa81488f6d2af8d57"
+                "reference": "64248923b17d0be8f67aca6cfff813643403f6a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/8df8cf14cfb856cbb012e83aa81488f6d2af8d57",
-                "reference": "8df8cf14cfb856cbb012e83aa81488f6d2af8d57",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/64248923b17d0be8f67aca6cfff813643403f6a9",
+                "reference": "64248923b17d0be8f67aca6cfff813643403f6a9",
                 "shasum": ""
             },
             "require": {
@@ -1712,9 +1712,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.50"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.51"
             },
-            "time": "2025-03-31T09:45:16+00:00"
+            "time": "2025-04-04T08:57:29+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/config/services.yml
+++ b/config/services.yml
@@ -1182,6 +1182,8 @@ services:
         lazy: true
         parent: demosplan\DemosPlanCoreBundle\Logic\CoreService
 
+    DemosEurope\DemosplanAddon\Contracts\Services\OrgaServiceInterface: '@demosplan\DemosPlanCoreBundle\Logic\User\OrgaService'
+
     demosplan\DemosPlanCoreBundle\Logic\User\OrgaService:
         lazy: true
         parent: demosplan\DemosPlanCoreBundle\Logic\CoreService

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use DemosEurope\DemosplanAddon\Contracts\Services\OrgaServiceInterface;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\AnonymousUser;
@@ -56,7 +57,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class OrgaService extends CoreService
+class OrgaService extends CoreService implements OrgaServiceInterface
 {
     /** @var MailService */
     protected $mailService;
@@ -834,7 +835,7 @@ class OrgaService extends CoreService
     }
 
     /**
-     * Get single orgaobject by filter.
+     * Gets a list of orgaInterfaces by filter.
      *
      * @param array $filter
      *


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15131/alt-EA5226-ADO-10592-DiPlanBeteiligung-ubernimmt-beim-Erstellen-eines-Beteiligungsverfahrens-den-Geltungsbereich-und-zeigt-diese

Description:
bump demosplan-addon version to include a orgaService Interface
linked pr: https://github.com/demos-europe/demosplan-addon/pull/138
