### PR TITLE
F adjust resourcetypes to avoid faulty api request

### DIFF
--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -480,8 +480,8 @@ export default {
         'paragraph',
         'document',
         'assignee',
-        'attachments',
-        'attachments.file',
+        'sourceAttachment',
+        'sourceAttachment.file',
         'files'
       ]
 
@@ -539,7 +539,7 @@ export default {
               ...statementFields,
               'anonymous',
               'assignee',
-              'attachments',
+              'sourceAttachment',
               'authoredDate',
               'authorName',
               'document',

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementAttachmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseStatementResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
@@ -19,7 +20,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Document\ParagraphVersion;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementFragment;
-use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\GenericStatementAttachmentResourceType;
 use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
@@ -101,7 +101,7 @@ use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
  * Statement Attachments properties
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,GenericStatementAttachmentResourceType> $genericAttachments
  * An Statement has only one source attachment, that is why the property is named singular even though it is a to-many relationship
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,StatementAttachment> $sourceAttachment
+ * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,StatementAttachmentInterface> $sourceAttachment
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Statement> $parentStatementOfSegment
  */
 class StatementResourceConfigBuilder extends BaseStatementResourceConfigBuilder

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SourceStatementAttachmentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SourceStatementAttachmentResourceType.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementAttachmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\BeforeResourceCreateFlushEvent;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -20,6 +21,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceTyp
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use EDT\JsonApi\RequestHandling\ModifiedEntity;
+use EDT\PathBuilding\End;
 use EDT\Wrapping\Contracts\ContentField;
 use EDT\Wrapping\CreationDataInterface;
 use Exception;
@@ -30,6 +32,7 @@ use Webmozart\Assert\Assert;
  *
  * @property-read FileResourceType      $file
  * @property-read StatementResourceType $statement
+ * @property-read End $attachmentType
  */
 final class SourceStatementAttachmentResourceType extends DplanResourceType
 {
@@ -80,6 +83,8 @@ final class SourceStatementAttachmentResourceType extends DplanResourceType
     {
         $properties = [
             $this->createIdentifier()->readable()->sortable()->filterable(),
+            $this->createAttribute($this->attachmentType)
+                ->setReadableByCallable(fn (StatementAttachment $attachment): string => StatementAttachmentInterface::SOURCE_STATEMENT)
         ];
 
         if ($this->currentUser->hasPermission('feature_read_source_statement_via_api')) {


### PR DESCRIPTION
Ticket:

Description: 
adjust resourcetypes to avoid faulty api request :   
- add missing property attachmentType
- use property right name : sourceAttachment instead attachments

Note : this pr is not yet ready to review, files property still cause a faulty api request and has to be fixed
