### PR TITLE
fix(refs dplan-15817): Make input values reactive

### DIFF
--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -67,13 +67,13 @@ export default {
       default: () => []
     },
 
-    initDataInputOrgas: {
+    initAuthUsers: {
       required: false,
       type: Array,
       default: () => []
     },
 
-    initAuthUsers: {
+    initDataInputOrgas: {
       required: false,
       type: Array,
       default: () => []
@@ -158,15 +158,15 @@ export default {
       isLoadingPlisData: false,
       pictogramAltText: this.initPictogramAltText,
       pictogramCopyright: this.initPictogramCopyright,
-      selectedAgencies: this.initAgencies,
-      selectedDataInputOrgas: this.initDataInputOrgas,
-      selectedAuthUsers: this.initAuthUsers,
-      selectedInternalPhase: this.initProcedurePhaseInternal,
-      selectedPublicPhase: this.initProcedurePhasePublic,
-      selectedProcedureCategories: this.initProcedureCategories,
-      selectedSimilarRecommendationProcedures: this.initSimilarRecommendationProcedures,
       procedureDescription: this.procedureExternalDesc,
-      procedureName: this.initProcedureName
+      procedureName: this.initProcedureName,
+      selectedAgencies: this.initAgencies,
+      selectedAuthUsers: this.initAuthUsers,
+      selectedDataInputOrgas: this.initDataInputOrgas,
+      selectedInternalPhase: this.initProcedurePhaseInternal,
+      selectedProcedureCategories: this.initProcedureCategories,
+      selectedPublicPhase: this.initProcedurePhasePublic,
+      selectedSimilarRecommendationProcedures: this.initSimilarRecommendationProcedures
     }
   },
 

--- a/client/js/components/procedure/basicSettings/DpBasicSettings.vue
+++ b/client/js/components/procedure/basicSettings/DpBasicSettings.vue
@@ -79,6 +79,18 @@ export default {
       default: () => []
     },
 
+    initPictogramAltText: {
+      required: false,
+      type: String,
+      default: ''
+    },
+
+    initPictogramCopyright: {
+      required: false,
+      type: String,
+      default: ''
+    },
+
     initProcedureCategories: {
       required: false,
       type: Array,
@@ -144,6 +156,8 @@ export default {
         value: ''
       },
       isLoadingPlisData: false,
+      pictogramAltText: this.initPictogramAltText,
+      pictogramCopyright: this.initPictogramCopyright,
       selectedAgencies: this.initAgencies,
       selectedDataInputOrgas: this.initDataInputOrgas,
       selectedAuthUsers: this.initAuthUsers,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -463,7 +463,10 @@
                                         </label>
                                         {% if proceduresettings.settings.pictogram is defined and proceduresettings.settings.pictogram != "" %}
                                             <br><br>
-                                            <img class="layout__item u-1-of-6 u-pl-0 u-mb" src="{{ path("core_logo", { 'hash': proceduresettings.settings.pictogram|getFile('hash') }) }}"><!--
+                                            <img
+                                                class="layout__item u-1-of-6 u-pl-0 u-mb"
+                                                src="{{ path("core_logo", { 'hash': proceduresettings.settings.pictogram|getFile('hash') }) }}"
+                                                alt="{{ proceduresettings.settings.pictogramAltText|default('procedure.pictogram'|trans) }}"><!--
                                          --><label class="layout__item u-1-of-3 cursor-pointer weight--normal">
                                             {{ 'procedure.pictogram.delete'|trans }}
                                             <input name="r_deletePictogram" type="checkbox" value="1">

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -492,25 +492,25 @@
                                         <dp-input
                                             id="r_pictogramCopyright"
                                             v-model="pictogramCopyright"
-                                            class="my-2"
-                                            data-cy="procedure:pictogramCopyright"
-                                            name="r_pictogramCopyright"
                                             :label="{
                                                 text: Translator.trans('procedure.pictogram.copyright')
                                             }"
+                                            class="my-2"
+                                            data-cy="procedure:pictogramCopyright"
+                                            name="r_pictogramCopyright"
                                             required>
                                         </dp-input>
 
                                         <dp-input
                                             id="r_pictogramAltText"
                                             v-model="pictogramAltText"
-                                            class="my-2"
-                                            data-cy="procedure:pictogramAltText"
-                                            name="r_pictogramAltText"
                                             :label="{
                                                 text: Translator.trans('procedure.pictogram.altText'),
                                                 tooltip: Translator.trans('procedure.pictogram.altText.toolTipp')
                                             }"
+                                            class="my-2"
+                                            data-cy="procedure:pictogramAltText"
+                                            name="r_pictogramAltText"
                                             required>
                                         </dp-input>
                                     </div>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -109,6 +109,8 @@
         init-procedure-phase-internal="{{ proceduresettings.phase }}"
         init-procedure-phase-public="{{ proceduresettings.publicParticipationPhase }}"
         :init-similar-recommendation-procedures="JSON.parse('{{ selectedAllowedSegmentAccessProcedures|json_encode|e('js', 'utf-8') }}')"
+        init-pictogram-alt-text="{{ proceduresettings.pictogramAltText|default }}"
+        init-pictogram-copyright="{{ proceduresettings.pictogramCopyright|default }}"
         procedure-id="{{ proceduresettings.id|default }}">
         <form
             ref="configForm"
@@ -489,18 +491,19 @@
 
                                         <dp-input
                                             id="r_pictogramCopyright"
+                                            v-model="pictogramCopyright"
                                             class="my-2"
                                             data-cy="procedure:pictogramCopyright"
                                             name="r_pictogramCopyright"
                                             :label="{
                                                 text: Translator.trans('procedure.pictogram.copyright')
                                             }"
-                                            value="{{ proceduresettings.pictogramCopyright|default }}"
                                             required>
                                         </dp-input>
 
                                         <dp-input
                                             id="r_pictogramAltText"
+                                            v-model="pictogramAltText"
                                             class="my-2"
                                             data-cy="procedure:pictogramAltText"
                                             name="r_pictogramAltText"
@@ -508,7 +511,6 @@
                                                 text: Translator.trans('procedure.pictogram.altText'),
                                                 tooltip: Translator.trans('procedure.pictogram.altText.toolTipp')
                                             }"
-                                            value="{{ proceduresettings.pictogramAltText|default }}"
                                             required>
                                         </dp-input>
                                     </div>


### PR DESCRIPTION
### Ticket
[DPLAN-15817](https://demoseurope.youtrack.cloud/issue/DPLAN-15817/Wenn-man-ein-Verfahrensschritt-wahlt-werden-die-Urheberrecht-des-Bildes-und-Alternativtext-des-Bildes-Inputs-geloscht)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

In the 'Grundeinstellungen' of a procedure, the following issue occurred: The user typed something in the form inputs ('Urheberrecht des Bildes' and 'Alternativtext des Bildes'), and upon choosing another option from the 'Verfahrensschritt für Institutionen' dropdown menu, the inputs were being reset. The problem was hard-coded value for the inputs. This PR implements v-model and add reactivity to the data.

Additionally, it:
- sorts the props, data and attributes alphabetically
- adds the missing alt attribute to the image 
- 
### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Log in as admin --> find a procedure, where the inputs 'Urheberrecht des Bildes* and  'Alternativtext des Bildes' in the 'Grundeinstellungen' > 'Informationen zum Verfahren' are still empty (or create a new procedure) --> change the option in the dropdown menu 'Verfahrensschritt für Institutionen' --> the input values that you filled in should not get reset.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

