### PR TITLE
Feat dplan 15567 delete custom fields related to procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/CustomFields/CustomFieldConfigurationFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/CustomFields/CustomFieldConfigurationFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\DataGenerator\Factory\CustomFields;
+
+use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
+use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
+use Doctrine\ORM\EntityRepository;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;
+
+/**
+ * @extends PersistentProxyObjectFactory<CustomFieldConfiguration>
+ *
+ * @method        CustomFieldConfiguration|Proxy                              create(array|callable $attributes = [])
+ * @method static CustomFieldConfiguration|Proxy                              createOne(array $attributes = [])
+ * @method static CustomFieldConfiguration|Proxy                              find(object|array|mixed $criteria)
+ * @method static CustomFieldConfiguration|Proxy                              findOrCreate(array $attributes)
+ * @method static CustomFieldConfiguration|Proxy                              first(string $sortedField = 'id')
+ * @method static CustomFieldConfiguration|Proxy                              last(string $sortedField = 'id')
+ * @method static CustomFieldConfiguration|Proxy                              random(array $attributes = [])
+ * @method static CustomFieldConfiguration|Proxy                              randomOrCreate(array $attributes = [])
+ * @method static CustomFieldConfigurationRepository|ProxyRepositoryDecorator repository()
+ * @method static CustomFieldConfiguration[]|Proxy[]                          all()
+ * @method static CustomFieldConfiguration[]|Proxy[]                          createMany(int $number, array|callable $attributes = [])
+ * @method static CustomFieldConfiguration[]|Proxy[]                          createSequence(iterable|callable $sequence)
+ * @method static CustomFieldConfiguration[]|Proxy[]                          findBy(array $attributes)
+ * @method static CustomFieldConfiguration[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
+ * @method static CustomFieldConfiguration[]|Proxy[]                          randomSet(int $number, array $attributes = [])
+ *
+ * @phpstan-method        CustomFieldConfiguration&Proxy<CustomFieldConfiguration> create(array|callable $attributes = [])
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> createOne(array $attributes = [])
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> find(object|array|mixed $criteria)
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> findOrCreate(array $attributes)
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> first(string $sortedField = 'id')
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> last(string $sortedField = 'id')
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> random(array $attributes = [])
+ * @phpstan-method static CustomFieldConfiguration&Proxy<CustomFieldConfiguration> randomOrCreate(array $attributes = [])
+ * @phpstan-method static ProxyRepositoryDecorator<CustomFieldConfiguration, EntityRepository> repository()
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> all()
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> createMany(int $number, array|callable $attributes = [])
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> createSequence(iterable|callable $sequence)
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> findBy(array $attributes)
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> randomRange(int $min, int $max, array $attributes = [])
+ * @phpstan-method static list<CustomFieldConfiguration&Proxy<CustomFieldConfiguration>> randomSet(int $number, array $attributes = [])
+ */
+final class CustomFieldConfigurationFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return CustomFieldConfiguration::class;
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     */
+    protected function defaults(): array|callable
+    {
+        return [
+            'createDate'        => self::faker()->dateTime(),
+            'modifyDate'        => self::faker()->dateTime(),
+            'sourceEntityClass' => self::faker()->text(),
+            'sourceEntityId'    => self::faker()->text(36),
+            'targetEntityClass' => self::faker()->text(),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -833,17 +833,17 @@ class ProcedureDeleter
      * @throws Exception
      */
     private function deleteCustomFields(array $procedureIds, bool $isDryRun): void {
-
-        $this->queriesService->deleteFromTableByMultipleConditions(
-            'custom_field_configuration',
-            'source_entity_id',
-            $procedureIds,
-            [
-                'source_entity_class' => 'PROCEDURE'
-            ],
-            $isDryRun
-        );
-
+        $entityClasses = ['PROCEDURE', 'PROCEDURE_TEMPLATE'];
+        
+        foreach ($entityClasses as $entityClass) {
+            $this->queriesService->deleteFromTableByMultipleConditions(
+                'custom_field_configuration',
+                'source_entity_id',
+                $procedureIds,
+                ['source_entity_class' => $entityClass],
+                $isDryRun
+            );
+        }
     }
     /**
      * @throws Exception

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -830,11 +830,17 @@ class ProcedureDeleter
     }
 
     /**
+     * Deletes custom fields for both PROCEDURE and PROCEDURE_TEMPLATE entity classes.
+     * 
+     * This handles both cases since procedures and procedure templates share the same 
+     * database table (templates are just procedures with isMaster=true), but are 
+     * referenced as separate entity classes in the custom_field_configuration table.
+     *
      * @throws Exception
      */
     private function deleteCustomFields(array $procedureIds, bool $isDryRun): void {
         $entityClasses = ['PROCEDURE', 'PROCEDURE_TEMPLATE'];
-        
+
         foreach ($entityClasses as $entityClass) {
             $this->queriesService->deleteFromTableByMultipleConditions(
                 'custom_field_configuration',

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -18,7 +18,7 @@ use Exception;
 class ProcedureDeleter
 {
     public function __construct(
-        private readonly SqlQueriesService $queriesService
+        private readonly SqlQueriesService $queriesService,
     ) {
     }
 
@@ -831,14 +831,15 @@ class ProcedureDeleter
 
     /**
      * Deletes custom fields for both PROCEDURE and PROCEDURE_TEMPLATE entity classes.
-     * 
-     * This handles both cases since procedures and procedure templates share the same 
-     * database table (templates are just procedures with isMaster=true), but are 
+     *
+     * This handles both cases since procedures and procedure templates share the same
+     * database table (templates are just procedures with isMaster=true), but are
      * referenced as separate entity classes in the custom_field_configuration table.
      *
      * @throws Exception
      */
-    private function deleteCustomFields(array $procedureIds, bool $isDryRun): void {
+    private function deleteCustomFields(array $procedureIds, bool $isDryRun): void
+    {
         $entityClasses = ['PROCEDURE', 'PROCEDURE_TEMPLATE'];
 
         foreach ($entityClasses as $entityClass) {
@@ -851,6 +852,7 @@ class ProcedureDeleter
             );
         }
     }
+
     /**
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -51,6 +51,10 @@ class ProcedureDeleter
         // delete procedure news
         $this->deleteProcedureNews($procedureIds, $isDryRun);
 
+        // delete custom fields
+
+        $this->deleteCustomFields($procedureIds, $isDryRun);
+
         // delete tag topics -> tags
         $this->processTags($procedureIds, $isDryRun);
 
@@ -825,6 +829,22 @@ class ProcedureDeleter
         $this->queriesService->deleteFromTableByIdentifierArray('_news', '_p_id', $procedureIds, $isDryRun);
     }
 
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomFields(array $procedureIds, bool $isDryRun): void {
+
+        $this->queriesService->deleteFromTableByMultipleConditions(
+            'custom_field_configuration',
+            'source_entity_id',
+            $procedureIds,
+            [
+                'source_entity_class' => 'PROCEDURE'
+            ],
+            $isDryRun
+        );
+
+    }
     /**
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Services/Queries/SqlQueriesService.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Queries/SqlQueriesService.php
@@ -60,10 +60,11 @@ class SqlQueriesService extends CoreService
         string $identifier,
         array $ids,
         array $conditions,
-        bool $isDryRun
+        bool $isDryRun,
     ): void {
         if (!$this->doesTableExist($tableName)) {
             $this->logger->warning("No table with the name $tableName exists in this database. Data could not be fetched.");
+
             return;
         }
 

--- a/demosplan/DemosPlanCoreBundle/Services/Queries/SqlQueriesService.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Queries/SqlQueriesService.php
@@ -30,7 +30,11 @@ class SqlQueriesService extends CoreService
     /**
      * @throws Exception
      */
-    public function deleteFromTableByIdentifierArray(string $tableName, string $identifier, array $ids, bool $isDryRun): void
+    public function deleteFromTableByIdentifierArray(
+        string $tableName,
+        string $identifier,
+        array $ids,
+        bool $isDryRun): void
     {
         if (!$this->doesTableExist($tableName)) {
             $this->logger->warning("No table with the name $tableName exists in this database. Data could not be fetched.");
@@ -43,6 +47,36 @@ class SqlQueriesService extends CoreService
             ->delete($tableName)
             ->where($identifier.' IN (:idList)')
             ->setParameter('idList', $ids, ArrayParameterType::STRING);
+
+        if ($isDryRun) {
+            return;
+        }
+
+        $deletionQueryBuilder->executeStatement();
+    }
+
+    public function deleteFromTableByMultipleConditions(
+        string $tableName,
+        string $identifier,
+        array $ids,
+        array $conditions,
+        bool $isDryRun
+    ): void {
+        if (!$this->doesTableExist($tableName)) {
+            $this->logger->warning("No table with the name $tableName exists in this database. Data could not be fetched.");
+            return;
+        }
+
+        $deletionQueryBuilder = $this->dbConnection->createQueryBuilder();
+        $deletionQueryBuilder
+            ->delete($tableName)
+            ->where($identifier.' IN (:idList)')
+            ->setParameter('idList', $ids, ArrayParameterType::STRING);
+
+        foreach ($conditions as $column => $value) {
+            $deletionQueryBuilder->andWhere("$column = :$column")
+                ->setParameter($column, $value);
+        }
 
         if ($isDryRun) {
             return;

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -20,7 +20,6 @@ use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use Tests\Base\FunctionalTestCase;
 use Zenstruck\Foundry\Persistence\Proxy;
 
-
 class ProcedureDeleterTest extends FunctionalTestCase
 {
     private Procedure|Proxy|null $testProcedure;
@@ -30,7 +29,7 @@ class ProcedureDeleterTest extends FunctionalTestCase
     protected $sut;
 
     /** @var SqlQueriesService */
-    private  $queriesService;
+    private $queriesService;
 
     protected function setUp(): void
     {
@@ -95,7 +94,7 @@ class ProcedureDeleterTest extends FunctionalTestCase
     }
 
     /**
-     * Creates custom fields for the test procedures
+     * Creates custom fields for the test procedures.
      *
      * @return int The total number of custom fields created
      */
@@ -113,7 +112,7 @@ class ProcedureDeleterTest extends FunctionalTestCase
     }
 
     /**
-     * Creates a custom field for a procedure
+     * Creates a custom field for a procedure.
      */
     private function createCustomField($procedure, string $sourceEntityClass, string $name, string $description, array $options): CustomFieldConfiguration
     {
@@ -132,7 +131,7 @@ class ProcedureDeleterTest extends FunctionalTestCase
     }
 
     /**
-     * Collects the IDs of all procedures in the database
+     * Collects the IDs of all procedures in the database.
      *
      * @return array List of procedure IDs
      */
@@ -142,13 +141,15 @@ class ProcedureDeleterTest extends FunctionalTestCase
         foreach ($this->getEntries(Procedure::class) as $procedure) {
             $procedureIds[] = $procedure->getId();
         }
+
         return $procedureIds;
     }
 
     /**
-     * Extracts test procedure IDs from an array of procedures
+     * Extracts test procedure IDs from an array of procedures.
      *
      * @param array $procedures Array of procedure objects
+     *
      * @return array List of procedure IDs
      */
     private function extractTestProcedureIds(array $procedures): array
@@ -157,11 +158,12 @@ class ProcedureDeleterTest extends FunctionalTestCase
         foreach ($procedures as $procedure) {
             $ids[] = $procedure->getId();
         }
+
         return $ids;
     }
 
     /**
-     * Assert that all procedure IDs in the first array exist in the second array
+     * Assert that all procedure IDs in the first array exist in the second array.
      */
     private function assertProceduresExist(array $procedureIds, array $allProcedureIds): void
     {

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -85,33 +85,26 @@ class ProcedureDeleterTest extends FunctionalTestCase
         }
 
         // Create custom fields for both procedure and procedure template entity classes
-        $customFieldsCount = 4;
-        $customFieldIds = [];
+        static::assertSame(0, $this->countEntries(CustomFieldConfiguration::class));
+        $customFieldsCount = 0;
 
         foreach ($this->testProcedures as $procedure) {
             // Create PROCEDURE custom fields
-            $customField1 = $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Color', 'Your favourite color', ['Blue', 'Orange', 'Green']);
-            $customField2 = $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Food', 'Your favourite food', ['Pizza', 'Sushi', 'Bread']);
+            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Color', 'Your favourite color', ['Blue', 'Orange', 'Green']);
+            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Food', 'Your favourite food', ['Pizza', 'Sushi', 'Bread']);
+            $customFieldsCount += 2; // Increment by the number of custom fields created per procedure
         }
 
         // Verify custom fields were created
-        $this->assertEquals($customFieldsCount, $this->countEntries(CustomFieldConfiguration::class));
+        static::assertSame($customFieldsCount, $this->countEntries(CustomFieldConfiguration::class));
 
         // Act
         $this->sut->deleteProcedures($ids, false);
 
         // Assert
         // Verify custom fields were deleted - we should have 0 custom fields for the deleted procedures
-        $remainingCustomFields = $this->getEntityManager()
-            ->createQueryBuilder()
-            ->select('c')
-            ->from(CustomFieldConfiguration::class, 'c')
-            ->where('c.sourceEntityId IN (:ids)')
-            ->setParameter('ids', $ids)
-            ->getQuery()
-            ->getResult();
 
-        $this->assertCount(0, $remainingCustomFields, "Custom fields should have been deleted for both PROCEDURE and PROCEDURE_TEMPLATE entity classes");
+        static::assertSame(0, $this->countEntries(CustomFieldConfiguration::class));
     }
 
 

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -161,18 +161,10 @@ class ProcedureDeleterTest extends FunctionalTestCase
     }
 
     /**
-     * Assert that a procedure ID exists in a list of IDs
-     */
-    private function assertContainsProcedure(string $procedureId, array $procedureIds): void
-    {
-        $this->assertEquals(in_array($procedureId, $procedureIds), 1);
-    }
-
-    /**
      * Assert that all procedure IDs in the first array exist in the second array
      */
     private function assertProceduresExist(array $procedureIds, array $allProcedureIds): void
     {
-        $this->assertEquals(count(array_intersect($procedureIds, $allProcedureIds)), count($procedureIds));
+        $this->assertCount(count(array_intersect($procedureIds, $allProcedureIds)), $procedureIds);
     }
 }

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -18,21 +18,21 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use Tests\Base\FunctionalTestCase;
-use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\Persistence\Proxy;
+
 
 class ProcedureDeleterTest extends FunctionalTestCase
 {
-    private null|Procedure|Proxy $testProcedure;
-
+    private Procedure|Proxy|null $testProcedure;
     private ?array $testProcedures;
 
     /** @var ProcedureDeleter */
     protected $sut;
 
     /** @var SqlQueriesService */
-    protected $queriesService;
+    private  $queriesService;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->sut = $this->getContainer()->get(ProcedureDeleter::class);
@@ -43,71 +43,78 @@ class ProcedureDeleterTest extends FunctionalTestCase
 
     public function testDeleteProcedure(): void
     {
-        $entriesIds = [];
-        foreach ($this->getEntries(Procedure::class) as $procedure) {
-            $entriesIds[] = $procedure->getId();
-        }
+        // Arrange
+        $procedureIds = $this->collectTotalProcedureIds();
+        static::assertContains($this->testProcedure->getId(), $procedureIds);
+        $totalProceduresBefore = $this->countEntries(Procedure::class);
 
-        $this->assertEquals(in_array($this->testProcedure->getId(), $entriesIds), 1);
-
-        $totalAmountOfProceduresBeforeDeletion = $this->countEntries(Procedure::class);
-
+        // Act
         $this->sut->deleteProcedures([$this->testProcedure->getId()], false);
 
-        static::assertSame($totalAmountOfProceduresBeforeDeletion - 1, $this->countEntries(Procedure::class));
+        // Assert
+        $expectedProceduresAfter = $totalProceduresBefore - 1;
+        static::assertSame($expectedProceduresAfter, $this->countEntries(Procedure::class));
     }
 
     public function testDeleteProcedures(): void
     {
-        $ids = [];
-        foreach ($this->testProcedures as $procedure) {
-            $ids[] = $procedure->getId();
-        }
+        // Arrange
+        $procedureIds = $this->extractTestProcedureIds($this->testProcedures);
+        $allProcedureIds = $this->collectTotalProcedureIds();
+        $this->assertProceduresExist($procedureIds, $allProcedureIds);
+        $totalProceduresBefore = $this->countEntries(Procedure::class);
 
-        $entriesIds = [];
-        foreach ($this->getEntries(Procedure::class) as $procedure) {
-            $entriesIds[] = $procedure->getId();
-        }
-        $this->assertEquals(count(array_intersect($ids, $entriesIds)), 2);
+        // Act
+        $this->sut->deleteProcedures($procedureIds, false);
 
-        $totalAmountOfProceduresBeforeDeletion = $this->countEntries(Procedure::class);
-
-        $this->sut->deleteProcedures($ids, false);
-
-        static::assertSame($totalAmountOfProceduresBeforeDeletion - 2, $this->countEntries(Procedure::class));
+        // Assert
+        $expectedProceduresAfter = $totalProceduresBefore - count($procedureIds);
+        static::assertSame($expectedProceduresAfter, $this->countEntries(Procedure::class));
     }
 
-    public function testProcedureDeleteCustomFields(): void {
+    public function testProcedureDeleteCustomFields(): void
+    {
         // Arrange
-        $ids = [];
-        foreach ($this->testProcedures as $procedure) {
-            $ids[] = $procedure->getId();
-        }
+        $procedureIds = $this->extractTestProcedureIds($this->testProcedures);
 
-        // Create custom fields for both procedure and procedure template entity classes
+        // Verify no custom fields exist initially
         static::assertSame(0, $this->countEntries(CustomFieldConfiguration::class));
-        $customFieldsCount = 0;
 
-        foreach ($this->testProcedures as $procedure) {
-            // Create PROCEDURE custom fields
-            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Color', 'Your favourite color', ['Blue', 'Orange', 'Green']);
-            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Food', 'Your favourite food', ['Pizza', 'Sushi', 'Bread']);
-            $customFieldsCount += 2; // Increment by the number of custom fields created per procedure
-        }
+        // Create custom fields for procedures
+        $customFieldsCount = $this->createCustomFieldsForProcedures();
 
         // Verify custom fields were created
         static::assertSame($customFieldsCount, $this->countEntries(CustomFieldConfiguration::class));
 
         // Act
-        $this->sut->deleteProcedures($ids, false);
+        $this->sut->deleteProcedures($procedureIds, false);
 
         // Assert
-        // Verify custom fields were deleted - we should have 0 custom fields for the deleted procedures
-
-        static::assertSame(0, $this->countEntries(CustomFieldConfiguration::class));
+        static::assertSame(0, $this->countEntries(CustomFieldConfiguration::class),
+            'All custom fields should be deleted when their procedures are deleted');
     }
 
+    /**
+     * Creates custom fields for the test procedures
+     *
+     * @return int The total number of custom fields created
+     */
+    private function createCustomFieldsForProcedures(): int
+    {
+        $customFieldsCount = 0;
 
+        foreach ($this->testProcedures as $procedure) {
+            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Color', 'Your favourite color', ['Blue', 'Orange', 'Green']);
+            $this->createCustomField($procedure, 'PROCEDURE', 'Favourite Food', 'Your favourite food', ['Pizza', 'Sushi', 'Bread']);
+            $customFieldsCount += 2;
+        }
+
+        return $customFieldsCount;
+    }
+
+    /**
+     * Creates a custom field for a procedure
+     */
     private function createCustomField($procedure, string $sourceEntityClass, string $name, string $description, array $options): CustomFieldConfiguration
     {
         $radioButton = new RadioButtonField();
@@ -122,5 +129,50 @@ class ProcedureDeleterTest extends FunctionalTestCase
             'targetEntityClass' => 'SEGMENT',
             'configuration'     => $radioButton,
         ])->_real();
+    }
+
+    /**
+     * Collects the IDs of all procedures in the database
+     *
+     * @return array List of procedure IDs
+     */
+    private function collectTotalProcedureIds(): array
+    {
+        $procedureIds = [];
+        foreach ($this->getEntries(Procedure::class) as $procedure) {
+            $procedureIds[] = $procedure->getId();
+        }
+        return $procedureIds;
+    }
+
+    /**
+     * Extracts test procedure IDs from an array of procedures
+     *
+     * @param array $procedures Array of procedure objects
+     * @return array List of procedure IDs
+     */
+    private function extractTestProcedureIds(array $procedures): array
+    {
+        $ids = [];
+        foreach ($procedures as $procedure) {
+            $ids[] = $procedure->getId();
+        }
+        return $ids;
+    }
+
+    /**
+     * Assert that a procedure ID exists in a list of IDs
+     */
+    private function assertContainsProcedure(string $procedureId, array $procedureIds): void
+    {
+        $this->assertEquals(in_array($procedureId, $procedureIds), 1);
+    }
+
+    /**
+     * Assert that all procedure IDs in the first array exist in the second array
+     */
+    private function assertProceduresExist(array $procedureIds, array $allProcedureIds): void
+    {
+        $this->assertEquals(count(array_intersect($procedureIds, $allProcedureIds)), count($procedureIds));
     }
 }

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -165,6 +165,6 @@ class ProcedureDeleterTest extends FunctionalTestCase
      */
     private function assertProceduresExist(array $procedureIds, array $allProcedureIds): void
     {
-        $this->assertCount(count(array_intersect($procedureIds, $allProcedureIds)), $procedureIds);
+        static::assertCount(count(array_intersect($procedureIds, $allProcedureIds)), $procedureIds);
     }
 }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15567/Delete-custom-fields-of-procedure-as-part-of-deleting-a-procedure
 ## Description 
- This PR implements functionality to delete custom fields associated with a procedure when that procedure is deleted. Custom fields are now properly cleaned up, preventing orphaned data from remaining in the database.                                                                                                                                                   - The implementation adds a new method to `ProcedureDeleter` that uses a new method in `SqlQueriesService` to delete database records based on multiple conditions, which allows for more precise deletion operations.                                                                                                                                                      

## Testing instructions 
1. Create a procedure with custom fields 
3. Delete the procedure
4. Verify that the custom fields associated with the procedure have been deleted                                                                                                       

## Related issue
 - DPLAN-15340