### PR TITLE
fix(refs #AB9149): remove obsolete .native modifier

### DIFF
--- a/client/js/components/statement/splitStatement/CardPane.vue
+++ b/client/js/components/statement/splitStatement/CardPane.vue
@@ -21,8 +21,10 @@
       @segment:confirm="$emit('segment:confirm', segment.id)"
       @edit-segment="$emit('edit-segment', segment.id)"
       @delete-segment="$emit('delete-segment', segment.id)"
-      @mouseenter.native="handleMouseEnter(segment.id)"
-      @mouseleave.native="handleMouseLeave(segment.id)"
+      @focusin="handleMouseEnter(segment.id)"
+      @focusout="handleMouseLeave(segment.id)"
+      @mouseenter="handleMouseEnter(segment.id)"
+      @mouseleave="handleMouseLeave(segment.id)"
       @check-card-overlap="positionCards" />
   </div>
 </template>

--- a/client/js/components/statement/splitStatement/CardPane.vue
+++ b/client/js/components/statement/splitStatement/CardPane.vue
@@ -18,14 +18,14 @@
       :data-range="segment.id"
       :offset="offset"
       ref="card"
+      @card:checkOverlap="positionCards"
       @segment:confirm="$emit('segment:confirm', segment.id)"
-      @edit-segment="$emit('edit-segment', segment.id)"
-      @delete-segment="$emit('delete-segment', segment.id)"
+      @segment:edit="$emit('segment:edit', segment.id)"
+      @segment:delete="$emit('segment:delete', segment.id)"
       @focusin="handleMouseEnter(segment.id)"
       @focusout="handleMouseLeave(segment.id)"
       @mouseenter="handleMouseEnter(segment.id)"
-      @mouseleave="handleMouseLeave(segment.id)"
-      @check-card-overlap="positionCards" />
+      @mouseleave="handleMouseLeave(segment.id)" />
   </div>
 </template>
 
@@ -57,8 +57,8 @@ export default {
   },
 
   emits: [
-    'delete-segment',
-    'edit-segment',
+    'segment:delete',
+    'segment:edit',
     'segment:confirm'
   ],
 

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -12,7 +12,11 @@
     class="card space-stack-xs"
     :class="{ 'highlighted': isHighlighted }"
     :style="{ top: offsetTop, left: (position * 5) + 'px', 'margin-top': (position * 5) + 'px' }"
-    :id="'tag_' + segment.id">
+    :id="'tag_' + segment.id"
+    @focusin="$emit('focusin')"
+    @focusout="$emit('focusout')"
+    @mouseenter="$emit('mouseenter')"
+    @mouseleave="$emit('mouseleave')">
     <div class="u-pr-0_25">
       <i
         :title="Translator.trans('tags')"
@@ -106,6 +110,10 @@ export default {
     'check-card-overlap',
     'delete-segment',
     'edit-segment',
+    'focusin',
+    'focusout',
+    'mouseenter',
+    'mouseleave',
     'segment:confirm'
   ],
 

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -62,7 +62,7 @@
       icon="edit"
       :text="Translator.trans('segment.edit')"
       variant="subtle"
-      @click="$emit('edit-segment', segment.id)" />
+      @click="$emit('segment:edit', segment.id)" />
     <addon-wrapper
       :addon-props="{
         class: 'mt-1',
@@ -76,7 +76,7 @@
       icon="delete"
       :text="Translator.trans('selection.tags.discard')"
       variant="subtle"
-      @click="$emit('delete-segment', segment.id)" />
+      @click="$emit('segment:delete', segment.id)" />
   </div>
 </template>
 
@@ -111,14 +111,14 @@ export default {
   },
 
   emits: [
-    'check-card-overlap',
-    'delete-segment',
-    'edit-segment',
+    'card:checkOverlap',
     'focusin',
     'focusout',
     'mouseenter',
     'mouseleave',
-    'segment:confirm'
+    'segment:confirm',
+    'segment:delete',
+    'segment:edit'
   ],
 
   data () {
@@ -163,7 +163,7 @@ export default {
         this.offsetTop = segmentOffset - mainOffset + 'px'
       }
 
-      this.$emit('check-card-overlap')
+      this.$emit('card:checkOverlap')
     }
   },
 
@@ -193,7 +193,7 @@ export default {
          * between segmentation-editor container and fixed header.
          */
         this.offsetTop = Math.abs(parent) + this.offset - 24 + 'px'
-        this.$emit('check-card-overlap')
+        this.$emit('card:checkOverlap')
       } else {
         this.calculateCardPosition()
       }

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -58,11 +58,15 @@
     </p>
 
     <dp-button
+      :class="{ 'mr-1': isFocused }"
       hide-text
       icon="edit"
       :text="Translator.trans('segment.edit')"
       variant="subtle"
-      @click="$emit('segment:edit', segment.id)" />
+      @blur="isFocused = false"
+      @click="$emit('segment:edit', segment.id)"
+      @focus="isFocused = !isMouseEvent"
+      @mousedown="isMouseEvent = true" />
     <addon-wrapper
       :addon-props="{
         class: 'mt-1',
@@ -72,11 +76,15 @@
       hook-name="split.statement.buttons"
       @segment:confirm="$emit('segment:confirm', segment.id)" />
     <dp-button
+      :class="{ 'ml-1': isFocused }"
       hide-text
       icon="delete"
       :text="Translator.trans('selection.tags.discard')"
       variant="subtle"
-      @click="$emit('segment:delete', segment.id)" />
+      @blur="isFocused = false"
+      @click="$emit('segment:delete', segment.id)"
+      @focus="isFocused = !isMouseEvent"
+      @mousedown="isMouseEvent = true" />
   </div>
 </template>
 
@@ -123,6 +131,8 @@ export default {
 
   data () {
     return {
+      isFocused: false,
+      isMouseEvent: false,
       offsetTop: 0,
       position: 0
     }

--- a/client/js/components/statement/splitStatement/CardPaneCard.vue
+++ b/client/js/components/statement/splitStatement/CardPaneCard.vue
@@ -57,9 +57,11 @@
       </span>
     </p>
 
-    <dp-button-icon
-      icon="fa-pencil"
+    <dp-button
+      hide-text
+      icon="edit"
       :text="Translator.trans('segment.edit')"
+      variant="subtle"
       @click="$emit('edit-segment', segment.id)" />
     <addon-wrapper
       :addon-props="{
@@ -69,16 +71,18 @@
       class="inline-block"
       hook-name="split.statement.buttons"
       @segment:confirm="$emit('segment:confirm', segment.id)" />
-    <dp-button-icon
-      icon="fa-trash"
+    <dp-button
+      hide-text
+      icon="delete"
       :text="Translator.trans('selection.tags.discard')"
+      variant="subtle"
       @click="$emit('delete-segment', segment.id)" />
   </div>
 </template>
 
 <script>
 import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
-import { DpButtonIcon } from '@demos-europe/demosplan-ui'
+import { DpButton } from '@demos-europe/demosplan-ui'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -86,7 +90,7 @@ export default {
 
   components: {
     AddonWrapper,
-    DpButtonIcon
+    DpButton
   },
 
   props: {

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -8,7 +8,12 @@
 </license>
 
 <template>
-  <div class="segmentation-editor">
+  <div
+    class="segmentation-editor"
+    @focus="event => $emit('focus', event)"
+    @focusout="$emit('focusout')"
+    @mouseleave="$emit('mouseleave')"
+    @mouseover="event => $emit('mouseover', event)">
     <div id="editor" />
   </div>
 </template>
@@ -51,6 +56,10 @@ export default {
   },
 
   emits: [
+    'focus',
+    'focusout',
+    'mouseleave',
+    'mouseover',
     'prosemirror-initialized',
     'prosemirror-max-range'
   ],

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -60,8 +60,8 @@ export default {
     'focusout',
     'mouseleave',
     'mouseover',
-    'prosemirror-initialized',
-    'prosemirror-max-range'
+    'prosemirror:initialized',
+    'prosemirror:maxRange'
   ],
 
   data () {
@@ -150,8 +150,8 @@ export default {
        */
       prosemirrorStateWrapper = Object.freeze(prosemirrorStateWrapper)
 
-      this.$emit('prosemirror-max-range', this.maxRange)
-      this.$emit('prosemirror-initialized', prosemirrorStateWrapper)
+      this.$emit('prosemirror:maxRange', this.maxRange)
+      this.$emit('prosemirror:initialized', prosemirrorStateWrapper)
     },
 
     transformSegments (segments) {

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -570,9 +570,9 @@ export default {
      * Adds highlighting background color to segment and border color to corresponding card
      * Updates currentlyHighlightedSegmentId in the store
      */
-    handleMouseOver (e) {
+    handleMouseOver (event) {
       if (!this.editModeActive) {
-        let segmentId = e.target.getAttribute('data-range') || e.target.closest('span[data-range]')?.getAttribute('data-range')
+        let segmentId = event.target.getAttribute('data-range') || event.target.closest('span[data-range]')?.getAttribute('data-range')
 
         /**
          * If the target element doesn't have the attribute 'data-range', it may be an html element inside the segment span,
@@ -581,7 +581,7 @@ export default {
          * exists, the hovered element is not inside a segment and highlighting is removed
          */
         if (!segmentId) {
-          const closestParent = e.target.closest('span[data-range]')
+          const closestParent = event.target.closest('span[data-range]')
           segmentId = closestParent ? closestParent.getAttribute('data-range') : null
         }
 

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -95,8 +95,10 @@
             <segmentation-editor
               @prosemirror-initialized="runPostInitTasks"
               @prosemirror-max-range="setMaxRange"
-              @mouseover.native="handleMouseOver"
-              @mouseleave.native="handleMouseLeave"
+              @focus="event => handleMouseOver(event)"
+              @focusout="handleMouseLeave"
+              @mouseover="event => handleMouseOver(event)"
+              @mouseleave="handleMouseLeave"
               :init-statement-text="initText ?? ''"
               :segments="segments"
               :range-change-callback="handleSegmentChanges"

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -93,8 +93,8 @@
             class="container pt-2"
             v-else-if="initialData">
             <segmentation-editor
-              @prosemirror-initialized="runPostInitTasks"
-              @prosemirror-max-range="setMaxRange"
+              @prosemirror:initialized="runPostInitTasks"
+              @prosemirror:maxRange="setMaxRange"
               @focus="event => handleMouseOver(event)"
               @focusout="handleMouseLeave"
               @mouseover="event => handleMouseOver(event)"
@@ -115,8 +115,8 @@
                 :max-range="maxRange"
                 :offset="headerOffset"
                 @segment:confirm="handleSegmentConfirmation"
-                @edit-segment="enableEditMode"
-                @delete-segment="immediatelyDeleteSegment" />
+                @segment:edit="enableEditMode"
+                @segment:delete="immediatelyDeleteSegment" />
             </transition>
 
             <transition


### PR DESCRIPTION
In Vue 3, the .native event modifier has been removed (see https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed).

- To be able to remove its usages, we need to emit the corresponding event from the component that we place the handler on
- Focus events were also added to allow for keyboard navigation
- The segmentation editor can't be focused, but we get an eslint vuejs-accessiblity warning due to `'vuejs-accessibility/mouse-events-have-key-events'` that I did not manage to disable for the corresponding lines, so I added the event listeners instead
- Some events have been renamed to match our conventions
- In CardPaneCard, DpButtonIcon has been replaced with DpButton, and unless it's used in an Addon (edit: it is), I think we can now remove the component from demosplan-ui (we can't)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Navigate to the split statement view and use the keyboard to focus buttons in the card pane cards - the corresponding segment and the card should be highlighted.
- Linting errors and warning should have gone from 
```
✖ 336 problems (44 errors, 292 warnings)
```
to
```
✖ 320 problems (40 errors, 280 warnings)
```

### Linked PRs
- [x] https://github.com/demos-europe/demosplan-ui/pull/1243
- [x] https://github.com/demos-europe/demosplan-core/pull/4575

### PR Checklist

- [x] Run `yarn lint`
