### PR TITLE
Fix(DPLAN-1932): restore sort option from the session storage

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -309,6 +309,7 @@ import {
   DpSelect,
   DpStickyElement,
   formatDate,
+  sessionStorageMixin,
   tableSelectAllItems
 } from '@demos-europe/demosplan-ui'
 import { mapActions, mapMutations, mapState } from 'vuex'
@@ -343,7 +344,7 @@ export default {
     cleanhtml: CleanHtml
   },
 
-  mixins: [paginationMixin, tableSelectAllItems],
+  mixins: [paginationMixin, sessionStorageMixin, tableSelectAllItems],
 
   props: {
     currentUserId: {
@@ -603,6 +604,7 @@ export default {
 
     applySort (sortValue) {
       this.selectedSort = sortValue
+      this.updateSessionStorage('selectedSort', sortValue)
       this.getItemsByPage(1)
     },
 
@@ -911,6 +913,14 @@ export default {
       this.$refs.customSearchStatements.toggleAllFields(false)
     },
 
+    restoreSelectedSort () {
+      const storedSort = this.getItemFromSessionStorage('selectedSort')
+
+      if (storedSort) {
+        this.selectedSort = storedSort
+      }
+    },
+
     /**
      * If the procedure is coupled get the num of total items, that are not synchronized yet and
      * therefor are selectable, and set the num of total items to it.
@@ -971,6 +981,7 @@ export default {
       }
     })
     this.initPagination()
+    this.restoreSelectedSort()
     this.getItemsByPage(this.pagination.currentPage)
   }
 }


### PR DESCRIPTION
### Ticket
[DPLAN-1932](https://demoseurope.youtrack.cloud/issue/DPLAN-1932/Sortierung-der-Stellungnahmenliste-andert-sich-wenn-man-die-Seite-aktualisiert)

**Description:** This PR fixes an issue where the sort option was lost after a page reload. To resolve this, I used session storage to restore the sort option within the same session. The value will be cleared if the user opens a new window or tab.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
