### PR TITLE
chore: bump demosplan-ui from v0.4.12 to v0.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^9.2.0",
-    "@demos-europe/demosplan-ui": "0.4.12",
+    "@demos-europe/demosplan-ui": "0.4.13",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,9 +2025,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.12":
-  version: 0.4.12
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.12"
+"@demos-europe/demosplan-ui@npm:0.4.13":
+  version: 0.4.13
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.13"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2079,7 +2079,7 @@ __metadata:
     vue-multiselect: "npm:^3.1.0"
     vue-omnibox: "npm:^0.3.7"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/34568ebad3f8384125a466c959315ae0e5073fcebd693f81a9e3d5f62d5dd2d99faeda04ccf8432776fb0117a9c929055fbfbd911e6322b0f65018deb82712d3
+  checksum: 10c0/4f343c24fcd8abc42ad563d2500d9df96fac850c11f171940c77e9e23300bdf21adc78ab69d954ce1f056d970a98b400611abb56404c3bd6776287a1b1010062
   languageName: node
   linkType: hard
 
@@ -12385,7 +12385,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^9.2.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.12"
+    "@demos-europe/demosplan-ui": "npm:0.4.13"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^6.0.0"


### PR DESCRIPTION
With the new version,
- DpButton emits blur, focus, and mousedown events
- it is possible to set an input width for DpSearchField
- the colCount for an empty DpDataTable is fixed
