### PR TITLE
fix(refs: DPLAN-12516): change margins in statement modal

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -67,7 +67,7 @@
       </header>
 
       <dp-inline-notification
-        :class="prefixClass('mt-3 mb-2')"
+        :class="prefixClass('mb-2')"
         dismissible
         dismissible-key="statementModalCloseExplanation"
         :message="Translator.trans('explanation.statement.autosave')"
@@ -79,7 +79,7 @@
         data-dp-validate="statementForm">
         <dp-inline-notification
           v-if="loggedIn === false"
-          :class="prefixClass('mt-3')"
+          :class="prefixClass('mb-2')"
           type="info">
           <p
             v-if="statementFormHintStatement"
@@ -90,7 +90,7 @@
 
         <dp-inline-notification
           v-if="dpValidate.statementForm === false"
-          :class="prefixClass('mt-3 mb-2')"
+          :class="prefixClass('mb-2')"
           id="statementFormErrors"
           aria-labelledby="statementFormErrorsContent"
           tabindex="0">


### PR DESCRIPTION
### Ticket
[DPLAN-12516](https://demoseurope.youtrack.cloud/issue/DPLAN-12516/Unnotiger-Leerraum-im-Stellungnahme-Fenster)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Change the margins in statement modal, because there was to much space between the headline and the next element when the notification boxes were disabled or hidden. Some margins are changed in core to be unified in diplanfest, diplanbau and diplanrog.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open a procedure and navigate to the tab "Interaktive Karte"
2. Click the button "Reden Sie mit!"
3. Check if the spaces between the headline and all following elements (notifications and labels), until the label of the dp-editor for the statements, have a margin of 12px
4. Check if all these margins are at the bottom of each element 

