### PR TITLE
Fix(dplan-15489): openLayers interaction issue

### DIFF
--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -270,9 +270,11 @@ export default {
     addMapEventListeners () {
       // Add event listener on click on features => toggle label modal
       this.map.on('dblclick', (e) => {
+        console.log('dblclick')
         let isFirstFeature = false
         if (this.currentInteractionName === 'select') {
           this.map.forEachFeatureAtPixel(e.pixel, (feature) => {
+            console.log('e.pixel, feature', e.pixel, feature)
             if (isFirstFeature === false) {
               // On double click open label-edit modal. Do it only once, even if there are more features at that pixel
               isFirstFeature = true
@@ -641,6 +643,8 @@ export default {
         format: new GeoJSON()
       })
 
+      console.log('Features loaded:', this.boxLayerSource.getFeatures().length)
+
       this.boxLayer = new VectorLayer({
         source: this.boxLayerSource,
         style: this.generateFeatureStyle()
@@ -660,9 +664,7 @@ export default {
           dragPan: true,
           keyboardPan: false,
           keyboardZoom: false,
-          mouseWheelZoom: true,
-          pointer: false,
-          select: true
+          mouseWheelZoom: true
         }),
         controls: [],
         layers: [

--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -271,11 +271,9 @@ export default {
     addMapEventListeners () {
       // Add event listener on click on features => toggle label modal
       this.map.on('dblclick', (e) => {
-        console.log('dblclick')
         let isFirstFeature = false
         if (this.currentInteractionName === 'select') {
           this.map.forEachFeatureAtPixel(e.pixel, (feature) => {
-            console.log('e.pixel, feature', e.pixel, feature)
             if (isFirstFeature === false) {
               // On double click open label-edit modal. Do it only once, even if there are more features at that pixel
               isFirstFeature = true
@@ -650,8 +648,6 @@ export default {
         features: (new GeoJSON()).readFeatures(this.geoJson),
         format: new GeoJSON()
       })
-
-      console.log('Features loaded:', this.boxLayerSource.getFeatures().length)
 
       this.boxLayer = new VectorLayer({
         source: this.boxLayerSource,

--- a/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
+++ b/client/js/components/procedure/imageAnnotator/DpImageAnnotator.vue
@@ -150,6 +150,7 @@ import DpSendBeacon from './DpSendBeacon'
 import GeoJSON from 'ol/format/GeoJSON'
 import ImageLayer from 'ol/layer/Image'
 import Map from 'ol/Map'
+import { markRaw } from 'vue'
 import { MultiPoint } from 'ol/geom'
 import Projection from 'ol/proj/Projection'
 import Static from 'ol/source/ImageStatic'
@@ -533,8 +534,15 @@ export default {
     },
 
     initInteractions () {
+      /*
+       * Wrap OpenLayers interactions in markRaw so that:
+       * 1) Vue won’t convert them into Proxies,
+       * 2) OL’s instanceof checks and internal state stay intact,
+       * otherwise map.addInteraction(this.currentInteraction) silently fails.
+       */
+
       // SELECT INTERACTION
-      this.selectInteraction = new Select({ layers: [this.boxLayer] })
+      this.selectInteraction = markRaw(new Select({ layers: [this.boxLayer] }))
 
       this.selectInteraction.on('select', e => {
         if (e.deselected.length === 1) {
@@ -553,11 +561,11 @@ export default {
       })
 
       // MODIFY INTERACTION
-      this.modifyInteraction = new Modify({
+      this.modifyInteraction = markRaw(new Modify({
         insertVertexCondition: () => false,
         pixelTolerance: 1,
         features: this.selectInteraction.getFeatures()
-      })
+      }))
 
       this.modifyInteraction.on('modifystart', (e) => {
         // Remove snap during modify action because it tries to snap to invisible features/vertices
@@ -584,7 +592,7 @@ export default {
       })
 
       // DRAW INTERACTION
-      this.drawInteraction = new Draw({
+      this.drawInteraction = markRaw(new Draw({
         source: this.boxLayerSource,
         type: 'Circle',
         geometryFunction: createBox(),
@@ -600,7 +608,7 @@ export default {
             })
           })
         })
-      })
+      }))
       this.drawInteraction.on('drawend', (e) => {
         const newFeature = e.feature
         newFeature.setId(uuid())
@@ -610,7 +618,7 @@ export default {
       })
 
       // SNAP INTERACTION
-      this.snapInteraction = new Snap({ source: this.boxLayerSource, edge: false, pixelTolerance: 15 })
+      this.snapInteraction = markRaw(new Snap({ source: this.boxLayerSource, edge: false, pixelTolerance: 15 }))
 
       // Set select as initial interaction
       this.setInteraction('select')

--- a/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
+++ b/client/js/components/procedure/imageAnnotator/DpLabelModal.vue
@@ -7,26 +7,28 @@
   All rights reserved
 </license>
 
-<dp-modal
-  ref="labelModal"
-  content-classes="w-14">
-  <h3>
-    {{ Translator.trans('format') }}
-  </h3>
-  <div class="flex space-inline-s">
-    <dp-select
-      v-model="selectedLabel"
-      classes="w-12"
-      name="labelSelect"
-      placeholder="-"
-      :options="labels" />
-    <button
-      @click="setLabel"
-      class="btn btn--primary">
-      {{ Translator.trans('accept') }}
-    </button>
-  </div>
-</dp-modal>
+<template>
+  <dp-modal
+    ref="labelModal"
+    content-classes="w-14">
+    <h3>
+      {{ Translator.trans('format') }}
+    </h3>
+    <div class="flex space-inline-s">
+      <dp-select
+        v-model="selectedLabel"
+        classes="w-12"
+        name="labelSelect"
+        placeholder="-"
+        :options="labels" />
+      <button
+        @click="setLabel"
+        class="btn btn--primary">
+        {{ Translator.trans('accept') }}
+      </button>
+    </div>
+  </dp-modal>
+</template>
 
 <script>
 import { DpModal, DpSelect } from '@demos-europe/demosplan-ui'


### PR DESCRIPTION
### Ticket
[DPLAN-15489](https://demoseurope.youtrack.cloud/issue/DPLAN-15489/PDF-Import-Nicht-moglich-um-Boxen-zu-wahlen-oder-bearbeiten-oder-hinzufugen)

**Description:** This PR fixes issue with OpenLayers interactions and the issue with `this.$refs.labelModal.toggle() is undefined`. These issues appeared after migration to vue3.

- wrap OpenLayers interactions in markRaw so that: Vue won’t convert them into Proxies, OL’s instanceof checks and internal state stay intact, otherwise `this.map.addInteraction(this.currentInteraction) `silently fails.
- fix the issue with `this.$refs.labelModal.toggle() is undefined` by adding the` <template>` tags to the component.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
