### PR TITLE
Fix(DPLAN-15601): no custom fields displayed on the page reload

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -812,21 +812,19 @@ export default {
         }
       }
 
-      const payloadTest = {
-        attributes: {
-          customFields: this.segment.attributes.customFields
-        },
-        type: 'StatementSegment',
-        id: this.segment.id
-      }
-
       this.setSegment({
         ...updatedSegment,
         id: this.segment.id
       })
 
-      dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, { data: payloadTest })
-      // This.saveSegmentAction(this.segment.id)
+      this.saveSegmentAction({
+        id: this.segment.id,
+        options: {
+          attributes: {
+            full: 'customFields'
+          }
+        }
+      })
         .then(checkResponse)
         .then(() => {
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
@@ -1055,7 +1053,7 @@ export default {
         if (this.segment.relationships.place) {
           this.selectedPlace = this.places.find(place => place.id === this.segment.relationships.place.data.id) || this.places[0]
         }
-        if (hasPermission('field_segments_custom_fields') && this.segment.attributes.customFields.length > 0) {
+        if (hasPermission('field_segments_custom_fields') && this.segment.attributes.customFields?.length > 0) {
           this.setInitiallySelectedCustomFieldValues()
         }
       })

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -817,6 +817,10 @@ export default {
         id: this.segment.id
       })
 
+      /**
+       * By default, only changed properties are sent; since `id` did not change, it is omitted by the diff.
+       * Using `full` forces the entire `customFields` object (including its unchanged `id`) into the update payload.
+       */
       this.saveSegmentAction({
         id: this.segment.id,
         options: {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -288,8 +288,7 @@
                 @select="(value) => setCustomFieldValue(value)"
                 label="name"
                 :options="customFieldsOptions[field.id]"
-                track-by="id">
-              </dp-multiselect>
+                track-by="id" />
             </template>
           </template>
         </div>
@@ -568,8 +567,8 @@ export default {
      */
     customFieldsOptions () {
       return Object.values(this.customFields).reduce((acc, el) => {
-        const opts =  [ ...el.attributes.options].map((opt) => ({ name: opt, id: `${el.id}:${opt}`, fieldId: el.id }))
-        opts.unshift({ name: Translator.trans('not.assigned'), id: 'unset', fieldId: el.id})
+        const opts = [...el.attributes.options].map((opt) => ({ name: opt, id: `${el.id}:${opt}`, fieldId: el.id }))
+        opts.unshift({ name: Translator.trans('not.assigned'), id: 'unset', fieldId: el.id })
 
         return {
           ...acc,
@@ -813,12 +812,21 @@ export default {
         }
       }
 
+      const payloadTest = {
+        attributes: {
+          customFields: this.segment.attributes.customFields
+        },
+        type: 'StatementSegment',
+        id: this.segment.id
+      }
+
       this.setSegment({
         ...updatedSegment,
         id: this.segment.id
       })
 
-      this.saveSegmentAction(this.segment.id)
+      dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, { data: payloadTest })
+      // This.saveSegmentAction(this.segment.id)
         .then(checkResponse)
         .then(() => {
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -418,13 +418,31 @@ export default {
   mounted () {
     if (Object.keys(this.segments).length === 0 && hasPermission('area_statement_segmentation')) {
       this.isLoading = true
+
+      const statementSegmentFields = [
+        'tags',
+        'text',
+        'assignee',
+        'place',
+        'comments',
+        'externId',
+        'internId',
+        'orderInProcedure',
+        'polygon',
+        'recommendation'
+      ]
+
+      if (hasPermission('field_segments_custom_fields')) {
+        statementSegmentFields.push('customFields')
+      }
+
       this.listSegments({
         include: ['assignee', 'comments', 'place', 'tag', 'assignee.orga', 'comments.submitter', 'comments.place'].join(),
         sort: 'orderInProcedure',
         fields: {
           Place: ['name', 'sortIndex'].join(),
           SegmentComment: ['creationDate', 'place', 'submitter', 'text'].join(),
-          StatementSegment: ['assignee', 'comments', 'externId', 'recommendation', 'text', 'place'].join(),
+          StatementSegment: statementSegmentFields.join(),
           User: ['lastname', 'firstname', 'orga'].join(),
           Orga: ['name'].join()
         },


### PR DESCRIPTION
### Ticket
[DPLAN-15590](https://demoseurope.youtrack.cloud/issue/DPLAN-15590/Die-gewahlte-Konfigurierbare-Abschnittsfelder-sind-nicht-sichtbar-beim-hooveren-auf-das-oder-unter-Option-Selektor)

Description: 

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
