### PR TITLE
fix(refs dplan-15184): Custom display for empty input values

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -28,13 +28,13 @@ All rights reserved
       <dp-input
         v-if="hasPermission('field_statement_meta_orga_department_name') && !this.localStatement.attributes.isSubmittedByCitizen"
         id="statementDepartmentName"
-        :value="getDisplayValue(localStatement.attributes.initialOrganisationDepartmentName)"
-        data-cy="statementSubmitter:departmentName"
-        class="mb-2"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('department')
         }"
+        :value="getDisplayValue(localStatement.attributes.initialOrganisationDepartmentName)"
+        class="mb-2"
+        data-cy="statementSubmitter:departmentName"
         @input="value => localStatement.attributes.initialOrganisationDepartmentName = value"
       />
 
@@ -42,43 +42,44 @@ All rights reserved
       <dp-input
         v-if="!this.localStatement.attributes.isSubmittedByCitizen"
         id="statementOrgaName"
-        :value="getDisplayValue(localStatement.attributes.initialOrganisationName)"
-        class="mb-2"
-        data-cy="statementSubmitter:orgaName"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('organisation')
         }"
+        :value="getDisplayValue(localStatement.attributes.initialOrganisationName)"
+        class="mb-2"
+        data-cy="statementSubmitter:orgaName"
         @input="value => localStatement.attributes.initialOrganisationName = value"
       />
 
       <dp-contextual-help
         v-if="isSubmitterAnonymized()"
+        :text="submitterHelpText"
         class="float-right mt-0.5"
-        :text="submitterHelpText" />
+      />
       <dp-input
         v-if="hasPermission('field_statement_meta_submit_name') && this.statementFormDefinitions.name.enabled"
         id="statementSubmitterName"
-        :value="getSubmitterNameValue()"
-        class="mb-2"
-        data-cy="statementSubmitter:submitterName"
         :disabled="!isStatementManual || !editable || isSubmitterAnonymized()"
         :label="{
           text: Translator.trans('name')
         }"
+        :value="getSubmitterNameValue()"
+        class="mb-2"
+        data-cy="statementSubmitter:submitterName"
         @input="value => localStatement.attributes[statementSubmitterField] = value"
       />
 
       <dp-input
         v-if="hasPermission('field_statement_submitter_email_address') || isStatementManual"
         id="statementEmailAddress"
-        :value="getDisplayValue(localStatement.attributes.submitterEmailAddress)"
-        class="mb-2"
-        data-cy="statementSubmitter:emailAddress"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('email')
         }"
+        :value="getDisplayValue(localStatement.attributes.submitterEmailAddress)"
+        class="mb-2"
+        data-cy="statementSubmitter:emailAddress"
         type="email"
         @input="value => localStatement.attributes.submitterEmailAddress = value"
       />
@@ -86,70 +87,71 @@ All rights reserved
       <dp-input
         v-if="localStatement.attributes.represents"
         id="statementRepresentation"
-        data-cy="statementSubmitter:representation"
-        disabled
         :label="{
           text: Translator.trans('statement.representation.assessment')
         }"
         :value="localStatement.attributes.represents"
+        data-cy="statementSubmitter:representation"
+        disabled
       />
       <dp-checkbox
         v-if="localStatement.attributes.represents"
         id="representationCheck"
         v-model="localStatement.attributes.representationChecked"
-        data-cy="statementSubmitter:representationCheck"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('statement.representation.checked')
-        }" />
+        }"
+        data-cy="statementSubmitter:representationCheck"
+      />
 
       <div class="o-form__group mb-2">
         <dp-input
           id="statementStreet"
-          :value="getDisplayValue(localStatement.attributes.initialOrganisationStreet)"
-          class="o-form__group-item"
-          data-cy="statementSubmitter:street"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('street')
           }"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationStreet)"
+          class="o-form__group-item"
+          data-cy="statementSubmitter:street"
           @input="value => localStatement.attributes.initialOrganisationStreet = value"
         />
         <dp-input
           id="statementHouseNumber"
-          :value="getDisplayValue(localStatement.attributes.initialOrganisationHouseNumber)"
-          class="o-form__group-item shrink"
-          data-cy="statementSubmitter:houseNumber"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('street.number.short')
           }"
           :size="3"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationHouseNumber)"
+          class="o-form__group-item shrink"
+          data-cy="statementSubmitter:houseNumber"
           @input="value => localStatement.attributes.initialOrganisationHouseNumber = value"
         />
       </div>
       <div class="o-form__group mb-2">
         <dp-input
           id="statementPostalCode"
-          :value="getDisplayValue(localStatement.attributes.initialOrganisationPostalCode)"
-          class="o-form__group-item shrink"
-          data-cy="statementSubmitter:postalCode"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('postalcode')
           }"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationPostalCode)"
+          class="o-form__group-item shrink"
+          data-cy="statementSubmitter:postalCode"
           pattern="^[0-9]{4,5}$"
           @input="value => localStatement.attributes.initialOrganisationPostalCode = value"
         />
         <dp-input
           id="statementCity"
-          :value="getDisplayValue(localStatement.attributes.initialOrganisationCity)"
-          class="o-form__group-item"
-          data-cy="statementSubmitter:city"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('city')
           }"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationCity)"
+          class="o-form__group-item"
+          data-cy="statementSubmitter:city"
           @input="value => localStatement.attributes.initialOrganisationCity = value"
         />
       </div>

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -23,29 +23,34 @@ All rights reserved
       {{ submitterRole }}
     </div>
 
+    <!--  In the following section, v-model is replaced with :value && @input to allow custom display if input values -->
     <div class="grid grid-cols-1 gap-x-4 md:grid-cols-2">
       <dp-input
         v-if="hasPermission('field_statement_meta_orga_department_name') && !this.localStatement.attributes.isSubmittedByCitizen"
         id="statementDepartmentName"
-        v-model="localStatement.attributes.initialOrganisationDepartmentName"
+        :value="getDisplayValue(localStatement.attributes.initialOrganisationDepartmentName)"
         data-cy="statementSubmitter:departmentName"
         class="mb-2"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('department')
-        }" />
+        }"
+        @input="value => localStatement.attributes.initialOrganisationDepartmentName = value"
+      />
 
       <!--  TO DO: add if not participationGuestOnly -->
       <dp-input
         v-if="!this.localStatement.attributes.isSubmittedByCitizen"
         id="statementOrgaName"
-        v-model="localStatement.attributes.initialOrganisationName"
+        :value="getDisplayValue(localStatement.attributes.initialOrganisationName)"
         class="mb-2"
         data-cy="statementSubmitter:orgaName"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('organisation')
-        }" />
+        }"
+        @input="value => localStatement.attributes.initialOrganisationName = value"
+      />
 
       <dp-contextual-help
         v-if="isSubmitterAnonymized()"
@@ -54,25 +59,29 @@ All rights reserved
       <dp-input
         v-if="hasPermission('field_statement_meta_submit_name') && this.statementFormDefinitions.name.enabled"
         id="statementSubmitterName"
-        v-model="statementSubmitterValue"
+        :value="getSubmitterNameValue()"
         class="mb-2"
         data-cy="statementSubmitter:submitterName"
         :disabled="!isStatementManual || !editable || isSubmitterAnonymized()"
         :label="{
           text: Translator.trans('name')
-        }" />
+        }"
+        @input="value => localStatement.attributes[statementSubmitterField] = value"
+      />
 
       <dp-input
         v-if="hasPermission('field_statement_submitter_email_address') || isStatementManual"
         id="statementEmailAddress"
-        v-model="localStatement.attributes.submitterEmailAddress"
+        :value="getDisplayValue(localStatement.attributes.submitterEmailAddress)"
         class="mb-2"
         data-cy="statementSubmitter:emailAddress"
         :disabled="!editable || !isStatementManual"
         :label="{
           text: Translator.trans('email')
         }"
-        type="email" />
+        type="email"
+        @input="value => localStatement.attributes.submitterEmailAddress = value"
+      />
 
       <dp-input
         v-if="localStatement.attributes.represents"
@@ -82,7 +91,8 @@ All rights reserved
         :label="{
           text: Translator.trans('statement.representation.assessment')
         }"
-        :value="localStatement.attributes.represents" />
+        :value="localStatement.attributes.represents"
+      />
       <dp-checkbox
         v-if="localStatement.attributes.represents"
         id="representationCheck"
@@ -96,28 +106,32 @@ All rights reserved
       <div class="o-form__group mb-2">
         <dp-input
           id="statementStreet"
-          v-model="localStatement.attributes.initialOrganisationStreet"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationStreet)"
           class="o-form__group-item"
           data-cy="statementSubmitter:street"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('street')
-          }" />
+          }"
+          @input="value => localStatement.attributes.initialOrganisationStreet = value"
+        />
         <dp-input
           id="statementHouseNumber"
-          v-model="localStatement.attributes.initialOrganisationHouseNumber"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationHouseNumber)"
           class="o-form__group-item shrink"
           data-cy="statementSubmitter:houseNumber"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('street.number.short')
           }"
-          :size="3" />
+          :size="3"
+          @input="value => localStatement.attributes.initialOrganisationHouseNumber = value"
+        />
       </div>
       <div class="o-form__group mb-2">
         <dp-input
           id="statementPostalCode"
-          v-model="localStatement.attributes.initialOrganisationPostalCode"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationPostalCode)"
           class="o-form__group-item shrink"
           data-cy="statementSubmitter:postalCode"
           :disabled="!editable || !isStatementManual"
@@ -125,16 +139,19 @@ All rights reserved
             text: Translator.trans('postalcode')
           }"
           pattern="^[0-9]{4,5}$"
+          @input="value => localStatement.attributes.initialOrganisationPostalCode = value"
         />
         <dp-input
           id="statementCity"
-          v-model="localStatement.attributes.initialOrganisationCity"
+          :value="getDisplayValue(localStatement.attributes.initialOrganisationCity)"
           class="o-form__group-item"
           data-cy="statementSubmitter:city"
           :disabled="!editable || !isStatementManual"
           :label="{
             text: Translator.trans('city')
-          }" />
+          }"
+          @input="value => localStatement.attributes.initialOrganisationCity = value"
+        />
       </div>
     </div>
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -237,16 +237,6 @@ export default {
       return submitterField
     },
 
-    statementSubmitterValue: {
-      get () {
-        return this.isSubmitterAnonymized() ? Translator.trans('anonymized') : this.localStatement.attributes[this.statementSubmitterField]
-      },
-
-      set (value) {
-        this.localStatement.attributes[this.statementSubmitterField] = value
-      }
-    },
-
     submitterHelpText () {
       const { consentRevoked, submitterAndAuthorMetaDataAnonymized } = this.localStatement.attributes
       let helpText = ''
@@ -277,6 +267,19 @@ export default {
   },
 
   methods: {
+    getDisplayValue (value) {
+      const isDisabled = !this.editable || !this.isStatementManual
+      return (isDisabled && (!value || value.trim() === '')) ? '---' : value
+    },
+
+    getSubmitterNameValue() {
+      if (this.isSubmitterAnonymized()) {
+        return Translator.trans('anonymized')
+      }
+      const value = this.localStatement.attributes[this.statementSubmitterField]
+      return this.getDisplayValue(value)
+    },
+
     isSubmitterAnonymized () {
       const { consentRevoked, submitterAndAuthorMetaDataAnonymized } = this.localStatement.attributes
 


### PR DESCRIPTION
### Ticket
[DPLAN-15184](https://demoseurope.youtrack.cloud/issue/DPLAN-15184/UI-Keine-ausgegraute-Input-Felder-sichtbar-in-STN-Detailansicht-wenn-die-Werte-nicht-eingegeben-war)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
In the statement editing section, there should 
This PR adds a placeholder to be displayed in the statement editing section, when pieces of personal data (like email or address) were not submitted with statement. For that purpose, the v-model is replaced with @input and :value options.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Log in as admin --> go to 'Stellungnahmen' --> 'Details und Erwiderung' --> 'Bearbeiten' --> In the non-editable mode, '---' should be rendered under the personal data labels that have no value. In the editable mode ('zugewiesen'), the corresponding inputs should be empty.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

