### PR TITLE
feature (DPLAN-12319): Set Default date time zone

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
+++ b/demosplan/DemosPlanCoreBundle/Application/DemosPlanKernel.php
@@ -81,7 +81,7 @@ class DemosPlanKernel extends Kernel
         bool $debug,
     ) {
         parent::__construct($environment, $debug);
-
+        date_default_timezone_set('Europe/Berlin');
         DemosPlanPath::setProjectPathFromConfig("projects/{$activeProject}");
     }
 


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12319/falsche-Zeitangabe-Versionen-der-Stellungnahme, https://demoseurope.youtrack.cloud/issue/DPLAN-15853/Falsches-Uhrzeit-beim-Verfahrensexport


Description: Set Default date/time zone

