### PR TITLE
fix(refs: closed DPLAN-15554) Adding data-dp-validate-topic attributes to form fieldsets

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -384,6 +384,7 @@
                         name="infoForm"
                         {% if proceduresettings.infoComplete is defined %}data-wizard-finished="true"{% endif %}
                         data-wizard-topic="{{ 'wizard.topic.info'|trans }}"
+                        data-dp-validate-topic="{{ 'wizard.topic.info'|trans }}"
                         class="o-wizard"
                         data-dp-validate="infoForm">
 


### PR DESCRIPTION
This fix addresses an oversight from the previous implementation of DPLAN-15554 where the `data-dp-validate-topic` attribute was missing from the "Informationen zum Verfahren" fieldset.

### How to review/test
- create new "Verfahren", delete "Ansprechperson" in "Informationen zum Verfahren" and save

### Linked PRs (optional)

- https://github.com/demos-europe/demosplan-core/pull/4655

