### PR TITLE
fix(refs DPLAN-15675): show not assigned in tooltip

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -62,7 +62,7 @@
                     {{ Object.values(customFields).find(field => field.id === customField.id)?.attributes?.name || '' }}:
                   </dt>
                   <dd>
-                    {{ customField.value }}
+                    {{ customField.value ? customField.value : Translator.trans('not.assigned')}}
                   </dd>
                 </div>
               </template>


### PR DESCRIPTION
### Ticket
[DPLAN-15675](https://demoseurope.youtrack.cloud/issue/DPLAN-15675/Nicht-zugewiesen-wird-nicht-beim-hooveren-auf-ein-Tooltip-angezeigt)

### How to review/test
 
set a customField to 'Nicht zugewiesen' and check the tooltip
