### PR TITLE
fix(refs dplan-15860): Rerender automatically after deleting a SimilarStatementSubmitters entry

### DIFF
--- a/client/js/bundles/procedure/administrationStatementSegmentsList.js
+++ b/client/js/bundles/procedure/administrationStatementSegmentsList.js
@@ -51,4 +51,8 @@ const apiStores = [
   'User'
 ]
 
+if (hasPermission('feature_similar_statement_submitter')) {
+  apiStores.push('SimilarStatementSubmitter')
+}
+
 initialize(components, stores, apiStores)

--- a/client/js/components/procedure/Shared/SimilarStatementSubmitters/SimilarStatementSubmitters.vue
+++ b/client/js/components/procedure/Shared/SimilarStatementSubmitters/SimilarStatementSubmitters.vue
@@ -310,25 +310,29 @@ export default {
     },
 
     deleteEntry (index) {
-      this.updateStatement({
-        id: this.statementId,
-        relationship: 'similarStatementSubmitters',
-        action: 'remove',
-        value: {
-          id: this.listEntries[index].id,
-          type: 'SimilarStatementSubmitter'
+      const name = this.listEntries[index]?.submitterName ? this.listEntries[index].submitterName : false
+
+      if (dpconfirm(Translator.trans('statement.similar.statement.submitter.delete', { name }))) {
+        this.updateStatement({
+          id: this.statementId,
+          relationship: 'similarStatementSubmitters',
+          action: 'remove',
+          value: {
+            id: this.listEntries[index].id,
+            type: 'SimilarStatementSubmitter'
+          }
+        })
+        this.setInitialStatement(this.statements[this.statementId])
+
+        this.listEntries.splice(index, 1)
+
+        if (this.isRequestFormPost === false) {
+          this.deleteSimilarStatementSubmitter()
         }
-      })
-      this.setInitialStatement(this.statements[this.statementId])
 
-      this.listEntries.splice(index, 1)
-
-      if (this.isRequestFormPost === false) {
-        this.deleteSimilarStatementSubmitter()
-      }
-
-      if (this.isRequestFormPost) {
-        this.resetFormFields()
+        if (this.isRequestFormPost) {
+          this.resetFormFields()
+        }
       }
     },
 

--- a/client/js/components/procedure/Shared/SimilarStatementSubmitters/SimilarStatementSubmitters.vue
+++ b/client/js/components/procedure/Shared/SimilarStatementSubmitters/SimilarStatementSubmitters.vue
@@ -312,7 +312,7 @@ export default {
     deleteEntry (index) {
       const name = this.listEntries[index]?.submitterName ? this.listEntries[index].submitterName : false
 
-      if (dpconfirm(Translator.trans('statement.similar.statement.submitter.delete', { name }))) {
+      if (dpconfirm(Translator.trans('statement.similarStatementSubmitters.delete', { name }))) {
         this.updateStatement({
           id: this.statementId,
           relationship: 'similarStatementSubmitters',

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3729,6 +3729,11 @@ statements.yours.list.description.short.gdpr_consent_may_revoke: "<a href=\"{hre
 statements.yours.list.description: "Hier können Sie alle Ihre eingereichten Stellungnahmen einsehen. Sobald ein Verfahren vom Verfahrensträger gelöscht wird, werden auch Ihre zugehörigen Stellungnahmen und personenbezogenen Daten gelöscht."
 statements.yours.list.description.short: "<a href=\"{href}\">Hier</a> können Sie alle Ihre eingereichten Stellungnahmen einsehen."
 statements: "Stellungnahmen"
+statement.similar.statement.submitter.delete: |
+    {name, select,
+            false { Möchten Sie die weitere einreichende Person wirklich löschen? }
+            other { Möchten Sie die weitere einreichende Person "{name}" wirklich löschen? }
+        }
 statement_vote.length: |
   {count, plural,
       =1 { # Person }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3581,6 +3581,11 @@ statement.send.email.label: "Sende unten stehende Stellungnahme an"
 statement.send: "Stellungnahme versenden"
 statement.similarStatementSubmitters: "Weitere Einreichende der gleichen Stellungnahme"
 statement.similarStatementSubmitters.add: "Einreicher*in hinzufügen"
+statement.similarStatementSubmitters.delete: |
+    {name, select,
+            false { Möchten Sie die weitere einreichende Person wirklich löschen? }
+            other { Möchten Sie die weitere einreichende Person "{name}" wirklich löschen? }
+        }
 statement.similarStatementSubmitters.hint: "Falls von weiteren Einreichenden inhaltlich identische Stellungnahmen eingegangen sind, können diese Personen hier angegeben werden."
 statement.solved.description: "Wenn sich alle Abschnitte einer Stellungnahme in einem solchen Bearbeitungsschritt befinden, bekommt die Stellungnahme den Status \"Abgeschlossen\"."
 statement.solved.hint: "Wenn sich alle Abschnitte einer Stellungnahme in Bearbeitungsschritten befinden, bei denen diese Checkbox aktiviert ist, bekommt die Stellungnahme den Status \"Abgeschlossen\"."

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3734,11 +3734,6 @@ statements.yours.list.description.short.gdpr_consent_may_revoke: "<a href=\"{hre
 statements.yours.list.description: "Hier können Sie alle Ihre eingereichten Stellungnahmen einsehen. Sobald ein Verfahren vom Verfahrensträger gelöscht wird, werden auch Ihre zugehörigen Stellungnahmen und personenbezogenen Daten gelöscht."
 statements.yours.list.description.short: "<a href=\"{href}\">Hier</a> können Sie alle Ihre eingereichten Stellungnahmen einsehen."
 statements: "Stellungnahmen"
-statement.similar.statement.submitter.delete: |
-    {name, select,
-            false { Möchten Sie die weitere einreichende Person wirklich löschen? }
-            other { Möchten Sie die weitere einreichende Person "{name}" wirklich löschen? }
-        }
 statement_vote.length: |
   {count, plural,
       =1 { # Person }


### PR DESCRIPTION
### Ticket
[DPLAN-15860](https://demoseurope.youtrack.cloud/issue/DPLAN-15860/Weitere-Einreichende-sind-nur-nach-einem-Seitenrefresh-geloscht)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
After deleting a 'weitere einreichende Person', the change was only visible after a manual reload of the page. The problem was that the SimilarStatementSubmitters was not registered in the store entry point of the parent component StatementSegementList.

This PR also adds the confirmation alert window with a translation for this case.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Logged in as an admin, go to 'Abschnitte - Bearbeiten' or 'Stellungnamhen - Details und Erwiderung- Bearbeiten'--> add an entry to 'Weitere Einreichende der gleichen Stellungnahme' --> delete the entry --> there should be a confirmation alert window, success pop up and the component should re-render.

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

