### PR TITLE
fix(DPLAN-15766): Fix testUpdateSetting test:

### DIFF
--- a/tests/backend/base/FunctionalTestCase.php
+++ b/tests/backend/base/FunctionalTestCase.php
@@ -390,12 +390,7 @@ class FunctionalTestCase extends WebTestCase
             return false;
         }
 
-        if (24 === strlen($dateString)) {
-            // Old format: 2025-05-28T07:22:25+0100 (24 chars)
-            $dateString[10] = ' ';
-            $dateString = substr($dateString, 0, -5);
-        } elseif (25 === strlen($dateString)) {
-            // New format: 2025-05-28T07:22:25+00:00 (25 chars)
+        if (25 === strlen($dateString)) {
             $dateString[10] = ' ';
             $dateString = substr($dateString, 0, -6);
         } else {


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-15766/Fix-BE-test-failing-test

**What this PR does:**

1. Fixes failing tests that started breaking after the timezone format change in commit 5870c52dd
2. Updates date validation in FunctionalTestCase to handle new ISO 8601 timezone format

**Root cause:**
- The issue was caused by commit 5870c52dd which updated DateHelper::convertDateToString() to use PHP's ISO 8601 format with the P timezone format.
- DateHelper::convertDateToString() now outputs 2025-05-28T07:22:25+00:00 (25 chars)
- Tests were still expecting 2025-05-28T07:22:25+0100 (24 chars)
- This broke date validation and timestamp conversion in tests
- For a better understanding, below date format examples:

_Date format examples:_
Old format (before timezone commit 5870c52dd):
2025-05-28T07:22:25+0100
- 24 characters total
- Timezone: +0100 (4 digits, no colon)

New format (after timezone commit 5870c52dd):
2025-05-28T07:22:25+00:00
- 25 characters total
- Timezone: +00:00 (5 characters with colon, ISO 8601 standard)

**Technical changes:**
1. Updated regex pattern in hasValidDateFormat() to accept +00:00 instead of only +0100
2. Fixed string length check in toTimestamp() to handle 25-character dates (was only expecting 24)
3. Adjusted timezone removal logic to strip 6 characters (+00:00) instead of 5 (+0100)

