### PR TITLE
ref(DPLAN-15552): adjust text

### DIFF
--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -4261,8 +4261,7 @@ warning.statement.delete: |
         =1 { Eine Stellungnahme wurde nicht gefunden. Wurde sie möglicherweise bereits gelöscht?}
         other { # Stellungnahmen wurden nicht gefunden. Wurden sie möglicherweise bereits gelöscht?}
     }
-warning.statement.in.segmentation.cannot.be.edited: "Der Stellungnahmetext kann derzeit nicht bearbeitet werden, da bereits mit der Aufteilung in Abschnitte begonnen und diese noch nicht abgeschlossen wurde. Um den Stellungnahmetext zu ändern, müssen zunächst alle bereits erstellten Abschnitte, die in Bearbeitung sind, entfernt werden.
-Alternativ kann der Text der erstellten Abschnitte auch nach der Aufteilung angepasst werden."
+warning.statement.in.segmentation.cannot.be.edited: "Der Stellungnahmetext kann momentan nicht bearbeitet werden, da sich die Stellungnahme in der Aufteilung befindet. Um den Stellungnahmetext zu ändern, müssen die bereits erstellten Abschnitte entfernt werden. Alternativ kann der Text der erstellten Abschnitte nach der Aufteilung angepasst werden."
 warning.statement.move: "Stellungnahme konnte nicht verschoben werden."
 warning.statement.needLock.generic: "Diese Stellungnahme ist zur Zeit in Bearbeitung. Um sie zu bearbeiten, müssen Sie diese zunächst für sich beanspruchen."
 warning.statement.needLock: "Die Stellungnahme {externId} ist zur Zeit niemandem zugewiesen. Um Ihre Änderungen speichern zu können, müssen Sie die Bearbeitung zunächst für sich beanspruchen."

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3227,6 +3227,7 @@ segments.import: "Abschnitte importieren"
 segments.import.error.submitType: "Unbekannte Einreichungsart {value}, valide Arten sind: {translatedSubmitTypes}."
 segments.none: "Es sind noch keine Abschnitte vorhanden."
 segments.recommendations.create: "Erwiderungen verfassen"
+segments.recommendations.none: "Zu diesem Schlagwort konnten keine Erwiderungs-Vorschläge gefunden werden."
 segments.recommendations.oracle: "Vorschläge zu inhaltlicher Ähnlichkeit"
 segments.recommendations.oracle.none: "Zu diesem Abschnitt konnten keine ähnlichen Abschnitte mit Erwiderung gefunden werden."
 segments.recommendations.tags: "Vorschläge zu Schlagworten"
@@ -4260,7 +4261,8 @@ warning.statement.delete: |
         =1 { Eine Stellungnahme wurde nicht gefunden. Wurde sie möglicherweise bereits gelöscht?}
         other { # Stellungnahmen wurden nicht gefunden. Wurden sie möglicherweise bereits gelöscht?}
     }
-warning.statement.in.segmentation.cannot.be.edited: "Der Stellungnahmetext kann momentan nicht bearbeitet werden, da sich die Stellungnahme in der Aufteilung befindet. Um den Stellungnahmetext zu ändern, müssen die bereits erstellten Abschnitte entfernt werden. Alternativ kann der Text der erstellten Abschnitte nach der Aufteilung angepasst werden."
+warning.statement.in.segmentation.cannot.be.edited: "Der Stellungnahmetext kann derzeit nicht bearbeitet werden, da bereits mit der Aufteilung in Abschnitte begonnen und diese noch nicht abgeschlossen wurde. Um den Stellungnahmetext zu ändern, müssen zunächst alle bereits erstellten Abschnitte, die in Bearbeitung sind, entfernt werden.
+Alternativ kann der Text der erstellten Abschnitte auch nach der Aufteilung angepasst werden."
 warning.statement.move: "Stellungnahme konnte nicht verschoben werden."
 warning.statement.needLock.generic: "Diese Stellungnahme ist zur Zeit in Bearbeitung. Um sie zu bearbeiten, müssen Sie diese zunächst für sich beanspruchen."
 warning.statement.needLock: "Die Stellungnahme {externId} ist zur Zeit niemandem zugewiesen. Um Ihre Änderungen speichern zu können, müssen Sie die Bearbeitung zunächst für sich beanspruchen."


### PR DESCRIPTION
### Ticket
[DPLAN-15552](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15552)

**Description:** This PR adjusts the warning message for the TagRecommendationTab component. The previous message was unclear: when a tag existed, it incorrectly stated that no tags had been created for the segment. It now clearly informs the user that there are no recommendations for the selected tag, or if there are no tags, we will show the previous text. additional PR in a Addon provided.

![image](https://github.com/user-attachments/assets/edf98fca-49d0-4e9b-a26f-cc3c4a1ef556)

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
