### PR TITLE
Remove unused vuejs-datepicker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "vue2-leaflet": "^2.7.1",
     "vue2-leaflet-markercluster": "^3.1.0",
     "vuedraggable": "^2.24.3",
-    "vuejs-datepicker": "^1.5.4",
     "vuex": "^4.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12517,7 +12517,6 @@ __metadata:
     vue2-leaflet: "npm:^2.7.1"
     vue2-leaflet-markercluster: "npm:^3.1.0"
     vuedraggable: "npm:^2.24.3"
-    vuejs-datepicker: "npm:^1.5.4"
     vuex: "npm:^4.0.2"
     webpack: "npm:^5.96.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
@@ -14486,15 +14485,6 @@ __metadata:
   dependencies:
     sortablejs: "npm:1.10.2"
   checksum: 10c0/1ae7913f90639900f8861a9ac70694e2a11f0ce9e59514d1324573535f98fed7a4b1d5fc48ed0f251c404128b45b41e4af3c424d15c7696e87ee971ae743d871
-  languageName: node
-  linkType: hard
-
-"vuejs-datepicker@npm:^1.5.4":
-  version: 1.6.2
-  resolution: "vuejs-datepicker@npm:1.6.2"
-  peerDependencies:
-    vue: ^2.6.10
-  checksum: 10c0/9f69334ed4b18c18a15fc028ee34aba510b6441815a40143ee65dd676b44fbc81e3e3dabd799154e027aca370580a4d7a2b190ac4f656cce18f94e298f2d24d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Ticket
General maintenance task - no specific ticket. After merge of #4592 this dependency is unused.

### Description
Remove unused vuejs-datepicker dependency from package.json. The project has already migrated to a11y-datepicker via @demos-europe/demosplan-ui, making vuejs-datepicker redundant. No code references to vuejs-datepicker remain in the codebase.

### How to review/test
- Verify that no references to vuejs-datepicker exist in the codebase
- Run `yarn dev:diplanbau` to ensure build still works
- Check that date picker functionality still works in the application

### PR Checklist
- [x] Run `yarn lint` 
- [x] Run `yarn test`
- [x] Verify build still works