### PR TITLE
fix(refs DPLAN-15558): Load branding/cssvars for orgas

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -202,6 +202,7 @@ const orgaFields = {
     'showlist',
     'showname',
     'state',
+    'statusInCustomer',
     'street',
     'submissionType',
     'types'
@@ -459,7 +460,7 @@ export default {
         },
         fields: orgaFields,
         sort: 'name',
-        include: ['branding', 'currentSlug', 'orgasInCustomer', 'orgasInCustomer.customer'].join()
+        include: ['branding', 'currentSlug', 'statusInCustomers', 'statusInCustomers.customer'].join()
       })
         .then(() => {
           this.pendingOrganisationsLoading = false

--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -169,15 +169,15 @@ import { mapActions, mapState } from 'vuex'
 import DpOrganisationListItem from './DpOrganisationListItem'
 
 const orgaFields = {
-  OrgaStatusInCustomer: [
-    'customer',
-    'status'
+  Branding: [
+    'cssvars'
   ].join(),
   Customer: [
     'name',
     'subdomain'
   ].join(),
   Orga: [
+    'branding',
     'canCreateProcedures',
     'ccEmail2',
     'city',
@@ -205,6 +205,10 @@ const orgaFields = {
     'street',
     'submissionType',
     'types'
+  ].join(),
+  OrgaStatusInCustomer: [
+    'customer',
+    'status'
   ].join()
 }
 
@@ -411,7 +415,7 @@ export default {
         sort: 'name',
         filter: filterObject,
         fields: orgaFields,
-        include: ['currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
+        include: ['branding', 'currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
       })
         .then(() => { this.isLoading = false })
     },
@@ -434,7 +438,7 @@ export default {
             }
           }
         },
-        include: ['currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
+        include: ['branding', 'currentSlug', 'statusInCustomers.customer', 'statusInCustomers'].join()
       })
         .then(() => {
           this.pendingOrganisationsLoading = false
@@ -455,7 +459,7 @@ export default {
         },
         fields: orgaFields,
         sort: 'name',
-        include: ['currentSlug', 'orgasInCustomer.customer'].join()
+        include: ['branding', 'currentSlug', 'orgasInCustomer', 'orgasInCustomer.customer'].join()
       })
         .then(() => {
           this.pendingOrganisationsLoading = false


### PR DESCRIPTION
Load branding/cssvars for orgas to display the saved values

### Ticket
DPLAN-15558


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The saved branding data where not displayed, so it was not possible to see what colorsettings where saved.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Ass support goto orga-edit and set branding colors. see if they get displayed after saving and after reloading the page. For both: pending and "accepted" orgas