### PR TITLE
chore: add caching to nginx

### DIFF
--- a/docker/demosplan-production/nginx.conf.template
+++ b/docker/demosplan-production/nginx.conf.template
@@ -1,5 +1,5 @@
 gzip on;
-gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript font/woff2;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/font-woff2 application/vnd.api+json;
 gzip_proxied any;
 gzip_vary on;
 
@@ -41,9 +41,29 @@ server
     fastcgi_read_timeout 600s;
     keepalive_timeout  600s;
 
-    # Handle requests to static files directly by Nginx
+    # Handle requests to static files directly by Nginx with caching
     location ~* ^/(css|files|fonts|img|js) {
         try_files $uri $uri/ =404;
+        
+        # Set MIME types
+        location ~* \.woff2$ {
+            add_header Content-Type application/font-woff2;
+        }
+        location ~* \.js$ {
+            add_header Content-Type application/javascript;
+        }
+        
+        # Cache images privately for 1 year
+        location ~* \.(jpg|jpeg|png|gif)$ {
+            expires 1y;
+            add_header Cache-Control "private, immutable";
+        }
+        
+        # Cache other static assets publicly for 1 year
+        location ~* \.(css|js|woff2)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
     }
 
     # Try all locations and relay to app.php as a fallback.


### PR DESCRIPTION
This pull request updates the Nginx configuration template to enhance compression and caching for static assets, improving performance and resource handling. The key changes include adding new MIME types for compression, introducing caching rules for static files, and ensuring proper headers are set for specific file types.

### Compression Enhancements:
* Updated the `gzip_types` directive to include `application/font-woff2` and `application/vnd.api+json` MIME types, enabling compression for these file types.

### Caching and MIME Type Configuration:
* Enhanced the static file handling section:
  - Added MIME type headers for `.woff2` and `.js` files.
  - Introduced caching rules:
    - Images (`.jpg`, `.jpeg`, `.png`, `.gif`) are cached privately for 1 year with an immutable directive.
    - Other static assets (`.css`, `.js`, `.woff2`) are cached publicly for 1 year with an immutable directive.


