### PR TITLE
fix(refs DPLAN-15199): catch and handle exception when screenshot info is missing

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -1002,9 +1002,14 @@ class DraftStatementService extends CoreService
         // hat das Statement ein Screenshot?
         if (0 < strlen($statementArray['mapFile'] ?? '')) {
             $this->getLogger()->info('DraftStatement hat einen Screenshot.');
-            $fileInfo = $this->fileService->getFileInfoFromFileString($statementArray['mapFile']);
+            $fileInfo = null;
+            try {
+                $fileInfo = $this->fileService->getFileInfoFromFileString($statementArray['mapFile']);
+            } catch (Exception $e) {
+                $this->getLogger()->error('Screenshot konnte nicht gefunden werden');
+            }
             // Wenn der Screenshot da sein müsste, es aber nicht ist, versuche ihn neu zu generieren
-            if (!$this->defaultStorage->fileExists($fileInfo->getAbsolutePath())) {
+            if (null === $fileInfo || !$this->defaultStorage->fileExists($fileInfo->getAbsolutePath())) {
                 $this->getLogger()->info('Screenshot konnte nicht gefunden werden');
                 if (0 < strlen((string) $statementArray['polygon'])) {
                     $this->getLogger()->info('Erzeuge Screenshot neu');

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -994,25 +994,25 @@ class DraftStatementService extends CoreService
 
     protected function checkMapScreenshotFile(array $statementArray, string $procedureId): array
     {
-        // hat das Statement einen Screenshot aber kein Polygon?
+        // Does the statement have a polygon but no screenshot?
         if (0 < strlen((string) $statementArray['polygon']) && 0 === strlen($statementArray['mapFile'] ?? '')) {
-            $this->getLogger()->info('DraftStatement hat ein Polygon, aber keinen Screenshot. Erzeuge ihn');
+            $this->getLogger()->info('DraftStatement has a polygon but no screenshot. Creating one');
             $statementArray['mapFile'] = $this->getServiceMap()->createMapScreenshot($procedureId, $statementArray['ident']);
         }
-        // hat das Statement ein Screenshot?
+        // Does the statement have a screenshot?
         if (0 < strlen($statementArray['mapFile'] ?? '')) {
-            $this->getLogger()->info('DraftStatement hat einen Screenshot.');
+            $this->getLogger()->info('DraftStatement has a screenshot.');
             $fileInfo = null;
             try {
                 $fileInfo = $this->fileService->getFileInfoFromFileString($statementArray['mapFile']);
             } catch (Exception $e) {
-                $this->getLogger()->error('Screenshot konnte nicht gefunden werden');
+                $this->getLogger()->warning('Screenshot could not be found', [$e]);
             }
-            // Wenn der Screenshot da sein müsste, es aber nicht ist, versuche ihn neu zu generieren
+            // If the screenshot should be there but isn't, try to regenerate it
             if (null === $fileInfo || !$this->defaultStorage->fileExists($fileInfo->getAbsolutePath())) {
-                $this->getLogger()->info('Screenshot konnte nicht gefunden werden');
+                $this->getLogger()->info('Screenshot could not be found');
                 if (0 < strlen((string) $statementArray['polygon'])) {
-                    $this->getLogger()->info('Erzeuge Screenshot neu');
+                    $this->getLogger()->info('Regenerating screenshot');
                     $statementArray['mapFile'] = $this->getServiceMap()->createMapScreenshot($procedureId, $statementArray['ident']);
                 }
             }


### PR DESCRIPTION
### Ticket
DPLAN-15199

### Description
This PR fixes an issue where institution coordinators were unable to download PDFs of statements.
The problem was caused by an unhandled exception when trying to get file information for screenshots
that might be missing or invalid. The fix adds proper exception handling and null checks.

I tried hard to create a Test, but DraftStatementService needs to be refactored beforehand.

### How to review/test
1. Login as an institution coordinator (I-Ko)
2. Submit a statement, save as draft
3. Release the statement
4. Reject the statement and release again
5. Try to download the statement as PDF - should work now

### PR Checklist
- [x] Run `yarn lint`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly