### PR TITLE
fix(refs DPLAN-16060): Add Loaded flag for mapSettings

### DIFF
--- a/client/js/components/map/admin/MapAdmin.vue
+++ b/client/js/components/map/admin/MapAdmin.vue
@@ -29,6 +29,7 @@
         }" />
     </div>
     <map-view
+      v-if="mapSettingsLoaded"
       ref="mapView"
       :bounding-box="boundingBoxAsPolygon"
       class="layout__item w-1/1 u-pb"
@@ -159,6 +160,7 @@ export default {
           strokeLineWidth: 3
         })
       },
+      mapSettingsLoaded: false,
       procedureMapSettings: {
         id: '',
         type: 'ProcedureMapSetting',
@@ -302,6 +304,7 @@ export default {
   async mounted () {
     const settings = await this.fetchProcedureMapSettings({ procedureId: this.procedureId, isMaster: this.isMaster })
     this.procedureMapSettings = JSON.parse(JSON.stringify(settings))
+    this.mapSettingsLoaded = true
   }
 }
 </script>


### PR DESCRIPTION
To prevent that the map get initialized before the settings are loaded, we add a loading flag. If this helps is hard to say, because the bug is not reliable reproducible. So lets give it a try.

### Ticket
DPLAN-16060
