### PR TITLE
Fix ProcedurePhase:: initialization

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -57,7 +57,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
     /**
      * Virtual Property bound on phase configuration in procedurephases.yml.
      */
-    protected string $permissionSet;
+    protected string $permissionSet = ProcedureInterface::PROCEDURE_PHASE_PERMISSIONSET_HIDDEN;
 
     /**
      * @ORM\Column(type="string", length=25, nullable=false, options={"default":""})


### PR DESCRIPTION
## Summary
- Fix typed property initialization error in ProcedurePhase entity
- Initialize $permissionSet with default value to prevent Doctrine proxy access errors

## Problem
The `ProcedurePhase::$permissionSet` property was typed as `string` but accessed before initialization when Doctrine created proxy objects. This caused the error:
```
Typed property demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhase::$permissionSet must not be accessed before initialization
```

## Solution
Added default value initialization to the property declaration:
```php
protected string $permissionSet = ProcedureInterface::PROCEDURE_PHASE_PERMISSIONSET_HIDDEN;
```

This ensures the property is always initialized, even when Doctrine creates proxy objects without calling the constructor.

## Test Plan
- [x] Verified PHP syntax is correct
- [x] Ran existing procedure phase tests - all pass
- [x] Property is properly initialized with expected default value
- [x] No breaking changes to existing functionality

## Files Changed
- `demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php`