### PR TITLE
feat (refs: DPLAN-15829): show layer preview for admin

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -88,6 +88,12 @@
       @deselectAll="deselectAllLayers"
     />
 
+    <dp-ol-map
+      v-if="hasPreview"
+      :procedure-id="procedureId"
+      small
+    />
+
     <input
       :value="layersInputValue"
       name="r_layers"
@@ -142,11 +148,13 @@
 <script>
 import { debounce, DpCheckbox, DpInput, DpLabel, DpMultiselect, DpSelect, externalApi } from '@demos-europe/demosplan-ui'
 import { WMSCapabilities, WMTSCapabilities } from 'ol/format'
+import DpOlMap from '../map/DpOlMap.vue'
 
 export default {
   name: 'LayerSettings',
 
   components: {
+    DpOlMap,
     DpCheckbox,
     DpInput,
     DpLabel,
@@ -159,6 +167,12 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+
+    hasPreview: {
+      type: Boolean,
+      required: false,
+      default: false
     },
 
     initLayers: {
@@ -198,6 +212,12 @@ export default {
     },
 
     initVersion: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    procedureId: {
       type: String,
       required: false,
       default: ''
@@ -524,6 +544,8 @@ export default {
   },
 
   mounted () {
+    console.log('hier')
+    console.log(this.currentProcedureId)
     this.getLayerCapabilities()
   }
 }

--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -88,16 +88,17 @@
       @deselectAll="deselectAllLayers"
     />
 
-    <dp-ol-map
-      v-if="hasPreview"
-      :procedure-id="procedureId"
-      small
-    />
-
     <input
       :value="layersInputValue"
       name="r_layers"
       type="hidden">
+
+    <dp-ol-map
+      v-if="hasPreview"
+      :layers="previewLayers"
+      :procedure-id="procedureId"
+      small
+    />
 
     <dp-select
       v-if="hasPermission('feature_map_wmts') && serviceType === 'wmts'"
@@ -289,6 +290,16 @@ export default {
 
     layersInputValue () {
       return this.layers.map(el => el.label).join(',')
+    },
+
+    previewLayers () {
+      return [{
+        name: `preview-layers-${this.layersInputValue}`, // Force component recreation on layer change (DpOlMapLayer)
+        url: this.url,
+        layers: this.layersInputValue,
+        mapOrder: 1,
+        layerType: 'overlay',
+      }]
     },
 
     serviceTypeOptions () {
@@ -544,8 +555,6 @@ export default {
   },
 
   mounted () {
-    console.log('hier')
-    console.log(this.currentProcedureId)
     this.getLayerCapabilities()
   }
 }

--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -106,11 +106,12 @@
           v-for="(layer, idx) in sortedLayers"
           :key="layer.name"
           :attributions="layer.attribution || ''"
-          :order="idx"
+          :order="options.hideDefaultLayer ? idx : idx + 1"
           :opacity="layer.opacity"
           :url="layer.url"
           :layers="layer.layers"
-          :projection="layer.projectionValue" />
+          :projection="layer.projectionValue"
+          :layer-type="layer.layerType || 'overlay'" />
       </div>
 
       <!-- Map container -->

--- a/client/js/components/map/map/DpOlMapLayer.vue
+++ b/client/js/components/map/map/DpOlMapLayer.vue
@@ -26,6 +26,12 @@ export default {
       default: ''
     },
 
+    layerType: {
+      required: false,
+      type: String,
+      default: 'base'
+    },
+
     layers: {
       required: true,
       type: String
@@ -69,7 +75,8 @@ export default {
 
   data () {
     return {
-      source: null
+      layer: null,
+      source: null,
     }
   },
 
@@ -125,15 +132,21 @@ export default {
       }
 
       this.source = createSourceTileWMS(url, this.layers, this.projection, this.defaultAttributions, this.map)
-      const layer = createTileLayer(this.title, this.name, this.source, this.opacity)
+      this.layer = createTileLayer(this.title, this.name, this.source, this.opacity, this.layerType)
 
       //  Insert layer at pos 0, making it the background layer
-      this.map.getLayers().insertAt(this.order, layer)
+      this.map.getLayers().insertAt(this.order, this.layer)
     }
   },
 
   mounted () {
     this.addLayer()
+  },
+
+  beforeUnmount () {
+    if (this.layer && this.map) {
+      this.map.removeLayer(this.layer)
+    }
   },
 
   render: () => null
@@ -178,13 +191,13 @@ const createSourceTileWMS = (url, layers, projection, attributions, map) => {
  * @return {object} ol/layer/Tile instance
  * @see https://openlayers.org/en/latest/apidoc/module-ol_layer_Tile-TileLayer.html
  */
-const createTileLayer = (title, name, source, opacity) => {
+const createTileLayer = (title, name, source, opacity, layerType = 'base') => {
   return new TileLayer({
     title,
     name,
     preload: 10,
     opacity: opacity / 100,
-    type: 'base',
+    type: layerType,
     visible: true,
     source
   })

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_edit.html.twig
@@ -156,6 +156,7 @@
 
                 {% block baseSettings %}
                     <layer-settings
+                        has-preview="true"
                         init-name="{{ gislayer.name|default }}"
                         init-service-type="{{ gislayer.serviceType|default }}"
                         init-url="{{ gislayer.url|default }}"
@@ -163,6 +164,7 @@
                         init-matrix-set="{{ gislayer.tileMatrixSet|default }}"
                         init-projection="{{ gislayer.projectionLabel|default }}"
                         init-version="{{ gislayer.layerVersion|default }}"
+                        procedure-id="{{ procedure }}"
                         :available-projections="JSON.parse('{{ templateVars.availableProjections|map(el => { label: el['label'], value: el['label'] })|json_encode|e('js', 'utf-8') }}')"
                         :show-xplan-default-layer="false"
                     ></layer-settings>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_new.html.twig
@@ -105,6 +105,7 @@
 
         {% block baseSettings %}
             <layer-settings
+                has-preview="true"
                 init-name="{{ templateVars.inData.r_name|default }}"
                 init-service-type="{{ templateVars.inData.r_serviceType|default }}"
                 init-url="{{ templateVars.inData.r_url|default }}"
@@ -113,6 +114,7 @@
                 xplan-default-layer="{{ mapglobals.xplanDefaultLayers|default }}"
                 init-matrix-set="{{ templateVars.inData.r_tileMatrixSet|default }}"
                 init-projection="{{ templateVars.inData.r_projection|default }}"
+                procedure-id="{{ procedure }}"
                 :available-projections="JSON.parse('{{ templateVars.availableProjections|map(el => { label: el['label'], value: el['label'] })|json_encode|e('js', 'utf-8') }}')"
             ></layer-settings>
         {% endblock baseSettings %}


### PR DESCRIPTION
### Ticket
[DPLAN-15829](https://demoseurope.youtrack.cloud/issue/DPLAN-15829/Ado-Issue-30419-Live-Vorschau-und-Layerwahl-beim-Einbinden-von-Planwerken-ermoglichen-um-die-Nutzerfreundlichkeit-zu-erhohen)

This PR adds a preview map for the external layer configuration for admins. The map takes the existing procedure settings and adds the currently selected layers from an external WMS/WMTS service. This makes it easier to decide which layers are needed.

### How to review/test
1. Login as admin, select a procedure, navigate to planning documents, navigate to map layers.
2. Either add a new layer or edit an existing one.
3. You should see a small preview map.
4. Change which layers are selected - the map should change.

I used [this WMS service](https://via.bund.de/bmf/inspire/so/wms?service=wms&request=getcapabilities) for testing. If you use a different service, please check in the network tab if it actually sends data and is not blocking you because of too many requests.
