### PR TITLE
fix(refs dplan-15812): Await all Promises before leaving the page when saving Layers

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -289,8 +289,10 @@ const LayersStore = {
 
     saveAll ({ state, dispatch }) {
       /* Save each GIS layer and GIS layer category with its relationships */
+      const allRequests = []
+
       state.apiData.included.forEach(el => {
-        dispatch('save', el)
+        allRequests.push(dispatch('save', el))
       })
     },
 
@@ -444,6 +446,8 @@ const LayersStore = {
       return state.apiData.included.filter(current => {
         return current.attributes[attribute.type] === attribute.value
       })
+
+      return Promise.all(allRequests)
     },
 
     /**

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitedPublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitedPublicAgencyResourceType.php
@@ -181,7 +181,7 @@ class InvitedPublicAgencyResourceType extends DplanResourceType
                 $procedure->getPhase()
             );
 
-            $hasValidResultFormat = is_array($invitationEmailList['result']) && 0 < count($invitationEmailList['result']);
+            $hasValidResultFormat = is_array($invitationEmailList['result']);
             Assert::true($hasValidResultFormat);
         } catch (Exception $e) {
             $this->logger->error(


### PR DESCRIPTION
### Ticket
DPLAN-15812

When saving layersort ls FPA, there are two ways: "save" and "save and return". On later one, it did not saved properly because the async save method did not waited untill all save actions (for each layer one request) where settled.
