### PR TITLE
Picked feature dplan 16042 add configurable feedback control for public participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## UNRELEASED
 - Allow to configure procedures to accept or not anonymous statements
+- Allow filtering of institution tags in AdminstrationMemberList / refactor twig
+- Add configurable feedback control for public participation statements
+
+## v4.5.0 (2025-06-25)
 - Export Original Statements as docx in the Statement List
 - Allow filtering of institution tags in DpAddOrganizationList
 - Allow filtering of institution tags in AdminstrationMemberList / refactor twig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@
 
 ## UNRELEASED
 - Allow to configure procedures to accept or not anonymous statements
-- Allow filtering of institution tags in AdminstrationMemberList / refactor twig
-- Add configurable feedback control for public participation statements
-
-## v4.5.0 (2025-06-25)
 - Export Original Statements as docx in the Statement List
 - Allow filtering of institution tags in DpAddOrganizationList
 - Allow filtering of institution tags in AdminstrationMemberList / refactor twig
+- Add configurable feedback control for public participation statements
 
 ## v4.4.0 (2025-06-13)
 ## v4.3.0 (2025-06-13)

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -566,6 +566,7 @@
           :is="formDefinition.component"
           :key="formDefinition.key"
           :draft-statement-id="draftStatementId"
+          :public-participation-feedback-enabled="publicParticipationFeedbackEnabled"
           :required="formDefinition.required" />
         <div :class="prefixClass('text-right mt-3')">
           <button
@@ -883,6 +884,12 @@ export default {
     },
 
     publicParticipationPublicationEnabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    publicParticipationFeedbackEnabled: {
       type: Boolean,
       required: false,
       default: false

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaEmail.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaEmail.vue
@@ -8,7 +8,12 @@
 </license>
 
 <template>
-  <div :class="[statement.r_getFeedback === 'on' ? prefixClass('bg-color--grey-light-2') : '', prefixClass('c-statement__formblock')]">
+  <div 
+    v-if="publicParticipationFeedbackEnabled"
+    :class="[
+      prefixClass('c-statement__formblock'),
+      { [prefixClass('bg-color--grey-light-2')]: statement.r_getFeedback === 'on' }
+    ]"
     <dp-checkbox
       id="r_getFeedback"
       aria-labelledby="statement-detail-require-information-mail"
@@ -74,6 +79,14 @@ export default {
     DpCheckbox
   },
 
-  mixins: [formGroupMixin]
+  mixins: [formGroupMixin],
+
+  props: {
+    publicParticipationFeedbackEnabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  }
 }
 </script>

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupEvaluationMailViaSnailMailOrEmail.vue
@@ -8,7 +8,9 @@
 </license>
 
 <template>
-  <div :class="[statement.r_getFeedback === 'on' ? prefixClass('bg-color--grey-light-2') : '', prefixClass('c-statement__formblock')]">
+  <div 
+    v-if="publicParticipationFeedbackEnabled"
+    :class="[statement.r_getFeedback === 'on' ? prefixClass('bg-color--grey-light-2') : '', prefixClass('c-statement__formblock')]">
     <dp-checkbox
       id="r_getFeedback"
       data-cy="personalInformationMail"
@@ -122,6 +124,14 @@ export default {
     DpRadio
   },
 
-  mixins: [formGroupMixin, prefixClassMixin]
+  mixins: [formGroupMixin, prefixClassMixin],
+
+  props: {
+    publicParticipationFeedbackEnabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  }
 }
 </script>

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -901,6 +901,10 @@ feature_export_protocol:
     label: 'Exportieren des Verfahrensprotokolls'
     loginRequired: true
     parent: area_admin_protocol
+feature_feedback_on_statement_controllable:
+    description: 'Enables the user to control whether feedback on statements is enabled or not.'
+    label: 'Control feedback on statements'
+    loginRequired: true
 feature_forum_dev_release_edit:
     description: 'Enables an user to edit the release entries in the development forum, which is sort of an parent entry for user-story discussions'
     label: 'edit release entry in development forum section'

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -668,6 +668,7 @@ class DemosPlanProcedureController extends BaseController
                 'r_publicParticipationEndDate',
                 'r_publicParticipationPhase',
                 'r_publicParticipationPublicationEnabled',
+                'r_publicParticipationFeedbackEnabled',
                 'allowAnonymousStatements',
                 'r_publicParticipationStartDate',
                 'r_sendMailsToCounties',

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/07/Version20250703101620.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/07/Version20250703101620.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250703101620 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-16042: Add flag to allow Feedback on statements';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure_settings ADD _p_public_participation_feedback_enabled TINYINT(1) DEFAULT 0 NOT NULL
+        SQL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure_settings DROP _p_public_participation_feedback_enabled
+        SQL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
@@ -291,6 +291,13 @@ class ProcedureSettings extends CoreEntity implements UuidEntityInterface, Proce
      */
     private $allowedSegmentAccessProcedures;
 
+    /**
+     * Enable publication of Feedback possibility.
+     *
+     * @ORM\Column(name="_p_public_participation_feedback_enabled", type="boolean", nullable=false, options={"default":true})
+     */
+    protected bool $publicParticipationFeedbackEnabled = false;
+
     public function __construct()
     {
         $this->allowedSegmentAccessProcedures = new ArrayCollection();
@@ -1113,5 +1120,17 @@ class ProcedureSettings extends CoreEntity implements UuidEntityInterface, Proce
             ->setDesignatedPhaseChangeUser($designatedPublicPhaseChangeUser);
 
         return $this;
+    }
+
+    public function setPublicParticipationFeedbackEnabled(bool $enabled): ProcedureSettingsInterface
+    {
+        $this->publicParticipationFeedbackEnabled = $enabled;
+
+        return $this;
+    }
+
+    public function isPublicParticipationFeedbackEnabled(): bool
+    {
+        return $this->publicParticipationFeedbackEnabled;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureToLegacyConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureToLegacyConverter.php
@@ -70,6 +70,7 @@ class ProcedureToLegacyConverter extends CoreService
             $procedureArray['pictogramCopyright'] = $procedureArray['settings']['pictogramCopyright'];
             $procedureArray['pictogramAltText'] = $procedureArray['settings']['pictogramAltText'];
             $procedureArray['allowAnonymousStatements'] = $procedureArray['settings']['allowAnonymousStatements'];
+            $procedureArray['publicParticipationFeedbackEnabled'] = $procedureArray['settings']['publicParticipationFeedbackEnabled'];
         }
 
         $procedureArray['isMapEnabled'] = false;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -494,6 +494,14 @@ class ServiceStorage implements ProcedureServiceStorageInterface
             $procedure['publicParticipationPublicationEnabled'] = false;
         }
 
+        if ($this->permissions->hasPermission('feature_feedback_on_statement_controllable')) {
+            if (array_key_exists('r_publicParticipationFeedbackEnabled', $data)) {
+                $procedure['settings']['publicParticipationFeedbackEnabled'] = true;
+            } else {
+                $procedure['settings']['publicParticipationFeedbackEnabled'] = false;
+            }
+        }
+
         // liegt das Enddatum vor dem Startdatum?
         if (isset($procedure['endDate']) && strtotime((string) $procedure['endDate']) < strtotime((string) $procedure['startDate'])) {
             $mandatoryErrors[] = [

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -804,6 +804,9 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             if (array_key_exists('allowAnonymousStatements', $data['settings'])) {
                 $procedureSettings->setAllowAnonymousStatements($data['settings']['allowAnonymousStatements']);
             }
+            if (array_key_exists('publicParticipationFeedbackEnabled', $data['settings'])) {
+                $procedureSettings->setPublicParticipationFeedbackEnabled($data['settings']['publicParticipationFeedbackEnabled']);
+            }
             if (array_key_exists('pictogramCopyright', $data['settings'])) {
                 $procedureSettings->setPictogramCopyright($data['settings']['pictogramCopyright']);
             }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -974,6 +974,16 @@
                                     <input type="hidden" name="r_publicParticipationPublicationEnabled" value="1">
                                 {% endif %}
 
+                                {% if hasPermission('feature_feedback_on_statement_controllable') %}
+                                    <label>
+                                        <input type="checkbox" name="r_publicParticipationFeedbackEnabled" {#  #}{{ proceduresettings.settings.publicParticipationFeedbackEnabled ? 'checked' : '' }}>
+                                        {{ "public.participation.feedback"|trans }}
+                                    </label>
+                                {% else %}
+                                    {# allow publishing the possibility of Feedback by default #}
+                                    <input type="hidden" name="r_publicParticipationFeedbackEnabled" value="1"> }
+                                {% endif %}
+
                                 {% if hasPermission('field_submit_anonymous_statements') %}
                                     <dp-checkbox
                                         id="allowAnonymousStatements"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -496,6 +496,7 @@
                         :personal-data-form-fields="JSON.parse('{{ personalDataFields|json_encode|e('js', 'utf-8') }}')"
                         :planning-documents-has-negative-statement="Boolean({{ templateVars.planningDocumentsHasNegativeStatement|default(false) }})"
                         :public-participation-publication-enabled="Boolean({{ proceduresettings.publicParticipationPublicationEnabled }})"
+                        :public-participation-feedback-enabled="Boolean({{ proceduresettings.publicParticipationFeedbackEnabled|default(false) }})"
                         :statement-form-fields="JSON.parse('{{ statementFields|json_encode|e('js', 'utf-8') }}')"
                         extra-personal-hint="{% block extra_personal_hint %}{% endblock %}"
                         project-name="{{ projectName }}"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail_form_personal_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail_form_personal_data.html.twig
@@ -75,6 +75,7 @@
 
     </fieldset>
 
+    {% if proceduresettings.publicParticipationFeedbackEnabled %}
     <div class="{{ 'c-statement__formblock u-mt'|prefixClass }}" data-toggle-id="getFeedback" aria-live="polite" aria-relevant="all">
         <label class="{{ 'u-mb-0_5 block'|prefixClass }}">
             <input
@@ -104,6 +105,7 @@
         </div>
 
     </div>
+    {% endif %}
 
     <button
         class="{{ 'btn btn--primary u-ml float-right u-1-of-1-palm u-mt-0_5-palm u-nojs-hide--inline-block js__statementForm'|prefixClass }}"

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2907,6 +2907,7 @@ public.participation.panel.institution.description_1: "Institutionen benötigen 
 public.participation.panel.institution.description_2: "<a class=\"{css}\" href=\"{url}\">Jetzt registrieren.</a>"
 public.participation.participate: "Stellung nehmen"
 public.participation.publication: "Veröffentlichung von Stellungnahmen von Bürger*innen in diesem Verfahren erlauben"
+public.participation.feedback: 'Die Checkbox "Ich möchte eine Rückmeldung zu meiner Stellungnahme erhalten" für die Bürger*innen hinzufügen.'
 public.participation.receive_notifications: "Expert*innen prüfen Ihre Stellungnahme. Lassen Sie sich über das Ergebnis informieren!"
 public.participation.relation: "Ortsbezug"
 public.participation.relation.map: "Ortsbezug in der Karte"


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16042/Ruckmeldung-zu-Stellungnahme-steuerbar

Description:  picked feature.
This feature adds administrative control over citizen feedback functionality in public participation procedures. Administrators can now enable or disable the feedback option that allows citizens to request notifications about statement processing results.

  - New checkbox in procedure settings to toggle feedback availability
  - Only users with feature_feedback_on_statement_controllable permission can modify this setting
  - When disabled, all feedback-related form elements (checkbox, email fields, postal options) are hidden from citizens


### How to review/test

You can now test this by toggling the publicParticipationFeedbackEnabled setting in the procedure administration form, and the feedback functionality should appear/disappear accordingly.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
- [X] Update changelog 
