### PR TITLE
f(refs DPLAN-15570): adjust dateFilter() function in DateExtension.ph…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Twig/Extension/DateExtension.php
+++ b/demosplan/DemosPlanCoreBundle/Twig/Extension/DateExtension.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Twig\Extension;
 
 use Carbon\Carbon;
 use DateTime;
+use DateTimeZone;
 use Exception;
 use Twig\TwigFilter;
 
@@ -51,7 +52,11 @@ class DateExtension extends ExtensionBase
 
         try {
             if (is_numeric($timestamp)) {
-                $dateResult = date($format, $timestamp);
+                $datetime = new DateTime();
+                $datetime->setTimestamp($timestamp);
+                $userTimezone = new DateTimeZone('Europe/Berlin');
+                $datetime->setTimezone($userTimezone);
+                $dateResult = $datetime->format($format);
             }
         } catch (Exception) {
         }


### PR DESCRIPTION
…p to reflect Berlin/ Europe timezone

### Ticket
[DPLAN-15570](https://demoseurope.youtrack.cloud/issue/DPLAN-15570) STN-Import Erstellungsdatum Uhrzeit ist falsch

Description; 
Adjusted timezone in DateExtension.php to reflect eurpoean timezone. 

### How to review/test
see ticket for instructions


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
