### PR TITLE
Fix DPLAN-16144 Fix PHP 7.4+ typed property initialization issues

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -178,6 +178,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         if (!isset($this->startDate)) {
             $this->startDate = new DateTime();
         }
+
         return $this->startDate;
     }
 
@@ -191,6 +192,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         if (!isset($this->endDate)) {
             $this->endDate = new DateTime();
         }
+
         return $this->endDate;
     }
 
@@ -204,6 +206,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         if (!isset($this->creationDate)) {
             $this->creationDate = new DateTime();
         }
+
         return $this->creationDate;
     }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -175,6 +175,9 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
 
     public function getStartDate(): DateTime
     {
+        if (!isset($this->startDate)) {
+            $this->startDate = new DateTime();
+        }
         return $this->startDate;
     }
 
@@ -185,6 +188,9 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
 
     public function getEndDate(): DateTime
     {
+        if (!isset($this->endDate)) {
+            $this->endDate = new DateTime();
+        }
         return $this->endDate;
     }
 
@@ -195,6 +201,9 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
 
     public function getCreationDate(): DateTime
     {
+        if (!isset($this->creationDate)) {
+            $this->creationDate = new DateTime();
+        }
         return $this->creationDate;
     }
 


### PR DESCRIPTION
Ticket

Description:  
PHP 7.4 introduced typed properties, and with them came the requirement that typed properties must be initialized before being accessed.
Initialize DateTime properties with lazy initialization in getters using isset() checks

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

