### PR TITLE
fix(refs DPLAN-16080): use search button in DpAutocomplete for small screens

### DIFF
--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -28,6 +28,7 @@
             query: searchString
           })
         }"
+        search-button
         @search-changed="updateSuggestions"
         @searched="search => setValueAndSubmitForm({ target: { value: search } }, 'search')"
         @selected="search => setValueAndSubmitForm({ target: { value: search.value } }, 'search')" />
@@ -48,10 +49,11 @@
           @enter="form.search = currentAutocompleteSearch; submitForm();" />
       </template>
 
+      <!-- Search button, if dp-autocomplete is used only displayed on lap-up screens -->
       <button
         type="button"
         data-cy="searchProcedureMapForm:procedureSearchSubmit"
-        :class="prefixClass('c-proceduresearch__search-btn btn btn--primary weight--bold')"
+        :class="[dplan.settings.useOpenGeoDb ? prefixClass('hidden md:block') : '', prefixClass('c-proceduresearch__search-btn btn btn--primary weight--bold')]"
         @click.prevent="form.search = currentAutocompleteSearch; submitForm();">
         {{ Translator.trans('searching') }}
       </button>


### PR DESCRIPTION
### Ticket
[DPLAN-16080](https://demoseurope.youtrack.cloud/issue/DPLAN-16080/Suchschlitz-nicht-schon-in-Mobilansicht)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- to avoid the placeholder in the autocomplete input being cut off on small screens, we can now use a (smaller, icon-only) search button attached to the input
- at the same time, the placeholder is moved outside of the input and displayed above it as a label, while (the shorter) 'search' is displayed as the placeholder in the input (these changes are implemented in demosplan-ui)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Go to the index page and check that the search input looks and works fine both on small and larger screens

### Linked PRs 

- [x] https://github.com/demos-europe/demosplan-ui/pull/1311

### Tasks

- [x] Merge https://github.com/demos-europe/demosplan-ui/pull/1311
- [x] Release new demosplan-ui 0.4.x version
- [x] Use the new demosplan-ui version in demosplan
- [ ] Merge this PR

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
