### PR TITLE
fix(refs DPLAN-15569) Wrap DpTab in a slot

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
@@ -13,22 +13,24 @@
     :active-id="activeTabId"
     use-url-fragment
     @change="setActiveTabId">
-    <dp-tab
-      id="institutionList"
-      :is-active="activeTabId === 'institutionList'"
-      :label="Translator.trans('invitable_institution.group')">
-      <slot>
-        <institution-list :is-active="isInstitutionListActive" />
-      </slot>
-    </dp-tab>
-    <dp-tab
-      id="tagList"
-      :is-active="activeTabId === 'tagList'"
-      :label="Translator.trans('tag.administrate')">
-      <slot>
-        <tag-list @tagIsRemoved="institutionListReset" />
-      </slot>
-    </dp-tab>
+    <slot>
+      <dp-tab
+        id="institutionList"
+        :is-active="activeTabId === 'institutionList'"
+        :label="Translator.trans('invitable_institution.group')">
+        <slot>
+          <institution-list :is-active="isInstitutionListActive" />
+        </slot>
+      </dp-tab>
+      <dp-tab
+        id="tagList"
+        :is-active="activeTabId === 'tagList'"
+        :label="Translator.trans('tag.administrate')">
+        <slot>
+          <tag-list @tagIsRemoved="institutionListReset" />
+        </slot>
+      </dp-tab>
+    </slot>
   </dp-tabs>
 </template>
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
@@ -18,17 +18,13 @@
         id="institutionList"
         :is-active="activeTabId === 'institutionList'"
         :label="Translator.trans('invitable_institution.group')">
-        <slot>
-          <institution-list :is-active="isInstitutionListActive" />
-        </slot>
+        <institution-list :is-active="isInstitutionListActive" />
       </dp-tab>
       <dp-tab
         id="tagList"
         :is-active="activeTabId === 'tagList'"
         :label="Translator.trans('tag.administrate')">
-        <slot>
-          <tag-list @tagIsRemoved="institutionListReset" />
-        </slot>
+        <tag-list @tagIsRemoved="institutionListReset" />
       </dp-tab>
     </slot>
   </dp-tabs>


### PR DESCRIPTION
### Ticket
DPLAN-15569

In Vue 3, the way slots are handled has changed compared to Vue 2. Specifically, Vue 3 enforces stricter rules for component structure and slot usage. Wrapping DpTabs in a <slot> was necessary to show the list.

### How to review/test
Institutionen verschlagworten, look if the list is rendered.

### PR Checklist

- [ x] Run `yarn lint`
- [ x] Run `yarn test`
- [ x] Link all relevant tickets
- [ x] Move the tickets on the board accordingly

