### PR TITLE
f(refs DPLAN-16138): add new permission feature_auto_logout_popup_war…

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -718,6 +718,12 @@ feature_assign_system_roles:
     label: 'Vergebe Systemrollen wie Support, Redakteur etc. an User'
     loginRequired: true
     parent: feature_assign_roles
+feature_auto_logout_popup_warning:
+    description: |
+        A pop up is enabled, reminding the user of the automatic log out that is going to happen automatically in time.
+    expose: true
+    label: 'Remind the user of the upcoming automatic log out'
+    loginRequired: true
 feature_auto_switch_element_state:
     description: |
         The FP can pick a date and time on which the state of the element will be switched.


### PR DESCRIPTION

DPLAN-16138
https://demoseurope.youtrack.cloud/issue/DPLAN-16138/Create-new-permission-to-display-banner-popup

Adding a new permission in permissions.yml and respective Permissions.php files of each project that has the feature of a popup, warning the user of the upcoming automatic logout. 

### How to review/test
Log in as users with different permissions, check if popup window appears.

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
