### PR TITLE
fix(refs dplan-2760): fix pagination display

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -1801,7 +1801,7 @@ class DemosPlanProcedureController extends BaseController
         // Öffentliche Stellungnahmen
         $publicLimit = $request->get('r_limit', 10);
         $publicPage = $request->get('page', 1);
-        $statementService->setPaginatorLimits([10]);
+        $statementService->setPaginatorLimits([10, 25, 50, 100]);
         $statements = $statementService->getStatementsByProcedureId(
             $procedureId,
             $filters,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
@@ -522,7 +522,12 @@ class ElasticSearchService extends CoreService
         $resultSet->setResult($list);
         $resultSet->setFilterSet($filterSet);
         $resultSet->setSortingSet($sortingSet);
-        $resultSet->setTotal(count($elasticsearchResult->getHits()['hits'] ?? []));
+        $total = $elasticsearchResult->getHits()['total'] ?? 0;
+        // Handle Elasticsearch 7+ format where total is an object with 'value' field
+        if (is_array($total) && array_key_exists('value', $total)) {
+            $total = $total['value'];
+        }
+        $resultSet->setTotal($total);
         $resultSet->setSearchFields($elasticsearchResult->getSearchFields());
         $resultSet->setSearch($search ?? '');
         $resultSet->setPager($elasticsearchResult->getPager());

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
@@ -10,8 +10,6 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
-use Elastica\Aggregation\Missing;
-use Elastica\Aggregation\Nested;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\CoreService;
@@ -19,6 +17,8 @@ use demosplan\DemosPlanCoreBundle\Logic\EditorService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ValueObject\ElasticsearchResult;
 use demosplan\DemosPlanCoreBundle\ValueObject\ElasticsearchResultSet;
+use Elastica\Aggregation\Missing;
+use Elastica\Aggregation\Nested;
 use Elastica\Query;
 use Elastica\Query\AbstractQuery;
 use Elastica\Query\BoolQuery;
@@ -98,9 +98,6 @@ class ElasticSearchService extends CoreService
         return $query;
     }
 
-    /**
-     * @param mixed $aggregationsMinDocumentCount
-     */
     public function setAggregationsMinDocumentCount($aggregationsMinDocumentCount): void
     {
         $this->aggregationsMinDocumentCount = $aggregationsMinDocumentCount;
@@ -127,8 +124,6 @@ class ElasticSearchService extends CoreService
      * @param string $labelKey
      * @param string $valueKey
      * @param string $countKey
-     *
-     * @return mixed
      */
     protected function addAggregationResultToArrayFromArray($keyInAggregation, $fromArray, $aggregation, $labelMap = [], $labelKey = 'key', $valueKey = 'key', $countKey = 'doc_count')
     {
@@ -250,7 +245,7 @@ class ElasticSearchService extends CoreService
         // sort by Label
         \usort(
             $bucket,
-            fn($a, $b) => \strnatcasecmp((string) $a['label'], (string) $b['label'])
+            fn ($a, $b) => \strnatcasecmp((string) $a['label'], (string) $b['label'])
         );
 
         return $bucket;
@@ -262,8 +257,6 @@ class ElasticSearchService extends CoreService
      * @param array  $fragmentAggregations
      * @param array  $aggregation
      * @param array  $labelMap
-     *
-     * @return mixed
      */
     public function addFragmentEsResultToArray($keyInFragmentEsResult, $keyInAggregation, $fragmentAggregations, $aggregation, $labelMap = [])
     {
@@ -403,7 +396,6 @@ class ElasticSearchService extends CoreService
      * @param string $key
      * @param array  $userFilters
      * @param array  $boolMustFilter
-     * @param mixed  $nullvalue
      * @param array  $rawFields
      * @param bool   $addAllAggregations - If true, will add all filters existing on $userFilters. Otherwise only those who also has a not empty value.
      *
@@ -448,8 +440,6 @@ class ElasticSearchService extends CoreService
     /**
      * Given a $filter (can be array or string) returns true if has no empty value and false otherwise.
      *
-     * @param mixed $filter
-     *
      * @return bool
      */
     private function hasFilterValue($filter)
@@ -482,7 +472,7 @@ class ElasticSearchService extends CoreService
         $search = '',
         $filters = [],
         $sort = null,
-        $resultKey = 'statements'
+        $resultKey = 'statements',
     ): ElasticsearchResultSet {
         $filterSet = [
             'total'   => is_countable($elasticsearchResult->getAggregations()) ? count($elasticsearchResult->getAggregations()) : 0,
@@ -539,8 +529,6 @@ class ElasticSearchService extends CoreService
      * Konvertiere das Ergebnis aus Elasticsearch zu Legacy.
      *
      * @param array $hit
-     *
-     * @return mixed
      */
     protected function convertElasticsearchHitToLegacy($hit)
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -658,7 +658,7 @@ class ElasticsearchResultCreator extends CoreService
             $paginator->setMaxPerPage((int) $limit);
             // try to paginate Result, check for validity
             try {
-                $paginator->setCurrentPage($page);
+                $paginator->setCurrentPage((int) $page);
             } catch (NotValidCurrentPageException $e) {
                 $this->logger->info('Received invalid Page for pagination', [$e]);
                 $paginator->setCurrentPage(1);


### PR DESCRIPTION
### Ticket
[DPLAN-2760](https://demoseurope.youtrack.cloud/issue/DPLAN-2760/Veroffentlichte-STN-Seitenanzeiger-nicht-sichtbar-Pager-funktioniert-nicht)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
Statement pagination in the public view statement list was not working - the amount of STNs on the current page was being rendered where the total amount of STNs should be, and clicking on 'nächste Seite' was redirecting to an error page.


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
In public vie, choose a procedure (possibly with many STNs published in the public view) --> go to 'Stellungnahmen' tab --> in the pagination 'Zeige X von Y', the X dropdown should show options for display, Y should equal the total amount of STNs.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

