### PR TITLE
fix(refs: DPLAN-15730): change data-cy for map button

### DIFF
--- a/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
+++ b/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
@@ -4,7 +4,7 @@
       id="statementModalButton"
       :class="prefixClass('left-[365px] top-[24px] pt-[11px] pb-[11px] pl-[20px] pr-[20px] !absolute z-above-zero')"
       :text="activeStatement ? Translator.trans('statement.participate.resume') : Translator.trans('statement.participate')"
-      data-cy="statementModal"
+      data-cy="publicStatementButton"
       rounded
       @click="openStatementModalOrLoginPage" />
 


### PR DESCRIPTION
### Ticket
DPLAN-15730


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

QA requested to change data-cy="statementModal" to data-cy="publicStatementButton" for the button on the diplan-karten map 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
1. Open a procedure in diplanfest
2. Search for the link tag that represents the button in the inspector
3. check if data-cy has the value publicStatementButton

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ x] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ x] Move the tickets on the board accordingly

