### PR TITLE
f-DPLAN-11632 Case insensitive email address comparison

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
@@ -106,6 +106,7 @@ class EmailAddressRepository extends CoreRepository implements EmailAddressRepos
      */
     protected function sortByGivenArray(array $sortedStrings, array $unsortedEntities): array
     {
+        $sortedEmailAddresses = [];
         foreach ($sortedStrings as $sortedEmailAddressString) {
             foreach ($unsortedEntities as $unsortedEmailAddressEntity) {
                 $fullAddress = $unsortedEmailAddressEntity->getFullAddress();

--- a/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/EmailAddressRepository.php
@@ -109,13 +109,12 @@ class EmailAddressRepository extends CoreRepository implements EmailAddressRepos
         foreach ($sortedStrings as $sortedEmailAddressString) {
             foreach ($unsortedEntities as $unsortedEmailAddressEntity) {
                 $fullAddress = $unsortedEmailAddressEntity->getFullAddress();
-                if (strcasecmp($sortedEmailAddressString, $fullAddress) === 0) {
+                if (0 === strcasecmp($sortedEmailAddressString, $fullAddress)) {
                     $sortedEmailAddresses[$sortedEmailAddressString] = $unsortedEmailAddressEntity;
                     break;
                 }
             }
         }
-
 
         return $sortedEmailAddresses;
     }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-11632/BOB-SH-Bauleitplanung-Prod-bestimmte-Mailadresse-kann-in-einem-Verfahren-nicht-gespeichert-werden-T36900

Description: 
Case insensitive email address comparison:
 - array_diff is case-sensitive, therefore the already existing email from input could not be found and so it appears in array_diff which causes an unique constraint error when updating.
 - this is done while sorting email addresses too otherwise emails with corresponding value will be incorrectly omitted from the return which causes errors too.


- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly

