### PR TITLE
fix(refs: DPLAN-16083): change location popup style for mobile

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -644,23 +644,6 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
 
         //  popup triggered with mapSingleClick()
         &__popup {
-
-            //  set popover fixed for mobile devices and handle long text-overflow
-            @include media-query('palm') {
-                inset: 2% 2% auto;
-                position: fixed;
-                z-index: 1040;
-
-                max-height: 96%;
-                min-height: 0;
-                overflow-y: auto;
-
-                //  hide the popup arrow which can not be positioned with overflow-y: auto
-                &::after {
-                    display: none;
-                }
-            }
-
             bottom: 12px;
             left: -50px;
             position: absolute;

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -427,7 +427,7 @@
                     <button id="popupAction" class="{{ 'c-map__popup__button btn btn--primary u-mt-0_5'|prefixClass }}">
                         <i :class="activeStatement ? prefixClass('fa fa-commenting') : prefixClass('fa fa-comment')" aria-hidden="true"></i>
                         <template v-if="activeStatement">
-                            {{ 'statement.form.edit.location_relation'|trans }}
+                            {{ 'statement.continue'|trans }}
                         </template>
                         <template v-else>
                             {{ 'statement.new'|trans }}


### PR DESCRIPTION
### Ticket
DPLAN-16083

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

After marking a location on map a popup opens on the marked position. This popup is too small in mobile view, so that the user cannot see the button to switch back to the statement modal. This change fix the style.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanbau or diplanrog and login as a private user
2. Open a procedure and switch to mobile view
3. Switch to mark location tab and mark a location on the map
4. Check if the popup is shown and you can see the all content of it including the Button
5. Check if the small triangle points nearly at the position where the location was clicked
6. Check if the Button text now explains more understandable what happens when the Button is clicked.


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
