### PR TITLE
Revert "fix(refs DPLAN-12612): remove toggle for chapter based doc categories"

### DIFF
--- a/client/js/components/document/ElementsAdminItem.vue
+++ b/client/js/components/document/ElementsAdminItem.vue
@@ -26,7 +26,6 @@
       large
       :text="designatedSwitchDate" />
     <dp-toggle
-      v-if="element.attributes.category !== 'paragraph'"
       class="u-mt-0_125"
       data-cy="categoryStatusSwitcher"
       :disabled="element.attributes.designatedSwitchDate !== null"


### PR DESCRIPTION
Misunderstood Ticket [DPLAN-12612](https://demoseurope.youtrack.cloud/issue/DPLAN-12612) (see comments there). The wrong toggle was removed.