### PR TITLE
Ds 82 preserve text formatting

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilder.php
@@ -25,6 +25,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -88,13 +89,18 @@ class StatementFromRowBuilder extends AbstractStatementFromRowBuilder
         return null;
     }
 
+    private function hasRichText(Cell $cell): bool
+    {
+        return $cell->getValue() instanceof RichText;
+    }
+
     public function setText(Cell $cell): ?ConstraintViolationListInterface
     {
         $statementText = $cell->getValue();
 
         // Prüfen, ob es Rich Text ist und Formatierungen extrahieren
-        if ($cell->hasRichText()) {
-            $richText = $cell->getRichText();
+        if ($this->hasRichText($cell)) {
+            $richText = $cell->getValue();
             $htmlText = '';
 
             // Durchlaufe alle Rich Text Elemente und extrahiere die Formatierung

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
@@ -114,23 +114,6 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
         return [$callBackMap, $builder];
     }
 
-    /**
-     * Verarbeitet Text und erhält dabei Formatierungen wie fett, kursiv und unterstrichen
-     */
-    protected function preserveFormatting(string $text): string
-    {
-        // Zuerst Zeilenumbrüche wie bisher verarbeiten
-        $text = str_replace(["_x000D_\n", "\n"], '<br>', $text);
-
-        // Bewahre Formatierung, indem wir Markdown-ähnliche Syntax in HTML umwandeln
-        // Dies deckt Fälle ab, in denen die Formatierung bereits als Markdown-Syntax vorliegt
-        $text = preg_replace('/\*\*(.*?)\*\*/', '<strong>$1</strong>', $text); // **bold** zu <strong>
-        $text = preg_replace('/\*(.*?)\*/', '<em>$1</em>', $text);             // *italic* zu <em>
-        $text = preg_replace('/__(.*?)__/', '<u>$1</u>', $text);               // __underline__ zu <u>
-
-        return $text;
-    }
-
     private function getStatementFromRowBuilder(ProcedureInterface $procedure): StatementFromRowBuilder
     {
         return new StatementFromRowBuilder(
@@ -140,7 +123,7 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
             $this->orgaService->getOrga(User::ANONYMOUS_USER_ORGA_ID),
             $this->elementsService,
             $this->getStatementTextConstraint(),
-            $this->preserveFormatting(...)
+            $this->replaceLineBreak(...)
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
@@ -114,6 +114,23 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
         return [$callBackMap, $builder];
     }
 
+    /**
+     * Verarbeitet Text und erhält dabei Formatierungen wie fett, kursiv und unterstrichen
+     */
+    protected function preserveFormatting(string $text): string
+    {
+        // Zuerst Zeilenumbrüche wie bisher verarbeiten
+        $text = str_replace(["_x000D_\n", "\n"], '<br>', $text);
+
+        // Bewahre Formatierung, indem wir Markdown-ähnliche Syntax in HTML umwandeln
+        // Dies deckt Fälle ab, in denen die Formatierung bereits als Markdown-Syntax vorliegt
+        $text = preg_replace('/\*\*(.*?)\*\*/', '<strong>$1</strong>', $text); // **bold** zu <strong>
+        $text = preg_replace('/\*(.*?)\*/', '<em>$1</em>', $text);             // *italic* zu <em>
+        $text = preg_replace('/__(.*?)__/', '<u>$1</u>', $text);               // __underline__ zu <u>
+
+        return $text;
+    }
+
     private function getStatementFromRowBuilder(ProcedureInterface $procedure): StatementFromRowBuilder
     {
         return new StatementFromRowBuilder(
@@ -123,7 +140,7 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
             $this->orgaService->getOrga(User::ANONYMOUS_USER_ORGA_ID),
             $this->elementsService,
             $this->getStatementTextConstraint(),
-            $this->replaceLineBreak(...)
+            $this->preserveFormatting(...)
         );
     }
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-82/Zip-Ex-Import-RO-EWM

Description : parse down statement text to preserve the provided formatting

 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
