### PR TITLE
feat (refs DPLAN-15650): Remove error prone flushes.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -870,6 +870,8 @@ class ElementsService extends CoreService implements ElementsServiceInterface
 
                 // copy related file
                 $this->copyElementRelatedFiles($destinationProcedure);
+
+                $elementIds[$elementToCopy->getId()] = $copiedElement->getId();
             }
             $entityManager->flush();
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -823,11 +823,9 @@ class ElementsService extends CoreService implements ElementsServiceInterface
     /**
      * Kopiert alle Elements (Planunterlagenkategorien) von einem Verfahren in ein anderes.
      *
-     * @return array<string, string>
-     *
-     * @throws Exception
+     * @throws Exception|Throwable
      */
-    public function copy(string $sourceProcedureId, Procedure $destinationProcedure): array
+    public function copy(string $sourceProcedureId, Procedure $destinationProcedure): void
     {
         $entityManager = $this->entityManager;
 
@@ -872,12 +870,8 @@ class ElementsService extends CoreService implements ElementsServiceInterface
 
                 // copy related file
                 $this->copyElementRelatedFiles($destinationProcedure);
-
-                $elementIds[$elementToCopy->getId()] = $copiedElement->getId();
             }
             $entityManager->flush();
-
-            return $elementIds;
         } catch (Exception $e) {
             $this->logger->warning('Copy elements failed. Message: ', [$e]);
             throw $e;

--- a/demosplan/DemosPlanCoreBundle/Repository/ParagraphRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ParagraphRepository.php
@@ -489,6 +489,7 @@ class ParagraphRepository extends FluentRepository implements ArrayInterface, Ob
     {
         $paragraphIdMapping = [];
         $paragraphsToCopy = $this->getParagraphOfElement($elementToCopy);
+        $copiedParagraphs = [];
         foreach ($paragraphsToCopy as $paragraphToCopy) {
             $copiedParagraph = new Paragraph();
             $copiedParagraph->setCategory($paragraphToCopy->getCategory());
@@ -507,23 +508,17 @@ class ParagraphRepository extends FluentRepository implements ArrayInterface, Ob
             $copiedParagraph->setProcedure($copiedElement->getProcedure());
 
             $this->getEntityManager()->persist($copiedParagraph);
-            $paragraphIdMapping[$paragraphToCopy->getId()] = $copiedParagraph->getId();
+            $paragraphIdMapping[$paragraphToCopy->getId()] = $copiedParagraph;
+            $copiedParagraphs[] = $copiedParagraph;
         }
-        $this->getEntityManager()->persist($copiedElement);
-        $this->getEntityManager()->flush();
 
-        $copiedParagraphs = $this->getParagraphOfElement($copiedElement);
         foreach ($copiedParagraphs as $copiedParagraph) {
             if ($copiedParagraph->getParent() instanceof Paragraph) {
                 $oldParentId = $copiedParagraph->getParent()->getId();
-                $relatedCopiedParagraph = $this->getEntityManager()->getReference(
-                    Paragraph::class, $paragraphIdMapping[$oldParentId]
-                );
+                $relatedCopiedParagraph = $paragraphIdMapping[$oldParentId];
                 $copiedParagraph->setParent($relatedCopiedParagraph);
             }
-            $this->getEntityManager()->persist($copiedParagraph);
         }
-        $this->getEntityManager()->flush();
     }
 
     /**


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-15650/Verfahren-kann-nicht-erstellt-werden

I removed two flush calls, redundant persist calls. In copyParagraphsOfElement I think we can use the new created paragraph entities directly. Until now I can't reproduce the Deadlock exception on this branch. I can well imagine that the deadlock exception could still occur. But perhaps less frequently?

### How to review/test
run locally bin/project dp:maintenance to start the maintenance task, then create a procedure via web interface


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [] Move the tickets on the board accordingly
- [ ] Update changelog 
