### PR TITLE
bug(refs DPLAN-12748): Add warning if there are no places

### DIFF
--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -15,6 +15,11 @@
           id="header"
           class="u-pv-0_25 flow-root">
           <dp-inline-notification
+            v-if="!isLoading && availablePlaces.length < 1"
+            class="mt-3 mb-2"
+            :message="Translator.trans('error.split_statement.no_place.link', { href: Routing.generate('DemosPlan_procedure_places_list', { procedureId: this.procedureId }) })"
+            type="warning" />
+          <dp-inline-notification
             v-if="!isLoading && isSegmentDraftUpdated"
             class="mt-3 mb-2"
             :message="Translator.trans('last.saved', { date: lastSavedTime })"
@@ -290,6 +295,7 @@ export default {
 
   computed: {
     ...mapGetters('SplitStatement', [
+      'availablePlaces',
       'currentlyHighlightedSegmentId',
       'editingSegment',
       'editingSegmentId',

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1308,6 +1308,7 @@ error.save.organisation: "Leider ist beim Speichern der Organisation {organisati
 error.save.organisation.slug.bulk: "Der gleiche Direktlink zu Verfahren kann nicht für mehrere Organisationen verwendet werden"
 error.savedFilterSet.deleted: "Die Filterkombination konnte nicht gelöscht werden."
 error.split_statement.no_place: "Bitte fügen Sie vor dem Aufteilen mindestens einen Bearbeitungsschritt hinzu."
+"error.split_statement.no_place.link": "Bitte fügen Sie vor dem Aufteilen mindestens einen Bearbeitungsschritt <a class=\"o-link--default\" href=\"{href}\">hier</a> hinzu."
 error.split_statement.segments: "Aufgrund von fehlerhaften Daten können keine von KI vorgeschlagenenen Abschnitte angezeigt werden."
 error.statement.anonymize: "Ihre Daten konnten nicht von der Stellungnahme {externId} entfernt werden."
 error.statement.already.segmented: "Diese Stellungnahme wurde bereits aufgeteilt"


### PR DESCRIPTION
### Ticket
DPLAN-12748

We want a notification for the user if there are no places yet, because without them the statement cannot be split into segments. 

### How to review/test
Go to a procedure without places (Bearbeitungsschritte) -> Stellungnahmen -> Aufteilen -> There should be a warning with a link to create places. 
