### PR TITLE
feat (ADO-24467): use interface when dispatching events

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AbstractRpcStatementBulkAction.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AbstractRpcStatementBulkAction.php
@@ -36,6 +36,7 @@ use Exception;
 use JsonException;
 use JsonSchema\Exception\InvalidSchemaException;
 use stdClass;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractRpcStatementBulkAction implements RpcMethodSolverInterface
 {
@@ -101,6 +102,7 @@ abstract class AbstractRpcStatementBulkAction implements RpcMethodSolverInterfac
         StatementService $statementService,
         StatementCopier $statementCopier,
         private readonly TransactionService $transactionService,
+        protected readonly EventDispatcherInterface $eventDispatcher,
         protected readonly StatementDeleter $statementDeleter,
     ) {
         $this->assessmentTableServiceOutput = $assessmentTableServiceOutput;

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/RpcBulkCopyStatements.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\AssessmentTable;
 
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Event\Statement\StatementCreatedEvent;
 use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Exception;
@@ -56,6 +58,8 @@ class RpcBulkCopyStatements extends AbstractRpcStatementBulkAction
         try {
             foreach ($statements as $statement) {
                 $copyResult = $this->statementCopier->copyStatementObjectWithinProcedureWithRelatedFiles($statement);
+                $event = new StatementCreatedEvent($copyResult);
+                $this->eventDispatcher->dispatch($event, StatementCreatedEventInterface::class);
                 if (!$copyResult instanceof Statement) {
                     return false;
                 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -16,6 +16,7 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\ManualOriginalStatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementUpdatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
@@ -417,7 +418,9 @@ class StatementService extends CoreService implements StatementServiceInterface
         }
 
         /** @var StatementCreatedEvent $statementCreatedEvent */
-        $statementCreatedEvent = $this->eventDispatcher->dispatch(new ManualOriginalStatementCreatedEvent($statement));
+        $statementCreatedEvent = $this->eventDispatcher->dispatch(
+            new ManualOriginalStatementCreatedEvent($statement),
+            ManualOriginalStatementCreatedEventInterface::class);
 
         // statement similarities are calculated?
         $statementSimilarities = $statementCreatedEvent->getStatementSimilarities();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxSegmentImport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxSegmentImport.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\ManualOriginalStatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedViaExcelEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -101,7 +102,10 @@ class XlsxSegmentImport
                     throw $exception;
                 }
 
-                $this->eventDispatcher->post(new ManualOriginalStatementCreatedEvent($statement));
+                $this->eventDispatcher->dispatch(
+                    new ManualOriginalStatementCreatedEvent($statement),
+                    ManualOriginalStatementCreatedEventInterface::class
+                );
             }
 
             $this->entityManager->flush();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxStatementImport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxStatementImport.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
+use DemosEurope\DemosplanAddon\Contracts\Events\ManualOriginalStatementCreatedEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Event\Statement\ManualOriginalStatementCreatedEvent;
 use demosplan\DemosPlanCoreBundle\Event\Statement\StatementCreatedEvent;
@@ -89,7 +90,10 @@ class XlsxStatementImport
                 }
 
                 /** @var StatementCreatedEvent $statementCreatedEvent */
-                $statementCreatedEvent = $this->eventDispatcher->post(new ManualOriginalStatementCreatedEvent($statement));
+                $statementCreatedEvent = $this->eventDispatcher->dispatch(
+                    new ManualOriginalStatementCreatedEvent($statement),
+                    ManualOriginalStatementCreatedEventInterface::class,
+                );
 
                 // inform user about statement similarities is not necessary
 


### PR DESCRIPTION
### Ticket
[ADO-24467](https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/24467)

Ensure that we dispatch event for original statement and statement creation and ensure that this event s can be used in addons.

WIP: Maybe the events for copied statements will be removed. If not we have to replace them with new events. Something like StatementCopiedEvent...

### How to review/test
code review
