### PR TITLE
chore: configure dependabot to run at night to avoid CI congestion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "02:00"
       timezone: Europe/Berlin
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     ignore:
       # D3 Upgrades are blocked because 8.x is not installing propperly
       # my guess: soething with fsevents 2.0
@@ -48,9 +48,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "09:01"
+      time: "02:01"
       timezone: Europe/Berlin
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     labels:
       - dependencies:composer
     ignore:


### PR DESCRIPTION
### Ticket
No specific ticket - infrastructure improvement

Configure dependabot to run during nighttime hours to prevent CI congestion during business hours.

### How to review/test
- [x] Verify .github/dependabot.yml configuration is valid
- [ ] Confirm dependabot runs according to schedule after merge

### PR Checklist
- [x] Run `yarn lint`
- [x] Run `yarn test`