### PR TITLE
DPLAN-15894: zero organisations have received an invitation mail is a valid case

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitedPublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitedPublicAgencyResourceType.php
@@ -181,7 +181,7 @@ class InvitedPublicAgencyResourceType extends DplanResourceType
                 $procedure->getPhase()
             );
 
-            $hasValidResultFormat = is_array($invitationEmailList['result']) && 0 < count($invitationEmailList['result']);
+            $hasValidResultFormat = is_array($invitationEmailList['result']);
             Assert::true($hasValidResultFormat);
         } catch (Exception $e) {
             $this->logger->error(


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15894

Description:
Remove the assertion that at least one organisation should be found having received an invitation mail.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
