### PR TITLE
bug(refs DPLAN-15495): Fix path for new statement

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_statements.html.twig
@@ -1,10 +1,7 @@
 {% extends '@DemosPlanCore/DemosPlanCore/base.html.twig' %}
 {% block component_part %}
 
-    {% set path = hasPermission('feature_statements_import_excel') or
-        hasPermission('feature_import_statement_pdf') or
-        hasPermission('feature_segments_import_excel') or
-        hasPermission('feature_simplified_new_statement_create') ? 'DemosPlan_procedure_import' : 'DemosPlan_statement_new_submitted' %}
+    {% set path = hasPermission('feature_simplified_new_statement_create') ? 'DemosPlan_procedure_import' : 'DemosPlan_statement_new_submitted' %}
 
     {% set permission = path == 'DemosPlan_procedure_import' ? 'area_admin_import' : 'feature_statement_data_input_orga' %}
 


### PR DESCRIPTION
### Ticket
DPLAN-15495

We only want to link to the import center if `feature_simplified_new_statement_create` is enabled. Otherwise, we need the old view for creating statements.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
Verfahren -> Stellungnahmen -> Neue Stellungnahme -> You should get to the "old" create new statement view and not the import center. 

