### PR TITLE
fix(DPLAN-15970): increase JWT token rate limit from 100 to 500 requests

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -19,5 +19,5 @@ framework:
         # the bearer token is reset at every page reload
         jwt_token:
             policy: 'fixed_window'
-            limit: 100
+            limit: 500
             interval: '30 days'


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-15970/PDF-Import-Wenn-man-ungefahr-100-PDFs-importiert-sind-die-importierte-PDFs-nur-nach-einem-Seitenrefresh-sichtbar

Description:
Prevents 'Too Many Requests' errors when uploading large numbers of files during import operations. The previous limit of 100 requests per 30 days was insufficient for bulk file operations in EWM.

### How to review/test
Fix already applied via vim edit to EWM-Dev.
You can try to upload 2 batches of files exceeding 100 together. (ask if you need testfiles)
Do not upload for than 92 files at once - this triggers a different error.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
