### PR TITLE
f DPLAN-15765 use Symfony's string component to provide Unicode handling, including whitespace and normalization functions

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -50,6 +50,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\String\UnicodeString;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -415,11 +416,13 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
             $tagTitles = explode(',', (string) $tagTitlesString);
 
             foreach ($tagTitles as $tagTitle) {
+                $tagTitle = new UnicodeString($tagTitle);
+                $tagTitle = $tagTitle->trim()->toString();
                 $matchingTag = $this->getMatchingTag($tagTitle, $procedureId);
 
                 $createNewTag = null === $matchingTag;
                 if ($createNewTag) {
-                    $matchingTag = $this->tagService->createTag(trim($tagTitle), $miscTopic, false);
+                    $matchingTag = $this->tagService->createTag($tagTitle, $miscTopic, false);
                 }
 
                 // Check if valid tag
@@ -619,7 +622,7 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
     private function getMatchingTag(string $tagTitle, string $procedureId): ?Tag
     {
         $titleCondition = $this->conditionFactory->allConditionsApply(
-            $this->conditionFactory->propertyHasValue(trim($tagTitle), $this->tagResourceType->title),
+            $this->conditionFactory->propertyHasValue($tagTitle, $this->tagResourceType->title),
             $this->conditionFactory->propertyHasValue($procedureId, $this->tagResourceType->topic->procedure->id),
         );
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15765/Abschnittsimport-Upoload-gibt-Fehlermeldung


Description: 
use Symfony's string component to provide Unicode handling, including whitespace and normalization functions:
Many "invisible" or "special" characters can find their way into Excel ".xlsx" cell data, especially with copy-paste, imports, or exports between various systems and formats which causes errors while uploading segments, that's why the tags titles strings have to be cleaned before be used and added.


- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly

