### PR TITLE
chore: bump demosplan-ui from 0.4.17 to 0.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^15.0.0",
-    "@demos-europe/demosplan-ui": "0.4.17",
+    "@demos-europe/demosplan-ui": "0.4.18",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,9 +2033,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.17":
-  version: 0.4.17
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.17"
+"@demos-europe/demosplan-ui@npm:0.4.18":
+  version: 0.4.18
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.18"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.4.5"
@@ -2086,7 +2086,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/416d17b8ed514fbc2035f09408207f29585d03f2a1b042ca1b61c3c384fcc64416ec8b509ed7d0919310d6ca11bffb7c563a79f1a6e606935b0ac0298e1a38ca
+  checksum: 10c0/e34b8260b28bb55ab4b1cd340d63af5d79c73e29892599bf2f8527813b46a6ba20c6796dddaf9dd83f4da58f4432a71eee34d329c6913a66e2c4c83faa4149a7
   languageName: node
   linkType: hard
 
@@ -12556,7 +12556,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^15.0.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.17"
+    "@demos-europe/demosplan-ui": "npm:0.4.18"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"


### PR DESCRIPTION
Changes in the new version:
- in DpSlidingPagination, page-change event is now only emitted if current page does not exceed total pages
- in DpTreeList, node selection is now handled without mutating store state