### PR TITLE
fix(refs DPLAN-16012): make condition check more robust

### DIFF
--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTableItem.vue
@@ -102,17 +102,17 @@
         </div>
 
         <div
-          v-if="statement.sourceAttachment !== '' || statement.files.length > 0 || statement.polygon !== ''"
+          v-if="statement.sourceAttachment || statement.files.length > 0 || statement.polygon !== ''"
           class="u-ml u-pr text-left border--top">
           <div
-            v-if="statement.sourceAttachment !== '' || statement.files.length > 0"
+            v-if="statement.sourceAttachment || statement.files.length > 0"
             class="break-words">
             <i
               :title="Translator.trans('attachment.original')"
               aria-hidden="true"
               class="fa fa-paperclip color--grey" />
             <a
-              v-if="statement.sourceAttachment !== '' && hasPermission('feature_read_source_statement_via_api')"
+              v-if="statement.sourceAttachment && hasPermission('feature_read_source_statement_via_api')"
               :title="statement.sourceAttachment.filename"
               target="_blank"
               rel="noopener"

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -188,7 +188,7 @@ function transformStatementStructure ({ el, includes, meta }) {
         }
 
         if (relationKey === 'sourceAttachment') {
-          statement.sourceAttachment = extractFileAttachments(items, includes)[0] ?? null
+          statement.sourceAttachment = extractFileAttachments(items, includes)[0] ?? ''
         }
 
         return


### PR DESCRIPTION
### Ticket
[DPLAN-16012](https://demoseurope.youtrack.cloud/issue/DPLAN-16012/Wir-zeigen-keine-Originalstellungnahmen)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The default for `sourceAttachment` had been changed from `''` to `null`, so the condition check broke. I made the check more robust but also changed the default back to `''` to make it consistent with the other properties.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- Go to the original statement list; the statements should be displayed.

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
