### PR TITLE
fix(refs: DPLAN-16101): filter elements before delete 

### DIFF
--- a/client/js/components/document/ElementsAdminList.vue
+++ b/client/js/components/document/ElementsAdminList.vue
@@ -201,6 +201,7 @@ export default {
             // Still perform cleanup even if some deletions failed
             this.buildTree()
             this.resetSelection()
+            lscache.remove(`${dplan.procedureId}:selectedElements`)
 
             dplan.notify.notify('error', Translator.trans('error.entries.marked.deleted'))
           })


### PR DESCRIPTION
### Ticket
[DPLAN-16101](https://demoseurope.youtrack.cloud/issue/DPLAN-16101/Fehler-wenn-man-importierte-Dokumente-loscht)

This PR modifies the bulkDelete() method to first filter out all child elements whose parents are also selected for deletion, since the backend automatically deletes all (grand-)children of parent elements. This way, there is no call for a child element to be deleted twice.

### How to review/test
1. Log in as an admin and navigate to documents in a procedure.
2. Upload a zip file with subfolders (test file is linked in ticket). 
3. Bulk delete folder with a subfolder.
