### PR TITLE
feat(refs: DPLAN-15854): update diplan-karten from 0.6.1 to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@demos-europe/demosplan-ui": "0.4.18",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
-    "@init/diplan-karten": "^0.6.1",
+    "@init/diplan-karten": "^0.7.2",
     "@masterportal/masterportalapi": "2.48.0",
     "@sentry/browser": "^9.24.0",
     "@sentry/tracing": "^7.120.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,9 +2414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@init/diplan-karten@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@init/diplan-karten@npm:0.6.1"
+"@init/diplan-karten@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@init/diplan-karten@npm:0.7.2"
   dependencies:
     "@formkit/addons": "npm:1.6.9"
     "@formkit/auto-animate": "npm:0.8.2"
@@ -2424,12 +2424,12 @@ __metadata:
     "@formkit/inputs": "npm:^1.6.9"
     "@formkit/vue": "npm:1.6.9"
     "@masterportal/masterportalapi": "npm:2.45.0"
-    "@oruga-ui/oruga-next": "npm:0.10.2"
+    "@oruga-ui/oruga-next": "npm:0.10.6"
     "@oruga-ui/theme-bootstrap": "npm:^0.8.2"
     "@turf/turf": "npm:^7.2.0"
-    "@vueuse/components": "npm:^13.0.0"
-    "@vueuse/core": "npm:^13.0.0"
-    axios: "npm:^1.7.9"
+    "@vueuse/components": "npm:^13.3.0"
+    "@vueuse/core": "npm:^13.3.0"
+    axios: "npm:^1.9.0"
     diplanung-style: "npm:^13.1.0"
     lodash-es: "npm:^4.17.21"
     ol: "npm:10.3.1"
@@ -2438,7 +2438,7 @@ __metadata:
     "@popperjs/core": ^2.11.8
     bootstrap: ^5.3.3
     vue: ^3.5.13
-  checksum: 10c0/dfb6941d8e43d9bab89a0fc99cdc56eb08f9abd21b05de167aa43e9604b7f84c413d938ccb35e4102968e74d731c08810c8d946a6be72847ecdc93c8e14c7d52
+  checksum: 10c0/7df4e9e7a66510706d6f90bcb9f1cbd7db8b78e38dbc48fca8a148db7ca5aff2531a5b8db415605077acd3e2798402f63fb58fea5893658027506d50fe166368
   languageName: node
   linkType: hard
 
@@ -2943,14 +2943,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oruga-ui/oruga-next@npm:0.10.2":
-  version: 0.10.2
-  resolution: "@oruga-ui/oruga-next@npm:0.10.2"
+"@oruga-ui/oruga-next@npm:0.10.6":
+  version: 0.10.6
+  resolution: "@oruga-ui/oruga-next@npm:0.10.6"
   dependencies:
-    vue-component-type-helpers: "npm:^2.2.8"
+    vue-component-type-helpers: "npm:^2.2.10"
   peerDependencies:
     vue: ^3.0.0
-  checksum: 10c0/94d0d11b469634edf15fa4253a37bee0fca8a7d83a698f6892147c78a08272126e91a3388ce0cef44fc3418e7c18ba720a6a3ca7d50342da4e8eda724f0ce81b
+  checksum: 10c0/cf28033d8f6f2d2652668cdaa489f728f4fae8ece05b7e08d8b089e64d2034724ea175383277613c65516b707f9fb7c89f793abffd35da1463efb607088f3b56
   languageName: node
   linkType: hard
 
@@ -5974,6 +5974,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vueuse/components@npm:^13.3.0":
+  version: 13.4.0
+  resolution: "@vueuse/components@npm:13.4.0"
+  dependencies:
+    "@vueuse/core": "npm:13.4.0"
+    "@vueuse/shared": "npm:13.4.0"
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 10c0/143fa9ee5396166462aa033185c97ed1ecd6d4b24c8717768fbb680c9e654a9bb2fe54320b0c6bd7821a9a632f510fdf3c5e562b11dfaf2449bd53deffeed8d3
+  languageName: node
+  linkType: hard
+
 "@vueuse/core@npm:11.3.0":
   version: 11.3.0
   resolution: "@vueuse/core@npm:11.3.0"
@@ -5986,7 +5998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vueuse/core@npm:13.3.0, @vueuse/core@npm:^13.0.0":
+"@vueuse/core@npm:13.3.0":
   version: 13.3.0
   resolution: "@vueuse/core@npm:13.3.0"
   dependencies:
@@ -5996,6 +6008,19 @@ __metadata:
   peerDependencies:
     vue: ^3.5.0
   checksum: 10c0/3e62bf0a4f6bb175eebb065df73b1e09bb62ecc02986fc1a07c9a7e212ca9388f09d01fd1d02a5149ec43e6cc1f51161e4f27ccb186a8a0d17f11d63bd8e7a51
+  languageName: node
+  linkType: hard
+
+"@vueuse/core@npm:13.4.0, @vueuse/core@npm:^13.3.0":
+  version: 13.4.0
+  resolution: "@vueuse/core@npm:13.4.0"
+  dependencies:
+    "@types/web-bluetooth": "npm:^0.0.21"
+    "@vueuse/metadata": "npm:13.4.0"
+    "@vueuse/shared": "npm:13.4.0"
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 10c0/a4ec26881cba3cefb8cb7eddb2148d80508c10c3d3efb07069c39119cec3f99a0dee578d776c4f440d57e4a23b07b0b65e66de0a66fecced28191ec4c6380805
   languageName: node
   linkType: hard
 
@@ -6062,6 +6087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vueuse/metadata@npm:13.4.0":
+  version: 13.4.0
+  resolution: "@vueuse/metadata@npm:13.4.0"
+  checksum: 10c0/223b3ec56c9b82586e3940a79f9f3d350986a3ee9f39b3b3bed74055e44fd1d947528c8b78574f2b0afcc4f8d48f6f56abccf1b5919782fc4aee858c0a12f3bb
+  languageName: node
+  linkType: hard
+
 "@vueuse/shared@npm:11.3.0":
   version: 11.3.0
   resolution: "@vueuse/shared@npm:11.3.0"
@@ -6077,6 +6109,15 @@ __metadata:
   peerDependencies:
     vue: ^3.5.0
   checksum: 10c0/3dd3186a8784f26f13f37f78144aaf9586bb12138a5cc84f0779a5e9f5dd20d317e0ca5377d1091dd51f159e1e6ae64a18f8967bf42aabace96e03cafe4e272b
+  languageName: node
+  linkType: hard
+
+"@vueuse/shared@npm:13.4.0":
+  version: 13.4.0
+  resolution: "@vueuse/shared@npm:13.4.0"
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 10c0/6a32f8bf1f655b42374f3f07efd370e1f5b2f2ab9ff7d67f544f8660a48dbf4cb21f206991be6b12fc20a0983e3c82117676583c636f435e369a91dfd5455d78
   languageName: node
   linkType: hard
 
@@ -6655,7 +6696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.7.9":
+"axios@npm:^1.9.0":
   version: 1.10.0
   resolution: "axios@npm:1.10.0"
   dependencies:
@@ -14785,7 +14826,7 @@ __metadata:
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"
-    "@init/diplan-karten": "npm:^0.6.1"
+    "@init/diplan-karten": "npm:^0.7.2"
     "@masterportal/masterportalapi": "npm:2.48.0"
     "@sentry/browser": "npm:^9.24.0"
     "@sentry/tracing": "npm:^7.120.3"
@@ -16748,7 +16789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-component-type-helpers@npm:^2.2.8":
+"vue-component-type-helpers@npm:^2.2.10":
   version: 2.2.10
   resolution: "vue-component-type-helpers@npm:2.2.10"
   checksum: 10c0/f4d2219941a6bb987dc813e5e132fa9f8880163efc73faa6871713241dae0358cbfb6ecbee3b7e6e2ef65c02e5b5a8204c6e44c4a7d213499957e4d36f8c99c7


### PR DESCRIPTION
### Ticket
DPLAN-15854

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The new version of diplan-karten is needed, to add the information of the local reference to a statement. The diplan-karten updates from 0.6.1 to 0.7.2 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanfest and open a procedure
2. In the tab "Interaktive Karte" the map should be loaded

