### PR TITLE
fix(DPLAN-2789): Fix timezone mismatch in logs

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/DateHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/DateHelper.php
@@ -45,13 +45,10 @@ class DateHelper
      *
      * @param DateTime $date , which is to be converted
      *
-     * @return string date in the format: Y-m-dTH:i:s+0100
+     * @return string date in ISO 8601 format with the system timezone offset
      */
     public function convertDateToString(DateTime $date)
     {
-        $date = $date->format('Y-m-d H:i:s');
-        $date[10] = 'T';
-
-        return $date.'+0100';
+        return $date->format('Y-m-d\TH:i:sP');
     }
 }

--- a/docker/demosplan-base/zzz-dplan-cli.ini
+++ b/docker/demosplan-base/zzz-dplan-cli.ini
@@ -6,6 +6,9 @@ memory_limit = 2G
 
 max_input_vars=3000
 
+; Set timezone to match Docker container timezone setting
+date.timezone = Europe/Berlin
+
 ; maximum memory that OPcache can use to store compiled PHP files
 opcache.memory_consumption=256
 

--- a/docker/demosplan-production/zzz-dplan-cli.ini
+++ b/docker/demosplan-production/zzz-dplan-cli.ini
@@ -6,6 +6,9 @@ memory_limit = 2G
 
 max_input_vars=3000
 
+; Set timezone to match Docker container timezone setting
+date.timezone = Europe/Berlin
+
 ; maximum memory that OPcache can use to store compiled PHP files
 opcache.memory_consumption=256
 

--- a/docker/demosplan-production/zzz-dplan.ini
+++ b/docker/demosplan-production/zzz-dplan.ini
@@ -6,6 +6,9 @@ memory_limit = 2G
 
 max_input_vars=3000
 
+; Set timezone to match Docker container timezone setting
+date.timezone = Europe/Berlin
+
 ; maximum memory that OPcache can use to store compiled PHP files
 opcache.memory_consumption=256
 

--- a/tests/backend/core/Core/Functional/DateHelperTest.php
+++ b/tests/backend/core/Core/Functional/DateHelperTest.php
@@ -30,8 +30,23 @@ class DateHelperTest extends FunctionalTestCase
         $dateStringToCreate = '2014-10-26T02:30:00';
         $date = new DateTime($dateStringToCreate);
         $convertedString = $this->sut->convertDateToString($date);
-
-        static::assertEquals($dateStringToCreate.'+0100', $convertedString);
-        static::assertEquals($date, new DateTime($dateStringToCreate));
+        
+        // Test that the date string follows ISO 8601 format with a timezone offset
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/', $convertedString);
+        
+        // Test that we can parse it back to the same date
+        $parsedDate = new DateTime($convertedString);
+        $this->assertEquals($date->getTimestamp(), $parsedDate->getTimestamp());
+    }
+    
+    public function testConvertDateToStringUsesSystemTimezone(): void
+    {
+        // Create a date with the system's timezone
+        $date = new DateTime();
+        $convertedString = $this->sut->convertDateToString($date);
+        
+        // The timezone in the output should match PHP's current timezone
+        $expectedTimezoneOffset = (new DateTime())->format('P');
+        $this->assertStringEndsWith($expectedTimezoneOffset, $convertedString);
     }
 }


### PR DESCRIPTION
### Ticket
DPLAN-2789

### Description
This PR fixes the timezone mismatch issue where logs appear to be 2 hours behind the system time due to inconsistent timezone configurations:

- Updated DateHelper to use system timezone with ISO 8601 format instead of hardcoded '+0100'
- Set PHP's date.timezone to Europe/Berlin in Docker configuration files to match Docker container TZ setting
- Updated DateHelper tests to verify correct timezone handling

### How to review/test
1. Check DateHelper.php changes: the convertDateToString method now uses PHP's format() with P specifier for proper timezone
2. Verify that all Docker PHP configuration files now set date.timezone to Europe/Berlin
3. Check DateHelperTest: it now properly tests ISO 8601 format with correct timezone
4. After deploying, verify that log timestamps correctly match the system time

### PR Checklist
- [x] Create/Update tests
- [x] Update documentation
- [ ] Add/Update data-cy attributes
- [x] Run tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog