### PR TITLE
fix(DPLAN-15474): filter reset issue

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -29,7 +29,7 @@
         <div class="ml-2 space-x-1 space-x-reverse">
           <filter-flyout
             v-for="(filter, idx) in Object.values(filters)"
-            :ref="`filterFlyout${idx}`"
+            ref="filterFlyout"
             :additional-query-params="{ searchPhrase: searchTerm }"
             :category="{ id: `${filter.labelTranslationKey}:${idx}`, label: Translator.trans(filter.labelTranslationKey) }"
             class="inline-block first:mr-1"
@@ -684,8 +684,8 @@ export default {
     resetQuery () {
       this.resetSearchQuery()
       this.appliedFilterQuery = []
-      Object.keys(this.filters).forEach((filter, idx) => {
-        this.$refs[`filterFlyout${idx}`].reset()
+      this.$refs.filterFlyout?.forEach(flyout => {
+        flyout.reset()
       })
       this.updateQueryHash()
       this.resetSelection()


### PR DESCRIPTION
### Ticket
[DPLAN-15474](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15474)

**Description:** This PR fixen an issue with `this.$refs[("filterFlyout" + (intermediate value))].reset is not a function`

- get all filterFlyout in the array and apply reset() to each flyout, instead of adding index to each flyout