### PR TITLE
chore(refs DPLAN-15320, #AB9149): bump demosplan-ui to v0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^9.2.0",
-    "@demos-europe/demosplan-ui": "0.4.9",
+    "@demos-europe/demosplan-ui": "0.4.11",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,9 +2025,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.9":
-  version: 0.4.9
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.9"
+"@demos-europe/demosplan-ui@npm:0.4.11":
+  version: 0.4.11
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.11"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2078,8 +2078,8 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-omnibox: "npm:^0.3.7"
-    vue-sliding-pagination: "npm:^1.3.2"
-  checksum: 10c0/d89ead6ab1336248daad0625de4ec5063626d23f2dbe58ce5f93e25e630ba5f12c2a16f42483534481f6e78e90dc32109865ddd72d3f74a101d8c49bb8faaa5a
+    vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
+  checksum: 10c0/f4da040b137cb8ad3621e4c06cc7c9f18c0b0da7aa8ac0029308cd16eb7da23f01f5778514856766d4fbde692061c08dd11981d2458e5cf274482229c89e9021
   languageName: node
   linkType: hard
 
@@ -3709,7 +3709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compat@npm:3.5.13":
+"@vue/compat@npm:3.5.13, @vue/compat@npm:^3.4.38":
   version: 3.5.13
   resolution: "@vue/compat@npm:3.5.13"
   dependencies:
@@ -12385,7 +12385,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^9.2.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.9"
+    "@demos-europe/demosplan-ui": "npm:0.4.11"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"
@@ -14405,6 +14405,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue-sliding-pagination@npm:^v2.0.0-alpha-1":
+  version: 2.0.0-alpha-1
+  resolution: "vue-sliding-pagination@npm:2.0.0-alpha-1"
+  dependencies:
+    "@vue/compat": "npm:^3.4.38"
+    vue: "npm:^3.4.38"
+  checksum: 10c0/07ba8090a8ced7b5526058d2f9a9441fb2fe379954236a1261d272020d135a5b5c06fefc564d2498dd1d4efefa0df4e79833d3d9a39941157eb6500786240d88
+  languageName: node
+  linkType: hard
+
 "vue-style-loader@npm:~4.1.3":
   version: 4.1.3
   resolution: "vue-style-loader@npm:4.1.3"
@@ -14437,7 +14447,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:3.5.13":
+"vue@npm:3.5.13, vue@npm:^3.4.38":
   version: 3.5.13
   resolution: "vue@npm:3.5.13"
   dependencies:


### PR DESCRIPTION
the new version contains
- a spacing fix for the flyout trigger in DpFlyout/DpResettableInput
- an update of vue-sliding-pagination that is compatible with vue 3
- a new component DpConfirmDialog
