### PR TITLE
f-DPLAN-15372 set visibility group id to null when unset overlays

### DIFF
--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -893,14 +893,14 @@ export default {
             this.setAttributeForLayer({
               id: relatedLayers[i].id,
               attribute: 'visibilityGroupId',
-              value: ''
+              value: null
             })
           }
         } else {
           this.setAttributeForLayer({
             id: this.layer.id,
             attribute: 'visibilityGroupId',
-            value: ''
+            value: null
           })
         }
       } else {

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/04/Version20250409062943.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/04/Version20250409062943.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250409062943 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-15372: set gislayer visibility_group_id to null if empty';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql("UPDATE _gis SET visibility_group_id = NULL
+                        WHERE visibility_group_id = ''",
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        // down migration is not possible
+        $this->abortIfNotMysql();
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/04/Version20250409062943.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/04/Version20250409062943.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15372/Produktion-BB-Bauleitplanung-Kartenlayer-lassen-sich-ggf.-nicht-einblenden-und-nicht-editieren-26426

DescriprionÄ:  set visibility group id to null when unset overlays


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

