### PR TITLE
f DS-43 remove JSON_FORCE_OBJECT flag : 

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Map/CoordinateJsonConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/CoordinateJsonConverter.php
@@ -16,7 +16,7 @@ class CoordinateJsonConverter
 {
     public function convertCoordinatesToJson(?array $coordinates): string
     {
-        return null === $coordinates ? '' : Json::encode($coordinates, JSON_FORCE_OBJECT);
+        return null === $coordinates ? '' : Json::encode($coordinates);
     }
 
     public function convertJsonToCoordinates(string $rawCoordinateValues): ?array


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-43/BOM-Fehlermeldung-bezuglich-Umgriff

Description: JSON_FORCE_OBJECT converts JSON arrays to PHP arrays, and JSON objects to associative arrays, in this case a we have to decode jsons by default weil a numeric arrays are expected and not associative arrays.


- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
