### PR TITLE
fix(DPLAN-1987): add c-styled-html class to dp-edit-field

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -39,6 +39,7 @@
             class="inline-block break-words"
             style="width: 95%">
           <dp-edit-field
+            class="c-styled-html"
             :editable="isAssigneeEditable(segment)"
             label=""
             :label-grid-cols="0"


### PR DESCRIPTION
### Ticket
[DPLAN-1987](https://demoseurope.youtrack.cloud/issue/DPLAN-1987) Nummerierungen können bei Aufteilung nicht in Abschnittstext übernommen werden

**Description:** This PR fixes an issue with the styling of lists in the statements segments list by adding c-styled-html class to the dp-edit-field component.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
