### PR TITLE
fix(refs DPLAN-14565): switch trash and edit buttons

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
@@ -21,14 +21,6 @@
     <div class="flex">
       <template v-if="!isEditing">
         <dp-button
-          color="secondary"
-          data-cy="tagListItem:delete"
-          hide-text
-          icon="delete"
-          :text="Translator.trans('delete')"
-          variant="subtle"
-          @click="deleteItem" />
-        <dp-button
           class="u-pl-0"
           color="secondary"
           data-cy="tagListItem:edit"
@@ -37,6 +29,14 @@
           :text="Translator.trans('edit')"
           variant="subtle"
           @click="edit" />
+        <dp-button
+          color="secondary"
+          data-cy="tagListItem:delete"
+          hide-text
+          icon="delete"
+          :text="Translator.trans('delete')"
+          variant="subtle"
+          @click="deleteItem" />
       </template>
       <template v-else>
         <dp-button


### PR DESCRIPTION
### Ticket
[DPLAN-14565](https://demoseurope.youtrack.cloud/issue/DPLAN-14565)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Switched edit and trash buttons in the template of TagListItem.vue so that edit appears first.
