### PR TITLE
fix(refs: DPLAN-15198): disable copy button if no item selected

### DIFF
--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTable.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTable.vue
@@ -76,7 +76,7 @@
       :procedure-id="procedureId" />
 
     <slot
-      v-bind="{ procedureId, allItemsOnPageSelected, copyStatements }"
+      v-bind="{ allItemsOnPageSelected, copyStatements, isNoItemSelected, procedureId }"
       name="filter"
       :toggle-export-modal="toggleExportModal" />
 
@@ -222,7 +222,12 @@ export default {
 
     allItemsOnPageSelected () {
       return Object.keys(this.statements).length === 0 ? false : Object.keys(this.statements).every(stn => Object.keys(this.selectedElements).includes(stn))
+    },
+
+    isNoItemSelected () {
+      return Object.keys(this.selectedElements).length === 0
     }
+
   },
 
   methods: {
@@ -261,12 +266,14 @@ export default {
     },
 
     copyStatements () {
-      if (dpconfirm(Translator.trans('check.entries.marked.copy'))) {
-        this.action = 'copy'
-        this.$nextTick(() => {
-          this.$refs.bpform.submit()
-        })
+      if (!dpconfirm(Translator.trans('check.entries.marked.copy'))) {
+        return
       }
+
+      this.action = 'copy'
+      this.$nextTick(() => {
+        this.$refs.bpform.submit()
+      })
     },
 
     handlePageChange (newPage) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
@@ -51,9 +51,10 @@
         </label>
 
         <button
-            type="submit"
-            data-cy="copyStatement"
             class="o-link--default btn--blank weight--normal line-height--2 u-ph-0_25"
+            data-cy="copyStatement"
+            type="submit"
+            :disabled="isNoItemSelected"
             @click.stop.prevent="copyStatements">
             <i class="fa fa-files-o" aria-hidden="true"></i>
             {{ "copy"|trans }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_view.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_view.html.twig
@@ -30,7 +30,7 @@
                 total: parseInt('{{ templateVars.totalResults|default(0) }}')
             }"
             procedure-id="{{ templateVars.table.procedure.ident }}">
-            <template v-slot:filter="{ allItemsOnPageSelected, procedureId, copyStatements, toggleExportModal }">
+            <template v-slot:filter="{ allItemsOnPageSelected, copyStatements, isNoItemSelected, procedureId, toggleExportModal }">
                 {# filters + sorting #}
                 {% include '@DemosPlanCore/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig' %}
             </template>


### PR DESCRIPTION
### Ticket
[DPLAN-15198](https://demoseurope.youtrack.cloud/issue/DPLAN-15198/Falsches-Notification-Reihenfolge-Bestatigungsnachricht-angezeigt-obwohl-keine-Originalstellungnahmen-selektiert-sind)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The copy button in the original statement list dialog has to be disabled, to prevent wrong notifications or a wrong order of notifications, when no item is selected.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanbau and navigate to the original statement list dialog
2. Check if the copy button is disabled, as long as no item is selected
3. Select an item and check, if the copy button turns active

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
