### PR TITLE
fix(refs DPLAN-12612): remove toggle for chapter based doc categories

### DIFF
--- a/client/js/components/document/ElementsAdminItem.vue
+++ b/client/js/components/document/ElementsAdminItem.vue
@@ -26,6 +26,7 @@
       large
       :text="designatedSwitchDate" />
     <dp-toggle
+      v-if="element.attributes.category !== 'paragraph'"
       class="u-mt-0_125"
       data-cy="categoryStatusSwitcher"
       :disabled="element.attributes.designatedSwitchDate !== null"
@@ -95,6 +96,7 @@ export default {
   },
 
   methods: {
+
     ...mapActions('Elements', {
       saveToggleElement: 'save'
     }),

--- a/client/js/components/document/ElementsAdminItem.vue
+++ b/client/js/components/document/ElementsAdminItem.vue
@@ -96,7 +96,6 @@ export default {
   },
 
   methods: {
-
     ...mapActions('Elements', {
       saveToggleElement: 'save'
     }),


### PR DESCRIPTION
### Ticket
[DPLAN-12612](https://demoseurope.youtrack.cloud/issue/DPLAN-12612/Kapitelbezogene-Kategorien-sollten-keine-Toggle-haben-weil-die-Kategorien-kapitelbezogen-sind) 

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR removes the toggle option for custom categories that are only chapter based, not for whole documents.

