### PR TITLE
fix(refs: DPLAN-16097): change behavior for selectedState in original statement

### DIFF
--- a/client/js/components/statement/originalStatementsTable/OriginalStatementsTable.vue
+++ b/client/js/components/statement/originalStatementsTable/OriginalStatementsTable.vue
@@ -129,7 +129,7 @@
           :key="idx"
           :procedure-id="procedureId"
           :statement-id="statement.id"
-          @add-to-selection="addToSelectionAction"
+          @add-to-selection="() => addToSelectionAction({ id: statement.id})"
           @remove-from-selection="removeFromSelectionAction" />
       </tbody>
     </table>

--- a/client/js/store/statement/Statement.js
+++ b/client/js/store/statement/Statement.js
@@ -239,10 +239,10 @@ export default {
 
   mutations: {
     /**
-     * @param {Object} elementId
+     * @param {Object} element
      */
-    addElementToSelection (state, elementId) {
-      state.selectedElements[elementId] = true
+    addElementToSelection (state, element) {
+      state.selectedElements[element.id] = element
     },
 
     /**
@@ -404,9 +404,9 @@ export default {
   actions: {
     /**
      * Add an element to selectedElements and the sessionStorage
-     * @param id : {elementId} contains id, editable
+     * @param data : {Object} contains id, editable
      */
-    addToSelectionAction ({ state, commit }, id) {
+    addToSelectionAction ({ state, commit }, data) {
       performance.mark('selection-start')
       const selectedEntries = JSON.parse(sessionStorage.getItem('selectedElements')) || {}
 
@@ -414,12 +414,12 @@ export default {
         selectedEntries[state.procedureId] = {}
       }
 
-      selectedEntries[state.procedureId][id] = true
+      selectedEntries[state.procedureId][data.id] = { ...data }
 
       if (state.persistStatementSelection) {
         sessionStorage.setItem('selectedElements', JSON.stringify(selectedEntries))
       }
-      commit('addElementToSelection', id)
+      commit('addElementToSelection', data)
       performance.mark('selection-end')
       performance.measure('selection-duration', 'selection-start', 'selection-end')
       return Promise.resolve(true)


### PR DESCRIPTION
### Ticket
[DPLAN-16097 ](https://demoseurope.youtrack.cloud/issue/DPLAN-16097)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This fix reverts the changes from ba9d15ef1d54f207e75dd8455f19f6bc68547696 to reach a stable statement copy behavior for the normal statement list and and adds a new select behavior to the original statement list. (in original statement an Object with the element id is added to the store Statement/selectedElements now)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

    1. Open diplanbau and navigate to the original statement list dialog
    2. Check if the copy button is disabled, as long as no item is selected
    3. Select an item and check, if the copy button turns active
    4. Check if in the normal statement list and the original statement list copy is possible without errors

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
