### PR TITLE
fix(refs DPLAN-15590): update segment to display correct data

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -795,13 +795,30 @@ export default {
         payload.data.attributes = attributes
       }
 
-      dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
+      const updatedSegment = {
+        id: this.segment.id,
+        type: 'StatementSegment',
+        attributes: {
+          ...this.segment.attributes,
+          customFields: {
+            ...this.segment.attributes.customFields,
+            ...payload.data.attributes?.customFields
+          }
+        },
+        relationships: {
+          ...this.segment.relationships,
+          ...payload.data.relationships
+        }
+      }
+
+      this.setSegment({
+        ...updatedSegment,
+        id: this.segment.id
+      })
+
+      this.saveSegmentAction(this.segment.id)
         .then(checkResponse)
         .then(() => {
-          /*
-           * @improve - once the vuex-json-api resolves with a response,
-           * we can handle success messages in checkResponse() again.
-           */
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
           this.isFullscreen = false
           this.isEditing = false

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -519,7 +519,9 @@ export default {
   },
 
   computed: {
-    ...mapState('SegmentSlidebar', ['slidebar']),
+    ...mapState('SegmentSlidebar', [
+      'slidebar'
+    ]),
 
     ...mapState('AssignableUser', {
       assignableUserItems: 'items'

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -332,9 +332,13 @@ export default {
       statements: 'items'
     }),
 
-    ...mapState('SegmentSlidebar', ['slidebar']),
+    ...mapState('SegmentSlidebar', [
+      'slidebar'
+    ]),
 
-    ...mapGetters('SegmentSlidebar', ['commentsList']),
+    ...mapGetters('SegmentSlidebar', [
+      'commentsList'
+    ]),
 
     additionalAttachments () {
       if (this.statement?.hasRelationship('genericAttachments')) {


### PR DESCRIPTION
### Ticket
[DPLAN-15590](https://demoseurope.youtrack.cloud/issue/DPLAN-15590/Die-gewahlte-Konfigurierbare-Abschnittsfelder-sind-nicht-sichtbar-beim-hooveren-auf-das-oder-unter-Option-Selektor)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The vuex json api library is now used for saving the new values for custom fields. That way, the segment in the store is updated and the correct data is displayed when hovering over the '#'. (Before, the selected values for custom fields were not displayed here).

### PR Checklist

- [ ] Run `yarn lint`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
