### PR TITLE
fix(refs DPLAN-15673): add question mark to length condition

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -1123,7 +1123,7 @@ export default {
     this.initPlaces()
     this.initAssignableUsers()
 
-    if (hasPermission('field_segments_custom_fields') && this.segment.attributes.customFields.length > 0) {
+    if (hasPermission('field_segments_custom_fields') && this.segment.attributes.customFields?.length > 0) {
       this.setInitiallySelectedCustomFieldValues()
     }
 


### PR DESCRIPTION
### Ticket
[DPLAN-15673](https://demoseurope.youtrack.cloud/issue/DPLAN-15673/Abschnitt-Aktionen-sind-alle-kaputt)

The bug occurs when some segments have customFields and some don't. The question mark ensures the length is only checked if there actually are customFields.

### How to review/test

1. have a statement with some segements that have customFields and some that don't
2. navigate to "Abschnitte"
3. check that actions mentioned in the ticket work
