### PR TITLE
fix(refs dplan-12599): Remove whitespace in map description

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_list.html.twig
@@ -100,7 +100,7 @@
                         data-cy="mapAdminGislayerList:mapHint"
                         required minlength="50"
                         maxlength="2000">
-                        {{ templateVars.procedure.settings.mapHint|default(templateVars.procedure.procedureUiDefinition.mapHintDefault) }}
+                        {{- templateVars.procedure.settings.mapHint|default(templateVars.procedure.procedureUiDefinition.mapHintDefault) -}}
                     </textarea>
                 </fieldset>
             {% endif %}


### PR DESCRIPTION
### Ticket
[DPLAN-12599](https://demoseurope.youtrack.cloud/issue/DPLAN-12599/Hinweise-zur-Karte-Text-nach-speichern-automatisch-mit-viel-Whitespace)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
After saving a description for a map, the typed in text was getting indented towards the middle of the page. This PR removes the whitespace before and after the variable input.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Log in as admin --> go to 'Planungsdokumente und Planzeichnung' - 'Kartenbeschreibung festlegen' --> add a description --> text indentation should stay the way you typed it.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

