### PR TITLE
fix(refs: DPLAN:15434): remove indentation of profile data on big screens

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_user.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_user.html.twig
@@ -7,6 +7,7 @@
     {% embed '@DemosPlanCore/DemosPlanCore/includes/participation_area_skeleton.html.twig' with {
         content_heading: 'profile'|trans,
         content_subheading: 'text.profile.edit'|trans,
+        full_width: true
     }%}
 
         {% block content %}


### PR DESCRIPTION
### Ticket
[DPLAN-15434](https://demoseurope.youtrack.cloud/issue/DPLAN-15434/Meine-Daten-Zeilen-verschoben)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Sets the full-width parameter to true so that the profile content takes the full screen-width (otherwise the participation_area_skeleton.html.twig renders an aside-element on the left side).

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ x ] Link all relevant tickets
- [ x ] Move the tickets on the board accordingly

