### PR TITLE
chore: exclude addon-folder. They should be treated manually

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     }
   ],
   ignorePatterns: [
+    '**/addonDev/**/*',
     '**/addons/**/*',
     '**/local_modules/**/*',
     '**/node_modules/**/*',


### PR DESCRIPTION
To avoid 3rd-Party errors when firing the linter