### PR TITLE
fix(refs dplan-16035): Transform geojson for diplan-karte

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -397,8 +397,6 @@ export default {
       proj4.defs(this._options.projection.code, this._options.projection.transform)
       register(proj4)
 
-      console.log(`Using projection ${this._options.projection.code} with transform ${this._options.projection.transform}`)
-
       const mapProjection = new Projection({
         code: this._options.projection.code,
         units: this._options.projection.units,

--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -397,6 +397,8 @@ export default {
       proj4.defs(this._options.projection.code, this._options.projection.transform)
       register(proj4)
 
+      console.log(`Using projection ${this._options.projection.code} with transform ${this._options.projection.transform}`)
+
       const mapProjection = new Projection({
         code: this._options.projection.code,
         units: this._options.projection.units,

--- a/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
+++ b/client/js/components/map/publicdetail/DiplanKarteWrapper.vue
@@ -10,18 +10,18 @@
 
     <diplan-karte
       v-if="isStoreAvailable"
-      :geojson="initDrawing"
+      :geojson="drawing"
       profile="beteiligung"
       @diplan-karte:geojson-update="handleDrawing"
     />
   </div>
 </template>
 
-
 <script setup>
+import { computed, getCurrentInstance, onMounted } from 'vue'
 import { DpButton, prefixClassMixin } from '@demos-europe/demosplan-ui'
 import { MapPlugin, registerWebComponent } from '@init/diplan-karten'
-import { computed, getCurrentInstance, onMounted } from 'vue'
+import { transformFeatureCollection } from '@DpJs/lib/map/transformFeature'
 import { useStore } from 'vuex'
 
 const { activeStatement, initDrawing, loginPath, styleNonce } = defineProps({
@@ -46,11 +46,16 @@ const { activeStatement, initDrawing, loginPath, styleNonce } = defineProps({
 
   styleNonce: {
     type: String,
-    required: true,
-  },
+    required: true
+  }
 })
 
-const emit = defineEmits(['location-drawing'])
+const drawing = computed(() => {
+  return initDrawing
+    ? transformFeatureCollection(JSON.parse(initDrawing), 'EPSG:3857', 'EPSG:4326')
+    : ''
+})
+const emit = defineEmits(['locationDrawing'])
 
 const instance = getCurrentInstance()
 const store = useStore()
@@ -59,7 +64,7 @@ instance.appContext.app.mixin(prefixClassMixin)
 instance.appContext.app.use(MapPlugin, {
   template: {
     compilerOptions: {
-      isCustomElement: (tag) => tag === "diplan-karte",
+      isCustomElement: (tag) => tag === 'diplan-karte'
     }
   }
 })
@@ -70,30 +75,31 @@ const isStoreAvailable = computed(() => {
 
 const handleDrawing = (event) => {
   let payload
+  const geometry = transformFeatureCollection(event.detail[0], 'EPSG:4326', 'EPSG:3857')
 
-  // if all geometry was deleted, reset location reference
-  if (event.detail[0].features.length === 0) {
+  // If all geometry was deleted, reset location reference
+  if (geometry.features.length === 0) {
     payload = {
-      "r_location": "notLocated",
-      "r_location_geometry": "",
-      "r_location_point": "",
-      "location_is_set": ""
+      r_location: 'notLocated',
+      r_location_geometry: '',
+      r_location_point: '',
+      location_is_set: ''
     }
   } else {
     payload = {
-      "r_location": "point",
-      "r_location_geometry": JSON.stringify(event.detail[0]),
-      "r_location_priority_area_key": "",
-      "r_location_priority_area_type": "",
-      "r_location_point": "",
-      "location_is_set": "geometry"
+      r_location: 'point',
+      r_location_geometry: JSON.stringify(geometry),
+      r_location_priority_area_key: '',
+      r_location_priority_area_type: '',
+      r_location_point: '',
+      location_is_set: 'geometry'
     }
   }
 
-  emit('location-drawing', payload)
+  emit('locationDrawing', payload)
 }
 
-const openStatementModalOrLoginPage= (event) => {
+const openStatementModalOrLoginPage = (event) => {
   if (!hasPermission('feature_new_statement')) {
     window.location.href = loginPath
 
@@ -111,7 +117,7 @@ const toggleStatementModal = (updateStatementPayload) => {
 
 onMounted(() => {
   registerWebComponent({
-    nonce: styleNonce,
+    nonce: styleNonce
   })
 })
 </script>

--- a/client/js/components/statement/assessmentTable/DpMapModal.vue
+++ b/client/js/components/statement/assessmentTable/DpMapModal.vue
@@ -26,6 +26,7 @@
       :procedure-id="procedureId">
       <dp-ol-map-layer-vector
         zoom-to-drawing
+        name="drawing"
         :features="drawing" />
     </dp-ol-map>
   </dp-modal>

--- a/client/js/lib/map/transformFeature.js
+++ b/client/js/lib/map/transformFeature.js
@@ -1,0 +1,92 @@
+import proj4 from 'proj4'
+
+function transformFeatureCollection (featureCollection, sourceProjection, targetProjection = 'EPSG:3857') {
+  const transformedFeatures = featureCollection.features.map(feature => {
+    console.log('transform Feature', feature)
+    const transformedGeometry = transformGeometry(feature.geometry, sourceProjection, targetProjection)
+
+    return {
+      ...feature,
+      geometry: transformedGeometry
+    }
+  })
+
+  return {
+    ...featureCollection,
+    features: transformedFeatures
+  }
+}
+
+function transformGeometry (geometry, sourceProjection, targetProjection = 'EPSG:3857') {
+  const transformer = proj4(sourceProjection, targetProjection)
+
+  switch (geometry.type) {
+    case 'Point':
+      return {
+        ...geometry,
+        coordinates: transformer.forward([...geometry.coordinates])
+      }
+    case 'LineString':
+    case 'MultiPoint':
+      return {
+        ...geometry,
+        coordinates: geometry.coordinates.map(coord => transformer.forward(coord))
+      }
+    case 'Polygon':
+    case 'MultiLineString':
+      return {
+        ...geometry,
+        coordinates: geometry.coordinates.map(ring => ring.map(coord => transformer.forward(coord)))
+      }
+    case 'MultiPolygon':
+      return {
+        ...geometry,
+        coordinates: geometry.coordinates.map(polygon =>
+          polygon.map(ring => ring.map(coord => transformer.forward(coord)))
+        )
+      }
+    default:
+      return geometry
+  }
+}
+
+
+
+// function transformGeometry (geometry, sourceProjection, targetProjection = 'EPSG:3857') {
+//   proj4.defs(sourceProjection[0], sourceProjection[1])
+//   const transformer = proj4(sourceProjection[0], targetProjection)
+//
+//   switch (geometry.type) {
+//     case 'Point':
+//       return {
+//         ...geometry,
+//         coordinates: transformer.forward(geometry.coordinates)
+//       }
+//     case 'LineString':
+//     case 'MultiPoint':
+//       return {
+//         ...geometry,
+//         coordinates: geometry.coordinates.map(coord => transformer.forward(coord))
+//       }
+//     case 'Polygon':
+//     case 'MultiLineString':
+//       return {
+//         ...geometry,
+//         coordinates: geometry.coordinates.map(ring => ring.map(coord => transformer.forward(coord)))
+//       }
+//     case 'MultiPolygon':
+//       return {
+//         ...geometry,
+//         coordinates: geometry.coordinates.map(polygon => {
+//           return polygon.map(ring => {
+//             console.log('multipolygon ring', ring)
+//             return ring.map(coord => transformer.forward(coord))
+//           })
+//         })
+//       }
+//     default:
+//       return geometry
+//   }
+// }
+
+export { transformFeatureCollection, transformGeometry }

--- a/client/js/lib/map/transformFeature.js
+++ b/client/js/lib/map/transformFeature.js
@@ -2,7 +2,6 @@ import proj4 from 'proj4'
 
 function transformFeatureCollection (featureCollection, sourceProjection, targetProjection = 'EPSG:3857') {
   const transformedFeatures = featureCollection.features.map(feature => {
-    console.log('transform Feature', feature)
     const transformedGeometry = transformGeometry(feature.geometry, sourceProjection, targetProjection)
 
     return {

--- a/client/js/lib/map/transformFeature.js
+++ b/client/js/lib/map/transformFeature.js
@@ -50,43 +50,4 @@ function transformGeometry (geometry, sourceProjection, targetProjection = 'EPSG
   }
 }
 
-
-
-// function transformGeometry (geometry, sourceProjection, targetProjection = 'EPSG:3857') {
-//   proj4.defs(sourceProjection[0], sourceProjection[1])
-//   const transformer = proj4(sourceProjection[0], targetProjection)
-//
-//   switch (geometry.type) {
-//     case 'Point':
-//       return {
-//         ...geometry,
-//         coordinates: transformer.forward(geometry.coordinates)
-//       }
-//     case 'LineString':
-//     case 'MultiPoint':
-//       return {
-//         ...geometry,
-//         coordinates: geometry.coordinates.map(coord => transformer.forward(coord))
-//       }
-//     case 'Polygon':
-//     case 'MultiLineString':
-//       return {
-//         ...geometry,
-//         coordinates: geometry.coordinates.map(ring => ring.map(coord => transformer.forward(coord)))
-//       }
-//     case 'MultiPolygon':
-//       return {
-//         ...geometry,
-//         coordinates: geometry.coordinates.map(polygon => {
-//           return polygon.map(ring => {
-//             console.log('multipolygon ring', ring)
-//             return ring.map(coord => transformer.forward(coord))
-//           })
-//         })
-//       }
-//     default:
-//       return geometry
-//   }
-// }
-
 export { transformFeatureCollection, transformGeometry }

--- a/tests/frontend/unit/transformFeature.test.js
+++ b/tests/frontend/unit/transformFeature.test.js
@@ -11,14 +11,10 @@ import { transformFeatureCollection, transformGeometry } from '@DpJs/lib/map/tra
 
 // Mock proj4 to avoid dependency on actual projections
 jest.mock('proj4', () => {
-  const mockTransformer = {
-    forward: jest.fn((coord) => {
-      // Mock transformation: simply add 1000 to each coordinate
-      return [coord[0] + 1000, coord[1] + 1000]
-    })
-  }
-  
-  return jest.fn(() => mockTransformer)
+  return jest.fn(() => ({
+    // Mock transformation: simply add 1000 to each coordinate
+    forward: jest.fn((coord) => [coord[0] + 1000, coord[1] + 1000])
+  }))
 })
 
 describe('transformFeature', () => {
@@ -186,11 +182,11 @@ describe('transformFeature', () => {
 
       expect(result.type).toBe('FeatureCollection')
       expect(result.features).toHaveLength(2)
-      
+
       // Check first feature
       expect(result.features[0].geometry.coordinates).toEqual([1010, 1020])
       expect(result.features[0].properties.name).toBe('Feature 1')
-      
+
       // Check second feature
       expect(result.features[1].geometry.coordinates).toEqual([[1030, 1040], [1050, 1060]])
       expect(result.features[1].properties.name).toBe('Feature 2')

--- a/tests/frontend/unit/transformFeature.test.js
+++ b/tests/frontend/unit/transformFeature.test.js
@@ -1,0 +1,281 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+import { transformFeatureCollection, transformGeometry } from '@DpJs/lib/map/transformFeature'
+
+// Mock proj4 to avoid dependency on actual projections
+jest.mock('proj4', () => {
+  const mockTransformer = {
+    forward: jest.fn((coord) => {
+      // Mock transformation: simply add 1000 to each coordinate
+      return [coord[0] + 1000, coord[1] + 1000]
+    })
+  }
+  
+  return jest.fn(() => mockTransformer)
+})
+
+describe('transformFeature', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('transformGeometry', () => {
+    it('transforms Point geometry', () => {
+      const pointGeometry = {
+        type: 'Point',
+        coordinates: [10, 20]
+      }
+
+      const result = transformGeometry(pointGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'Point',
+        coordinates: [1010, 1020]
+      })
+    })
+
+    it('transforms LineString geometry', () => {
+      const lineStringGeometry = {
+        type: 'LineString',
+        coordinates: [[10, 20], [30, 40]]
+      }
+
+      const result = transformGeometry(lineStringGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'LineString',
+        coordinates: [[1010, 1020], [1030, 1040]]
+      })
+    })
+
+    it('transforms MultiPoint geometry', () => {
+      const multiPointGeometry = {
+        type: 'MultiPoint',
+        coordinates: [[10, 20], [30, 40]]
+      }
+
+      const result = transformGeometry(multiPointGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'MultiPoint',
+        coordinates: [[1010, 1020], [1030, 1040]]
+      })
+    })
+
+    it('transforms Polygon geometry', () => {
+      const polygonGeometry = {
+        type: 'Polygon',
+        coordinates: [[[10, 20], [30, 40], [50, 60], [10, 20]]]
+      }
+
+      const result = transformGeometry(polygonGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'Polygon',
+        coordinates: [[[1010, 1020], [1030, 1040], [1050, 1060], [1010, 1020]]]
+      })
+    })
+
+    it('transforms MultiLineString geometry', () => {
+      const multiLineStringGeometry = {
+        type: 'MultiLineString',
+        coordinates: [[[10, 20], [30, 40]], [[50, 60], [70, 80]]]
+      }
+
+      const result = transformGeometry(multiLineStringGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'MultiLineString',
+        coordinates: [[[1010, 1020], [1030, 1040]], [[1050, 1060], [1070, 1080]]]
+      })
+    })
+
+    it('transforms MultiPolygon geometry', () => {
+      const multiPolygonGeometry = {
+        type: 'MultiPolygon',
+        coordinates: [
+          [[[10, 20], [30, 40], [50, 60], [10, 20]]],
+          [[[70, 80], [90, 100], [110, 120], [70, 80]]]
+        ]
+      }
+
+      const result = transformGeometry(multiPolygonGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual({
+        type: 'MultiPolygon',
+        coordinates: [
+          [[[1010, 1020], [1030, 1040], [1050, 1060], [1010, 1020]]],
+          [[[1070, 1080], [1090, 1100], [1110, 1120], [1070, 1080]]]
+        ]
+      })
+    })
+
+    it('returns original geometry for unknown type', () => {
+      const unknownGeometry = {
+        type: 'UnknownType',
+        coordinates: [10, 20]
+      }
+
+      const result = transformGeometry(unknownGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result).toEqual(unknownGeometry)
+    })
+
+    it('uses default target projection when not specified', () => {
+      const pointGeometry = {
+        type: 'Point',
+        coordinates: [10, 20]
+      }
+
+      transformGeometry(pointGeometry, 'EPSG:4326')
+
+      // Check that proj4 was called with correct parameters
+      const proj4 = require('proj4')
+      expect(proj4).toHaveBeenCalledWith('EPSG:4326', 'EPSG:3857')
+    })
+
+    it('preserves original geometry properties', () => {
+      const pointGeometry = {
+        type: 'Point',
+        coordinates: [10, 20],
+        customProperty: 'test'
+      }
+
+      const result = transformGeometry(pointGeometry, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result.customProperty).toBe('test')
+    })
+  })
+
+  describe('transformFeatureCollection', () => {
+    it('transforms all features in a feature collection', () => {
+      const featureCollection = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 20]
+            },
+            properties: {
+              name: 'Feature 1'
+            }
+          },
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates: [[30, 40], [50, 60]]
+            },
+            properties: {
+              name: 'Feature 2'
+            }
+          }
+        ]
+      }
+
+      const result = transformFeatureCollection(featureCollection, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result.type).toBe('FeatureCollection')
+      expect(result.features).toHaveLength(2)
+      
+      // Check first feature
+      expect(result.features[0].geometry.coordinates).toEqual([1010, 1020])
+      expect(result.features[0].properties.name).toBe('Feature 1')
+      
+      // Check second feature
+      expect(result.features[1].geometry.coordinates).toEqual([[1030, 1040], [1050, 1060]])
+      expect(result.features[1].properties.name).toBe('Feature 2')
+    })
+
+    it('preserves feature collection properties', () => {
+      const featureCollection = {
+        type: 'FeatureCollection',
+        customProperty: 'test',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 20]
+            },
+            properties: {}
+          }
+        ]
+      }
+
+      const result = transformFeatureCollection(featureCollection, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result.customProperty).toBe('test')
+    })
+
+    it('uses default target projection when not specified', () => {
+      const featureCollection = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 20]
+            },
+            properties: {}
+          }
+        ]
+      }
+
+      transformFeatureCollection(featureCollection, 'EPSG:4326')
+
+      // Check that proj4 was called with correct parameters
+      const proj4 = require('proj4')
+      expect(proj4).toHaveBeenCalledWith('EPSG:4326', 'EPSG:3857')
+    })
+
+    it('handles empty feature collection', () => {
+      const featureCollection = {
+        type: 'FeatureCollection',
+        features: []
+      }
+
+      const result = transformFeatureCollection(featureCollection, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result.type).toBe('FeatureCollection')
+      expect(result.features).toHaveLength(0)
+    })
+
+    it('preserves feature properties and type', () => {
+      const featureCollection = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            id: 'test-id',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 20]
+            },
+            properties: {
+              name: 'Test Feature',
+              description: 'A test feature'
+            }
+          }
+        ]
+      }
+
+      const result = transformFeatureCollection(featureCollection, 'EPSG:4326', 'EPSG:3857')
+
+      expect(result.features[0].type).toBe('Feature')
+      expect(result.features[0].id).toBe('test-id')
+      expect(result.features[0].properties.name).toBe('Test Feature')
+      expect(result.features[0].properties.description).toBe('A test feature')
+    })
+  })
+})


### PR DESCRIPTION
### Ticket
DPLAN-16035

This is sort of a interim fix until diplan-karte can handle projection settings from outside.

diplan-karte uses a different projection then the parent app. And since some of the settings in the parent app are stored in the database and not jet configurable in the interface for the project, where diplan-karte is used, its easiest to transform the geoJson.

## how to Test:
as "privatperson" try to make some drawings for a statement and then save as draft. goto the drafts list and see if you can see the drawing in the map modal there. 
It also should work to go back to the publick detail with "edit statement" and still/gain see the drawing.
(this may only works for the region, defined as map_public_extent in the project-settings)