### PR TITLE
fix (refs: DPLAN-16194): remove white color importance

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_flyout.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_flyout.scss
@@ -139,7 +139,7 @@
         }
 
         h3 {
-            color: $dp-color-white !important;
+            color: $dp-color-white;
         }
     }
 


### PR DESCRIPTION
### Ticket
[DPLAN-16194](https://demoseurope.youtrack.cloud/issue/DPLAN-16194)

This PR removes the `!important` flag form the white color for flyout h3 elements, so that they are visible again. This was necessary because of the changed behavior of `!important` after the Tailwind 4 update.

### How to review/test
Log in as private person, select a procedure and check the STN flyout.

