### PR TITLE
feat (ref: DPLAN-15915 ) : switch routes depends on global news or not

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanNews/news_admin_edit.html.twig
@@ -317,18 +317,19 @@
 
                 <p class="lbl">{{ "pdf.document"|trans }}</p>
 
-                {% if procedure is not null %}
-                    {% set pdfPath = path("core_file_procedure", { 'procedureId': procedure, 'hash': news.pdf|getFile('hash') }) %}
-                {% else %}
-                    {% set pdfPath = path("core_file", {'hash': news.pdf|getFile('hash') }) %}
-                {% endif %}
+                {% set fileHash = news.pdf|getFile('hash') %}
+                {% set isGlobal = templateVars.isGlobal is defined and
+                    templateVars.isGlobal == true %}
+                {% set fileUrl = isGlobal ? path("core_file", { 'hash': fileHash }) :
+                    path("core_file_procedure", { 'procedureId': procedure, 'hash': fileHash})
+                %}
 
                 <a
                     id="news_pdf"
                     class="o-hellip break-words u-mb-0_25"
                     target="_blank"
                     rel="noopener"
-                    href="{{ pdfPath }}">
+                    href="{% fileUrl %}">
                     <i class="fa fa-file-o"></i>
                     {{ news.pdftitle|default(news.pdf|getFile('name')) }}
                     {% if ( news.pdf|getFile('size')|length > 0 or news.pdf|getFile('mimeType')|length > 0 ) %}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15915/Bild-und-PDF-Upload-wird-nach-Speichern-nicht-ubernommen-angezeigt

Description:
The Twig template news_admin_edit.html.twig always attempted to use core_file_procedure, even if procedure was empty (for Global News):

 Distinguish between news types with templateVars.isGlobal:
 - Global News (templateVars.isGlobal == true): Use core_file route no procedureId required)
 - Procedure News (templateVars.isGlobal is not set): Use core_file_procedure route (with procedureId)

 This logic ensures that:
 - Global News files are accessible via core_file (since they are not bound to procedures)
 - Procedure News files are accessible via core_file_procedure (with appropriate access control)

picked from https://github.com/demos-europe/demosplan-core/pull/4886

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

