### PR TITLE
fix(refs DPLAN-15379): use updated data for checks

### DIFF
--- a/client/js/components/assessmenttable/DpNewStatement.vue
+++ b/client/js/components/assessmenttable/DpNewStatement.vue
@@ -224,11 +224,11 @@ export default {
       }
     },
 
-    checkForParagraphsAndFiles () {
+    checkForParagraphsAndFiles (selectedElement) {
       this.values.paragraph = { id: '', title: '-' }
       this.values.document = { id: '', title: '-' }
-      this.elementHasParagraphs = hasOwnProp(this.paragraph, this.values.element.id)
-      this.elementHasFiles = hasOwnProp(this.documents, this.values.element.id)
+      this.elementHasParagraphs = hasOwnProp(this.paragraph, selectedElement.id)
+      this.elementHasFiles = hasOwnProp(this.documents, selectedElement.id)
     },
 
     handlePhaseSelect () {

--- a/client/js/store/statement/AssessmentTable.js
+++ b/client/js/store/statement/AssessmentTable.js
@@ -168,8 +168,8 @@ const AssessmentTable = {
         .then(this.api.checkResponse)
         .then(response => response.data)
 
-      return new Promise((resolve, reject) => {
-        // To prevent invalid type error missmatch of array and object
+      return new Promise((resolve) => {
+        // To prevent invalid type error mismatch of array and object
         if (Array.isArray(data.accessibleProcedures)) {
           data.accessibleProcedures = {}
         }

--- a/client/js/store/statement/AssessmentTable.js
+++ b/client/js/store/statement/AssessmentTable.js
@@ -156,6 +156,8 @@ const AssessmentTable = {
 
   actions: {
     /**
+     * @param commit
+     * @param state
      * @param {String} procedureId
      */
     async applyBaseData ({ commit, state }, procedureId) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
@@ -316,11 +316,13 @@
 
                     <label
                         v-if="hasPermission('field_procedure_elements')"
+                        for="element"
                         class="o-form__label">
                         {{ "plandocument"|trans }}
                     </label>
                     <dp-multiselect
                         v-model="values.element"
+                        id="element"
                         class="o-form__control-wrapper u-mb-0_75"
                         label="title"
                         data-cy="submitterForm:elements"
@@ -335,11 +337,14 @@
 
                     {% if hasPermission('field_procedure_paragraphs') %}
                         <template v-if="elementHasParagraphs">
-                            <label class="o-form__label">
+                            <label
+                                class="o-form__label"
+                                for="paragraph">
                                 {{ "paragraph"|trans }}*
                             </label>
                             <dp-multiselect
                                 v-model="values.paragraph"
+                                id="paragraph"
                                 class="o-form__control-wrapper u-mb-0_75"
                                 label="title"
                                 data-cy="submitterForm:paragraph"
@@ -356,11 +361,14 @@
 
                     {% if hasPermission('field_procedure_documents') %}
                         <template v-if="elementHasFiles">
-                            <label class="o-form__label">
+                            <label
+                                class="o-form__label"
+                                for="file">
                                 {{ "file"|trans }}*
                             </label>
                             <dp-multiselect
                                 v-model="values.document"
+                                id="file"
                                 class="o-form__control-wrapper u-mb-0_75"
                                 label="title"
                                 data-cy="submitterForm:document"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_new_statement.html.twig
@@ -326,7 +326,7 @@
                         data-cy="submitterForm:elements"
                         :options="elements"
                         track-by="id"
-                        @input="checkForParagraphsAndFiles()">
+                        @input="selectedElement => checkForParagraphsAndFiles(selectedElement)">
                         <template v-slot:option="{ props }">
                             {% verbatim %}{{ props.option.title }}{% endverbatim %}
                         </template>


### PR DESCRIPTION
### Ticket
[DPLAN-15379](https://demoseurope.youtrack.cloud/issue/DPLAN-15379/Beim-wahlen-von-ein-Planungsdokument-Uncaught-in-promise-TypeError-this.options-is-undefined)

- it seems the update of `this.values` via `v-model` is not completed in the `@input` handler, so we now use the updated value directly that is emitted by `DpMultiselect`
- before, `this.values.element.id` always contained the previously selected element id or `undefined` (if no element had been selected before)

### PR Checklist

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly