### PR TITLE
DPLAN-15803: Add InvitedPublicAgencyResourceType 

### DIFF
--- a/config/json-schema/rpc-invited-institutions-bulk-delete-schema.json
+++ b/config/json-schema/rpc-invited-institutions-bulk-delete-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "invitedInstitutions.bulk.delete",
+  "type": "object",
+  "required": ["jsonrpc", "method", "id", "params"],
+  "properties": {
+    "jsonrpc": {
+      "enum": ["2.0"]
+    },
+    "method": {
+      "enum": ["invitedInstitutions.bulk.delete"]
+    },
+    "id": {
+      "type": "string"
+    },
+    "params": {
+      "$id": "#/items/anyOf/0/properties/params",
+      "type": "object",
+      "properties": {
+        "ids": {
+          "$id": "ids",
+          "type": "array",
+          "minItems": 1,
+          "additionalItems": false,
+          "items": {
+            "$id": "ids/items",
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      },
+      "required": ["ids"]
+    }
+  }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/RpcInstitutionInvitationRemover.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/RpcInstitutionInvitationRemover.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic;
+
+use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use DemosEurope\DemosplanAddon\Logic\Rpc\RpcErrorGeneratorInterface;
+use DemosEurope\DemosplanAddon\Logic\Rpc\RpcMethodSolverInterface;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use DemosEurope\DemosplanAddon\Validator\JsonSchemaValidator;
+use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedException;
+use demosplan\DemosPlanCoreBundle\Exception\OrgaNotFoundException;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
+use Doctrine\ORM\EntityManager;
+use Exception;
+use Psr\Log\LoggerInterface;
+use stdClass;
+use Webmozart\Assert\Assert;
+
+use function sprintf;
+
+class RpcInstitutionInvitationRemover implements RpcMethodSolverInterface
+{
+    public const SUPPORTED_METHOD_NAME = 'invitedInstitutions.bulk.delete';
+
+    public function __construct(
+        private readonly MessageBagInterface $messageBag,
+        private readonly LoggerInterface $logger,
+        private readonly RpcErrorGeneratorInterface $rpcErrorGenerator,
+        private readonly TransactionService $transactionService,
+        private readonly CurrentUserInterface $currentUser,
+        private readonly ProcedureService $procedureService,
+        private readonly JsonSchemaValidator $jsonSchemaValidator,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return self::SUPPORTED_METHOD_NAME === $method;
+    }
+
+    /**
+     * This method handles the removal of multiple institutions from a procedure's invitation list.
+     */
+    public function execute(?ProcedureInterface $procedure, $rpcRequests): array
+    {
+        if (!$this->currentUser->hasPermission('area_admin_invitable_institution')) {
+            $this->logger->error('User does not have permission to manage invited institutions');
+
+            return [$this->rpcErrorGenerator->internalError()];
+        }
+
+        if (null === $procedure) {
+            $this->logger->error('No procedure provided for invited institution deletion');
+
+            return [$this->rpcErrorGenerator->internalError()];
+        }
+
+        try {
+            return $this->transactionService->executeAndFlushInTransaction(
+                fn (EntityManager $entityManager): array => $this->handleExecute($procedure, $rpcRequests)
+            );
+        } catch (Exception $e) {
+            $this->logger->error(
+                'An error occurred trying to remove invited institutions via RpcInstitutionInvitationRemover',
+                ['ExceptionMessage' => $e->getMessage(), 'Exception' => $e]
+            );
+            $this->messageBag->add('error', 'warning.invited.institutions.bulk.delete.generic.error');
+
+            return [$this->rpcErrorGenerator->internalError($rpcRequests)];
+        }
+    }
+
+    private function handleExecute(ProcedureInterface $procedure, $rpcRequests): array
+    {
+        $resultResponse = [];
+        $rpcRequests = is_object($rpcRequests)
+            ? [$rpcRequests]
+            : $rpcRequests;
+
+        foreach ($rpcRequests as $rpcRequest) {
+            try {
+                /** @var array<int, array{id: string}> $institutionIds */
+                $institutionIds = $rpcRequest->params->ids ?? null;
+                Assert::isIterable($institutionIds, 'expected params->ids to be a list of institution IDs');
+
+                $invitedInstitutions = $procedure->getOrganisation();
+                $institutionsToRemove = [];
+
+                foreach ($institutionIds as $institutionData) {
+                    $institutionId = $institutionData->id ?? '';
+                    Assert::stringNotEmpty($institutionId, 'institutionId is expected to be a non-empty string');
+
+                    $institution = $invitedInstitutions->filter(
+                        static fn ($org) => $org->getId() === $institutionId
+                    )->first();
+
+                    if (false === $institution) {
+                        $errorMessage = sprintf('Institution %s is not invited to procedure %s', $institutionId, $procedure->getId());
+                        $this->logger->error($errorMessage);
+                        $this->messageBag->add('error', 'error.institution.not.invited');
+                        throw new OrgaNotFoundException($errorMessage);
+                    }
+
+                    $institutionsToRemove[] = $institution;
+                }
+
+                if (0 < count($institutionsToRemove)) {
+                    $this->procedureService->detachOrganisations($procedure, $institutionsToRemove);
+                    $this->logger->info(sprintf('Removed %d institutions from procedure %s', count($institutionsToRemove), $procedure->getId()));
+                }
+
+                $resultResponse[] = $this->generateMethodSuccessResult($rpcRequest);
+                $this->messageBag->add('confirm', 'confirm.invitable_institutions.deleted');
+            } catch (Exception $e) {
+                $this->messageBag->add('error', 'warning.invited.institutions.bulk.delete.generic.error');
+                $this->logger->error(
+                    'An error occurred trying to remove invited institutions via RpcInstitutionInvitationRemover',
+                    ['ExceptionMessage' => $e->getMessage(), 'Exception' => $e]
+                );
+                $resultResponse[] = $this->rpcErrorGenerator->internalError($rpcRequest);
+            }
+        }
+
+        return $resultResponse;
+    }
+
+    public function isTransactional(): bool
+    {
+        return true;
+    }
+
+    public function validateRpcRequest(object $rpcRequest): void
+    {
+        if (!$this->currentUser->hasPermission('area_admin_invitable_institution')) {
+            throw new AccessDeniedException('User does not have permission to manage invited institutions');
+        }
+
+        $this->jsonSchemaValidator->validate(
+            Json::encode($rpcRequest),
+            DemosPlanPath::getConfigPath('json-schema/rpc-invited-institutions-bulk-delete-schema.json')
+        );
+    }
+
+    private function generateMethodSuccessResult(object $rpcRequest): object
+    {
+        $result = new stdClass();
+        $result->jsonrpc = '2.0';
+        $result->result = true;
+        $result->id = $rpcRequest->id;
+
+        return $result;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -68,6 +68,7 @@ use Illuminate\Support\Collection;
 use Pagerfanta\Pagerfanta;
 use ReflectionException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Webmozart\Assert\Assert;
 
 use function array_combine;
 
@@ -1155,11 +1156,13 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     }
 
     /**
+     * Gets statements created or imported by the procedure-owning organisation
+     * including statements created on behalf of a specified organisation by the owning organisation.
+     *
      * @return array<int, Statement>
      */
     public function getStatementsOfProcedureAndOrganisation(string $procedureId, string $organisationId): array
     {
-        // get all original statements from statements
         return $this->getEntityManager()->createQueryBuilder()
             ->select('original.id, original.created, original.externId')
             ->from(Statement::class, 'statement')
@@ -1178,6 +1181,39 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
             ->orderBy('original.created', 'DESC')
             ->getQuery()
             ->getArrayResult();
+    }
+
+    /**
+     * Counts statements submitted by an organisation via the draft-to-statement workflow.
+     * This method counts statements where the organisation is set directly on the statement
+     * (indicating they were submitted via the draft-to-statement workflow) rather than through statement.meta.
+     *
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     * @throws InvalidArgumentException
+     */
+    public function countDraftToStatementSubmissionsByOrganisation(string $procedureId, string $organisationId): int
+    {
+        $singleScalarResult = $this->getEntityManager()->createQueryBuilder()
+            ->select('COUNT(original.id)')
+            ->from(Statement::class, 'statement')
+            ->leftJoin('statement.original', 'original')
+            ->andWhere('original.original IS NULL')
+            ->andWhere('statement.deleted = false')
+            ->andWhere('original.deleted = false')
+            ->andWhere('statement.movedStatement IS NULL') // isPlaceholder === false
+            ->andWhere('statement.procedure = :procedureId')
+            ->andWhere('original.procedure = :procedureId')
+            ->setParameter('procedureId', $procedureId)
+            ->andWhere('statement.original IS NOT NULL')
+            ->andWhere('original.organisation = :orgaId')
+            ->setParameter('orgaId', $organisationId)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        Assert::integer($singleScalarResult);
+
+        return $singleScalarResult;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitedPublicAgencyResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitedPublicAgencyResourceConfigBuilder.php
@@ -23,6 +23,8 @@ use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 /**
  * @template-extends BaseOrgaResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,OrgaInterface>
  *
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $hasReceivedInvitationMailInCurrentProcedurePhase
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $originalStatementsCountInProcedure
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $legalName
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $competenceDescription
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $participationFeedbackEmailAddress

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedureResourceType.php
@@ -33,9 +33,9 @@ use EDT\PathBuilding\End;
  * @property-read End                                 $deleted
  * @property-read End                                 $agencyMainEmailAddress
  * @property-read OrgaResourceType                    $owningOrganisation
- * @property-read OrgaResourceType                    $invitedOrganisations
+ * @property-read InvitedPublicAgencyResourceType     $invitedOrganisations
  * @property-read OrgaResourceType                    $orga                         Do not expose! Alias usage only.
- * @property-read OrgaResourceType                    $organisation                 Do not expose! Alias usage only.
+ * @property-read InvitedPublicAgencyResourceType     $organisation                 Do not expose! Alias usage only.
  * @property-read ProcedureTypeResourceType           $procedureType
  * @property-read ProcedureUiDefinitionResourceType   $procedureUiDefinition
  * @property-read StatementFormDefinitionResourceType $statementFormDefinition
@@ -168,20 +168,35 @@ final class ProcedureResourceType extends DplanResourceType implements Procedure
         $external = $this->currentUser->getUser()->isPublicUser();
 
         $owningOrganisation = $this->createToOneRelationship($this->owningOrganisation)->aliasedPath($this->orga);
-        $invitedOrganisations = $this->createToManyRelationship($this->invitedOrganisations)->aliasedPath($this->organisation);
+
         $properties = [
             $this->createIdentifier()->readable()->sortable()->filterable(),
-            $this->createAttribute($this->name)->readable(true, fn (Procedure $procedure): ?string => !$external || $this->accessEvaluator->isOwningProcedure($this->currentUser->getUser(), $procedure)
-                ? $procedure->getName()
-                : null)->sortable()->filterable(),
+            $this->createAttribute($this->name)
+                ->readable(
+                    true,
+                    fn (Procedure $procedure): ?string => !$external || $this->accessEvaluator->isOwningProcedure($this->currentUser->getUser(), $procedure)
+                    ? $procedure->getName() : null
+                )
+                ->sortable()
+                ->filterable(),
             $owningOrganisation,
-            $invitedOrganisations,
         ];
 
         $properties[] = $this->createToManyRelationship($this->availableElements)->readable()->sortable()->filterable()->aliasedPath($this->elements);
+
+        if ($this->currentUser->hasAllPermissions(
+            'area_admin_invitable_institution',
+            'area_main_procedures',
+        )) {
+            $properties[] = $this->createToManyRelationship($this->invitedOrganisations)
+                ->readable()
+                ->sortable()
+                ->filterable()
+                ->aliasedPath($this->organisation);
+        }
+
         if ($this->hasAdminPermissions()) {
             $owningOrganisation->readable()->sortable()->filterable();
-            $invitedOrganisations->readable()->sortable()->filterable();
             $properties[] = $this->createAttribute($this->agencyMainEmailAddress)->readable(true)->sortable()->filterable();
         }
 

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1280,6 +1280,7 @@ error.organisation.not.existent: "Ausgewählte Organisation wurde nicht gefunden
 error.organisation.not.selected: "Es wurden keine zwei Organisationen ausgewählt"
 error.organisation.not.switched: "Die Organisation konnte nicht gewechselt werden"
 error.organisation.of.user.not.found: "Es konnte keine Organisation zum/-r Nutzer*in gefunden werden."
+error.institution.not.invited: "Eine oder mehrere Institutionen sind nicht zu diesem Verfahren eingeladen."
 error.paragraph.no_circular_references: "Ein Kapitel darf keinem seiner eigenen Unterkapitel als Unterkapitel zugewiesen werden."
 error.paragraph.no_self_references: "Ein Kapitel darf sich nicht selbst als Unterkapitel zugewiesen werden."
 error.password.change: "Das Passwort konnte nicht geändert werden."
@@ -1375,6 +1376,8 @@ error.statments.zip.export.attachment: |
     }
 error.statements.zip.export.attachments.not.addable: 'Es konnten dem ZIP-Archiv keine Anhänge hinzugefügt werden. Export abgebrochen.'
 error.statements.zip.import.contains.error.textfile: 'Es wurde versucht, ein fehlerhaft erstelltes ZIP-Archiv zu importieren. Bitte versuchen Sie das Zip-Archiv zu ersetzen.'
+error.statements.of.institution.count.retrieval.failed: "Die Anzahl der Stellungnahmen der Institution konnte nicht ermittelt werden."
+error.institution.invitation.mail.list.retrieval.failed: "Es konnte nicht für alle Institutionen ermittelt werden, ob bereits eine Einladung verschickt wurde."
 error.tag.notfound: "Das Schlagwort konnte nicht gefunden werden."
 error.topic.notfound: "Das Thema wurde nicht gefunden. Möglicherweise wurde es zwischenzeitlich gelöscht."
 error.text: "Bitte geben Sie einen Text der Stellungnahme ein."
@@ -4243,6 +4246,7 @@ warning.story.exist: "Die Userstory existiert bereits."
 warning.story.missing: "Die Userstory existiert nicht."
 warning.tag.deleted: "Das Schlagwort {tagname} konnte nicht gelöscht werden."
 warning.tag.bulk.delete.generic.error: "Beim Löschen Der Schlagworte bzw. Themen Gruppe ist ein Fehler aufgetreten."
+warning.invited.institutions.bulk.delete.generic.error: "Beim Entfernen der eingeladenen Institutionen ist ein Fehler aufgetreten."
 warning.tag.empty: "Der Name des Schlagwortes darf nicht leer sein."
 warning.tag.multiple.tags.found: "Im Verfahren wurden mehrere Schlagworte mit dem Namen {tagname} gefunden. Bitte prüfen Sie, ob das korrekte Schlagwort {tagname} den Abschnitten hinzugefügt wurde und passen Sie es ggf. an."
 warning.tag.in.use: "Das Schlagwort {tagname} kann nicht gelöscht werden, weil es verwendet wird."


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-14556/ADO-Issue-22376-Fachplanung-Institutionen-mit-Schlagworten-in-der-Institutionen-verwalten-Liste-Anzeigen-Filtern-und-Suchen

https://demoseurope.youtrack.cloud/issue/DPLAN-15803/Create-sceleton-InvitedToebResourceType-and-the-access-conditions.

Description:
Add InvitedPublicAgencyResourceType  and its ConfigBuilder. Setup getAccess method and basic property retrieval.

How to review/test:
Scratch list request example:
```
### Get list of InvitedPublicAgencies
GET http://diplanbau.dplan.local/app_dev.php/api/2.0/InvitedToeb?
    include=assignedTags&
    fields[InvitableInstitution]=assignedTags&
    fields[InstitutionTag]=name
Cookie: PHPSESSID=ob7qdp4rvusssssssshpljo;
X-Demosplan-Procedure-Id: cc4768a5-61ff-4ba8-a2ae-7002eacac216
Accept: application/vnd.api+json
X-JWT-Authorization: Bearer eyJ0eXAiOiJKV1Qi
```

linked PRs:
The todos within the new ResourceType will be addressed here: https://github.com/demos-europe/demosplan-core/pull/4777

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
