### PR TITLE
fix(refs: DPLAN-16168): change style for disabled flyout options

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_button.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_button.scss
@@ -417,6 +417,7 @@
 // links shouldn't have any pointer events if they are 'disabled'
 a.is-disabled {
     pointer-events: none !important;
+    @extend %disabled-opacity;
 }
 
 


### PR DESCRIPTION
### Ticket
[DPLAN-16168](https://demoseurope.youtrack.cloud/issue/DPLAN-16168/Originalstellungnahme-Option-ist-nicht-ausgegraut-in-der-Menu-wenn-man-keine-STNs-als-Anhang-hat)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

In statement list dialog in the flyout for every statement, the option to show the original statement pdf did not change the color, even if it was disabled because no pdf was available. With this PR the style is changed to show the option in the same disabled color like it is for other options. 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Open diplanrog and as admin and koordination role and open a procedure with statements
2. navigate to the statement list and click on the three dots (...) next to a statement without an attached document
3. check if the original pdf option has the same disabled color like other disabled options in the same flyout

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly 
