### PR TITLE
feat: provide a securityVoter to check if user is active

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -43,6 +43,10 @@ parameters:
     # who are granted access (true)
     procedure_user_restricted_access: false
 
+    # User activity checking thresholds (in days)
+    user_activity_last_login_threshold_days: 180
+    user_activity_claimed_statements_threshold_days: 180
+
     # Route and parameters for the public index page
     #
     # - Using the controller forward notation here will result in an internal forward

--- a/config/services.yml
+++ b/config/services.yml
@@ -1173,6 +1173,24 @@ services:
     demosplan\DemosPlanCoreBundle\Logic\User\UserHasher:
         lazy: true
 
+    # User Activity Infrastructure
+    demosplan\DemosPlanCoreBundle\Logic\User\LastLoginActivityChecker:
+        arguments:
+            $dayThreshold: '%user_activity_last_login_threshold_days%'
+        tags:
+            - { name: user_activity_checker }
+
+    demosplan\DemosPlanCoreBundle\Logic\User\ClaimedStatementsActivityChecker:
+        arguments:
+            $dayThreshold: '%user_activity_claimed_statements_threshold_days%'
+        tags:
+            - { name: user_activity_checker }
+
+    demosplan\DemosPlanCoreBundle\Authorization\Voter\UserActivityVoter:
+        arguments:
+            $activityCheckers: !tagged_iterator 'user_activity_checker'
+        tags:
+            - { name: security.voter }
 
     demosplan\DemosPlanCoreBundle\Logic\User\RoleService:
         lazy: true

--- a/demosplan/DemosPlanCoreBundle/Authorization/Voter/README.md
+++ b/demosplan/DemosPlanCoreBundle/Authorization/Voter/README.md
@@ -1,0 +1,137 @@
+# User Activity Voter Infrastructure
+
+This infrastructure provides a flexible way to determine if a user is "active" based on various criteria using Symfony's SecurityVoter pattern.
+
+## Components
+
+### UserActivityInterface
+Defines the contract for activity checkers with methods:
+- `isUserActive(UserInterface $user): bool` - Check if user is active
+- `getActivityDescription(): string` - Human-readable description
+- `getPriority(): int` - Priority for multiple checkers (higher = more important)
+
+### UserActivityVoter
+The main voter that orchestrates activity checking using the attribute `IS_ACTIVE_USER`.
+
+### Built-in Activity Checkers
+
+#### LastLoginActivityChecker
+- **Criteria**: User has logged in within a configurable threshold
+- **Default**: 30 days (configurable via `user_activity_last_login_threshold_days`)
+- **Priority**: 100 (high)
+
+#### ClaimedStatementsActivityChecker  
+- **Criteria**: User has claimed statements/segments with recent activity
+- **Default**: 90 days (configurable via `user_activity_claimed_statements_threshold_days`)
+- **Priority**: 75 (medium-high)
+
+## Usage Examples
+
+### In Controllers
+```php
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class MyController
+{
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker
+    ) {}
+    
+    public function someAction(User $user)
+    {
+        if ($this->authorizationChecker->isGranted('IS_ACTIVE_USER', $user)) {
+            // User is considered active
+            return $this->render('active_user_view.html.twig');
+        }
+        
+        // User is inactive
+        return $this->render('inactive_user_view.html.twig');
+    }
+}
+```
+
+### In Twig Templates
+```twig
+{% if is_granted('IS_ACTIVE_USER', user) %}
+    <span class="badge badge-success">Active User</span>
+{% else %}
+    <span class="badge badge-warning">Inactive User</span>
+{% endif %}
+```
+
+### In Services
+```php
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class UserAnalyticsService
+{
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker
+    ) {}
+    
+    public function getActiveUserCount(array $users): int
+    {
+        return count(array_filter($users, fn($user) => 
+            $this->authorizationChecker->isGranted('IS_ACTIVE_USER', $user)
+        ));
+    }
+}
+```
+
+## Configuration
+
+### Parameters (config/parameters_default.yml)
+```yaml
+parameters:
+    # Threshold for last login activity checker (days)
+    user_activity_last_login_threshold_days: 180
+    
+    # Threshold for claimed statements activity checker (days)
+    user_activity_claimed_statements_threshold_days: 180
+```
+
+### Services (config/services.yml)
+Activity checkers are automatically registered with the `user_activity_checker` tag and injected into the voter via tagged iterators.
+
+## Creating Custom Activity Checkers
+
+1. Implement `UserActivityInterface`
+2. Register as a service with the `user_activity_checker` tag
+3. Define priority to control evaluation order
+
+Example:
+```php
+class CustomActivityChecker implements UserActivityInterface
+{
+    public function isUserActive(UserInterface $user): bool
+    {
+        // Your custom logic here
+        return true;
+    }
+    
+    public function getActivityDescription(): string
+    {
+        return 'Custom activity criteria';
+    }
+    
+    public function getPriority(): int
+    {
+        return 50; // Medium priority
+    }
+}
+```
+
+Service registration:
+```yaml
+services:
+    App\Logic\CustomActivityChecker:
+        tags:
+            - { name: user_activity_checker }
+```
+
+## Behavior
+
+- **Multiple Checkers**: Uses OR logic - user is active if ANY checker considers them active
+- **Priority**: Higher priority checkers are evaluated first
+- **No Checkers**: If no activity checkers are configured, all users are considered active
+- **Performance**: Checkers are sorted by priority once per request

--- a/demosplan/DemosPlanCoreBundle/Authorization/Voter/UserActivityVoter.php
+++ b/demosplan/DemosPlanCoreBundle/Authorization/Voter/UserActivityVoter.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Authorization\Voter;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserActivityInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class UserActivityVoter extends Voter
+{
+    public const IS_ACTIVE_USER = 'IS_ACTIVE_USER';
+
+    /**
+     * @var UserActivityInterface[]
+     */
+    private array $activityCheckers = [];
+
+    /**
+     * @param iterable<UserActivityInterface> $activityCheckers
+     */
+    public function __construct(iterable $activityCheckers = [])
+    {
+        foreach ($activityCheckers as $checker) {
+            $this->addActivityChecker($checker);
+        }
+    }
+
+    public function addActivityChecker(UserActivityInterface $checker): void
+    {
+        $this->activityCheckers[] = $checker;
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return self::IS_ACTIVE_USER === $attribute && $subject instanceof UserInterface;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        if (!$subject instanceof UserInterface) {
+            return false;
+        }
+
+        // If no activity checkers are configured, consider all users as active
+        if (empty($this->activityCheckers)) {
+            return true;
+        }
+
+        // Sort checkers by priority (highest first)
+        $sortedCheckers = $this->activityCheckers;
+        usort($sortedCheckers, static fn(UserActivityInterface $a, UserActivityInterface $b): int => 
+            $b->getPriority() <=> $a->getPriority()
+        );
+
+        // Check activity with each checker, returning true if any checker considers the user active
+        foreach ($sortedCheckers as $checker) {
+            if ($checker->isUserActive($subject)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all registered activity checkers, sorted by priority.
+     *
+     * @return UserActivityInterface[]
+     */
+    public function getActivityCheckers(): array
+    {
+        $checkers = $this->activityCheckers;
+        usort($checkers, static fn(UserActivityInterface $a, UserActivityInterface $b): int => 
+            $b->getPriority() <=> $a->getPriority()
+        );
+
+        return $checkers;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/UserFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/UserFactory.php
@@ -79,6 +79,17 @@ final class UserFactory extends PersistentProxyObjectFactory
      */
     protected function initialize(): static
     {
-        return $this;
+        return $this->afterInstantiate(function (User $user): void {
+            // Set default flag values that match expected behavior for new users
+            $user->setNewUser(true);
+            $user->setProfileCompleted(false);
+            $user->setAccessConfirmed(false);
+            $user->setNewsletter(false);
+            $user->setForumNotification(false);
+            $user->setAssignedTaskNotification(false);
+            
+            // For new users, modifiedDate should equal createdDate to indicate no activity
+            $user->setModifiedDate($user->getCreatedDate());
+        });
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/ClaimedStatementsActivityChecker.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/ClaimedStatementsActivityChecker.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\User;
+
+use DateTimeImmutable;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
+
+class ClaimedStatementsActivityChecker implements UserActivityInterface
+{
+    private StatementRepository $statementRepository;
+    private int $dayThreshold;
+
+    public function __construct(StatementRepository $statementRepository, int $dayThreshold = 180)
+    {
+        $this->statementRepository = $statementRepository;
+        $this->dayThreshold = $dayThreshold;
+    }
+
+    public function isUserActive(UserInterface $user): bool
+    {
+        $threshold = new DateTimeImmutable(sprintf('-%d days', $this->dayThreshold));
+
+        // Count statements/segments assigned to the user and modified within the threshold period
+        $claimedStatements = $this->statementRepository->findBy([
+            'assignee' => $user,
+        ]);
+
+        if (empty($claimedStatements)) {
+            return false;
+        }
+
+        // Check if any of the claimed statements were modified within the threshold
+        foreach ($claimedStatements as $statement) {
+            $modifyDate = $statement->getModified();
+            if ($modifyDate && $modifyDate >= $threshold) {
+                return true;
+            }
+        }
+
+        // If user has claimed statements but none were modified recently, consider them inactive
+        return false;
+    }
+
+    public function getActivityDescription(): string
+    {
+        return sprintf('User has claimed statements or segments with activity within the last %d days', $this->dayThreshold);
+    }
+
+    public function getPriority(): int
+    {
+        return 75; // Medium-high priority for work-based activity
+    }
+
+    public function getDayThreshold(): int
+    {
+        return $this->dayThreshold;
+    }
+
+    public function setDayThreshold(int $dayThreshold): void
+    {
+        $this->dayThreshold = $dayThreshold;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/User/LastLoginActivityChecker.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/LastLoginActivityChecker.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\User;
+
+use DateTimeImmutable;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+
+class LastLoginActivityChecker implements UserActivityInterface
+{
+    private int $dayThreshold;
+
+    public function __construct(int $dayThreshold = 180)
+    {
+        $this->dayThreshold = $dayThreshold;
+    }
+
+    public function isUserActive(UserInterface $user): bool
+    {
+        $lastLogin = $user->getLastLogin();
+
+        if (null === $lastLogin) {
+            // User has never logged in - check other indicators of user activity
+            return $this->hasUserEverBeenActive($user);
+        }
+
+        $threshold = new DateTimeImmutable(sprintf('-%d days', $this->dayThreshold));
+
+        return $lastLogin >= $threshold;
+    }
+
+    private function hasUserEverBeenActive(UserInterface $user): bool
+    {
+        // If user is no longer marked as "new", they have completed initial setup
+        if (!$user->isNewUser()) {
+            return true;
+        }
+
+        // If profile is completed, user has done some work
+        if ($user->isProfileCompleted()) {
+            return true;
+        }
+
+        // If access is confirmed, user has been administratively activated
+        if ($user->isAccessConfirmed()) {
+            return true;
+        }
+
+        // If the user record has been modified since creation, there has been some activity
+        $createdDate = $user->getCreatedDate();
+        $modifiedDate = $user->getModifiedDate();
+
+        if ($createdDate && $modifiedDate && $createdDate !== $modifiedDate) {
+            return true;
+        }
+
+        // User appears to be completely inactive - never logged in and no signs of activity
+        return false;
+    }
+
+    public function getActivityDescription(): string
+    {
+        return sprintf('User has logged in within the last %d days or shows signs of account activity', $this->dayThreshold);
+    }
+
+    public function getPriority(): int
+    {
+        return 100; // High priority for login-based activity
+    }
+
+    public function getDayThreshold(): int
+    {
+        return $this->dayThreshold;
+    }
+
+    public function setDayThreshold(int $dayThreshold): void
+    {
+        $this->dayThreshold = $dayThreshold;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserActivityInterface.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserActivityInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\User;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+
+interface UserActivityInterface
+{
+    /**
+     * Check if a user is considered active based on the specific implementation criteria.
+     *
+     * @param UserInterface $user The user to check activity for
+     *
+     * @return bool True if the user is considered active, false otherwise
+     */
+    public function isUserActive(UserInterface $user): bool;
+
+    /**
+     * Get a human-readable description of what this activity checker considers as "active".
+     *
+     * @return string Description of the activity criteria
+     */
+    public function getActivityDescription(): string;
+
+    /**
+     * Get the priority of this activity checker. Higher values mean higher priority.
+     * When multiple checkers are used, the one with the highest priority takes precedence.
+     *
+     * @return int Priority value (default: 0)
+     */
+    public function getPriority(): int;
+}

--- a/tests/backend/core/User/Functional/UserActivityVoterIntegrationTest.php
+++ b/tests/backend/core/User/Functional/UserActivityVoterIntegrationTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\User\Functional;
+
+use DateTimeImmutable;
+use demosplan\DemosPlanCoreBundle\Authorization\Voter\UserActivityVoter;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
+use demosplan\DemosPlanCoreBundle\Logic\User\ClaimedStatementsActivityChecker;
+use demosplan\DemosPlanCoreBundle\Logic\User\LastLoginActivityChecker;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Tests\Base\FunctionalTestCase;
+
+class UserActivityVoterIntegrationTest extends FunctionalTestCase
+{
+    private $authorizationChecker;
+    private $userActivityVoter;
+    private $lastLoginChecker;
+    private $claimedStatementsChecker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = self::getContainer();
+        $this->authorizationChecker = $container->get(AuthorizationCheckerInterface::class);
+        $this->userActivityVoter = $container->get(UserActivityVoter::class);
+        $this->lastLoginChecker = $container->get(LastLoginActivityChecker::class);
+        $this->claimedStatementsChecker = $container->get(ClaimedStatementsActivityChecker::class);
+    }
+
+    public function testUserIsActiveWhenRecentLogin(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-10 days'),
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertTrue($isActive);
+    }
+
+    public function testUserIsInactiveWhenOldLogin(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-200 days'),
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertFalse($isActive);
+    }
+
+    public function testUserIsInactiveWhenNeverLoggedIn(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert - User should be inactive since they're new, haven't completed profile, and have no activity
+        $this->assertFalse($isActive);
+    }
+
+    public function testUserIsActiveWithRecentClaimedStatementActivity(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-200 days'), // Old login
+        ]);
+
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => new DateTimeImmutable('-30 days'),
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertTrue($isActive);
+    }
+
+    public function testUserIsInactiveWithOldClaimedStatementActivity(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-200 days'), // Old login
+        ]);
+
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => new DateTimeImmutable('-200 days'), // Old activity
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertFalse($isActive);
+    }
+
+    public function testActivityCheckersAreRegisteredAndSortedByPriority(): void
+    {
+        // Act
+        $checkers = $this->userActivityVoter->getActivityCheckers();
+
+        // Assert
+        $this->assertCount(2, $checkers);
+
+        // LastLoginActivityChecker should be first (priority 100)
+        $this->assertInstanceOf(LastLoginActivityChecker::class, $checkers[0]);
+        $this->assertEquals(100, $checkers[0]->getPriority());
+
+        // ClaimedStatementsActivityChecker should be second (priority 75)
+        $this->assertInstanceOf(ClaimedStatementsActivityChecker::class, $checkers[1]);
+        $this->assertEquals(75, $checkers[1]->getPriority());
+    }
+
+    public function testParametersAreInjectedCorrectly(): void
+    {
+        // Act & Assert
+        $this->assertEquals(180, $this->lastLoginChecker->getDayThreshold());
+        $this->assertEquals(180, $this->claimedStatementsChecker->getDayThreshold());
+    }
+
+    public function testActivityDescriptionsAreCorrect(): void
+    {
+        // Act & Assert
+        $this->assertEquals(
+            'User has logged in within the last 180 days or shows signs of account activity',
+            $this->lastLoginChecker->getActivityDescription()
+        );
+
+        $this->assertEquals(
+            'User has claimed statements or segments with activity within the last 180 days',
+            $this->claimedStatementsChecker->getActivityDescription()
+        );
+    }
+
+    public function testUserIsActiveWhenEitherCheckerReturnsTrue(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-200 days'), // Old login (would make LastLoginActivityChecker return false)
+        ]);
+
+        // But create recent statement activity (makes ClaimedStatementsActivityChecker return true)
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => new DateTimeImmutable('-10 days'),
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertTrue($isActive);
+    }
+
+    public function testVoterSupportsIsActiveUserAttribute(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+
+        // Act - Test through authorization checker since supports() is protected
+        // This indirectly tests that the voter supports the IS_ACTIVE_USER attribute
+        $result = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert - If the voter didn't support this attribute, it would return false
+        // Since we have activity checkers configured, the result will depend on user activity
+        $this->assertIsBool($result);
+    }
+
+    public function testVoterDoesNotSupportOtherAttributes(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+
+        // Act - Test unsupported attribute through authorization checker
+        $result = $this->authorizationChecker->isGranted('OTHER_ATTRIBUTE', $user->_real());
+
+        // Assert - Should return false for unsupported attributes
+        $this->assertFalse($result);
+    }
+
+    public function testUserIsActiveAtExactThreshold(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-179 days'), // Just within threshold (180 days)
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertTrue($isActive);
+    }
+
+    public function testUserIsInactiveJustBeyondThreshold(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-181 days'), // Just beyond threshold
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertFalse($isActive);
+    }
+
+    public function testMultipleStatementsWithMixedActivity(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne([
+            'lastLogin' => new DateTimeImmutable('-200 days'), // Old login
+        ]);
+
+        // Create multiple statements with different activity levels
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => new DateTimeImmutable('-200 days'), // Old
+        ]);
+
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => null, // No modification date
+        ]);
+
+        StatementFactory::createOne([
+            'assignee' => $user,
+            'modified' => new DateTimeImmutable('-30 days'), // Recent - this should make user active
+        ]);
+
+        // Act
+        $isActive = $this->authorizationChecker->isGranted(UserActivityVoter::IS_ACTIVE_USER, $user->_real());
+
+        // Assert
+        $this->assertTrue($isActive);
+    }
+}

--- a/tests/backend/core/User/Unit/ClaimedStatementsActivityCheckerTest.php
+++ b/tests/backend/core/User/Unit/ClaimedStatementsActivityCheckerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\User\Unit;
+
+use DateTimeImmutable;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Logic\User\ClaimedStatementsActivityChecker;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Base\UnitTestCase;
+
+class ClaimedStatementsActivityCheckerTest extends UnitTestCase
+{
+    protected $sut;
+
+    /** @var StatementRepository&MockObject */
+    private $mockStatementRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->mockStatementRepository = $this->createMock(StatementRepository::class);
+        $this->sut = new ClaimedStatementsActivityChecker($this->mockStatementRepository, 90);
+    }
+
+    public function testIsUserActiveReturnsFalseWhenUserHasNoClaimedStatements(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenUserHasRecentlyModifiedClaimedStatements(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statement = $this->createMock(Statement::class);
+        $recentModification = new DateTimeImmutable('-10 days');
+        
+        $statement->method('getModified')->willReturn($recentModification);
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveReturnsFalseWhenUserHasOnlyOldClaimedStatements(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statement = $this->createMock(Statement::class);
+        $oldModification = new DateTimeImmutable('-100 days');
+        
+        $statement->method('getModified')->willReturn($oldModification);
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenOneOfMultipleStatementsIsRecentlyModified(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $oldStatement = $this->createMock(Statement::class);
+        $recentStatement = $this->createMock(Statement::class);
+        
+        $oldStatement->method('getModified')->willReturn(new DateTimeImmutable('-100 days'));
+        $recentStatement->method('getModified')->willReturn(new DateTimeImmutable('-10 days'));
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$oldStatement, $recentStatement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveReturnsFalseWhenStatementHasNullModifiedDate(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statement = $this->createMock(Statement::class);
+        
+        $statement->method('getModified')->willReturn(null);
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenStatementModifiedNearThreshold(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statement = $this->createMock(Statement::class);
+        // Create a modification that's just within the threshold
+        $nearThresholdModification = new DateTimeImmutable('-89 days 23 hours 59 minutes');
+        
+        $statement->method('getModified')->willReturn($nearThresholdModification);
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testGetActivityDescriptionReturnsCorrectDescription(): void
+    {
+        // Act
+        $description = $this->sut->getActivityDescription();
+
+        // Assert
+        $this->assertEquals(
+            'User has claimed statements or segments with activity within the last 90 days',
+            $description
+        );
+    }
+
+    public function testGetActivityDescriptionWithCustomThreshold(): void
+    {
+        // Arrange
+        $checker = new ClaimedStatementsActivityChecker($this->mockStatementRepository, 60);
+
+        // Act
+        $description = $checker->getActivityDescription();
+
+        // Assert
+        $this->assertEquals(
+            'User has claimed statements or segments with activity within the last 60 days',
+            $description
+        );
+    }
+
+    public function testGetPriorityReturnsMediumHighPriority(): void
+    {
+        // Act
+        $priority = $this->sut->getPriority();
+
+        // Assert
+        $this->assertEquals(75, $priority);
+    }
+
+    public function testGetDayThresholdReturnsCorrectValue(): void
+    {
+        // Act
+        $threshold = $this->sut->getDayThreshold();
+
+        // Assert
+        $this->assertEquals(90, $threshold);
+    }
+
+    public function testSetDayThresholdUpdatesValue(): void
+    {
+        // Arrange
+        $newThreshold = 120;
+
+        // Act
+        $this->sut->setDayThreshold($newThreshold);
+
+        // Assert
+        $this->assertEquals($newThreshold, $this->sut->getDayThreshold());
+    }
+
+    public function testSetDayThresholdAffectsActivityCheck(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statement = $this->createMock(Statement::class);
+        $modification100DaysAgo = new DateTimeImmutable('-100 days');
+        
+        $statement->method('getModified')->willReturn($modification100DaysAgo);
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statement]);
+
+        // Act - First with 90 day threshold (should be inactive)
+        $resultWith90Days = $this->sut->isUserActive($user);
+        
+        // Act - Then with 120 day threshold (should be active)
+        $this->sut->setDayThreshold(120);
+        $resultWith120Days = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($resultWith90Days);
+        $this->assertTrue($resultWith120Days);
+    }
+
+    public function testIsUserActiveWithMixedStatementsReturnsCorrectResult(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $statementWithNullDate = $this->createMock(Statement::class);
+        $oldStatement = $this->createMock(Statement::class);
+        $recentStatement = $this->createMock(Statement::class);
+        
+        $statementWithNullDate->method('getModified')->willReturn(null);
+        $oldStatement->method('getModified')->willReturn(new DateTimeImmutable('-200 days'));
+        $recentStatement->method('getModified')->willReturn(new DateTimeImmutable('-30 days'));
+        
+        $this->mockStatementRepository
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([$statementWithNullDate, $oldStatement, $recentStatement]);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testRepositoryIsCalledWithCorrectParameters(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        
+        $this->mockStatementRepository
+            ->expects($this->once())
+            ->method('findBy')
+            ->with(['assignee' => $user])
+            ->willReturn([]);
+
+        // Act
+        $this->sut->isUserActive($user);
+
+        // Assert - Verified by expects() above
+    }
+}

--- a/tests/backend/core/User/Unit/LastLoginActivityCheckerTest.php
+++ b/tests/backend/core/User/Unit/LastLoginActivityCheckerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\User\Unit;
+
+use DateTimeImmutable;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\LastLoginActivityChecker;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Base\UnitTestCase;
+
+class LastLoginActivityCheckerTest extends UnitTestCase
+{
+    protected $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = new LastLoginActivityChecker(30);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenUserLoggedInWithinThreshold(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $recentLogin = new DateTimeImmutable('-10 days');
+        $user->method('getLastLogin')->willReturn($recentLogin);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveReturnsFalseWhenUserLoggedInOutsideThreshold(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $oldLogin = new DateTimeImmutable('-40 days');
+        $user->method('getLastLogin')->willReturn($oldLogin);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenUserNeverLoggedIn(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getLastLogin')->willReturn(null);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenUserLoggedInExactlyAtThreshold(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        // Create a login that's exactly 30 days ago (slightly after the threshold to ensure it passes)
+        $thresholdLogin = new DateTimeImmutable('-29 days 23 hours 59 minutes');
+        $user->method('getLastLogin')->willReturn($thresholdLogin);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveReturnsTrueWhenUserLoggedInToday(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $todayLogin = new DateTimeImmutable('now');
+        $user->method('getLastLogin')->willReturn($todayLogin);
+
+        // Act
+        $result = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testGetActivityDescriptionReturnsCorrectDescription(): void
+    {
+        // Act
+        $description = $this->sut->getActivityDescription();
+
+        // Assert
+        $this->assertEquals('User has logged in within the last 30 days or shows signs of account activity', $description);
+    }
+
+    public function testGetActivityDescriptionWithCustomThreshold(): void
+    {
+        // Arrange
+        $checker = new LastLoginActivityChecker(60);
+
+        // Act
+        $description = $checker->getActivityDescription();
+
+        // Assert
+        $this->assertEquals('User has logged in within the last 60 days or shows signs of account activity', $description);
+    }
+
+    public function testGetPriorityReturnsHighPriority(): void
+    {
+        // Act
+        $priority = $this->sut->getPriority();
+
+        // Assert
+        $this->assertEquals(100, $priority);
+    }
+
+    public function testGetDayThresholdReturnsCorrectValue(): void
+    {
+        // Act
+        $threshold = $this->sut->getDayThreshold();
+
+        // Assert
+        $this->assertEquals(30, $threshold);
+    }
+
+    public function testSetDayThresholdUpdatesValue(): void
+    {
+        // Arrange
+        $newThreshold = 45;
+
+        // Act
+        $this->sut->setDayThreshold($newThreshold);
+
+        // Assert
+        $this->assertEquals($newThreshold, $this->sut->getDayThreshold());
+    }
+
+    public function testSetDayThresholdAffectsActivityCheck(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $login35DaysAgo = new DateTimeImmutable('-35 days');
+        $user->method('getLastLogin')->willReturn($login35DaysAgo);
+
+        // Act - First with 30 day threshold (should be inactive)
+        $resultWith30Days = $this->sut->isUserActive($user);
+        
+        // Act - Then with 40 day threshold (should be active)
+        $this->sut->setDayThreshold(40);
+        $resultWith40Days = $this->sut->isUserActive($user);
+
+        // Assert
+        $this->assertFalse($resultWith30Days);
+        $this->assertTrue($resultWith40Days);
+    }
+
+    public function testIsUserActiveWithOneDayThreshold(): void
+    {
+        // Arrange
+        $checker = new LastLoginActivityChecker(1);
+        $user = $this->createMock(UserInterface::class);
+        // Login from yesterday should be active with 1-day threshold
+        $yesterdayLogin = new DateTimeImmutable('-12 hours');
+        $user->method('getLastLogin')->willReturn($yesterdayLogin);
+
+        // Act
+        $result = $checker->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsUserActiveWithVeryLargeDayThreshold(): void
+    {
+        // Arrange
+        $checker = new LastLoginActivityChecker(3650); // ~10 years
+        $user = $this->createMock(UserInterface::class);
+        $veryOldLogin = new DateTimeImmutable('-5 years');
+        $user->method('getLastLogin')->willReturn($veryOldLogin);
+
+        // Act
+        $result = $checker->isUserActive($user);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+}

--- a/tests/backend/core/User/Unit/UserActivityVoterTest.php
+++ b/tests/backend/core/User/Unit/UserActivityVoterTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\User\Unit;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Authorization\Voter\UserActivityVoter;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserActivityInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Tests\Base\UnitTestCase;
+
+class UserActivityVoterTest extends UnitTestCase
+{
+    protected $sut;
+
+    /** @var UserActivityInterface&MockObject */
+    private $mockActivityChecker1;
+
+    /** @var UserActivityInterface&MockObject */
+    private $mockActivityChecker2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockActivityChecker1 = $this->createMock(UserActivityInterface::class);
+        $this->mockActivityChecker2 = $this->createMock(UserActivityInterface::class);
+
+        $this->sut = new UserActivityVoter([$this->mockActivityChecker1, $this->mockActivityChecker2]);
+    }
+
+    public function testVotesOnIsActiveUserAttribute(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $token = $this->createMock(TokenInterface::class);
+
+        $this->mockActivityChecker1->method('getPriority')->willReturn(100);
+        $this->mockActivityChecker1->method('isUserActive')->with($user)->willReturn(true);
+
+        $this->mockActivityChecker2->method('getPriority')->willReturn(50);
+
+        // Act
+        $result = $this->sut->vote($token, $user, [UserActivityVoter::IS_ACTIVE_USER]);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_GRANTED, $result);
+    }
+
+    public function testAbstainsOnOtherAttributes(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $token = $this->createMock(TokenInterface::class);
+
+        // Act
+        $result = $this->sut->vote($token, $user, ['OTHER_ATTRIBUTE']);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_ABSTAIN, $result);
+    }
+
+    public function testAbstainsOnNonUserSubjects(): void
+    {
+        // Arrange
+        $nonUser = new \stdClass();
+        $token = $this->createMock(TokenInterface::class);
+
+        // Act
+        $result = $this->sut->vote($token, $nonUser, [UserActivityVoter::IS_ACTIVE_USER]);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_ABSTAIN, $result);
+    }
+
+    public function testVoteOnAttributeReturnsTrueWhenAnyCheckerReturnsTrue(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $token = $this->createMock(TokenInterface::class);
+
+        $this->mockActivityChecker1->method('getPriority')->willReturn(100);
+        $this->mockActivityChecker1->method('isUserActive')->with($user)->willReturn(false);
+
+        $this->mockActivityChecker2->method('getPriority')->willReturn(50);
+        $this->mockActivityChecker2->method('isUserActive')->with($user)->willReturn(true);
+
+        // Act
+        $result = $this->sut->vote($token, $user, [UserActivityVoter::IS_ACTIVE_USER]);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_GRANTED, $result);
+    }
+
+    public function testVoteOnAttributeReturnsFalseWhenAllCheckersReturnFalse(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $token = $this->createMock(TokenInterface::class);
+
+        $this->mockActivityChecker1->method('getPriority')->willReturn(100);
+        $this->mockActivityChecker1->method('isUserActive')->with($user)->willReturn(false);
+
+        $this->mockActivityChecker2->method('getPriority')->willReturn(50);
+        $this->mockActivityChecker2->method('isUserActive')->with($user)->willReturn(false);
+
+        // Act
+        $result = $this->sut->vote($token, $user, [UserActivityVoter::IS_ACTIVE_USER]);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_DENIED, $result);
+    }
+
+    public function testVoteOnAttributeReturnsTrueWhenNoCheckersConfigured(): void
+    {
+        // Arrange
+        $user = $this->createMock(UserInterface::class);
+        $token = $this->createMock(TokenInterface::class);
+        $voterWithoutCheckers = new UserActivityVoter([]);
+
+        // Act
+        $result = $voterWithoutCheckers->vote($token, $user, [UserActivityVoter::IS_ACTIVE_USER]);
+
+        // Assert
+        $this->assertEquals(UserActivityVoter::ACCESS_GRANTED, $result);
+    }
+
+    public function testCheckersAreSortedByPriorityHighestFirst(): void
+    {
+        // Arrange
+        $lowPriorityChecker = $this->createMock(UserActivityInterface::class);
+        $highPriorityChecker = $this->createMock(UserActivityInterface::class);
+
+        $lowPriorityChecker->method('getPriority')->willReturn(10);
+        $highPriorityChecker->method('getPriority')->willReturn(100);
+
+        $voter = new UserActivityVoter([$lowPriorityChecker, $highPriorityChecker]);
+
+        // Act
+        $checkers = $voter->getActivityCheckers();
+
+        // Assert
+        $this->assertSame($highPriorityChecker, $checkers[0]);
+        $this->assertSame($lowPriorityChecker, $checkers[1]);
+    }
+
+    public function testAddActivityChecker(): void
+    {
+        // Arrange
+        $newChecker = $this->createMock(UserActivityInterface::class);
+        $newChecker->method('getPriority')->willReturn(200);
+
+        // Act
+        $this->sut->addActivityChecker($newChecker);
+        $checkers = $this->sut->getActivityCheckers();
+
+        // Assert
+        $this->assertCount(3, $checkers);
+        $this->assertSame($newChecker, $checkers[0]); // Should be first due to highest priority
+    }
+
+}


### PR DESCRIPTION
### Ticket
No specific ticket - security infrastructure improvement

Provide a security voter to check if a user is active, enabling proper authorization checks based on user activity status throughout the application.

This security voter integrates with Symfony's authorization framework to automatically deny access to inactive users across all protected resources, providing a centralized way to enforce user activity requirements without modifying individual controllers or services.

### How to review/test
- [ ] Review the security voter implementation for correct logic
- [ ] Test that active/inactive users get appropriate access

### PR Checklist
- [ ] Create/Update tests
- [ ] Run `yarn lint`
- [ ] Run `yarn test`