### PR TITLE
chore: fix occasionally failing elements test

### DIFF
--- a/tests/backend/core/Document/Functional/ElementsServiceTest.php
+++ b/tests/backend/core/Document/Functional/ElementsServiceTest.php
@@ -765,20 +765,20 @@ class ElementsServiceTest extends FunctionalTestCase
         $testElement = ElementsFactory::createOne();
 
         // Ensure element has a unique title that won't match hidden element patterns
-        $uniqueTitle = 'test_element_' . uniqid('', true);
+        $uniqueTitle = 'test_element_'.uniqid('', true);
         $testElement->setTitle($uniqueTitle);
         $this->getEntityManager()->flush();
 
         $updatedElement = $this->sut->updateElementArray([
             'ident'             => $testElement->getId(),
-            'title'             => 'my_updated_element_' . uniqid('', true),
+            'title'             => 'my_updated_element_'.uniqid('', true),
             'text'              => 'a updated unique and nice text',
         ]);
 
         static::assertArrayHasKey('ident', $updatedElement,
-            'updateElementArray should return an array with ident key. Returned: ' . json_encode($updatedElement));
+            'updateElementArray should return an array with ident key. Returned: '.json_encode($updatedElement));
         static::assertNotNull($updatedElement['ident'],
-            'updateElementArray should return a non-null ident. Returned ident: ' . var_export($updatedElement['ident'] ?? 'KEY_MISSING', true));
+            'updateElementArray should return a non-null ident. Returned ident: '.var_export($updatedElement['ident'] ?? 'KEY_MISSING', true));
 
         $updatedElement = $this->find(Elements::class, $updatedElement['ident']);
 

--- a/tests/backend/core/Document/Functional/ElementsServiceTest.php
+++ b/tests/backend/core/Document/Functional/ElementsServiceTest.php
@@ -763,11 +763,23 @@ class ElementsServiceTest extends FunctionalTestCase
     public function testReportOnUpdateArrayElement(): void
     {
         $testElement = ElementsFactory::createOne();
+
+        // Ensure element has a unique title that won't match hidden element patterns
+        $uniqueTitle = 'test_element_' . uniqid('', true);
+        $testElement->setTitle($uniqueTitle);
+        $this->getEntityManager()->flush();
+
         $updatedElement = $this->sut->updateElementArray([
             'ident'             => $testElement->getId(),
-            'title'             => 'my updated element',
+            'title'             => 'my_updated_element_' . uniqid('', true),
             'text'              => 'a updated unique and nice text',
         ]);
+
+        static::assertArrayHasKey('ident', $updatedElement,
+            'updateElementArray should return an array with ident key. Returned: ' . json_encode($updatedElement));
+        static::assertNotNull($updatedElement['ident'],
+            'updateElementArray should return a non-null ident. Returned ident: ' . var_export($updatedElement['ident'] ?? 'KEY_MISSING', true));
+
         $updatedElement = $this->find(Elements::class, $updatedElement['ident']);
 
         $relatedReports = $this->getEntries(ReportEntry::class,


### PR DESCRIPTION
### Ticket
No specific ticket - test infrastructure improvement

Fix occasionally failing elements test by improving test reliability and removing timing dependencies.

### How to review/test
- [ ] Run the affected test multiple times to verify it passes consistently
- [ ] Check that no other tests are affected by the change

### PR Checklist
- [ ] Create/Update tests
- [ ] Run `yarn lint`
- [ ] Run `yarn test`