### PR TITLE
f(refs DPLAN-1620): adjust translation keys public.participation.feed…

### DIFF
--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2907,7 +2907,7 @@ public.participation.panel.institution.description_1: "Institutionen benötigen 
 public.participation.panel.institution.description_2: "<a class=\"{css}\" href=\"{url}\">Jetzt registrieren.</a>"
 public.participation.participate: "Stellung nehmen"
 public.participation.publication: "Veröffentlichung von Stellungnahmen von Bürger*innen in diesem Verfahren erlauben"
-public.participation.feedback: 'Die Checkbox "Ich möchte informiert werden, wenn die Auswertung der Stellungnahme online verfügbar ist" für die Bürger*innen hinzufügen.'
+public.participation.feedback: 'Die Checkbox "Ich möchte eine Rückmeldung zu meiner Stellungnahme erhalten" für die Bürger*innen hinzufügen.'
 public.participation.receive_notifications: "Expert*innen prüfen Ihre Stellungnahme. Lassen Sie sich über das Ergebnis informieren!"
 public.participation.relation: "Ortsbezug"
 public.participation.relation.map: "Ortsbezug in der Karte"


### PR DESCRIPTION
…back and statement.detail.form.personal.require_information_mail

### Ticket
[DPLAN-16209](https://demoseurope.youtrack.cloud/issue/DPLAN-16209) Rückmeldung zur Stellungnahme - falscher Text


Description:
Adjusted translation keys so that the correct text "Ich möchte eine Rückmeldung zu meiner Stellungnahme erhalten" is being displayed as an option for the admin and user during statement creation process. 

### How to review/test
Log in as admin --> verfahren --> Grundeinstellungen --> Verfahrensschritt Öffentlichkeit --> click on Die Checkbox "Ich möchte informiert werden, wenn die Auswertung der Stellungnahme online verfügbar ist" für die Bürger*innen hinzufügen. 

Log out, check as a guest if this feature is now available during the statement creation process. 

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
