### PR TITLE
fix (refs: DPLAN-16094): remove click listener

### DIFF
--- a/client/js/lib/core/libs/touchFriendlyUserbox.js
+++ b/client/js/lib/core/libs/touchFriendlyUserbox.js
@@ -67,8 +67,6 @@ function initUserbox () {
   if (flyouts.length > 0) {
     flyouts.forEach(flyout => {
       flyout.addEventListener('touchstart', toggleFlyout, { passive: false })
-      // Also add click handler as fallback for some touch devices
-      flyout.addEventListener('click', toggleFlyout)
     })
 
     // Use click instead of touchstart for body to prevent race condition


### PR DESCRIPTION
### Ticket
[DPLAN-16094](https://demoseurope.youtrack.cloud/issue/DPLAN-16094/Mobilansicht-Stellungnahmen-zum-Verfahren-Link-funktioniert-nicht)
This PR removes the click fallback that was causing the flyout to close immediately. Most of the ticket was already addressed in the linked PR.
### How to review/test
1. log in as private person, click on a procedure and enter mobile view.
2. click on 'stellungnahmen zum verfahren' and see if the flyout opens.
3. click outside the flyout and see if it closes.

### Linked PRs (optional)
#4937 

