### PR TITLE
fix(refs DPLAN-15821): add spread operator to updateStore

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentLocationMap.vue
@@ -313,7 +313,7 @@ export default {
         ...this.segment,
         attributes: {
           ...this.segment.attributes,
-          updatedAttributes
+          ...updatedAttributes
         },
         id: this.segment.id
       }


### PR DESCRIPTION
### Ticket
[DPLAN-15821](https://demoseurope.youtrack.cloud/issue/DPLAN-15821/Abschnitte-Ortsmarkierung-wird-nur-nach-einem-Seitenrefresh-angezeigt)

This PR fixes the updateStore function by spreading the updatedAttributes object. Now the changes are made correctly in the vuex store and the polygon changes show immediately. 


### How to review/test
1. Navigate to "Erwiderungen verfassen" in a statement with segments.
2. Click the pin icon on a segment to open the "Ortsbezug" modal.
3. Change or add a polygon, save it and close the modal.
4. Open the modal again and check if your changes show.
