### PR TITLE
fix(refs: DPLAN-16164): change statement button style

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_actionbox.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_actionbox.scss
@@ -94,7 +94,7 @@
     // Title + main action
     &__title,
     &__title--button {
-        color: $actionbox-color-contrast !important;
+        color: $actionbox-color-contrast;
 
         font-family: $normal-font-family;
         font-weight: $normal-font-weight;
@@ -121,10 +121,8 @@
 
         text-align: center;
 
-        &,
         &:hover {
-            color: $actionbox-color-inactive !important;
-
+            color: $actionbox-color-inactive;
             text-decoration: none;
         }
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/includes/actionbox.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/includes/actionbox.html.twig
@@ -17,7 +17,7 @@
                 id="statementModalButton"
             {% endif %}
             @click.stop.prevent="toggleStatementModal({})"
-            class="{{ 'c-actionbox__title--button is-active font-size-h1 u-mb-0_5 has-i'|prefixClass }} {{ context == 'statements' ? 'u-nojs-hide--block'|prefixClass : '' }}"
+            class="{{ 'c-actionbox__title--button is-active text-h4 mb-0.5 has-i'|prefixClass }} {{ context == 'statements' ? 'u-nojs-hide--block'|prefixClass : '' }}"
             data-cy="statementModal"
             aria-controls="statementModal"
             aria-describedby="statementActionDescription{{ context|capitalize }}"

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -87,7 +87,7 @@
                                 href="#publicStatementForm"
                                 id="statementModalButton"
                                 @click.stop.prevent="toggleStatementModal({})"
-                                class="{{ 'c-actionbox__title c-actionbox__title--button u-mb-0_5 is-active'|prefixClass }}"
+                                class="{{ 'c-actionbox__title c-actionbox__title--button text-h4 mb-0.5 is-active'|prefixClass }}"
                                 data-cy="publicStatementButton"
                                 aria-controls="statementModal"
                                 aria-describedby="statementActionDescriptionMap"
@@ -114,7 +114,7 @@
 
                             <button
                                 type="button"
-                                class="{{ 'c-actionbox__title c-actionbox__title--button o-spinner is-active u-mb-0_5 js__statementForm'|prefixClass }}"
+                                class="{{ 'c-actionbox__title c-actionbox__title--button text-h4 o-spinner is-active mb-0.5 js__statementForm'|prefixClass }}"
                                 data-statement-action="activateQueryAreaButton"
                                 id="queryAreaButton">
                                 {{  "statement.map.choose_priority_area"|trans }}
@@ -190,7 +190,7 @@
 
                                 <button
                                     type="button"
-                                    class="{{ 'c-actionbox__title--button u-mt-0_5 hidden'|prefixClass }}"
+                                    class="{{ 'c-actionbox__title--button text-h4 mt-0.5 hidden'|prefixClass }}"
                                     id="saveStatementButton"
                                     title="{{ "statement.map.draw.no_drawing_warning"|trans }}">
                                     {{ "statement.map.draw_to_map"|trans }}
@@ -204,7 +204,7 @@
                                 <button
                                     type="button"
                                     data-maptools-id="markLocationButtonResponsive"
-                                    class="{{ 'c-actionbox__title c-actionbox__title--button is-active'|prefixClass }}">
+                                    class="{{ 'c-actionbox__title c-actionbox__title--button text-h4 is-active'|prefixClass }}">
                                     {{ "statement.map.draw.mark_place"|trans }}
                                 </button>
 
@@ -225,7 +225,7 @@
                                 <button
                                     type="button"
                                     id="markLocationButton"
-                                    class="{{ 'c-actionbox__title c-actionbox__title--button o-spinner u-mb-0_5 is-active'|prefixClass }}">
+                                    class="{{ 'c-actionbox__title c-actionbox__title--button text-h4 o-spinner mb-0.5 is-active'|prefixClass }}">
                                     {{ "statement.map.draw.mark_place"|trans }}
                                 </button>
 


### PR DESCRIPTION
### Ticket
[DPLAN-16164](https://demoseurope.youtrack.cloud/issue/DPLAN-16164/Reden-Sie-mit-Button-ist-riesig-auf-der-Planungsdokumenten-Seite-und-der-Button-Text-ist-zu-leicht-grau)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The text in the statement button in the actionbox was to large and also the text color kept staying at the hover text color. This PR fixes the font size, the color and brings back the hover effect. 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open a procedure with documents and statements the public detail view
2. Change to documents tab and check if the text of the statement button is in a normal size and the hover effect works
3. Check the same in the statements tab 


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
