### PR TITLE
fix: Populate _ms_error_message field with actual mail error details

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/MailService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MailService.php
@@ -367,6 +367,9 @@ class MailService extends CoreService
                     $this->mailer->send($message);
                     $mail->setStatus('sent');
                     $mail->setSendDate(new DateTime());
+                    // Clear any previous error information on successful send
+                    $mail->setErrorCode('');
+                    $mail->setErrorMessage('');
                 } catch (TransportExceptionInterface $e) {
                     $this->logger->warning('Could not send Mail',
                         [
@@ -381,12 +384,16 @@ class MailService extends CoreService
                     );
                     // update number of send attempts
                     $mail->setSendAttempt($mail->getSendAttempt() + 1);
+                    $mail->setErrorCode($e->getCode());
+                    $mail->setErrorMessage($e->getMessage());
                     $em->persist($mail);
 
                     continue;
                 } catch (Exception $e) {
                     $this->logger->error('General exception on sending e-mail.', [$e]);
                     $mail->setSendAttempt($mail->getSendAttempt() + 1);
+                    $mail->setErrorCode($e->getCode());
+                    $mail->setErrorMessage($e->getMessage());
                     $em->persist($mail);
 
                     continue;

--- a/demosplan/DemosPlanCoreBundle/Logic/MailService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/MailService.php
@@ -416,11 +416,11 @@ class MailService extends CoreService
                 foreach ($mail->getAttachments() as $attachment) {
                     try {
                         if ($attachment->getDeleteOnSent()
-                            && $mail->getStatus() === 'sent'
+                            && 'sent' === $mail->getStatus()
                             && $this->defaultStorage->fileExists($attachment->getFilename())
-                            ) {
-                                $this->defaultStorage->delete($attachment->getFilename());
-                            }
+                        ) {
+                            $this->defaultStorage->delete($attachment->getFilename());
+                        }
                     } catch (Exception $exception) {
                         $this->logger->warning('failed to remove email attachment', [$exception]);
                     }


### PR DESCRIPTION
### Description
The `_ms_error_message` field in the MailSend entity was not being populated when mail sending failed. This change ensures that both error code and error message from mail transport exceptions are properly stored in the database for debugging purposes.

### Changes
- Store exception message and code in MailSend entity when transport fails  
- Clear error fields on successful mail sending
- Improve error tracking for failed mail delivery

### How to review/test
1. Review the changes in `demosplan/DemosPlanCoreBundle/Logic/MailService.php`
2. Verify that `setErrorCode()` and `setErrorMessage()` are called in exception handlers
3. Check that error fields are cleared on successful mail sending
4. Test mail sending failures to ensure errors are properly stored in the database

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog