### PR TITLE
fix(DPLAN-15309): ubble menu is missing when the user highlights text to the end of a paragraph

### DIFF
--- a/client/js/lib/prosemirror/utilities.js
+++ b/client/js/lib/prosemirror/utilities.js
@@ -240,7 +240,9 @@ const createCreatorMenu = (view, anchor, head) => {
     arrow: false,
     theme: 'light-border',
     getReferenceClientRect: () => {
-      const positions = view.coordsAtPos(head, -1)
+      const pickPositionProps = ({ top, bottom, left, right }) => ({ top, bottom, left, right })
+      const positions = pickPositionProps(view.coordsAtPos(head, -1))
+
       return {
         height: 10,
         width: 0,


### PR DESCRIPTION
### Ticket
[DPLAN-15309](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15309)

**Description:** This PR fixes an issue where the bubble menu is missing when the user highlights text to the end of a paragraph.

There are two issues: 

- the highlight worked only within the text area, so if the user clicked even slightly outside of it, the rangeCreator plugin did not react because the mouseup event was triggered only inside the editor area. To fix this, a global mouseup handler (globalHandler) was added to the document in the view() lifecycle hook. 

- view.coordsAtPos method from ProseMirror does not always return a plain object with the essential coordinates (when clicking outside the editor zone). Because of that, an additional check was added to return only the important coordinates for the tippy 

### How to review/test
STN Aufteilen -> Text von rechts nach komplett links wählen -> kein + Bubble

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
