### PR TITLE
Use Event in Post Method

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -90,13 +90,13 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
         $templateVars['boilerplates'] = $procedureService->getBoilerplateList($procedure);
         if (null !== $data['action']) {
             $this->getMessageBag()->add('confirm', 'confirm.tag.edited');
+                $eventDispatcher->dispatch(
+                    new UpdateTagEvent($tagEntity->getId()),
+                    UpdateTagEventInterface::class
+                );
 
             return $this->redirectToRoute('DemosPlan_statement_administration_tags', ['procedure' => $procedure]);
         }
-        $eventDispatcher->dispatch(
-            new UpdateTagEvent($tag),
-            UpdateTagEventInterface::class
-        );
 
         return $this->renderTemplate(
             '@DemosPlanCore/DemosPlanStatement/edit_tag.html.twig',

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -90,10 +90,10 @@ class DemosPlanStatementTagController extends DemosPlanStatementController
         $templateVars['boilerplates'] = $procedureService->getBoilerplateList($procedure);
         if (null !== $data['action']) {
             $this->getMessageBag()->add('confirm', 'confirm.tag.edited');
-                $eventDispatcher->dispatch(
-                    new UpdateTagEvent($tagEntity->getId()),
-                    UpdateTagEventInterface::class
-                );
+            $eventDispatcher->dispatch(
+                new UpdateTagEvent($tagEntity->getId()),
+                UpdateTagEventInterface::class
+            );
 
             return $this->redirectToRoute('DemosPlan_statement_administration_tags', ['procedure' => $procedure]);
         }


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15654/Nach-der-Umbenennung-und-dem-Verschieben-in-das-neue-Thema-wird-das-bereits-beim-Aufteilen-verwendete-Schlagwort-nicht-mehr

Description: Trigger Event when method is Post