### PR TITLE
chore: bump demosplan-ui from 0.4.16 to 0.4.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^15.0.0",
-    "@demos-europe/demosplan-ui": "0.4.16",
+    "@demos-europe/demosplan-ui": "0.4.17",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,9 +1998,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.16":
-  version: 0.4.16
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.16"
+"@demos-europe/demosplan-ui@npm:0.4.17":
+  version: 0.4.17
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.17"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2051,7 +2051,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/0ca36d3d00b2a4160f54c6ead5b6079b78ed83eef6c5943d43d2cf796261c08f3afc6671b72c0a2daeeb3cc1b9baf1689bdb1a08c5777ec8d19cb741dfa9d3d4
+  checksum: 10c0/416d17b8ed514fbc2035f09408207f29585d03f2a1b042ca1b61c3c384fcc64416ec8b509ed7d0919310d6ca11bffb7c563a79f1a6e606935b0ac0298e1a38ca
   languageName: node
   linkType: hard
 
@@ -12406,7 +12406,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^15.0.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.16"
+    "@demos-europe/demosplan-ui": "npm:0.4.17"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"


### PR DESCRIPTION
New version contains these changes:
- `data-dp-validate-topic` option can be passed to dpValidateMixin
- BREAKING: `'select-all'` event in `DpDataTable` is renamed to `'selectAll'`, `'select-all'` and `'unselect-all'` events in `DpMultiselect` are renamed to `'selectAll'` and `'deselectAll'`
