### PR TITLE
fix(DPLAN-15994): display the original pdf when available

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -720,7 +720,7 @@ export default {
         'textIsTruncated',
         // Relationships:
         'assignee',
-        'genericAttachments',
+        'sourceAttachment',
         'segments'
       ]
       if (this.isSourceAndCoupledProcedure) {
@@ -751,13 +751,13 @@ export default {
         include: [
           'segments',
           'assignee',
-          'genericAttachments',
-          'genericAttachments.file'
+          'sourceAttachment',
+          'sourceAttachment.file'
         ].join(),
         fields: {
           Statement: statementFields.join(),
-          File: [
-            'hash'
+          SourceStatementAttachment: [
+            'file'
           ].join()
         }
       }).then((data) => {
@@ -775,15 +775,18 @@ export default {
      * Returns the hash of the original statement attachment
      */
     getOriginalPdfAttachmentHash (el) {
-      if (el.hasRelationship('genericAttachments')) {
-        const originalAttachment = Object.values(el.relationships.genericAttachments.list())
-          .filter(attachment => attachment.attributes.attachmentType === 'source_statement')
-        if (originalAttachment.length === 1) {
-          return originalAttachment[0].relationships.file.get().attributes.hash
-        }
+      if (!el.hasRelationship('sourceAttachment')) {
+        return null
       }
 
-      return null
+      const attachments = el.relationships.sourceAttachment.list()
+      const firstAttachment = Object.values(attachments)[0]
+
+      if (!firstAttachment?.relationships?.file) {
+        return null
+      }
+
+      return firstAttachment.relationships.file.get()?.attributes?.hash || null
     },
 
     /**


### PR DESCRIPTION
### Ticket
[DPLAN-15994](https://demoseurope.youtrack.cloud/issue/DPLAN-15994) Original-PDF Option bleibt ausgegraut obwohl da ein PDF ist

**Description:** This PR fixes an issue where the wrong field was used, replacing `genericAttachments` with `sourceAttachment` to retrieve the original PDF.

### How to review/test
STN mit STN als Anhang hinzufügen -> zu STN-Detailansicht navigieren -> Bearbeiten -> Anhänge (wir zeigen das Original PDF hier) -> zu Stellungnahmen navigieren -> Ellipsis von STN ListElement klicken -> Original PDF bleibt ausgegraut