### PR TITLE
fix(refs: DPLAN:15188): Add spacing between btns

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_boilerplate_group.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_boilerplate_group.html.twig
@@ -36,26 +36,29 @@
             <input name="id" type="hidden" value="{{ form.vars.value.id }}">
         </label><!--
 
-        --><div class="layout__item u-1-of-3 u-m-0 u-mt text-right space-inline-s">
-            {% if  form.vars.value.id is defined  and form.vars.value.id != '' %}
-                <button class="btn btn--primary" name="r_editGroup" type="submit">{{ "save"|trans }}</button>
-                <a class="btn btn--secondary" href="{{ path('DemosPlan_procedure_boilerplate_list', {'procedure': procedure}) }}">
-                    {{ "abort"|trans }}
-                </a>
-            {% else %}
-                <button
-                    class="btn btn--primary"
-                    data-cy="editBoilerplateGroupForm:createGroup"
-                    name="r_createGroup">
-                    {{ "group.new"|trans }}
-                </button>
-                <a
-                    class="btn btn--secondary"
-                    data-cy="editBoilerplateGroupForm:abort"
-                    href="{{ path('DemosPlan_procedure_boilerplate_list', {'procedure': procedure}) }}">
-                    {{ "abort"|trans }}
-                </a>
-            {% endif %}
+        --><div class="layout__item u-1-of-3 u-m-0 u-mt">
+            <div class="flex flex-wrap gap-2 justify-end">
+                {% if  form.vars.value.id is defined  and form.vars.value.id != '' %}
+                    <button class="btn btn--primary" name="r_editGroup" type="submit">{{ "save"|trans }}</button>
+                    <a class="btn btn--secondary"
+                       href="{{ path('DemosPlan_procedure_boilerplate_list', {'procedure': procedure}) }}">
+                        {{ "abort"|trans }}
+                    </a>
+                {% else %}
+                    <button
+                        class="btn btn--primary"
+                        data-cy="editBoilerplateGroupForm:createGroup"
+                        name="r_createGroup">
+                        {{ "group.new"|trans }}
+                    </button>
+                    <a
+                        class="btn btn--secondary"
+                        data-cy="editBoilerplateGroupForm:abort"
+                        href="{{ path('DemosPlan_procedure_boilerplate_list', {'procedure': procedure}) }}">
+                        {{ "abort"|trans }}
+                    </a>
+                {% endif %}
+            </div>
         </div>
 
         <hr class="">


### PR DESCRIPTION
On smaller screens when the btns stack vertically.

### Ticket
[DPLAN-15188](https://demoseurope.youtrack.cloud/issue/DPLAN-15188/Keine-Padding-zwischen-Gruppe-anlegen-und-Abbrechen-wenn-kleinere-Window)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Adds an additional wrapper-div to the buttons to implement flexbox independently from the 'layout__item' class.