### PR TITLE
New Event to cover update Tag in topicalTag Addon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "cocur/slugify": "^4.0",
     "composer/composer": "^2.8",
     "composer/package-versions-deprecated": "1.11.99.5",
-    "demos-europe/demosplan-addon": "^0.54",
+    "demos-europe/demosplan-addon": "dev-b_dplan_15654_send_update_tag_to_ai",
     "doctrine/annotations": "^2.0",
     "doctrine/common": "^3.2",
     "doctrine/doctrine-bundle": "^2",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "cocur/slugify": "^4.0",
     "composer/composer": "^2.8",
     "composer/package-versions-deprecated": "1.11.99.5",
-    "demos-europe/demosplan-addon": "dev-b_dplan_15654_send_update_tag_to_ai",
+    "demos-europe/demosplan-addon": "v0.55",
     "doctrine/annotations": "^2.0",
     "doctrine/common": "^3.2",
     "doctrine/doctrine-bundle": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c25d517523e3a7358944f9525056f457",
+    "content-hash": "c427190f075f89fe8d8269ad0be84bbb",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1636,16 +1636,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.54",
+            "version": "v0.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "797cf78a4c1938a7346595ec2060e9bfe5976807"
+                "reference": "f337ada350d9dc24d558627efcc5bac44d6a1ded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/797cf78a4c1938a7346595ec2060e9bfe5976807",
-                "reference": "797cf78a4c1938a7346595ec2060e9bfe5976807",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/f337ada350d9dc24d558627efcc5bac44d6a1ded",
+                "reference": "f337ada350d9dc24d558627efcc5bac44d6a1ded",
                 "shasum": ""
             },
             "require": {
@@ -1712,9 +1712,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.54"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.55"
             },
-            "time": "2025-05-05T15:15:12+00:00"
+            "time": "2025-05-20T11:24:49+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -97,6 +97,7 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
             new UpdateTagEvent($tag),
             UpdateTagEventInterface::class
         );
+
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanStatement/edit_tag.html.twig',
             [

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -10,7 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Statement;
 
+use DemosEurope\DemosplanAddon\Contracts\Events\UpdateTagEventInterface;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
+use demosplan\DemosPlanCoreBundle\Event\Tag\UpdateTagEvent;
 use demosplan\DemosPlanCoreBundle\Exception\DuplicatedTagTitleException;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\FileUploadService;
@@ -23,6 +25,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function array_key_exists;
@@ -48,6 +51,7 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
         TranslatorInterface $translator,
         string $procedure,
         string $tag,
+        EventDispatcherInterface $eventDispatcher,
     ): Response {
         $requestPost = $request->request->all();
         $data = [];
@@ -89,7 +93,10 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
 
             return $this->redirectToRoute('DemosPlan_statement_administration_tags', ['procedure' => $procedure]);
         }
-
+        $eventDispatcher->dispatch(
+            new UpdateTagEvent($tag),
+            UpdateTagEventInterface::class
+        );
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanStatement/edit_tag.html.twig',
             [

--- a/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace demosplan\DemosPlanCoreBundle\Event\Tag;
 
 use DemosEurope\DemosplanAddon\Contracts\Events\UpdateTagEventInterface;

--- a/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Event\Tag;
+
+use DemosEurope\DemosplanAddon\Contracts\Events\UpdateTagEventInterface;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
+class UpdateTagEvent extends DPlanEvent implements UpdateTagEventInterface
+{
+    public function __construct(private string $tagId)
+    {
+    }
+
+    public function getTagId(): string
+    {
+        return $this->tagId;
+    }
+
+}

--- a/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Tag/UpdateTagEvent.php
@@ -15,5 +15,4 @@ class UpdateTagEvent extends DPlanEvent implements UpdateTagEventInterface
     {
         return $this->tagId;
     }
-
 }


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15654/Nach-der-Umbenennung-und-dem-Verschieben-in-das-neue-Thema-wird-das-bereits-beim-Aufteilen-verwendete-Schlagwort-nicht-mehr

Description: Add new Event to cover update Tag in TopicalTagAddon 