### PR TITLE
fix(refs dplan-16085):  Add mobile version of StatementModal nav

### DIFF
--- a/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImportErrors.vue
+++ b/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImportErrors.vue
@@ -62,7 +62,9 @@
     <dp-progress-bar
       v-if="errors.length > 1"
       :label="Translator.trans('done.capital') + ':'"
-      :percentage="completedPercent" />
+      :percentage="completedPercent"
+      showPercentage
+    />
 
     <a
       :href="Routing.generate('DemosPlan_procedure_import', { procedureId: procedureId })"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -66,11 +66,11 @@
           <div :class="prefixClass('mb-3 flex items-center justify-start gap-1')">
             <i
               v-if="stepsData[step].icon"
-              :class="['fa', stepsData[step].icon, prefixClass('mt-0.5')]"
+              :class="['fa', stepsData[step].icon, prefixClass('mt-[2px]')]"
               aria-hidden="true" />
-            <h4 :class="prefixClass('m-0 font-semibold')">
+            <h3 :class="prefixClass('m-0 text-lg font-medium')">
               {{  stepsData[step].label }}
-            </h4>
+            </h3>
           </div>
 
           <!-- Reset padding styles from _progress-bar.scss for this case -->

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1190,6 +1190,12 @@ export default {
         })
     },
 
+    goToPreviousStep () {
+      if (this.step > 0) {
+        this.step -= 1
+      }
+    },
+
     /*
      * When clicking the little ✎ icon in the "recheck" step, users are sent to the
      * respective multistep step, and afterwards the element they want to edit is focused.

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -69,7 +69,7 @@
               :class="[prefixClass('fa'), prefixClass(stepsData[step].icon), prefixClass('text-lg leading-none mt-[2px]')]"
               aria-hidden="true" />
             <h3 :class="prefixClass('m-0 text-lg leading-none font-medium')">
-              {{  stepsData[step].label }}
+              {{ stepsData[step].label }}
             </h3>
           </div>
 

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -63,12 +63,12 @@
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>
 
-          <div :class="prefixClass('mb-3 flex items-center justify-start gap-1')">
+          <div :class="prefixClass('mb-3 flex items-center gap-2')">
             <i
               v-if="stepsData[step].icon"
-              :class="[prefixClass('fa'), prefixClass(stepsData[step].icon), prefixClass('mt-[2px]')]"
+              :class="[prefixClass('fa'), prefixClass(stepsData[step].icon), prefixClass('text-lg leading-none mt-[2px]')]"
               aria-hidden="true" />
-            <h3 :class="prefixClass('m-0 text-lg font-medium')">
+            <h3 :class="prefixClass('m-0 text-lg leading-none font-medium')">
               {{  stepsData[step].label }}
             </h3>
           </div>
@@ -129,17 +129,18 @@
             }"
             value="0" />
           <dp-radio
-            :disabled="canNotBeNegativeReport"
-            name="r_isNegativeReport"
             id="negative_report_true"
-            data-cy="statementModal:indicationerror"
             :checked="formData.r_isNegativeReport === '1'"
-            @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
+            data-cy="statementModal:indicationerror"
+            :disabled="canNotBeNegativeReport"
             :label="{
               hint: Translator.trans('link.title.indicationerror'),
               text: Translator.trans('indicationerror')
             }"
-            value="1" />
+            name="r_isNegativeReport"
+            value="1"
+            @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
+          />
         </div>
 
         <div :class="prefixClass('c-statement__text')">
@@ -148,11 +149,9 @@
             for="statementText"
             :required="formData.r_isNegativeReport !== '1'" />
           <dp-editor
+            id="statementText"
             :class="prefixClass('u-mb')"
             :data-dp-validate-error-fieldname="Translator.trans('statement.text.short')"
-            hidden-input="r_text"
-            id="statementText"
-            ref="statementEditor"
             :readonly="formData.r_isNegativeReport === '1'"
             :required="formData.r_isNegativeReport !== '1'"
             :toolbar-items="{
@@ -160,6 +159,8 @@
               strikethrough: true
             }"
             :value="formData.r_text || ''"
+            hidden-input="r_text"
+            ref="statementEditor"
             @input="val => setStatementData({r_text: val})" />
         </div>
         <div
@@ -582,7 +583,7 @@
           :key="formDefinition.key"
           :draft-statement-id="draftStatementId"
           :required="formDefinition.required" />
-        <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
+        <div :class="prefixClass('flex flex-col sm:flex-row justify-between gap-2 mt-6')">
           <button
             :class="prefixClass('btn btn--secondary sm:w-1/2 md:w-auto')"
             data-cy="statementModal:backToStatement"
@@ -658,7 +659,7 @@
           required
           @change="val => setStatementData({r_gdpr_consent: val ? 'on' : 'off'})" />
 
-        <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
+        <div :class="prefixClass('flex flex-col sm:flex-row justify-between gap-2 mt-6')">
           <button
             :class="prefixClass('btn btn--secondary sm:w-1/2 md:w-auto')"
             data-cy="statementModal:backToPersonalData"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -47,23 +47,36 @@
         v-if="loggedIn === false && showHeader"
         role="banner"
         :class="prefixClass('c-statement__header u-mb-0_5')">
-        <dp-multistep-nav
-          :active-step="step"
-          :class="prefixClass('pb-0')"
-          :steps="[{
-            label: Translator.trans('statement.yours'),
-            icon: commentingIcon,
-            title: Translator.trans('statement.modal.step.write')
-          }, {
-            label: Translator.trans('personal.data'),
-            icon: 'fa-user',
-            title: Translator.trans('statement.modal.step.personal.data')
-          }, {
-            label: Translator.trans('recheck'),
-            icon: 'fa-check',
-            title: Translator.trans('statement.modal.step.recheck')
-          }]"
-          @change-step="val => step = val" />
+
+        <!-- Desktop -->
+        <div :class="prefixClass('hidden md:block')">
+          <dp-multistep-nav
+            :active-step="step"
+            :class="prefixClass('pb-0')"
+            :steps="stepsData"
+            @change-step="val => step = val" />
+        </div>
+
+        <!-- Mobile-->
+        <div :class="prefixClass('md:hidden text-start')">
+          <div :class="prefixClass('mb-0.5 text-muted')">
+            Schritt {{ step + 1 }} von {{ stepsData.length }}
+          </div>
+
+          <div :class="prefixClass('mb-2 flex items-center justify-start')">
+            <i
+              v-if="stepsData[step].icon"
+              :class="['fa', stepsData[step].icon, prefixClass('mt-0.5 mr-1')]"
+              aria-hidden="true" />
+            <h4 :class="prefixClass('m-0 font-bold')">
+              {{  stepsData[step].label }}
+            </h4>
+          </div>
+
+          <dp-progress-bar
+            :percentage="Math.round(((step + 1) / stepsData.length) * 100)"
+          />
+        </div>
       </header>
 
       <dp-inline-notification
@@ -718,6 +731,7 @@ import {
   DpLoading,
   DpModal,
   DpMultistepNav,
+  DpProgressBar,
   DpRadio,
   DpUploadFiles,
   dpValidateMixin,

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -58,7 +58,7 @@
         </div>
 
         <!-- Mobile-->
-        <div :class="prefixClass('md:hidden text-start')">
+        <div :class="prefixClass('md:hidden')">
           <div :class="prefixClass('mb-0.5 text-muted')">
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>
@@ -660,7 +660,6 @@
             :class="prefixClass('btn btn--secondary md:hidden')"
             data-cy="statementModal:backToPersonalData"
             type="button"
-            :class="prefixClass('btn btn--secondary md:hidden')"
             @click.prevent="goToPreviousStep">
             {{ Translator.trans('go.back.to.personal.data') }}
           </button>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -45,11 +45,11 @@
 
       <header
         v-if="loggedIn === false && showHeader"
-        :class="prefixClass('c-statement__header u-mb-0_5')"
+        :class="prefixClass('c-statement__header mb-2')"
         role="banner"
       >
         <!-- Desktop -->
-        <div class="tablet-desktop-nav">
+        <div :class="prefixClass('tablet-desktop-nav')">
           <dp-multistep-nav
             :active-step="step"
             :class="prefixClass('pb-0')"
@@ -57,9 +57,9 @@
             @change-step="val => step = val" />
         </div>
 
-        <!-- Mobile-->
-        <div class="mobile-nav">
-          <div :class="prefixClass('mb-0_5 text-muted')">
+        <!-- Mobile -->
+        <div :class="prefixClass('mobile-nav')">
+          <div :class="prefixClass('mb-0.5 text-muted')">
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>
 

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -49,7 +49,7 @@
         role="banner"
       >
         <!-- Desktop -->
-        <div :class="prefixClass('tablet-desktop-nav')">
+        <div :class="prefixClass('c-statement__formnav tablet-desktop')">
           <dp-multistep-nav
             :active-step="step"
             :class="prefixClass('pb-0')"
@@ -58,7 +58,7 @@
         </div>
 
         <!-- Mobile -->
-        <div :class="prefixClass('mobile-nav')">
+        <div :class="prefixClass('c-statement__formnav mobile')">
           <div :class="prefixClass('mb-0.5 text-muted')">
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -428,7 +428,7 @@
         <!-- for not logged in users -->
         <div
           v-else
-          :class="prefixClass('text-right sm:text-center md:text-right mb-2')">
+          :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
           <dp-loading
             v-if="isLoading"
             :class="prefixClass('align-text-bottom inline-block')"
@@ -436,7 +436,7 @@
           <button
             type="reset"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--secondary u-1-of-1-palm u-1-of-2-lap')"
+            :class="prefixClass('btn btn--secondary sm:w-1/2 md:w-auto')"
             data-cy="statementModal:discardStatement"
             @click.prevent="() => reset()">
             {{ Translator.trans('discard.statement') }}
@@ -445,7 +445,7 @@
             type="submit"
             data-cy="statementFormSubmit"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--primary u-1-of-1-palm u-1-of-2-lap u-mt-0_5-lap-down u-ml-0_5-desk-up')"
+            :class="prefixClass('btn btn--primary sm:w-1/2 md:w-auto')"
             form-name="statementForm"
             @click="validateStatementStep">
             {{ Translator.trans('continue.personal_data') }}

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -794,6 +794,7 @@ export default {
     DpLoading,
     DpModal,
     DpMultistepNav,
+    DpProgressBar,
     DpRadio,
     DpEditor: defineAsyncComponent(async () => {
       const { DpEditor } = await import('@demos-europe/demosplan-ui')

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -75,10 +75,8 @@
 
           <!-- Reset padding styles from _progress-bar.scss for this case -->
           <dp-progress-bar
-            :class="prefixClass('p-0 pb-3')"
+            :class="prefixClass('p-0 pb-3 border-0')"
             :percentage="Math.round(((step + 1) / stepsData.length) * 100)"
-            alternative-color
-            hide-border
             hide-percentage
           />
         </div>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -45,13 +45,11 @@
 
       <header
         v-if="loggedIn === false && showHeader"
+        :class="prefixClass('c-statement__header u-mb-0_5')"
         role="banner"
-        :class="prefixClass('c-statement__header u-mb-0_5')">
-
+      >
         <!-- Desktop -->
-        <div
-          class="tablet-desktop-nav"
-        >
+        <div class="tablet-desktop-nav">
           <dp-multistep-nav
             :active-step="step"
             :class="prefixClass('pb-0')"
@@ -598,11 +596,12 @@
           </button>
 
           <button
-            type="button"
-            data-cy="submitterForm"
             :class="prefixClass('btn btn--primary sm:w-1/2 md:w-auto')"
+            data-cy="submitterForm"
             form-name="submitterForm"
-            @click="dpValidateAction('submitterForm', validatePersonalDataStep, true)">
+            type="button"
+            @click="dpValidateAction('submitterForm', validatePersonalDataStep, true)"
+          >
             {{ Translator.trans('continue.submission') }}
           </button>
         </div>
@@ -676,11 +675,12 @@
             :class="prefixClass('align-text-bottom inline-block')"
             hide-label />
           <button
-            type="button"
-            data-cy="sendStatementNow"
-            :disabled="isLoading"
             :class="prefixClass('btn btn--primary sm:w-1/2 md:w-auto')"
-            @click.prevent="e => dpValidateAction('recheckForm', () => sendStatement(e))">
+            :disabled="isLoading"
+            data-cy="sendStatementNow"
+            type="button"
+            @click.prevent="e => dpValidateAction('recheckForm', () => sendStatement(e))"
+          >
             {{ Translator.trans('statement.submit.now') }}
           </button>
         </div>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -580,7 +580,15 @@
           :key="formDefinition.key"
           :draft-statement-id="draftStatementId"
           :required="formDefinition.required" />
-        <div :class="prefixClass('text-right mt-3')">
+        <div :class="prefixClass('flex justify-end gap-2 mt-3')">
+          <button
+            :class="prefixClass('btn btn--secondary md:hidden')"
+            type="button"
+            @click="goToPreviousStep"
+          >
+            {{ Translator.trans('go.back.to.statement') }}
+          </button>
+
           <button
             type="button"
             data-cy="submitterForm"
@@ -646,7 +654,14 @@
           required
           @change="val => setStatementData({r_gdpr_consent: val ? 'on' : 'off'})" />
 
-        <div :class="prefixClass('text-right')">
+        <div :class="prefixClass('flex justify-end gap-2')">
+          <button
+            type="button"
+            :class="prefixClass('btn btn--secondary md:hidden')"
+            @click.prevent="goToPreviousStep">
+            {{ Translator.trans('go.back.to.personal.data') }}
+          </button>
+
           <dp-loading
             v-if="isLoading"
             :class="prefixClass('align-text-bottom inline-block')"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -589,7 +589,7 @@
           :required="formDefinition.required" />
         <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
           <button
-            :class="[prefixClass('btn btn--secondary sm:w-1/2 md:w-auto'), 'mobile-nav']"
+            :class="prefixClass('btn btn--secondary sm:w-1/2 md:w-auto')"
             data-cy="statementModal:backToStatement"
             type="button"
             @click="goToPreviousStep"
@@ -664,7 +664,7 @@
 
         <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
           <button
-            :class="[prefixClass('btn btn--secondary sm:w-1/2 md:w-auto'), 'mobile-nav']"
+            :class="prefixClass('btn btn--secondary sm:w-1/2 md:w-auto')"
             data-cy="statementModal:backToPersonalData"
             type="button"
             @click.prevent="goToPreviousStep">

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -66,14 +66,13 @@
           <div :class="prefixClass('mb-3 flex items-center justify-start gap-1')">
             <i
               v-if="stepsData[step].icon"
-              :class="['fa', stepsData[step].icon, prefixClass('mt-[2px]')]"
+              :class="[prefixClass('fa'), prefixClass(stepsData[step].icon), prefixClass('mt-[2px]')]"
               aria-hidden="true" />
             <h3 :class="prefixClass('m-0 text-lg font-medium')">
               {{  stepsData[step].label }}
             </h3>
           </div>
 
-          <!-- Reset padding styles from _progress-bar.scss for this case -->
           <dp-progress-bar
             :class="prefixClass('p-0 pb-3 border-0')"
             :percentage="Math.round(((step + 1) / stepsData.length) * 100)"

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -49,7 +49,9 @@
         :class="prefixClass('c-statement__header u-mb-0_5')">
 
         <!-- Desktop -->
-        <div :class="prefixClass('hidden md:block')">
+        <div
+          class="tablet-desktop-nav"
+        >
           <dp-multistep-nav
             :active-step="step"
             :class="prefixClass('pb-0')"
@@ -58,7 +60,7 @@
         </div>
 
         <!-- Mobile-->
-        <div :class="prefixClass('md:hidden')">
+        <div class="mobile-nav">
           <div :class="prefixClass('mb-0.5 text-muted')">
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -61,22 +61,27 @@
 
         <!-- Mobile-->
         <div class="mobile-nav">
-          <div :class="prefixClass('mb-0.5 text-muted')">
+          <div :class="prefixClass('mb-0_5 text-muted')">
             Schritt {{ step + 1 }} von {{ stepsData.length }}
           </div>
 
-          <div :class="prefixClass('mb-2 flex items-center justify-start')">
+          <div :class="prefixClass('mb-3 flex items-center justify-start gap-1')">
             <i
               v-if="stepsData[step].icon"
-              :class="['fa', stepsData[step].icon, prefixClass('mt-0.5 mr-1')]"
+              :class="['fa', stepsData[step].icon, prefixClass('mt-0.5')]"
               aria-hidden="true" />
-            <h4 :class="prefixClass('m-0 font-bold')">
+            <h4 :class="prefixClass('m-0 font-semibold')">
               {{  stepsData[step].label }}
             </h4>
           </div>
 
+          <!-- Reset padding styles from _progress-bar.scss for this case -->
           <dp-progress-bar
+            :class="prefixClass('p-0 pb-3')"
             :percentage="Math.round(((step + 1) / stepsData.length) * 100)"
+            alternative-color
+            hide-border
+            hide-percentage
           />
         </div>
       </header>

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1043,6 +1043,22 @@ export default {
       return this.feedbackFormFields.map(el => {
         return { ...el, ...this.availableFormComponents[el.name] }
       })
+    },
+
+    stepsData () {
+      return [{
+        label: Translator.trans('statement.yours'),
+        icon: this.commentingIcon,
+        title: Translator.trans('statement.modal.step.write')
+      }, {
+        label: Translator.trans('personal.data'),
+        icon: 'fa-user',
+        title: Translator.trans('statement.modal.step.personal.data')
+      }, {
+        label: Translator.trans('recheck'),
+        icon: 'fa-check',
+        title: Translator.trans('statement.modal.step.recheck')
+      }]
     }
   },
 

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -583,6 +583,7 @@
         <div :class="prefixClass('flex justify-end gap-2 mt-3')">
           <button
             :class="prefixClass('btn btn--secondary md:hidden')"
+            data-cy="statementModal:backToStatement"
             type="button"
             @click="goToPreviousStep"
           >
@@ -656,6 +657,8 @@
 
         <div :class="prefixClass('flex justify-end gap-2')">
           <button
+            :class="prefixClass('btn btn--secondary md:hidden')"
+            data-cy="statementModal:backToPersonalData"
             type="button"
             :class="prefixClass('btn btn--secondary md:hidden')"
             @click.prevent="goToPreviousStep">

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -580,9 +580,9 @@
           :key="formDefinition.key"
           :draft-statement-id="draftStatementId"
           :required="formDefinition.required" />
-        <div :class="prefixClass('flex justify-end gap-2 mt-3')">
+        <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
           <button
-            :class="prefixClass('btn btn--secondary md:hidden')"
+            :class="[prefixClass('btn btn--secondary sm:w-1/2 md:w-auto'), 'mobile-nav']"
             data-cy="statementModal:backToStatement"
             type="button"
             @click="goToPreviousStep"
@@ -593,7 +593,7 @@
           <button
             type="button"
             data-cy="submitterForm"
-            :class="prefixClass('btn btn--primary')"
+            :class="prefixClass('btn btn--primary sm:w-1/2 md:w-auto')"
             form-name="submitterForm"
             @click="dpValidateAction('submitterForm', validatePersonalDataStep, true)">
             {{ Translator.trans('continue.submission') }}
@@ -655,9 +655,9 @@
           required
           @change="val => setStatementData({r_gdpr_consent: val ? 'on' : 'off'})" />
 
-        <div :class="prefixClass('flex justify-end gap-2')">
+        <div :class="prefixClass('flex flex-col sm:flex-row justify-end gap-2 mt-4')">
           <button
-            :class="prefixClass('btn btn--secondary md:hidden')"
+            :class="[prefixClass('btn btn--secondary sm:w-1/2 md:w-auto'), 'mobile-nav']"
             data-cy="statementModal:backToPersonalData"
             type="button"
             @click.prevent="goToPreviousStep">
@@ -672,7 +672,7 @@
             type="button"
             data-cy="sendStatementNow"
             :disabled="isLoading"
-            :class="prefixClass('btn btn--primary')"
+            :class="prefixClass('btn btn--primary sm:w-1/2 md:w-auto')"
             @click.prevent="e => dpValidateAction('recheckForm', () => sendStatement(e))">
             {{ Translator.trans('statement.submit.now') }}
           </button>

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_progress-bar.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_progress-bar.scss
@@ -16,18 +16,9 @@
     border-radius: $inuit-base-spacing-unit--tiny;
     border: 1px solid $dp-color-neutral-light-2;
 
-    &--no-border {
-        border: none;
-    }
-
     &__line {
         height: 10px;
-        background: $color-confirm;
-
-        // Alternative color for blue progress bar
-        &--blue {
-            background: $dp-color-blue-dark-2;
-        }
+        background: $dp-color-blue-dark-1;
 
         &.is-animated,
         &.is-animated::before {

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_progress-bar.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_progress-bar.scss
@@ -16,9 +16,18 @@
     border-radius: $inuit-base-spacing-unit--tiny;
     border: 1px solid $dp-color-neutral-light-2;
 
+    &--no-border {
+        border: none;
+    }
+
     &__line {
         height: 10px;
         background: $color-confirm;
+
+        // Alternative color for blue progress bar
+        &--blue {
+            background: $dp-color-blue-dark-2;
+        }
 
         &.is-animated,
         &.is-animated::before {

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
@@ -175,7 +175,7 @@
             &.mobile {
                 display: block;
 
-                @media screen and (min-width: 710px) {
+                @media screen and (width >= 710px) {
                     display: none;
                 }
             }
@@ -183,7 +183,7 @@
             &.tablet-desktop {
                 display: none;
 
-                @media screen and (min-width: 710px) {
+                @media screen and (width >= 710px) {
                     display: block;
                 }
             }

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
@@ -171,3 +171,22 @@
         }
     }
 }
+
+// Custom breakpoint for StatementModal.vue navigation (710px)
+.mobile-nav {
+    display: block;
+}
+
+.tablet-desktop-nav {
+    display: none;
+}
+
+@media screen and (min-width: 710px) {
+    .mobile-nav {
+        display: none;
+    }
+
+    .tablet-desktop-nav {
+        display: block;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_statement.scss
@@ -169,24 +169,24 @@
                 padding-bottom: 12px !important;
             }
         }
-    }
-}
 
-// Custom breakpoint for StatementModal.vue navigation (710px)
-.mobile-nav {
-    display: block;
-}
+        // Custom breakpoint for StatementModal.vue navigation (710px)
+        &__formnav {
+            &.mobile {
+                display: block;
 
-.tablet-desktop-nav {
-    display: none;
-}
+                @media screen and (min-width: 710px) {
+                    display: none;
+                }
+            }
 
-@media screen and (min-width: 710px) {
-    .mobile-nav {
-        display: none;
-    }
+            &.tablet-desktop {
+                display: none;
 
-    .tablet-desktop-nav {
-        display: block;
+                @media screen and (min-width: 710px) {
+                    display: block;
+                }
+            }
+        }
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_display-visibility.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_display-visibility.scss
@@ -140,21 +140,3 @@
     }
 }
 
-// Custom breakpoint for StatementModal.vue navigation (710px)
-.mobile-nav {
-    display: block;
-}
-
-.tablet-desktop-nav {
-    display: none;
-}
-
-@media screen and (min-width: 710px) {
-    .mobile-nav {
-        display: none;
-    }
-
-    .tablet-desktop-nav {
-        display: block;
-    }
-}

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_display-visibility.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/utility/_display-visibility.scss
@@ -139,3 +139,22 @@
         display: none;
     }
 }
+
+// Custom breakpoint for StatementModal.vue navigation (710px)
+.mobile-nav {
+    display: block;
+}
+
+.tablet-desktop-nav {
+    display: none;
+}
+
+@media screen and (min-width: 710px) {
+    .mobile-nav {
+        display: none;
+    }
+
+    .tablet-desktop-nav {
+        display: block;
+    }
+}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1929,6 +1929,8 @@ gislayer.define: 'Kartenebenen definieren'
 gislayer.visibilitygroup.toggle: 'Sichtbarkeit der Gruppe umschalten'
 globalnews.administrate: "Portal-Mitteilungen verwalten"
 globalnews: "Portal-Mitteilungen"
+go.back.to.personal.data: "Zurück zu Kontaktdaten"
+go.back.to.statement: "Zurück zur Stellungnahme"
 goto.participation: "Zur Beteiligung: {procedure}"
 group: "Gruppe"
 group.create: "Gruppe erstellen"


### PR DESCRIPTION
### Ticket
[DPLAN-16085](https://demoseurope.youtrack.cloud/issue/DPLAN-16085/STN-Offentlichkeits-Mobilansicht-Reiter-Layout-ist-kaputt)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
The layout of the header navigation in StatementModal for not logged-in users was broken. This PR implements a mobile version of it --> instead of a 3 step-header, only the current step is rendered in the header (with a modified progress bar component). For navigating to the previous steps, 'Zurück'-buttons were added (also on big screens).

It solves the 'missing padding between buttons' part of this layout-bug-ticket:
DPLAN-16082: https://demoseurope.youtrack.cloud/issue/DPLAN-16082/Keine-Padding-auf-rechter-linker-Seite-beim-Beteiligung-in-Offentlichkeitsansicht

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Click on the 'Reden Sie mit' button --> check the layout and the functionality of the 3-steps navigation on different screen sizes.

** before testing, the PR for the progress-bar component modification has to be merged: https://github.com/demos-europe/demosplan-ui/pull/1314 **

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

