### PR TITLE
fix(DPLAN-15840): loading state issue that occurred after changing the priority or other fields

### DIFF
--- a/client/js/components/statement/assessmentTable/DpEditField.vue
+++ b/client/js/components/statement/assessmentTable/DpEditField.vue
@@ -215,7 +215,7 @@ export default {
   },
 
   mounted () {
-    this.$root.$on('save-success', () => {
+    this.$root.$on('entity:updated', () => {
       this.loading = false
       this.editingEnabled = false
     })


### PR DESCRIPTION
### Ticket
[DPLAN-15840](https://demoseurope.youtrack.cloud/issue/DPLAN-15840) STN: Prio Änderung bleibt beim Laden

**Description:** This PR fixes a loading state issue that occurred after changing the priority or other fields in the DpAssessmentTableCard.vue component.

-  the event name used in the DpEditField.vue component was incorrect; replace it with the existing event `entity:updated` which is set in the saveStatement method of DpAssessmentTableCard.vue

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
