### PR TITLE
B dplan 15915 fix file display global news

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -317,12 +317,18 @@
 
                 <p class="lbl">{{ "pdf.document"|trans }}</p>
 
+                {% if procedure is not null %}
+                    {% set filePath = path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) %}
+                {% else %}
+                    {% set filePath = path("core_file", {'hash': news.pdf|getFile('hash') }) %}
+                {% endif %}
+
                 <a
                     id="news_pdf"
                     class="o-hellip break-words u-mb-0_25"
                     target="_blank"
                     rel="noopener"
-                    href="{{ procedure is not null ? path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) : path("core_file", {'hash': news.pdf|getFile('hash') }) }}">
+                    href="{{ filePath }}">
                     <i class="fa fa-file-o"></i>
                     {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                     {% if ( news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -322,7 +322,7 @@
                     class="o-hellip break-words u-mb-0_25"
                     target="_blank"
                     rel="noopener"
-                    href="{{ path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) }}">
+                    href="{{ procedure is not null ? path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) : path("core_file", {'hash': news.pdf|getFile('hash') }) }}">
                     <i class="fa fa-file-o"></i>
                     {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                     {% if ( news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -318,9 +318,9 @@
                 <p class="lbl">{{ "pdf.document"|trans }}</p>
 
                 {% if procedure is not null %}
-                    {% set filePath = path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) %}
+                    {% set pdfPath = path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) %}
                 {% else %}
-                    {% set filePath = path("core_file", {'hash': news.pdf|getFile('hash') }) %}
+                    {% set pdfPath = path("core_file", {'hash': news.pdf|getFile('hash') }) %}
                 {% endif %}
 
                 <a
@@ -328,7 +328,7 @@
                     class="o-hellip break-words u-mb-0_25"
                     target="_blank"
                     rel="noopener"
-                    href="{{ filePath }}">
+                    href="{{ pdfPath }}">
                     <i class="fa fa-file-o"></i>
                     {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                     {% if ( news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-15915/Bild-und-PDF-Upload-wird-nach-Speichern-nicht-ubernommen-angezeigt

The problem is that the template `news_admin_edit.html` is using the `core_file_procedure` route which requires a `procedureId` parameter. When rendering the template for the global news, procedure is null, so we need to use the `core_file` route instead.

This template is used for rendering both procedure and global news templates, that is why we should check if we use core_file_procedure or code_file to show the pdf url consequently


### How to review/test
- Create a Global News using MandatenRole, use an image and pdf
- Logout and check the global news in public view
- Image and Pdf should be rendered

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
