### PR TITLE
fix (refs: DPLAN-15999): Use all() method is designed to handle array…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2360,12 +2360,12 @@ class DemosPlanProcedureController extends BaseController
         if ($requestPost->has('boilerplateDeleteChecked')) {
             // Delete checked Boilerplates
             if ($requestPost->has('boilerplate_delete')) {
-                $this->handleDeleteBoilerplates($procedureHandler, $requestPost->get('boilerplate_delete'));
+                $this->handleDeleteBoilerplates($procedureHandler, $requestPost->all('boilerplate_delete'));
             }
 
             // Delete checked BoilerplateGroups
             if ($requestPost->has('boilerplateGroupIdsTo_delete')) {
-                $this->handleDeleteBoilerplateGroups($requestPost->get('boilerplateGroupIdsTo_delete'));
+                $this->handleDeleteBoilerplateGroups($requestPost->all('boilerplateGroupIdsTo_delete'));
             }
 
             if (false ===


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-15999
Change get() to all() to get an array from the request

Same fix as this PR https://github.com/demos-europe/demosplan-core/pull/4852 applied to ewm