### PR TITLE
bug(refs DPLAN-15396): Fix custom search

### DIFF
--- a/client/js/components/procedure/SegmentsList/CustomSearch.vue
+++ b/client/js/components/procedure/SegmentsList/CustomSearch.vue
@@ -182,6 +182,7 @@ export default {
     handleChange (field, selected = null) {
       this.toggleField(field, selected)
       this.broadcastChanges()
+      this.handleSearch(this.currentSearchTerm)
     },
 
     handleSearch (term) {

--- a/client/js/components/statement/listStatements/CustomSearchStatements.vue
+++ b/client/js/components/statement/listStatements/CustomSearchStatements.vue
@@ -161,7 +161,6 @@ export default {
     toggleAllFields (selectAll) {
       this.selectedFields = selectAll ? this.filterCheckBoxesItems.map(({ value }) => value) : []
       this.broadcastChanges()
-      this.handleSearch(this.currentSearchTerm)
     },
 
     // Check or uncheck single field. To prevent duplication, the array is checked for the field.


### PR DESCRIPTION
### Ticket
DPLAN-15396

- Remove handleSearch from toggleAllFields, because it is not needed and sets the searchTerm falsly after resetting
- Add handleSearch to handleChange, because we need to update items list after changes

### How to review/test
- Use current main from demosplan-ui
- Verfahren -> Stellungnahmen -> Use search -> Resetting the search should show whole list and remove search term from search input
- Verfahren -> Abschnitte:
  - Copy paste a word into search input -> Search should work
  - Search for something -> Click settings in search field -> toggle all fields -> List should be updated



### Linked PRs (optional)
https://github.com/demos-europe/demosplan-ui/pull/1236


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
