### PR TITLE
Fix(dplan 15291): toggle all does not work

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
@@ -46,10 +46,10 @@
       <!--Segments, if there are any-->
       <div v-else>
         <statement-segment
-          v-for="(segment, idx) in segments"
+          v-for="segment in segments"
           :key="'segment_' + segment.id"
+          ref="segment"
           :segment="segment"
-          :ref="`segment${idx}`"
           :statement-id="statementId"
           :current-user-id="currentUser.id"
           :current-user-first-name="currentUser.firstname"
@@ -271,8 +271,11 @@ export default {
 
     toggleAll () {
       this.isAllCollapsed = this.isAllCollapsed === false
-      this.segments.forEach((_segment, idx) => {
-        this.$refs['segment' + idx].isCollapsed = this.isAllCollapsed
+
+      this.$refs.segment.forEach(segment => {
+        if (segment) {
+          segment.isCollapsed = this.isAllCollapsed
+        }
       })
     }
   },

--- a/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
@@ -247,15 +247,7 @@ export default {
             const segmentId = queryParams.get('segment') || ''
             if (segmentId) {
               scrollTo('#segment_' + segmentId, { offset: -110 })
-              let segmentComponent = null
-
-              for (let i = 0; i <= this.segments.length; i++) {
-                if (this.segments[i].id === segmentId) {
-                  segmentComponent = this.$refs['segment' + i]
-
-                  break
-                }
-              }
+              const segmentComponent = this.$refs.segment.find(el => el.segment.id === segmentId)
 
               if (segmentComponent) {
                 segmentComponent.isCollapsed = false


### PR DESCRIPTION
### Ticket
[DPLAN-15291](https://demoseurope.youtrack.cloud/agiles/141-63/current?settings&tab=allgemeines&issue=DPLAN-15291)

Description: This PR fixes an issue with the toggle-all function in the segments list. The problem appeared after the Vue 3 migration. Unfortunately, using the ref with dynamic keys do not work as expected in Vue 3. Use ref="segment" within the loop instead, which sets `this.$refs.segment` to an array of component instances.

- while technically still allowed, Vue 3 does not recommend using dynamic keys like :ref="'segment' + idx' inside v-for, use a static ref name instead.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
