### PR TITLE
DPLAN-15822: fix draft pdf export inPublicView as Admin

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -893,9 +893,13 @@ class DraftStatementService extends CoreService
 
         $filenameSuffix .= '.pdf';
 
-        $selectedStatementsToExport = isset($itemsToExport)
-            ? explode(',', $itemsToExport)
-            : null;
+        $selectedStatementsToExport = null;
+        if (isset($itemsToExport) && is_string($itemsToExport)) {
+            $selectedStatementsToExport = explode(',', $itemsToExport);
+        }
+        if (isset($itemsToExport) && is_array($itemsToExport) && !empty($itemsToExport)) {
+            $selectedStatementsToExport = $itemsToExport;
+        }
 
         $filteredStatementList = collect($draftStatementList)->filter(fn ($statement) => null === $selectedStatementsToExport || in_array($this->entityHelper->extractId($statement), $selectedStatementsToExport))->map(function (array $statement) use ($procedureId) {
             $statement['documentlist'] = $this->paragraphService->getParaDocumentObjectList($procedureId, $statement['elementId']);


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15822/Offentlichkeitsansicht-Download-als-PDF-weiterleitet-zu-einer-Fehlerseite

Description:
In case you log in as an admin and chose the publicView of a procedure. There you navigate to stn-drafts - do not choose any - chlick downlad pdf. Ann empty array gets send for itemsToExport
Adjust the logic to handle an empty array like null - which means getAll.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
