### PR TITLE
fix: resolve TypeError in organisation list when checking permissions

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -169,14 +169,14 @@ import {
 import { mapActions, mapState } from 'vuex'
 import DpOrganisationListItem from './DpOrganisationListItem'
 
-const orgaFields = {
+const orgaFieldsArrays = {
   Branding: [
     'cssvars'
-  ].join(),
+  ],
   Customer: [
     'name',
     'subdomain'
-  ].join(),
+  ],
   Orga: [
     'addressExtension',
     'branding',
@@ -208,15 +208,22 @@ const orgaFields = {
     'street',
     'submissionType',
     'types'
-  ].join(),
+  ],
   OrgaStatusInCustomer: [
     'customer',
     'status'
-  ].join()
+  ]
 }
 
 if (hasPermission('feature_manage_procedure_creation_permission')) {
-  orgaFields.Orga.push('canCreateProcedures')
+  orgaFieldsArrays.Orga.push('canCreateProcedures')
+}
+
+const orgaFields = {
+  Branding: orgaFieldsArrays.Branding.join(),
+  Customer: orgaFieldsArrays.Customer.join(),
+  Orga: orgaFieldsArrays.Orga.join(),
+  OrgaStatusInCustomer: orgaFieldsArrays.OrgaStatusInCustomer.join()
 }
 
 export default {


### PR DESCRIPTION
## Summary
- Fixed JavaScript TypeError in DpOrganisationList component where `orgaFields.Orga.push()` was called on a string
- Restructured orgaFields initialization to properly handle conditional field addition based on permissions
- The error occurred because orgaFields.Orga was already joined to a string before the conditional push operation

## Changes
- Split orgaFields definition into `orgaFieldsArrays` (arrays) and `orgaFields` (joined strings)
- Conditional permission check now modifies the array before joining
- Maintains existing functionality while preventing the runtime error

## Test plan
- [x] Verify organisation list loads without JavaScript errors
- [x] Test with and without `feature_manage_procedure_creation_permission`
- [x] Confirm all organisation list functionality works as expected

refs: DPLAN-16071