### PR TITLE
fix: resolve critical PHPStan errors

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
@@ -302,13 +302,32 @@ class RemoveUserDataCommand extends CoreCommand
 
     protected function removeUserDataFromAddresses(): void
     {
+        $germanStates = [
+            'Baden-Württemberg',
+            'Bayern',
+            'Berlin',
+            'Brandenburg',
+            'Bremen',
+            'Hamburg',
+            'Hessen',
+            'Mecklenburg-Vorpommern',
+            'Niedersachsen',
+            'Nordrhein-Westfalen',
+            'Rheinland-Pfalz',
+            'Saarland',
+            'Sachsen',
+            'Sachsen-Anhalt',
+            'Schleswig-Holstein',
+            'Thüringen'
+        ];
+
         /** @var Address[] $allAddresses */
         $allAddresses = $this->initializeRemovingDataForEntity(Address::class);
         foreach ($allAddresses as $address) {
             $address->setCode(null); // ?
             $address->setStreet($this->map($address->getStreet(), $this->faker->streetName));
             $address->setStreet1($this->map($address->getStreet1(), $this->faker->streetName));
-            $address->setState($this->map($address->getState(), $this->faker->state));
+            $address->setState($this->map($address->getState(), $this->faker->randomElement($germanStates)));
             $address->setPostalcode($this->map($address->getPostalcode(), $this->faker->postcode));
             $address->setCity($this->map($address->getCity(), $this->faker->city));
             $address->setRegion(''); // this->faker->domainWord

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
@@ -42,7 +42,7 @@ class LocationSearchController extends BaseController
             $result = $restResponse['body'] ?? [];
 
             $suggestions = [];
-            $maxSuggestions = $query['maxResults'] ?? (is_countable($result) ? count($result) : 0);
+            $maxSuggestions = (int)($query['maxResults'] ?? (is_countable($result) ? count($result) : 0));
 
             for ($i = 0; $i < $maxSuggestions; ++$i) {
                 if (isset($result[$i])) {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -495,7 +495,7 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
 
             $result = $locationResponse['body'];
 
-            $maxSuggestions = $requestGet['maxResults'] ?? (is_countable($result) ? count($result) : 0);
+            $maxSuggestions = (int)($requestGet['maxResults'] ?? (is_countable($result) ? count($result) : 0));
             // Es gibt Ergebnisse, aber weniger als maxResults
             if ((is_countable($result) ? count($result) : 0) < $maxSuggestions) {
                 $maxSuggestions = is_countable($result) ? count($result) : 0;

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -612,7 +612,7 @@ class ElementsService extends CoreService implements ElementsServiceInterface
             if (!is_array($orgaIds)) {
                 $orgaIds = [$orgaIds];
             }
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->entityManager;
             $elementEntity = $this->getElementsRepository()
                 ->get($elementId);
 
@@ -652,7 +652,7 @@ class ElementsService extends CoreService implements ElementsServiceInterface
             if (!is_array($orgaIds)) {
                 $orgaIds = [$orgaIds];
             }
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->entityManager;
             $elementEntity = $this->getElementsRepository()
                 ->get($elementId);
 


### PR DESCRIPTION
Description: resolve PHPStan errors
  ## Faker Generator state() method fix
  - Problem: `$this->faker->state()` undefined method for German locale
  - Solution: Custom German states array with `randomElement()` for authentic data

  ## Mixed-type comparison operations fix
  - Problem: Unsafe comparisons between int and mixed types from HTTP requests
  - Solution: Added explicit `(int)` type casting for request parameters

  ## Doctrine ObjectManager getReference() fix
  - Problem: `getReference()` method undefined on ObjectManager interface
  - Solution: Use injected EntityManagerInterface instead of getDoctrine()->getManager()
