### PR TITLE
fix(refs: DPLAN-16053): add contextualHelp to fields of API call

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -380,6 +380,7 @@ const LayersStore = {
           GisLayer: [
             'canUserToggleVisibility',
             'categoryId',
+            'contextualHelp',
             'hasDefaultVisibility',
             'isBaseLayer',
             'isBplan',


### PR DESCRIPTION
### Ticket
[DPLAN-16053](https://demoseurope.youtrack.cloud/issue/DPLAN-16053/ADO-31431-Integration-ROG-Hinterlegter-Text-im-Kontexhilfe-wird-nicht-angezeigt)

This PR adds 'contextualHelp' to the fields of the API call made in the Layers vuex store so that DpPublicLayerList.vue can actually access the data.

### How to review/test
1. Create a procedure with at least one map layer.
2. Navigate to 'Planungsdokumente und Planzeichnung' > edit 'Kartenebenen' > edit 'Overlays'
3. Write something in the contextual help field and save.
4. Switch to 'Oeffentlichkeits/Institutionenansicht' and unfold 'Kartenebenen' on the left.
5. There should be a small '?' symbol next to the edited layer.
6. Hover over the '?' and check if your text shows.
