### PR TITLE
fix: adapt hook name

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -233,7 +233,7 @@
                             <div class="u-mb">
                                 {% set addonProps = { 'procedureId': templateVars.proceduresettings.id } %}
                                 <addon-wrapper
-                                    hook-name="adminstration.edit.extra_fields"
+                                    hook-name="administration.edit.extra.fields"
                                     :addon-props="JSON.parse('{{ addonProps|json_encode|e('js', 'utf-8') }}')">
                                 </addon-wrapper>
                             </div>


### PR DESCRIPTION
This PR fixes a typo in a hook name. Related PRs in projects and addons are available.