### PR TITLE
feat(refs DPLAN-15771, #AB29551): add selectAll to layers

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -84,8 +84,8 @@
       multiple
       required
       @input="filterMatrixSetByLayers"
-      @select-all="selectAllLayers"
-      @unselect-all="resetLayerSelection"
+      @selectAll="selectAllLayers"
+      @unselectAll="resetLayerSelection"
     />
 
     <input

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -10,24 +10,24 @@
 <template>
   <div>
     <dp-input
-      class="u-mb-0_5"
       id="r_name"
       v-model="name"
       :label="{
         text: Translator.trans('name')
       }"
+      class="u-mb-0_5"
       data-cy="newMapLayerName"
       name="r_name"
       required
     />
 
     <dp-input
-      class="u-mb-0_5"
       id="r_url"
       v-model="url"
       :label="{
         text: Translator.trans('url')
       }"
+      class="u-mb-0_5"
       data-cy="newMapLayerURL"
       name="r_url"
       required
@@ -36,12 +36,12 @@
     />
 
     <dp-select
-      class="u-mb-0_5"
       v-model="serviceType"
       :label="{
         text: Translator.trans('type')
       }"
       :options="serviceTypeOptions"
+      class="u-mb-0_5"
       data-cy="layerSettings:serviceType"
       name="r_serviceType"
       required
@@ -55,12 +55,12 @@
 
     <dp-checkbox
       v-if="hasPermission('feature_xplan_defaultlayers') && showXplanDefaultLayer"
-      class="u-mb-0_5"
       id="r_xplanDefaultlayers"
       :label="{
         text: Translator.trans('explanation.gislayer.xplan.default')
       }"
       :title="Translator.trans('explanation.gislayer.default.defined') + ': ' + xplanDefaultLayer"
+      class="u-mb-0_5"
       name="r_xplanDefaultlayers"
       style="display: none;"
       value="1"
@@ -73,11 +73,10 @@
     />
 
     <dp-multiselect
-      class="u-mb-0_5"
       id="r_layers"
       v-model="layers"
       :options="layersOptions"
-      :selection-controls="true"
+      class="u-mb-0_5"
       data-cy="newMapLayerLayers"
       label="label"
       track-by="label"
@@ -96,7 +95,6 @@
 
     <dp-select
       v-if="hasPermission('feature_map_wmts') && serviceType === 'wmts'"
-      class="u-mb-0_5"
       id="r_tileMatrixSet"
       v-model="matrixSet"
       :disabled="disabledMatrixSelect"
@@ -104,6 +102,7 @@
         text: Translator.trans('map.tilematrixset')
       }"
       :options="matrixSetOptions"
+      class="u-mb-0_5"
       data-cy="layerSettings:matrixSet"
       name="r_tileMatrixSet"
       required
@@ -116,7 +115,6 @@
       type="hidden">
 
     <dp-select
-      class="u-mb-0_5"
       id="r_layerProjection"
       v-model="projection"
       :disabled="disabledProjectionSelect"
@@ -124,6 +122,7 @@
         text: Translator.trans('projection')
       }"
       :options="projectionOptions"
+      class="u-mb-0_5"
       name="r_layerProjection"
       required
     />

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -83,6 +83,7 @@
       track-by="label"
       multiple
       required
+      selection-controls
       @input="filterMatrixSetByLayers"
       @selectAll="selectAllLayers"
       @unselectAll="unselectAllLayers"

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -10,68 +10,74 @@
 <template>
   <div>
     <dp-input
+      class="u-mb-0_5"
       id="r_name"
       v-model="name"
-      class="u-mb-0_5"
-      data-cy="newMapLayerName"
       :label="{
         text: Translator.trans('name')
       }"
+      data-cy="newMapLayerName"
       name="r_name"
-      required />
+      required
+    />
 
     <dp-input
+      class="u-mb-0_5"
       id="r_url"
       v-model="url"
-      class="u-mb-0_5"
-      data-cy="newMapLayerURL"
       :label="{
         text: Translator.trans('url')
       }"
+      data-cy="newMapLayerURL"
       name="r_url"
       required
       @blur="getLayerCapabilities"
-      @enter="getLayerCapabilities" />
+      @enter="getLayerCapabilities"
+    />
 
     <dp-select
-      v-model="serviceType"
       class="u-mb-0_5"
-      data-cy="layerSettings:serviceType"
+      v-model="serviceType"
       :label="{
         text: Translator.trans('type')
       }"
-      name="r_serviceType"
       :options="serviceTypeOptions"
-      required
-      @select="setServiceInUrl" />
-    <input
-      type="hidden"
+      data-cy="layerSettings:serviceType"
       name="r_serviceType"
-      v-model="serviceType">
+      required
+      @select="setServiceInUrl"
+    />
+
+    <input
+      v-model="serviceType"
+      name="r_serviceType"
+      type="hidden">
 
     <dp-checkbox
       v-if="hasPermission('feature_xplan_defaultlayers') && showXplanDefaultLayer"
-      id="r_xplanDefaultlayers"
       class="u-mb-0_5"
+      id="r_xplanDefaultlayers"
       :label="{
         text: Translator.trans('explanation.gislayer.xplan.default')
       }"
+      :title="Translator.trans('explanation.gislayer.default.defined') + ': ' + xplanDefaultLayer"
       name="r_xplanDefaultlayers"
       style="display: none;"
-      :title="Translator.trans('explanation.gislayer.default.defined') + ': ' + xplanDefaultLayer"
-      value="1" />
+      value="1"
+    />
 
     <dp-label
       :text="Translator.trans('layers')"
       for="r_layers"
-      required />
+      required
+    />
 
     <dp-multiselect
+      class="u-mb-0_5"
       id="r_layers"
       v-model="layers"
       :options="layersOptions"
       :selection-controls="true"
-      class="u-mb-0_5"
       data-cy="newMapLayerLayers"
       label="label"
       track-by="label"
@@ -83,48 +89,53 @@
     />
 
     <input
-      type="hidden"
       :value="layersInputValue"
-      name="r_layers">
+      name="r_layers"
+      type="hidden">
+
     <dp-select
       v-if="hasPermission('feature_map_wmts') && serviceType === 'wmts'"
+      class="u-mb-0_5"
       id="r_tileMatrixSet"
       v-model="matrixSet"
-      class="u-mb-0_5"
-      data-cy="layerSettings:matrixSet"
       :disabled="disabledMatrixSelect"
       :label="{
         text: Translator.trans('map.tilematrixset')
       }"
-      name="r_tileMatrixSet"
       :options="matrixSetOptions"
-      required
-      @select="filterProjectionsByMatrixSet" />
-    <input
-      type="hidden"
+      data-cy="layerSettings:matrixSet"
       name="r_tileMatrixSet"
-      v-model="matrixSet">
+      required
+      @select="filterProjectionsByMatrixSet"
+    />
+
+    <input
+      v-model="matrixSet"
+      name="r_tileMatrixSet"
+      type="hidden">
 
     <dp-select
+      class="u-mb-0_5"
       id="r_layerProjection"
       v-model="projection"
-      class="u-mb-0_5"
       :disabled="disabledProjectionSelect"
       :label="{
         text: Translator.trans('projection')
       }"
-      name="r_layerProjection"
       :options="projectionOptions"
-      required />
-    <input
-      type="hidden"
       name="r_layerProjection"
-      v-model="projection">
+      required
+    />
 
     <input
-      type="hidden"
+      v-model="projection"
+      name="r_layerProjection"
+      type="hidden">
+
+    <input
+      v-model="version"
       name="r_layerVersion"
-      v-model="version">
+      type="hidden">
   </div>
 </template>
 

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -85,7 +85,7 @@
       selection-controls
       @input="filterMatrixSetByLayers"
       @selectAll="selectAllLayers"
-      @unselectAll="unselectAllLayers"
+      @deselectAll="deselectAllLayers"
     />
 
     <input
@@ -504,7 +504,7 @@ export default {
       this.layers = [...this.layersOptions]
     },
 
-    unselectAllLayers () {
+    deselectAllLayers () {
       this.layers = []
     },
 

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -65,17 +65,22 @@
       :text="Translator.trans('layers')"
       for="r_layers"
       required />
+
     <dp-multiselect
-      @input="filterMatrixSetByLayers"
-      required
-      track-by="label"
-      label="label"
-      multiple
       id="r_layers"
       v-model="layers"
-      data-cy="newMapLayerLayers"
       :options="layersOptions"
-      class="u-mb-0_5" />
+      :selection-controls="true"
+      class="u-mb-0_5"
+      data-cy="newMapLayerLayers"
+      label="label"
+      track-by="label"
+      multiple
+      required
+      @input="filterMatrixSetByLayers"
+      @select-all="selectAllLayers"
+      @unselect-all="resetLayerSelection"
+    />
 
     <input
       type="hidden"
@@ -482,6 +487,14 @@ export default {
         // Otherwise reset selection to empty
         this.layers = []
       }
+    },
+
+    selectAllLayers () {
+      this.layers = [...this.layersOptions]
+    },
+
+    unselectAllLayers () {
+      this.layers = []
     },
 
     setServiceInUrl () {

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -85,7 +85,7 @@
       required
       @input="filterMatrixSetByLayers"
       @selectAll="selectAllLayers"
-      @unselectAll="resetLayerSelection"
+      @unselectAll="unselectAllLayers"
     />
 
     <input

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -123,7 +123,7 @@
           :multi-page-selection-items-toggled="toggledItems.length"
           :should-be-selected-items="currentlySelectedItems"
           track-by="id"
-          @select-all="handleSelectAll"
+          @selectAll="handleSelectAll"
           @items-toggled="handleToggleItem">
           <template v-slot:externId="rowData">
             <v-popover trigger="hover focus">

--- a/client/js/components/statement/listOriginalStatements/ListOriginalStatements.vue
+++ b/client/js/components/statement/listOriginalStatements/ListOriginalStatements.vue
@@ -58,7 +58,7 @@
         :should-be-selected-items="currentlySelectedItems"
         track-by="id"
         @items-toggled="handleToggleItem"
-        @select-all="handleSelectAll">
+        @selectAll="handleSelectAll">
         <template v-slot:externId="{ externId }">
           <span
             class="font-semibold"

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -95,7 +95,7 @@
         :should-be-selected-items="currentlySelectedItems"
         track-by="id"
         :translations="{ lockedForSelection: Translator.trans('item.lockedForSelection.sharedStatement') }"
-        @select-all="handleSelectAll"
+        @selectAll="handleSelectAll"
         @items-toggled="handleToggleItem">
         <template v-slot:externId="{ assignee = {}, externId, id: statementId, synchronized }">
           <span

--- a/client/js/components/user/DpTableCardList/DpTableCardListHeader.vue
+++ b/client/js/components/user/DpTableCardList/DpTableCardListHeader.vue
@@ -14,7 +14,7 @@
         v-if="selectable"
         id="selectAll"
         class="inline-block w-[20px] u-pv-0_25"
-        @change="val => $emit('select-all', val)" /><!--
+        @change="val => $emit('selectAll', val)" /><!--
     --><div
         class="layout__item weight--bold u-pv-0_5"
         :class="[item.classes ? item.classes : '', item.width ? item.width : '']"
@@ -72,7 +72,7 @@ export default {
 
   emits: [
     'search',
-    'select-all',
+    'selectAll',
     'reset-search'
   ]
 }

--- a/client/js/components/user/DpUserListExtended.vue
+++ b/client/js/components/user/DpUserListExtended.vue
@@ -14,7 +14,7 @@
       :items="headerItems"
       class="u-pt"
       @reset-search="resetSearch"
-      @select-all="val => dpToggleAll(val, users)"
+      @selectAll="val => dpToggleAll(val, users)"
       @search="val => handleSearch(val)"
       search-placeholder="search.users"
       searchable

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -293,8 +293,8 @@
                                         :options="authUsersOptions"
                                         selection-controls
                                         track-by="id"
-                                        @select-all="selectAllAuthUsers"
-                                        @unselect-all="unselectAllAuthUsers">
+                                        @selectAll="selectAllAuthUsers"
+                                        @unselectAll="unselectAllAuthUsers">
                                         <template v-slot:option="{ props }">
                                             {% verbatim %}{{ props.option.name }}{% endverbatim %}
                                         </template>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -294,7 +294,7 @@
                                         selection-controls
                                         track-by="id"
                                         @selectAll="selectAllAuthUsers"
-                                        @unselectAll="unselectAllAuthUsers">
+                                        @deselectAll="unselectAllAuthUsers">
                                         <template v-slot:option="{ props }">
                                             {% verbatim %}{{ props.option.name }}{% endverbatim %}
                                         </template>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
@@ -85,8 +85,8 @@
                         selection-controls
                         track-by="id"
                         @input="sortSelected('AuthUsers')"
-                        @select-all="selectAllAuthUsers"
-                        @unselect-all="unselectAllAuthUsers">
+                        @selectAll="selectAllAuthUsers"
+                        @unselectAll="unselectAllAuthUsers">
                         <template v-slot:option="{ props }">
                             {% verbatim %}{{ props.option.name }}{% endverbatim %}
                         </template>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit_master.html.twig
@@ -86,7 +86,7 @@
                         track-by="id"
                         @input="sortSelected('AuthUsers')"
                         @selectAll="selectAllAuthUsers"
-                        @unselectAll="unselectAllAuthUsers">
+                        @deselectAll="unselectAllAuthUsers">
                         <template v-slot:option="{ props }">
                             {% verbatim %}{{ props.option.name }}{% endverbatim %}
                         </template>


### PR DESCRIPTION
### Ticket
[DPLAN-15771](https://demoseurope.youtrack.cloud/issue/DPLAN-15771/ADO-Issue-29551-Funktion-zur-Auswahl-aller-Layer-beim-Einbinden-von-WMS-Diensten.)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR deals with the map layers options. So far, it was possible to choose or deselect single layers. This PR activates the 'selectAll' and 'unselectAll' options, so that all available layers can be handled in one go. 

It also adjusts:
- the ordering of component attributes in accordance with the Vue.js Style Guide
- the custom event names to camelCase

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Choose a STN --> go to 'Planungsdokumente und Planzeichnung' --> 'Kartenebenen definieren' --> edit 'Grundkarten' --> 'Layer' dropdown menu. Apart from being able to select/deselect single layers, it should also be possible to select/deselect all layers at once.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->
- [ x ] Run `yarn lint`
- [ x ] Move the tickets on the board accordingly

