### PR TITLE
fix(DPLAN-15284): splitStatement: dropdown menu open direction

### DIFF
--- a/client/js/components/statement/splitStatement/SideBar.vue
+++ b/client/js/components/statement/splitStatement/SideBar.vue
@@ -74,6 +74,7 @@
           <tag-select
             v-for="(topic, idx) in tagTopics"
             :class="{'mb-1': idx < tagTopics.length + 1}"
+            :dropdown-direction="idx < 6 ? 'bottom' : ''"
             :entity="topic"
             :selected="selectedTags.filter(tag => (hasOwnProp(tag, 'relationships') && hasOwnProp(tag.relationships, 'topic')) ? tag.relationships.topic.data.id === topic.id : false)"
             :key="`category_${idx}`" />

--- a/client/js/components/statement/splitStatement/TagSelect.vue
+++ b/client/js/components/statement/splitStatement/TagSelect.vue
@@ -12,6 +12,7 @@ All rights reserved
     class="multiselect--dark inline-block align-bottom cursor-pointer w-full"
     :class="{'has-selection': selected.length}"
     :placeholder="placeHolder"
+    :open-direction="dropdownDirection"
     :options="tagsByTopic"
     :close-on-select="false"
     :searchable="false"
@@ -40,6 +41,12 @@ export default {
   },
 
   props: {
+    dropdownDirection: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
     entity: {
       type: Object,
       default: () => ({})


### PR DESCRIPTION
**Description:** Vue-Multiselect automatically positions the dropdown where there is the most space. The multiselect is inside a scrollable container, and sometimes this causes the dropdown to appear above (because the dropdown menu is absolutely positioned, the container does not scroll it, but simply clips it)

I tried different approaches: adding a min-height or removing the absolute positioning, but there were always issues and none were perfect. I settled on having the first six dropdowns open downward (since the dropdowns max-height is 300 px). I know it is not the ideal solution, but I find it better than the others...

Additional PR in UI is provided

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
