### PR TITLE
fix DPLAN-15776: Display FileNames when exporting Original stn as csv, also Stn as excel

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
@@ -62,6 +62,10 @@ class StatementArrayConverter
             $segmentOrStatement->isSubmittedByCitizen()
         );
 
+        if ($segmentOrStatement instanceof Statement) {
+            $exportData['fileNames'] = $segmentOrStatement->getFileNames();
+        }
+
         // Some data is stored on parentStatement instead on Segment and have to get from there
         if ($segmentOrStatement instanceof Segment) {
             $parentStatement = $segmentOrStatement->getParentStatementOfSegment();

--- a/tests/backend/core/Statement/Export/StatementArrayConverterTest.php
+++ b/tests/backend/core/Statement/Export/StatementArrayConverterTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Statement\Export;
 
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\FileFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Workflow\PlaceFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
@@ -272,4 +273,41 @@ class StatementArrayConverterTest extends FunctionalTestCase
 
         return $segment->_real();
     }
+
+    /**
+     * Test that fileNames field is correctly set when segmentOrStatement is Statement instance.
+     */
+    public function testConvertIntoExportableArrayStatementFileNames(): void
+    {
+        $this->loginTestUser();
+
+        $statement = $this->createMinimalTestStatement('test', 'internal123', 'a');
+
+        // Create file strings - no need to create actual File entities since files property is transient
+        $fileStrings = [
+            'test-document.pdf:test-file-id-1',
+            'test-image.jpg:test-file-id-2'
+        ];
+
+        // Work with the real entity and set files
+        $realStatement = $statement->_real();
+        $realStatement->setFiles($fileStrings);
+
+
+        // Test the converter with the entity that has files set
+        $result = $this->sut->convertIntoExportableArray($realStatement);
+
+        // Verify fileNames field is present for Statement instances
+        self::assertArrayHasKey('fileNames', $result);
+
+        // The fileNames should come from the statement's getFileNames() method
+        self::assertEquals($realStatement->getFileNames(), $result['fileNames']);
+
+        self::assertEquals(['test-document.pdf', 'test-image.jpg'], $result['fileNames']);
+
+        // Verify we have the expected number of files
+        self::assertCount(2, $result['fileNames']);
+    }
+
+
 }

--- a/tests/backend/core/Statement/Export/StatementArrayConverterTest.php
+++ b/tests/backend/core/Statement/Export/StatementArrayConverterTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Tests\Core\Statement\Export;
 
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\FileFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Workflow\PlaceFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
@@ -286,13 +285,12 @@ class StatementArrayConverterTest extends FunctionalTestCase
         // Create file strings - no need to create actual File entities since files property is transient
         $fileStrings = [
             'test-document.pdf:test-file-id-1',
-            'test-image.jpg:test-file-id-2'
+            'test-image.jpg:test-file-id-2',
         ];
 
         // Work with the real entity and set files
         $realStatement = $statement->_real();
         $realStatement->setFiles($fileStrings);
-
 
         // Test the converter with the entity that has files set
         $result = $this->sut->convertIntoExportableArray($realStatement);
@@ -308,6 +306,4 @@ class StatementArrayConverterTest extends FunctionalTestCase
         // Verify we have the expected number of files
         self::assertCount(2, $result['fileNames']);
     }
-
-
 }


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-15776/Obwohl-STN-Dateien-hat-wurden-die-Dateinamen-nicht-im-Originalstellungnahme-Export-angezeigt



Display filenames when exporting original statement in csv
Also this fix works for exporting stn segements on excel