### PR TITLE
fix(refs dplan-15815): procedure settings inputs layout

### DIFF
--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -37,12 +37,16 @@
           :options="phaseOptions" /><!--
 
      --><div class="layout__item u-1-of-3 u-1-of-1-lap-down">
+          <dp-label
+            class="mb-0.5"
+            :for="switchDateId"
+            :text="Translator.trans('phase.autoswitch.datetime')"
+            required />
           <dp-datetime-picker
             :data-cy="`autoSwitchProcedurePhaseForm:${switchDateId}`"
             :disabled="!autoSwitchPhase"
             hidden-input
             :id="switchDateId"
-            :label="Translator.trans('phase.autoswitch.datetime')"
             :max-date="switchDateMax"
             :min-date="minSwitchDate"
             :name="switchDateId"
@@ -52,6 +56,7 @@
 
      --><div class="layout__item u-1-of-3">
           <dp-label
+            class="mb-0.5"
             for="procedurePhasePeriod"
             :text="Translator.trans('period.new')"
             required />
@@ -292,3 +297,4 @@ export default {
   }
 }
 </script>
+

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -17,7 +17,8 @@
       :label="{
         text: Translator.trans('procedure.public.phase.autoswitch')
       }"
-      :name="checkboxId" />
+      :name="checkboxId"
+    />
 
     <transition
       name="slide-fade"
@@ -26,7 +27,6 @@
         v-if="!hasPermission('feature_auto_switch_to_procedure_end_phase') || (hasPermission('feature_auto_switch_to_procedure_end_phase') && !isParticipationPhaseSelected)"
         class="layout u-mt-0_25 u-pl">
         <dp-select
-          class="layout__item u-1-of-3 u-1-of-1-lap-down"
           v-model="selectedPhase"
           :data-cy="`selectedPhase:${checkboxId}`"
           :disabled="!autoSwitchPhase"
@@ -34,47 +34,53 @@
             text: Translator.trans('procedure.phase.autoswitch.targetphase')
           }"
           :name="phaseSelectId"
-          :options="phaseOptions" /><!--
+          :options="phaseOptions"
+          class="layout__item u-1-of-3 u-1-of-1-lap-down"
+        /><!--
 
      --><div class="layout__item u-1-of-3 u-1-of-1-lap-down">
           <dp-label
-            class="mb-0.5"
             :for="switchDateId"
             :text="Translator.trans('phase.autoswitch.datetime')"
-            required />
+            class="mb-0.5"
+            required
+          />
           <dp-datetime-picker
+            :id="switchDateId"
+            v-model="switchDate"
             :data-cy="`autoSwitchProcedurePhaseForm:${switchDateId}`"
             :disabled="!autoSwitchPhase"
             hidden-input
-            :id="switchDateId"
             :max-date="switchDateMax"
             :min-date="minSwitchDate"
             :name="switchDateId"
             required
-            v-model="switchDate" />
+          />
         </div><!--
 
      --><div class="layout__item u-1-of-3">
           <dp-label
+            :text="Translator.trans('period.new')"
             class="mb-0.5"
             for="procedurePhasePeriod"
-            :text="Translator.trans('period.new')"
-            required />
+            required
+          />
           <dp-date-range-picker
             id="procedurePhasePeriod"
+            :data-cy="dataCyPhasePeriod"
             :end-disabled="!autoSwitchPhase"
             :end-id="endDateId"
             :end-name="endDateId"
             :end-value="endDate"
-            enforce-plausible-dates
             :min-date="startDate"
-            required
-            :data-cy="dataCyPhasePeriod"
-            start-disabled
             :start-id="startDateId"
             :start-name="startDateId"
             :start-value="startDate"
-            @input:end-date="handleInputEndDate" />
+            enforce-plausible-dates
+            required
+            start-disabled
+            @input:end-date="handleInputEndDate"
+          />
         </div>
 
         <transition
@@ -82,17 +88,19 @@
           mode="out-in">
           <dp-inline-notification
             v-if="showAutoSwitchToAnalysisHint"
-            class="mt-3 mb-0"
             :message="Translator.trans('period.autoswitch.hint', { phase: Translator.trans(isInternal ? 'procedure.phases.internal.analysis' : 'procedure.phases.external.evaluating')})"
-            type="warning" />
+            class="mt-3 mb-0"
+            type="warning"
+          />
         </transition>
       </div>
 
       <dp-inline-notification
         v-else-if="hasPermission('feature_auto_switch_to_procedure_end_phase') && isParticipationPhaseSelected"
-        class="mt-3 mb-0"
         :message="Translator.trans('period.autoswitch.hint', { phase: Translator.trans(isInternal ? 'procedure.phases.internal.analysis' : 'procedure.phases.external.evaluating')})"
-        type="warning" />
+        class="mt-3 mb-0"
+        type="warning"
+      />
     </transition>
   </div>
 </template>


### PR DESCRIPTION
### Ticket
[DPLAN-15815](https://demoseurope.youtrack.cloud/issue/DPLAN-15815/Verfahrensschritt-automatisch-umstellen-Input-Layout-Problem)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
The layout in AutoSwitchProcedurePhaseForm.vue was broken - the spacing between labels and input fields was not consistent. The issue is that 2 of the used components have dp-label built-in

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Logged in as admin, go to 'Grundeinstellungen' of a procedure --> ' Verfahrensschritt Institutionen' --> check the 'Verfahrensschritt automatisch umstellen' checkbox to see the inputs layout. The same form is included in the section below 'Verfahrensschritt Öffentlichkeit'

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly


