### PR TITLE
fix: inverse side does not exists

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -453,7 +453,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var Customer
      *
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer", inversedBy="proceure")
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer")
      *
      * @ORM\JoinColumn(name="customer", referencedColumnName="_c_id", nullable=true)
      */


### PR DESCRIPTION
Error in symfony toolbar indicated this problem.

No migration needed, because this is doctrine only and was never modeled.
