### PR TITLE
fix(DPLAN-16032): use all() instead of get() for array parameters in UserHandler

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -1208,8 +1208,8 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
      */
     protected function handleWipeSelectedOrgas(ParameterBag $requestData)
     {
-        if ($requestData->has('elementsToAdminister') && 0 < (is_countable($requestData->get('elementsToAdminister')) ? count($requestData->get('elementsToAdminister')) : 0)) {
-            $orgaIdsToDelete = $requestData->get('elementsToAdminister');
+        if ($requestData->has('elementsToAdminister') && 0 < (is_countable($requestData->all('elementsToAdminister')) ? count($requestData->all('elementsToAdminister')) : 0)) {
+            $orgaIdsToDelete = $requestData->all('elementsToAdminister');
 
             foreach ($orgaIdsToDelete as $orgaId) {
                 $result = $this->wipeOrganisationData($orgaId);
@@ -1375,8 +1375,8 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
      */
     protected function handleWipeSelectedDepartments(ParameterBag $requestData)
     {
-        if ($requestData->has('elementsToAdminister') && 0 < (is_countable($requestData->get('elementsToAdminister')) ? count($requestData->get('elementsToAdminister')) : 0)) {
-            $itemIdsToDelete = $requestData->get('elementsToAdminister');
+        if ($requestData->has('elementsToAdminister') && 0 < (is_countable($requestData->all('elementsToAdminister')) ? count($requestData->all('elementsToAdminister')) : 0)) {
+            $itemIdsToDelete = $requestData->all('elementsToAdminister');
             foreach ($itemIdsToDelete as $departmentId) {
                 try {
                     $result = $this->wipeDepartmentDataById($departmentId);


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-16032

Description:
Fixed handleWipeSelectedDepartments and handleWipeSelectedOrgas methods
to properly handle elementsToAdminister array parameter by using
$requestData->all() instead of $requestData->get().

This resolves the "non-scalar value" error when multiple items are
selected for deletion operations.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
