### PR TITLE
fix(refs DPLAN-16062): Remove allowEmptyString option

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureUiDefinition.php
@@ -131,7 +131,7 @@ class ProcedureUiDefinition extends CoreEntity implements UuidEntityInterface, P
      *
      * @ORM\Column(type="string", length=500, nullable=false, options={"default":""})
      */
-    #[Assert\Length(min: 0, max: 500, maxMessage: 'procedureUiDefinition.statementPublicSubmitConfirmationText.maxLength', options: ['allowEmptyString' => true])]
+    #[Assert\Length(min: 0, max: 500, maxMessage: 'procedureUiDefinition.statementPublicSubmitConfirmationText.maxLength')]
     #[Assert\NotNull]
     private $statementPublicSubmitConfirmationText = '';
 


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-16062/Wenn-man-Verfahrenstyp-Anderungen-speichern-probiert-bekommt-man-ein-Fehlermeldung-mit-Es-ist-ein-Fehler-aufgetreten.-Bitte

-  allowEmptyString is not a valid parameter for Symfony's Length constraint.
- This 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
