### PR TITLE
Fix DPLAN-16144 Change direct property access to use getters in copyValuesFromPhase

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -274,8 +274,8 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         $this->designatedSwitchDate = $sourcePhase->designatedSwitchDate;
         $this->designatedPhase = $sourcePhase->designatedPhase;
         $this->permissionSet = $sourcePhase->permissionSet;
-        $this->startDate = $sourcePhase->startDate;
-        $this->endDate = $sourcePhase->endDate;
+        $this->startDate = $sourcePhase->getStartDate();
+        $this->endDate = $sourcePhase->getEndDate();
     }
 
     public function getIteration(): int

--- a/tests/backend/core/Document/Functional/ElementsServiceTest.php
+++ b/tests/backend/core/Document/Functional/ElementsServiceTest.php
@@ -761,7 +761,7 @@ class ElementsServiceTest extends FunctionalTestCase
             'title'             => 'my updated element',
             'text'              => 'a updated unique and nice text',
         ]);
-        $updatedElement = $this->find(Elements::class, $updatedElement['ident']);
+        $updatedElement = $this->find(Elements::class, $updatedElement['id']);
 
         $relatedReports = $this->getEntries(ReportEntry::class,
             [


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16144/Nicht-moglich-um-Verfahren-zu-hinzufugen

Description: 
Problem: Direct property access ($sourcePhase->startDate) on Doctrine-hydrated objects that bypass the constructor, leaving typed properties uninitialized.

Solution: Changed to use getters ($sourcePhase->getStartDate()) which have the isset() safety checks to initialize properties if needed.

a little bit more explanation why this has to be fixed : 
 Why this matters with PHP typed properties:

  1. With default values: PHP considers the property "initialized" because it has a default value assigned at declaration time. Direct access works fine.
  2. Without default values: PHP considers these "uninitialized" until explicitly assigned. Accessing them before assignment throws the "Typed property must not be accessed before  initialization" error.
  3. Doctrine hydration: When Doctrine loads objects from the database, it uses reflection to set property values directly, bypassing the constructor. If a property doesn't have a  default value AND Doctrine doesn't set it (e.g., NULL in database), the property remains uninitialized.

  Additional factor - Nullable types:

  Notice that designatedPhase, designatedSwitchDate, and designatedEndDate are nullable (?DateTime, ?string). Even without explicit default values, nullable typed properties can be  accessed because PHP treats them as implicitly having a null default.

properties with default values (or nullable types) work fine with direct access, while non-nullable properties without defaults require initialization  before access - which is why the getters with isset() checks are needed.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
