### PR TITLE
fix(refs dplan-2760): fix pagination display

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -1801,7 +1801,7 @@ class DemosPlanProcedureController extends BaseController
         // Öffentliche Stellungnahmen
         $publicLimit = $request->get('r_limit', 10);
         $publicPage = $request->get('page', 1);
-        $statementService->setPaginatorLimits([10]);
+        $statementService->setPaginatorLimits([10, 25, 50]);
         $statements = $statementService->getStatementsByProcedureId(
             $procedureId,
             $filters,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
@@ -522,7 +522,12 @@ class ElasticSearchService extends CoreService
         $resultSet->setResult($list);
         $resultSet->setFilterSet($filterSet);
         $resultSet->setSortingSet($sortingSet);
-        $resultSet->setTotal(count($elasticsearchResult->getHits()['hits'] ?? []));
+        $total = $elasticsearchResult->getHits()['total'] ?? 0;
+        // Handle Elasticsearch 7+ format where total is an object with 'value' field
+        if (is_array($total) && array_key_exists('value', $total)) {
+            $total = $total['value'];
+        }
+        $resultSet->setTotal($total);
         $resultSet->setSearchFields($elasticsearchResult->getSearchFields());
         $resultSet->setSearch($search ?? '');
         $resultSet->setPager($elasticsearchResult->getPager());

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -658,7 +658,7 @@ class ElasticsearchResultCreator extends CoreService
             $paginator->setMaxPerPage((int) $limit);
             // try to paginate Result, check for validity
             try {
-                $paginator->setCurrentPage($page);
+                $paginator->setCurrentPage((int) $page);
             } catch (NotValidCurrentPageException $e) {
                 $this->logger->info('Received invalid Page for pagination', [$e]);
                 $paginator->setCurrentPage(1);


### PR DESCRIPTION
### Ticket
[DPLAN-2760](https://demoseurope.youtrack.cloud/issue/DPLAN-2760/Veroffentlichte-STN-Seitenanzeiger-nicht-sichtbar-Pager-funktioniert-nicht)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
Statement pagination in the public view statement list was not working - the amount of STNs on the current page was being rendered where the total amount of STNs should be, and clicking on 'nächste Seite' was redirecting to an error page.


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
In public vie, choose a procedure (possibly with many STNs published in the public view) --> go to 'Stellungnahmen' tab --> in the pagination 'Zeige X von Y', the X dropdown should show options for display, Y should equal the total amount of STNs.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
