### PR TITLE
fix(refs: DPLAN-16003): show existing drawings

### DIFF
--- a/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
+++ b/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
@@ -9,6 +9,8 @@
       @click="openStatementModalOrLoginPage" />
 
     <diplan-karte
+      v-if="store.state.PublicStatement.storeInitialised"
+      :geojson="props.initDrawing"
       @diplan-karte:geojson-update="handleDrawing"
     />
   </div>
@@ -18,12 +20,20 @@
 <script setup>
 import { DpButton, prefixClassMixin } from '@demos-europe/demosplan-ui'
 import { MapPlugin, registerWebComponent } from '@init/diplan-karten'
-import { getCurrentInstance } from 'vue'
+import { getCurrentInstance, onMounted } from 'vue'
+import { useStore } from 'vuex'
 
 const props = defineProps({
   activeStatement: {
     type: Boolean,
     required: true
+  },
+
+  initDrawing: {
+    type: Object,
+    required: false,
+    default: { "type": "FeatureCollection",
+    "features": []}
   },
 
   loginPath: {
@@ -40,6 +50,7 @@ const props = defineProps({
 const emit = defineEmits(['location-drawing'])
 
 const instance = getCurrentInstance()
+const store = useStore()
 
 instance.appContext.app.mixin(prefixClassMixin)
 instance.appContext.app.use(MapPlugin, {
@@ -91,7 +102,9 @@ const toggleStatementModal = (updateStatementPayload) => {
   instance.parent.refs.statementModal.toggleModal(true, updateStatementPayload)
 }
 
-registerWebComponent({
-  nonce: props.styleNonce,
+onMounted(() => {
+  registerWebComponent({
+    nonce: props.styleNonce,
+  })
 })
 </script>

--- a/client/js/store/statement/PublicStatement.js
+++ b/client/js/store/statement/PublicStatement.js
@@ -73,6 +73,7 @@ const PublicStatementStore = {
     procedureId: '',
     showMapHint: false,
     statement: statementStructure,
+    storeInitialised: false,
     draftStatements: {},
     unsavedDrafts: []
   },
@@ -114,6 +115,8 @@ const PublicStatementStore = {
       state.unsavedDrafts.forEach(draftId => {
         state.initDraftStatements[draftId] = localStorage.getItem(`init:publicStatement:${state.userId}:${state.procedureId}:${draftId}`)
       })
+
+      state.storeInitialised = true
     },
 
     clearDraftState (state, draftStatementId) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -397,6 +397,7 @@
                             login-path="{{ getLoginPath() }}"
                             style-nonce="{{ csp_nonce('style') }}"
                             :active-statement="activeStatement"
+                            :init-drawing="statement.r_location_geometry"
                             @location-drawing="handleLocationDrawing"
                         />
                     {% else %}


### PR DESCRIPTION
### Ticket
[DPLAN-16003](https://demoseurope.youtrack.cloud/issue/DPLAN-16003)

This PR sends any saved geometry to the map to be displayed. registerWebComponent is moved to onMounted because otherwise the map loads before the props are loaded and shows nothing.

### How to review/test
1. Log in as a private person and select a procedure.
2. Begin a drawing, click 'back' in your browser and then 'forward' - the drawing should still be there.
3. Save a statement draft with a drawing, go to your statement drafts and click 'edit' on this statement draft.
4. In the modal, click 'Ihre Einzeichnung' - you should see the map with your drawing. 

### Linked PRs
#4839 Drawings were enabled in this user story.

### PR Checklist
- [ ] Move the tickets on the board accordingly
