### PR TITLE
fix(DPLAN-1880): Fix double-login requirement for newly authorized users

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
@@ -225,7 +226,7 @@ class OzgKeycloakUserDataMapper
             }
         }
         $this->entityManager->persist($existingOrga);
-        $this->entityManager->flush();
+        // Removed flush() call - let the main transaction handle persistence
 
         $this->logger->info(
             'Organisation updated',
@@ -369,7 +370,7 @@ class OzgKeycloakUserDataMapper
     {
         $orgaTypesNeeded = [];
         foreach ($requestedRoles as $requestedRole) {
-            foreach (OrgaType::ORGATYPE_ROLE as $orgaType => $type) {
+            foreach (OrgaTypeInterface::ORGATYPE_ROLE as $orgaType => $type) {
                 if (in_array($requestedRole->getCode(), $type, true)
                     && !in_array($orgaType, $orgaTypesNeeded, true)
                 ) {
@@ -542,7 +543,7 @@ class OzgKeycloakUserDataMapper
         $dplanUser->setProvidedByIdentityProvider(true);
 
         $this->entityManager->persist($dplanUser);
-        $this->entityManager->flush();
+        // Removed flush() call - let the main transaction handle persistence
 
         $this->logger->info(
             'Existing user was updated.',

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -54,34 +54,35 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
         $accessToken = $this->fetchAccessToken($client);
         $this->logger->info('login attempt', ['accessToken' => $accessToken ?? null]);
 
+        // Execute user creation immediately instead of deferring it
+        try {
+            $this->entityManager->getConnection()->beginTransaction();
+            $this->logger->info('Start of doctrine transaction.');
+            $this->logger->info('raw token', [$client->fetchUserFromToken($accessToken)->toArray()]);
+
+            $this->ozgKeycloakUserData->fill($client->fetchUserFromToken($accessToken));
+            $this->logger->info('Found user data: '.$this->ozgKeycloakUserData);
+            $user = $this->ozgKeycloakUserDataMapper->mapUserData($this->ozgKeycloakUserData);
+
+            $this->entityManager->getConnection()->commit();
+            $this->logger->info('doctrine transaction commit.');
+            $request->getSession()->set('userId', $user->getId());
+        } catch (Exception $e) {
+            $this->entityManager->getConnection()->rollBack();
+            $this->logger->info('doctrine transaction rollback.');
+            $this->logger->error(
+                'login failed',
+                [
+                    'requestValues' => $this->ozgKeycloakUserData ?? null,
+                    'exception'     => $e,
+                ]
+            );
+            throw new AuthenticationException('You shall not pass!');
+        }
+
         return new SelfValidatingPassport(
-            new UserBadge($accessToken->getToken(), function () use ($accessToken, $client, $request) {
-                try {
-                    $this->entityManager->getConnection()->beginTransaction();
-                    $this->logger->info('Start of doctrine transaction.');
-                    $this->logger->info('raw token', [$client->fetchUserFromToken($accessToken)->toArray()]);
-
-                    $this->ozgKeycloakUserData->fill($client->fetchUserFromToken($accessToken));
-                    $this->logger->info('Found user data: '.$this->ozgKeycloakUserData);
-                    $user = $this->ozgKeycloakUserDataMapper->mapUserData($this->ozgKeycloakUserData);
-
-                    $this->entityManager->getConnection()->commit();
-                    $this->logger->info('doctrine transaction commit.');
-                    $request->getSession()->set('userId', $user->getId());
-
-                    return $user;
-                } catch (Exception $e) {
-                    $this->entityManager->getConnection()->rollBack();
-                    $this->logger->info('doctrine transaction rollback.');
-                    $this->logger->error(
-                        'login failed',
-                        [
-                            'requestValues' => $this->ozgKeycloakUserData ?? null,
-                            'exception'     => $e,
-                        ]
-                    );
-                    throw new AuthenticationException('You shall not pass!');
-                }
+            new UserBadge($user->getUserIdentifier(), function () use ($user) {
+                return $user;
             })
         );
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -38,7 +38,7 @@ class OzgKeycloakAuthenticator extends OAuth2Authenticator implements Authentica
         private readonly OzgKeycloakUserData $ozgKeycloakUserData,
         private readonly LoggerInterface $logger,
         private readonly OzgKeycloakUserDataMapper $ozgKeycloakUserDataMapper,
-        private readonly RouterInterface $router
+        private readonly RouterInterface $router,
     ) {
     }
 


### PR DESCRIPTION
## Summary
- Fixes issue where newly authorized users needed to click login twice
- Moves user creation logic out of deferred UserBadge closure to execute synchronously
- Removes intermediate flush() calls to ensure atomic user+role assignment

## Root Cause Analysis
The problem was a race condition in the authentication flow where:
1. User creation happened inside a deferred UserBadge closure
2. Authentication validation occurred before user+role assignment was complete
3. First login failed because user existed without roles
4. Second login succeeded because roles were assigned by then

## Technical Changes
1. **OzgKeycloakAuthenticator**: Move user creation logic outside UserBadge closure for synchronous execution
2. **OzgKeycloakUserDataMapper**: Remove intermediate flush() calls to ensure atomic persistence

## References
- **YouTrack**: DPLAN-1880