### PR TITLE
fix(refs: DPLAN-15406): change data-cy for new statement

### DIFF
--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -31,13 +31,13 @@
         v-for="role in roles"
         :key="role.value">
         <input
-          type="radio"
-          :data-cy="`roleInput:${role.dataCy}`"
           name="r_role"
-          :value="role.value"
-          @change="() => $emit('role-changed', currentRole)"
+          type="radio"
+          v-model="currentRole"
+          :data-cy="`roleInput:${role.dataCy}`"
           :id="`r_role_${role.value}`"
-          v-model="currentRole"><!--
+          :value="role.value"
+          @change="() => $emit('role-changed', currentRole)"><!--
      --><label
           class="lbl--text inline-block u-mb-0_5 u-pr u-ml-0_25"
           :for="`r_role_${role.value}`">

--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -32,7 +32,7 @@
         :key="role.value">
         <input
           type="radio"
-          :data-cy="`roleInput-${role.dataCy}`"
+          :data-cy="`roleInput:${role.dataCy}`"
           name="r_role"
           :value="role.value"
           @change="() => $emit('role-changed', currentRole)"


### PR DESCRIPTION
### Ticket
[DPLAN-15406](https://demoseurope.youtrack.cloud/issue/DPLAN-15406/Privatperson-und-Institution-Radio-Buttons-Hooks-fixen)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

QA requested to change data-cy="roleInput-citizen" to data-cy="roleInput:citizen" and data-cy="roleInput-invitableInstitution" to data-cy="roleInput:invitableInstitution"

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

   1. Open a procedure with Fachplanung-Admin role and go to the statement list
   2. Open the dialog for a new statement
   3. Search for the corresponding radio button in the inspector
   4. check if data-cy has the value roleInput:citizen or roleInput:invitableInstitution

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Move the tickets on the board accordingly