### PR TITLE
Fix(DPLAN-15601): rendering DpTreeList inside a DpTab that uses v-sho…

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionTagManagement.vue
@@ -24,7 +24,9 @@
         id="tagList"
         :is-active="activeTabId === 'tagList'"
         :label="Translator.trans('tag.administrate')">
-        <tag-list @tagIsRemoved="institutionListReset" />
+        <tag-list
+          v-if="activeTabId === 'tagList'"
+          @tagIsRemoved="institutionListReset" />
       </dp-tab>
     </slot>
   </dp-tabs>

--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagList.vue
@@ -18,6 +18,7 @@
         :text="Translator.trans('tag.new')"
         @click="handleAddNewTagForm" />
       <dp-button
+        class="ml-1"
         :color="tagCategoriesWithTags.length === 0 ? 'primary' : 'secondary'"
         data-cy="tagList:newCategory"
         :text="Translator.trans('tag.category.new')"


### PR DESCRIPTION
### Ticket
[DPLAN-15601](https://demoseurope.youtrack.cloud/agiles/141-202/142-669?issue=DPLAN-15601)

Description: This PR fixes an issue with the Sticky-Header inside the DpTreeList component.

- the rendering DpTreeList inside a DpTab that uses v-show directive causes an error, because v-show applies 'display: none', so measurements like `offsetHeight` return zero. Instead, render the TagList component only when its tab is active and add some adjustments in UI library.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
