### PR TITLE
fix(refs: DPLAN-15664): Render correct error message

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -198,13 +198,14 @@
                                     showPlainHint: true
                                 } %}
                                 {{ form_errors(form.agencyMainEmailAddress) }}
-                                <input id="{{ form.agencyMainEmailAddress.vars.id }}"
-                                       name="agencyMainEmailAddress[fullAddress]"
-                                       value="{{ form.agencyMainEmailAddress.vars.value.fullAddress }}"
-                                       data-cy="internal:agencyMainEmailAddress"
-                                       class="o-form__control-input w-full"
-                                       type="email"
-                                       required>
+                                <dp-input
+                                    id="main-email"
+                                    data-cy="agencyMainEmailAddress"
+                                    name="agencyMainEmailAddress[fullAddress]"
+                                    required
+                                    type="email"
+                                    value="{{ form.agencyMainEmailAddress.vars.value.fullAddress }}">
+                                </dp-input>
                             </div>
 
                             <div class="u-mb">


### PR DESCRIPTION
### Ticket
[DPLAN-15664](https://demoseurope.youtrack.cloud/issue/DPLAN-15664/Nach-dem-speichern-von-alle-Pflichtfelder-und-wieder-loschen-von-ein-paar-Pflichtfelder-und-speichern-zeigen-wir-nicht-das)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
The Bug is fixed in the administration_edit.html.twig. In this file there is an {% include ... %} that includes the label and a tooltip. I replaced the following input element with a dp-input component. The dp-input component can have an own label (i deleted it because it is the same like the include but without the tooltip).  

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ x] Move the tickets on the board accordingly
