### PR TITLE
fix(DPLAN-15610): allow short layer names

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomerResourceType.php
@@ -219,7 +219,7 @@ final class CustomerResourceType extends DplanResourceType
                 function (Customer $object, string $baseLayerLayers): array {
                     // the previously set value may be invalid, hence this validation can only be executed when the
                     // value is changed, not on any update
-                    $violations = $this->validator->validate($baseLayerLayers, [new Length(null, 5, 4096)]);
+                    $violations = $this->validator->validate($baseLayerLayers, [new Length(null, 1, 4096)]);
                     if (0 === $violations->count()) {
                         $object->setBaseLayerLayers($baseLayerLayers);
                     } else {


### PR DESCRIPTION
## Summary
- Reduces minimum length for base layer names from 5 to 1 characters so that valid short layer names like 'web' can be used

## Test plan
- [ ] Check that a layer name shorter than 5 characters can be used in customer settings