### PR TITLE
chore(refs DPLAN-16080): bump demosplan-ui from v0.4.19 to v0.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^15.0.0",
-    "@demos-europe/demosplan-ui": "0.4.19",
+    "@demos-europe/demosplan-ui": "0.4.22",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,9 +2018,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.4.19":
-  version: 0.4.19
-  resolution: "@demos-europe/demosplan-ui@npm:0.4.19"
+"@demos-europe/demosplan-ui@npm:0.4.22":
+  version: 0.4.22
+  resolution: "@demos-europe/demosplan-ui@npm:0.4.22"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2074,7 +2074,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/03295bf87e1f901ee1c730544ce876530ea5ea65fdba40b55305ef4c5b9eb2b574933ebf5afa26ad495ed43f29de60fbca0eae21ee0779436a3b043c1e8eb4cd
+  checksum: 10c0/97cc18757d6e0114522ba6c55470c0cc5a13facb75cc8ff7b9be9ad106b67088fbef0902cde8eb8fc26e02e4913e764736315310d7fff9061a0f343511d496b5
   languageName: node
   linkType: hard
 
@@ -12794,7 +12794,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^15.0.0"
-    "@demos-europe/demosplan-ui": "npm:0.4.19"
+    "@demos-europe/demosplan-ui": "npm:0.4.22"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"


### PR DESCRIPTION
Bumps demosplan-ui to the newest 0.4.x version.

- DpEditableList now has a closeOnSuccess prop
- keyboard navigation for ActionMenu.js has been improved
- DpProgressbar now shows a blue bar (instead of green), and the percentage can be hidden
- DpAutocomplete can now have an icon-only search button inside the input


### Linked PRs 
- [ ] https://github.com/demos-europe/demosplan-core/pull/4926
- [ ] https://github.com/demos-europe/demosplan-core/pull/4923

