### PR TITLE
Fix(DPLAN-15946): error while saving the available groups on the FAQ page

### DIFF
--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -223,7 +223,9 @@ export default {
         return this.faqItem.attributes[key] !== value
       }).length !== 0
       if (hasChangedAttributes === true) {
-        this.updateFaq({ ...faqCpy, id: faqCpy.id })
+        const { attributes, id, type } = faqCpy
+
+        this.updateFaq({ id, type, attributes })
         const saveAction = () => {
           return this.saveFaq(this.faqItem.id)
             .then(() => {


### PR DESCRIPTION
### Ticket
[DPLAN-15946](https://demoseurope.youtrack.cloud/issue/DPLAN-15946) Fehlermeldung beim Ändern des Status in "Häufige Fragen"

**Description:** This PR fixes an issue where saving the available groups caused an error.

-  send/save only relevant data: 'id', 'type' and 'attributes' instead of the entire FAQ object 

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
