### PR TITLE
fix (refs: DPLAN-16082): add padding to mobile view

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_map.scss
@@ -179,6 +179,7 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
 
             @include media-query('palm') {
                 height: 80vh;
+                padding-left: 24px;
             }
 
             z-index: 0;
@@ -541,6 +542,10 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
             min-width: 200px;
             background-color: $dp-color-white;
             width: auto !important;
+
+            @include media-query('palm') {
+                left: 72px;
+            }
         }
 
         //  Custom zoom controls
@@ -874,6 +879,10 @@ $map-layer-color-active-hover: $dp-token-color-brand-cta-dark;
     .c-map .ol-zoom {
         left: $inuit-base-spacing-unit--small;
         top: $inuit-base-spacing-unit--small;
+
+        @include media-query('palm') {
+            left: 36px;
+        }
     }
 
     .c-map .ol-viewport {

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_tabs.scss
@@ -105,7 +105,6 @@
             height: 0;
             overflow: hidden;
             visibility: hidden;
-            padding: 0;
         }
 
         &.is-active-tab {


### PR DESCRIPTION
### Ticket
[DPLAN-16082](https://demoseurope.youtrack.cloud/issue/DPLAN-16082/Keine-Padding-auf-rechter-linker-Seite-beim-Beteiligung-in-Offentlichkeitsansicht)

This PR changes some SCSS to add a bit of padding and an area for scrolling to the mobile view of the public detail section.

### How to review/test
Select a procedure and check out the mobile view, either logged out or as a private person.