### PR TITLE
Move getSynopseFileName to FileNameGenerator

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -109,6 +109,7 @@ class SegmentsExportController extends BaseController
         methods: 'GET'
     )]
     public function exportByStatementsFilterAction(
+        FileNameGenerator $fileNameGenerator,
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
         JsonApiActionService $requestHandler,
@@ -152,7 +153,7 @@ class SegmentsExportController extends BaseController
             }
         );
 
-        $this->setResponseHeaders($response, $exporter->getSynopseFileName($procedure, 'docx'));
+        $this->setResponseHeaders($response, $fileNameGenerator->getSynopseFileName($procedure, 'docx'));
 
         return $response;
     }
@@ -172,6 +173,7 @@ class SegmentsExportController extends BaseController
         methods: 'GET'
     )]
     public function exportByStatementsFilterXlsAction(
+        FileNameGenerator $fileNameGenerator,
         JsonApiActionService $jsonApiActionService,
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
@@ -201,7 +203,7 @@ class SegmentsExportController extends BaseController
 
         $procedure = $this->procedureHandler->getProcedureWithCertainty($procedureId);
         $response->headers->set('Content-Disposition', $this->nameGenerator->generateDownloadFilename(
-            $exporter->getSynopseFileName($procedure, 'xlsx'))
+            $fileNameGenerator->getSynopseFileName($procedure, 'xlsx'))
         );
 
         return $response;
@@ -219,6 +221,7 @@ class SegmentsExportController extends BaseController
         methods: 'GET'
     )]
     public function exportPackagedStatementsAction(
+        FileNameGenerator $fileNameGenerator,
         SegmentsByStatementsExporter $exporter,
         StatementResourceType $statementResourceType,
         JsonApiActionService $requestHandler,
@@ -252,7 +255,7 @@ class SegmentsExportController extends BaseController
         );
 
         return $zipExportService->buildZipStreamResponse(
-            $exporter->getSynopseFileName($procedure, 'zip'),
+            $fileNameGenerator->getSynopseFileName($procedure, 'zip'),
             static function (ZipStream $zipStream) use (
                 $statements,
                 $exporter,

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/FileNameGenerator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/FileNameGenerator.php
@@ -14,6 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export;
 
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -37,6 +38,11 @@ class FileNameGenerator
     {
         $this->translator = $translator;
         $this->slugify = $slugify;
+    }
+
+    public function getSynopseFileName(Procedure $procedure, string $suffix): string
+    {
+        return 'Synopse-'.$this->slugify->slugify($procedure->getName()).'.'.$suffix;
     }
 
     public function getFileName(Statement $statement, string $templateName = '', bool $censored = false): string

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -56,11 +56,6 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         parent::__construct($currentUser, $htmlHelper, $imageManager, $imageLinkConverter, $slugify, $styleInitializer, $translator);
     }
 
-    public function getSynopseFileName(Procedure $procedure, string $suffix): string
-    {
-        return 'Synopse-'.$this->slugify->slugify($procedure->getName()).'.'.$suffix;
-    }
-
     /**
      * @throws Exception
      */


### PR DESCRIPTION
Move getSynopseFileName from SegmentsByStatementsExporter to FileNameGenerator

### How to review/test
code review

### Linked PRs (optional)

https://github.com/demos-europe/demosplan-core/pull/3462
