### PR TITLE
chore: validate fields before triggering addon calls

### DIFF
--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -233,19 +233,19 @@ export default {
       const addonExists = !!window.dplan.loadedAddons['addon.additional.field']
       const addonHasValue = !!this.addonPayload.value || !!this.addonPayload.initValue
 
-      if (addonExists && addonHasValue) {
-        this.handleAddonRequest().then(() => {
+      this.dpValidateAction('configForm', () => {
+        if (addonExists && addonHasValue) {
+          this.handleAddonRequest().then(() => {
+            this.submitConfigForm()
+          })
+        } else {
           this.submitConfigForm()
-        })
-      } else {
-        this.submitConfigForm()
-      }
+        }
+      }, false)
     },
 
     submitConfigForm () {
-      this.dpValidateAction('configForm', () => {
-        this.$refs.configForm.submit()
-      }, false)
+      this.$refs.configForm.submit()
     },
 
     unselectAllAuthUsers () {


### PR DESCRIPTION
This pull request includes a change to the `DpBasicSettings.vue` file to improve the validation and submission process of the configuration form. The main adjustments involve moving the `dpValidateAction` call to a different part of the code to ensure proper validation before form submission.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
