### PR TITLE
Fix return Type of getRecords in ExcelImporterHandleImportedTagsRecordsEvent

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Event/Statement/ExcelImporterHandleImportedTagsRecordsEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/ExcelImporterHandleImportedTagsRecordsEvent.php
@@ -39,6 +39,6 @@ class ExcelImporterHandleImportedTagsRecordsEvent extends DPlanEvent implements 
 
     public function getRecords(): MapIterator
     {
-        return $this->records;
+        return new MapIterator($this->records, fn($record) => $record);
     }
 }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15506
Description: return should be of Type MapIterator not ArrayIterator. Because we insert CSV file