### PR TITLE
feat(refs: DPLAN-15692): Render mobile design for Map

### DIFF
--- a/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
+++ b/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
@@ -4,11 +4,17 @@
       id="statementModalButton"
       :class="prefixClass('left-[365px] top-[24px] pt-[11px] pb-[11px] pl-[20px] pr-[20px] absolute z-above-zero')"
       data-cy="statementModal"
-      :disabled="!hasPermission('feature_new_statement')"
-      href="#publicStatementForm"
+      :href="hasPermission('feature_new_statement') ? '#publicStatementForm' : Routing.generate('DemosPlan_user_login_alternative')"
       rounded
       :text="Translator.trans('statement.participate')"
-      @click.stop.prevent="() => hasPermission('feature_new_statement') ? toggleStatementModal({}) : null" />
+      @click="(event) => {
+        if (!hasPermission('feature_new_statement')) {
+          return
+        }
+        event.preventDefault()
+        event.stopPropagation()
+        toggleStatementModal({})
+      }" />
 
     <diplan-karte />
   </div>


### PR DESCRIPTION
### Ticket
[DPLAN-15692](https://demoseurope.youtrack.cloud/issue/DPLAN-15692/ADO-Issue-28779-Mobile-Design-fur-Karte)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR renders the mobile design for the new map. It also fixes the following bugs:

1. [DPLAN-15689](https://demoseurope.youtrack.cloud/issue/DPLAN-15689/Unangemeldeter-Benutzer-Reden-Sie-Mit-Button-funktioniert-nicht)
2. [DPLAN-15729](https://demoseurope.youtrack.cloud/issue/DPLAN-15729/Wir-zeigen-grosses-Whitespace-unter-Planungsdokumenten-und-Stellungnahmen-Offentlichkeitsansicht)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanfest and choose a procedure
2. Switch to a mobile view
3. Check if the "Reden Sie mit!" button is placed on the map and leads to the login screen, if the user isn't logged in
4. Login with a private user and check if the button opens the modal
5. Open the map layers and check if the button doesn't overlap any menu
6. Check if the button is under the search field
7. Switch to desktop view and check if the button is right next to the search field 

