### PR TITLE
Fix DPLAN-16144  initialize $key property before accessing

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -600,8 +600,8 @@ class Procedure extends SluggedEntity implements ProcedureInterface
         $this->notificationReceivers = new ArrayCollection();
         $this->exportFieldsConfigurations = new ArrayCollection();
         $this->segmentPlaces = new ArrayCollection();
-        $this->phase = new ProcedurePhase();
-        $this->publicParticipationPhase = new ProcedurePhase();
+        $this->phase = new ProcedurePhase('configuration', '');
+        $this->publicParticipationPhase = new ProcedurePhase('configuration', '');
         $this->customFieldConfiguration = null;
     }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -52,7 +52,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
     /**
      * @ORM\Column(name="phase_key", type="string", nullable=false)
      */
-    protected string $key;
+    protected string $key = 'configuration';
 
     /**
      * Virtual Property bound on phase configuration in procedurephases.yml.
@@ -124,7 +124,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
     #[Assert\Positive]
     protected int $iteration = 1;
 
-    public function __construct(string $key = 'configuration', string $step = '')
+    public function __construct(string $key, string $step)
     {
         $this->key = $key;
         $this->step = $step;

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -272,9 +272,9 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
             $procedure->setXtaPlanId($data['xtaPlanId'] ?? '');
             $procedure->setElements(new ArrayCollection());
 
-            $procedure->setPhaseObject(new ProcedurePhase());
+            $procedure->setPhaseObject(new ProcedurePhase('configuration', ''));
             $procedure->getPhaseObject()->copyValuesFromPhase($procedureMaster->getPhaseObject());
-            $procedure->setPublicParticipationPhaseObject(new ProcedurePhase());
+            $procedure->setPublicParticipationPhaseObject(new ProcedurePhase('configuration', ''));
             $procedure->getPublicParticipationPhaseObject()->copyValuesFromPhase(
                 $procedureMaster->getPublicParticipationPhaseObject()
             );


### PR DESCRIPTION
### Ticket
Description: 
initialize $key property before accessing

  - Add default value 'configuration' to $key property to prevent uninitialized access
  - Remove default parameters from constructor to make key and step required
  - Resolves "Typed property must not be accessed before initialization" error

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

