### PR TITLE
fix(refs: DPLAN-15778): Prevent layout shift when modal closes

### DIFF
--- a/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
+++ b/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
@@ -2,7 +2,7 @@
   <div class="h-full w-full">
     <dp-button
       id="statementModalButton"
-      :class="prefixClass('left-[365px] top-[24px] pt-[11px] pb-[11px] pl-[20px] pr-[20px] absolute z-above-zero')"
+      :class="prefixClass('left-[365px] top-[24px] pt-[11px] pb-[11px] pl-[20px] pr-[20px] !absolute z-above-zero')"
       data-cy="statementModal"
       rounded
       :text="Translator.trans('statement.participate')"


### PR DESCRIPTION
### Ticket
DPLAN-15778

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanfest an login as Hannes Rudzkam (Private User)
2. Open a procedure and visit the tab "Interaktive Karte"
3. Klick at the Button "Reden Sie mit!" -> Modal opens
4. Close the modal and check if the map shifted down under the button

There should be no layout shifts in the end
