### PR TITLE
fix ( ref: DPLAN-584 ) set email while create user : email has to be …

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -306,6 +306,7 @@ final class AdministratableUserResourceType extends DplanResourceType implements
             }
             $attributes = $entityData->getAttributes();
             $user->setLogin($attributes[$this->email->getAsNamesInDotNotation()]);
+            $user->setEmail($attributes[$this->email->getAsNamesInDotNotation()]);
             $this->userRepository->persistEntities([$user]);
             $this->userHandler->inviteUser($user);
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-584


Description:
set email while create user : email has to be set too otherwise it will be missing while creating and sending the registration emails.



- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

