### PR TITLE
fix(DPLAN-11742): console issue when deleting an unregistered public agency

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/unregistered_publicagency_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/unregistered_publicagency_list.html.twig
@@ -65,6 +65,7 @@
         <h3 class="u-mt-0_5 u-pt">{{ 'invitable_institutions.unregistered'|trans }}</h3>
 
         <form
+            id="unregisteredPublicAgencyList"
             action="{{ path('DemosPlan_delete_email_addresses_entry', {'organisationId': currentUser.organisationId}) }}"
             method="post">
             {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}


### PR DESCRIPTION
### Ticket
[DPLAN-11742](https://demoseurope.youtrack.cloud/issue/DPLAN-11742) Unregistrierte Insti: Klick auf entfernen -> Uncaught DOMException: Document.querySelectorAll: '[id=] [data-form-actions-added]' is not a valid selector


**Description:** This PR fixes a console issue that occurred when deleting an unregistered public agency.

- to be able to remove the form's hidden field (FormAction.js), an ID is required: the ID `unregisteredPublicAgencyList` has been added to the form in the `unregistered_publicagency_list.html.twig` file.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
