### PR TITLE
Add Hello World command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/HelloWorldCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/HelloWorldCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class HelloWorldCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:hello-world';
+    protected static $defaultDescription = 'Display a friendly hello world message';
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        parent::__construct($parameterBag);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp('This command displays a friendly hello world message with the current date.')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Name to greet', 'World');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Don't set up IO in quiet mode to prevent any output
+        if ($output->isQuiet()) {
+            return Command::SUCCESS;
+        }
+        
+        $io = $this->setupIo($input, $output);
+        $name = $input->getArgument('name');
+        $currentDate = date('Y-m-d H:i:s');
+        
+        $io->title('DemosPlan Hello World');
+        $io->success("Hello, $name!");
+        $io->text("Current date and time: $currentDate");
+        
+        return Command::SUCCESS;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/HelloWorldCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/HelloWorldCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class HelloWorldCommand extends CoreCommand
@@ -40,15 +39,15 @@ class HelloWorldCommand extends CoreCommand
         if ($output->isQuiet()) {
             return Command::SUCCESS;
         }
-        
+
         $io = $this->setupIo($input, $output);
         $name = $input->getArgument('name');
         $currentDate = date('Y-m-d H:i:s');
-        
+
         $io->title('DemosPlan Hello World');
         $io->success("Hello, $name!");
         $io->text("Current date and time: $currentDate");
-        
+
         return Command::SUCCESS;
     }
 }

--- a/tests/backend/core/Core/Functional/Command/HelloWorldCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/HelloWorldCommandTest.php
@@ -53,7 +53,7 @@ class HelloWorldCommandTest extends FunctionalTestCase
         // Act
         $exitCode = $commandTester->execute([
             'command' => $command->getName(),
-            'name' => $name,
+            'name'    => $name,
         ]);
         $output = $commandTester->getDisplay();
 
@@ -89,7 +89,7 @@ class HelloWorldCommandTest extends FunctionalTestCase
         $application = new ConsoleApplication($kernel, false);
 
         $parameterBag = $this->createMock(ParameterBagInterface::class);
-        
+
         $application->add(
             new HelloWorldCommand($parameterBag)
         );

--- a/tests/backend/core/Core/Functional/Command/HelloWorldCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/HelloWorldCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace backend\core\Core\Functional\Command;
+
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\HelloWorldCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+use Tests\Core\Core\Functional\CommandTesterTrait;
+
+class HelloWorldCommandTest extends FunctionalTestCase
+{
+    use CommandTesterTrait;
+
+    public function testExecuteWithoutName(): void
+    {
+        // Arrange
+        $command = $this->createCommandTester();
+        $commandTester = new CommandTester($command);
+
+        // Act
+        $exitCode = $commandTester->execute([
+            'command' => $command->getName(),
+        ]);
+        $output = $commandTester->getDisplay();
+
+        // Assert
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Hello, World!', $output);
+        $this->assertStringContainsString(date('Y-m-d'), $output);
+    }
+
+    public function testExecuteWithName(): void
+    {
+        // Arrange
+        $command = $this->createCommandTester();
+        $commandTester = new CommandTester($command);
+        $name = 'DemosPlan';
+
+        // Act
+        $exitCode = $commandTester->execute([
+            'command' => $command->getName(),
+            'name' => $name,
+        ]);
+        $output = $commandTester->getDisplay();
+
+        // Assert
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString("Hello, $name!", $output);
+        $this->assertStringContainsString(date('Y-m-d'), $output);
+    }
+
+    public function testExecuteWithQuietOption(): void
+    {
+        // Arrange
+        $command = $this->createCommandTester();
+        $commandTester = new CommandTester($command);
+
+        // Act
+        $exitCode = $commandTester->execute(
+            [
+                'command' => $command->getName(),
+            ],
+            ['verbosity' => OutputInterface::VERBOSITY_QUIET]
+        );
+        $output = $commandTester->getDisplay();
+
+        // Assert
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertEmpty($output);
+    }
+
+    private function createCommandTester(): Command
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        
+        $application->add(
+            new HelloWorldCommand($parameterBag)
+        );
+
+        return $application->find(HelloWorldCommand::getDefaultName());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new `dplan:hello-world` command that displays a friendly greeting message with current date and time
- Implement comprehensive tests using AAA pattern (Arrange-Act-Assert)
- Support optional name parameter and quiet mode execution
- Follow existing command patterns and code style guidelines

## Test plan
- Unit tests pass and verify all functionality
- Command works correctly when executed directly via CLI
- Proper handling of optional parameters and quiet mode

🤖 Generated with [Claude Code](https://claude.ai/code)