### PR TITLE
DemosPipes2 part 2

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/06/Version20250612064045.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/06/Version20250612064045.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 
@@ -21,7 +31,6 @@ class Version20250612064045 extends AbstractMigration
     {
         $this->abortIfNotMysql();
         $this->addSql("ALTER TABLE _procedure ADD demos_pipes_pi_retries INT NOT NULL DEFAULT 0 COMMENT 'Number of retries for Demos Pipes PI to process this procedure.'");
-
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/06/Version20250612064045.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/06/Version20250612064045.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250612064045 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-15608: Add demos_pipes_pi_retries column to _procedure table ';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql("ALTER TABLE _procedure ADD demos_pipes_pi_retries INT NOT NULL DEFAULT 0 COMMENT 'Number of retries for Demos Pipes PI to process this procedure.'");
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        $this->addSql('ALTER TABLE _procedure DROP COLUMN demos_pipes_pi_retries');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -581,8 +581,6 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     private $segmentPlaces;
 
     /**
-     * @var int
-     *
      * @ORM\Column(name="demos_pipes_pi_retries", type="integer", options={"default": 0}, nullable=false, options="comment: 'Number of retries for Demos Pipes PI to process this procedure.'})")
      */
     private int $demosPipesPiRetries = 0;

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -585,7 +585,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @ORM\Column(name="demos_pipes_pi_retries", type="integer", options={"default": 0}, nullable=false, options="comment: 'Number of retries for Demos Pipes PI to process this procedure.'})")
      */
-    private $demosPipesPiRetries;
+    private int $demosPipesPiRetries = 0;
 
     protected ?CustomFieldConfiguration $customFieldConfiguration = null;
 
@@ -610,7 +610,6 @@ class Procedure extends SluggedEntity implements ProcedureInterface
         $this->phase = new ProcedurePhase();
         $this->publicParticipationPhase = new ProcedurePhase();
         $this->customFieldConfiguration = null;
-        $this->demosPipesPiRetries = 0;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -580,6 +580,13 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      */
     private $segmentPlaces;
 
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="demos_pipes_pi_retries", type="integer", options={"default": 0}, nullable=false, options="comment: 'Number of retries for Demos Pipes PI to process this procedure.'})")
+     */
+    private $demosPipesPiRetries;
+
     protected ?CustomFieldConfiguration $customFieldConfiguration = null;
 
     public function __construct()
@@ -603,6 +610,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
         $this->phase = new ProcedurePhase();
         $this->publicParticipationPhase = new ProcedurePhase();
         $this->customFieldConfiguration = null;
+        $this->demosPipesPiRetries = 0;
     }
 
     /**
@@ -2268,5 +2276,15 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     public function getCustomFieldConfiguration(): ?CustomFieldConfiguration
     {
         return $this->customFieldConfiguration;
+    }
+
+    public function getDemosPipesPiRetries(): int
+    {
+        return $this->demosPipesPiRetries;
+    }
+
+    public function incrementDemosPipesPiRetries(): void
+    {
+        ++$this->demosPipesPiRetries;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureSoftDeletedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureSoftDeletedEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Event\Procedure;
+
+use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureSoftDeletedEventInterface;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
+class PostProcedureSoftDeletedEvent extends DPlanEvent implements PostProcedureSoftDeletedEventInterface
+{
+    public function __construct(protected string $procedureId)
+    {
+    }
+
+    public function getProcedureId(): string
+    {
+        return $this->procedureId;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Event/Statement/SegmentDeleteEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/SegmentDeleteEvent.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace demosplan\DemosPlanCoreBundle\Event\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;

--- a/demosplan/DemosPlanCoreBundle/Event/Statement/SegmentDeleteEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/SegmentDeleteEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Event\Statement;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\SegmentDeleteEventInterface;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
+class SegmentDeleteEvent extends DPlanEvent implements SegmentDeleteEventInterface
+{
+    protected SegmentInterface $segment;
+
+    public function __construct(SegmentInterface $segment)
+    {
+        $this->segment = $segment;
+    }
+
+    public function getSegment(): SegmentInterface
+    {
+        return $this->segment;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Event/Statement/StatementDeleteEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/StatementDeleteEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\Event\Statement;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementDeleteEventInterface;
+use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+class StatementDeleteEvent extends DPlanEvent implements StatementDeleteEventInterface
+{
+    protected StatementInterface $statement;
+
+    public function __construct(StatementInterface $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    public function getStatement(): StatementInterface
+    {
+        return $this->statement;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Event/Statement/StatementDeleteEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Statement/StatementDeleteEvent.php
@@ -1,10 +1,19 @@
 <?php
 
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 namespace demosplan\DemosPlanCoreBundle\Event\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementDeleteEventInterface;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
+
 class StatementDeleteEvent extends DPlanEvent implements StatementDeleteEventInterface
 {
     protected StatementInterface $statement;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -929,6 +929,10 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
                 try {
                     $this->updateProcedure($data);
                     $this->getLogger()->info('Procedure marked as deleted: '.\var_export($procedureId, true));
+                    $this->eventDispatcher->dispatch(
+                        new PostProcedureDeletedEvent($procedureId),
+                        PostProcedureDeletedEventInterface::class
+                    );
                     ++$deletionCount;
                 } catch (Exception $e) {
                     $this->getLogger()->warning("Mark Procedure '$procedureId' as deleted failed Message: ", [$e]);

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -17,6 +17,7 @@ use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostNewProcedureCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureDeletedEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureSoftDeletedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureUpdatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Form\Procedure\AbstractProcedureFormTypeInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
@@ -42,6 +43,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Workflow\Place;
 use demosplan\DemosPlanCoreBundle\Event\Procedure\NewProcedureAdditionalDataEvent;
 use demosplan\DemosPlanCoreBundle\Event\Procedure\PostNewProcedureCreatedEvent;
 use demosplan\DemosPlanCoreBundle\Event\Procedure\PostProcedureDeletedEvent;
+use demosplan\DemosPlanCoreBundle\Event\Procedure\PostProcedureSoftDeletedEvent;
 use demosplan\DemosPlanCoreBundle\Event\Procedure\PostProcedureUpdatedEvent;
 use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Exception\CriticalConcernException;
@@ -930,8 +932,8 @@ class ProcedureService extends CoreService implements ProcedureServiceInterface
                     $this->updateProcedure($data);
                     $this->getLogger()->info('Procedure marked as deleted: '.\var_export($procedureId, true));
                     $this->eventDispatcher->dispatch(
-                        new PostProcedureDeletedEvent($procedureId),
-                        PostProcedureDeletedEventInterface::class
+                        new PostProcedureSoftDeletedEvent($procedureId),
+                        PostProcedureSoftDeletedEventInterface::class
                     );
                     ++$deletionCount;
                 } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementPreDeleteEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementDeleteEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\SegmentDeleteEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
+use demosplan\DemosPlanCoreBundle\Event\Statement\SegmentDeleteEvent;
+use demosplan\DemosPlanCoreBundle\Event\Statement\StatementDeleteEvent;
 use demosplan\DemosPlanCoreBundle\Event\Statement\StatementPreDeleteEvent;
 use demosplan\DemosPlanCoreBundle\Exception\DemosException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
@@ -193,6 +197,14 @@ class StatementDeleter extends CoreService
                     }
 
                     $this->entityContentChangeService->deleteByEntityIds([$statementId]);
+                    $this->eventDispatcher->dispatch(
+                        new StatementDeleteEvent($statement),
+                        StatementDeleteEventInterface::class
+                    );
+                    $this->eventDispatcher->dispatch(
+                        new SegmentDeleteEvent($statement),
+                        SegmentDeleteEventInterface::class
+                    );
                     $success = true;
                 } catch (DemosException $demosException) {
                     $this->getLogger()->error('Fehler beim Löschen eines Statements: ', [$demosException]);

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
-use DemosEurope\DemosplanAddon\Contracts\Events\StatementPreDeleteEventInterface;
-use DemosEurope\DemosplanAddon\Contracts\Events\StatementDeleteEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\SegmentDeleteEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementDeleteEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\StatementPreDeleteEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -124,7 +124,7 @@ class StatementDeleter extends CoreService
         Statement $statement,
         bool $ignoreAssignment = false,
         bool $ignoreOriginal = false,
-        bool $canTransaction = true
+        bool $canTransaction = true,
     ): bool {
         /** @var Connection $doctrineConnection */
         $doctrineConnection = $this->getDoctrine()->getConnection();


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15608/Runde-2-Implementierung-von-demospipes-2-in-demosplan
- Add demosPipesPiRetries as a new column in procedure entity
- Add related methos to service
- create two new event to delete Statement and procedure
- add migration to add new column in table