### PR TITLE
bug(refs DPLAN-15421): Enable saving button for documents

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaLocationAndDocumentReference.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaLocationAndDocumentReference.vue
@@ -202,12 +202,21 @@ export default {
     },
 
     isButtonRowDisabled () {
+      let isButtonRowDisabled = true
+
       const elementIsChanged = this.selectedElementId !== this.initiallySelectedElementId
       const paragraphIsChanged = this.selectedParagraphId !== this.initiallySelectedParagraphId
       const documentIsChanged = this.selectedDocumentId !== this.initiallySelectedDocumentId
 
-      return !elementIsChanged ||
-        (elementIsChanged && ((this.paragraphOptions.length > 0 && !paragraphIsChanged) || (this.documentOptions.length > 0 && !documentIsChanged)))
+      const isOnlyElementValid = !this.paragraphOptions.length && !this.documentOptions.length && elementIsChanged
+      const isParagraphValid = this.paragraphOptions.length > 0 && paragraphIsChanged && !!this.selectedElementId
+      const isDocumentValid = this.documentOptions.length > 0 && documentIsChanged && !!this.selectedElementId
+
+      if (isOnlyElementValid || isDocumentValid || isParagraphValid) {
+        isButtonRowDisabled = false
+      }
+
+      return isButtonRowDisabled
     },
 
     paragraphOptions () {


### PR DESCRIPTION
### Ticket
DPLAN-15421

Saving button should also be enabled if we already have an element set and only change the document or paragraph. Also refactor logic for better understanding.


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Stellungnahmen -> Detailansicht -> Bearbeiten -> Orts- und Dokumentenbezug -> select different elements, documents and paragraphs
