### PR TITLE
fix(refs: DPLAN-15898): add search reset on organisation and institution list

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/ClientSideTagFilter.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/ClientSideTagFilter.vue
@@ -106,6 +106,12 @@ export default {
       required: true
     },
 
+    searchApplied: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
     rawItems: {
       type: Array,
       required: true
@@ -141,7 +147,7 @@ export default {
     }),
 
     isQueryApplied () {
-      return Object.keys(this.appliedFilterQuery).length > 0
+      return Object.keys(this.appliedFilterQuery).length > 0 || this.searchApplied
     },
 
     filterCategoriesToBeDisplayed () {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/ClientSideTagFilter.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/ClientSideTagFilter.vue
@@ -106,16 +106,16 @@ export default {
       required: true
     },
 
+    rawItems: {
+      type: Array,
+      required: true
+    },
+
     searchApplied: {
       type: Boolean,
       required: false,
       default: false
     },
-
-    rawItems: {
-      type: Array,
-      required: true
-    }
   },
 
   emits: [
@@ -138,17 +138,13 @@ export default {
       filterQuery: 'getFilterQuery'
     }),
 
-    ...mapState('InstitutionTagCategory', {
-      institutionTagCategories: 'items'
-    }),
-
     ...mapState('InstitutionTag', {
       institutionTagItems: 'items'
     }),
 
-    isQueryApplied () {
-      return Object.keys(this.appliedFilterQuery).length > 0 || this.searchApplied
-    },
+    ...mapState('InstitutionTagCategory', {
+      institutionTagCategories: 'items'
+    }),
 
     filterCategoriesToBeDisplayed () {
       return (this.filterCategories || [])
@@ -156,8 +152,8 @@ export default {
           this.currentlySelectedFilterCategories.includes(filter.label))
     },
 
-    selectedFilterCategories () {
-      return this.currentlySelectedFilterCategories
+    isQueryApplied () {
+      return Object.keys(this.appliedFilterQuery).length > 0 || this.searchApplied
     },
 
     queryIds () {
@@ -167,7 +163,11 @@ export default {
       return Object.values(this.appliedFilterQuery)
         .filter(el => el && el.condition && el.condition.value)
         .map(el => el.condition.value)
-    }
+    },
+
+    selectedFilterCategories () {
+      return this.currentlySelectedFilterCategories
+    },
   },
 
   watch: {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -32,8 +32,8 @@
         <client-side-tag-filter
           v-if="hasPermission('feature_institution_tag_read')"
           :filter-categories="allFilterCategories"
-          :search-applied="isSearchApplied"
           :raw-items="institutionList"
+          :search-applied="isSearchApplied"
           @items-filtered="filteredItems = $event"
           @reset="resetSearch" />
       </div>
@@ -482,10 +482,6 @@ export default {
         .map(el => el.name)
     },
 
-    resetSearch () {
-      this.$refs.searchField.handleReset()
-    },
-
     handleReset () {
       this.searchTerm = ''
       this.getInstitutionsByPage(1)
@@ -498,6 +494,10 @@ export default {
         .then(() => {
           this.isLoading = false
         })
+    },
+
+    resetSearch () {
+      this.$refs.searchField.handleReset()
     },
 
     separateByCommas (institutionTags) {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -32,9 +32,10 @@
         <client-side-tag-filter
           v-if="hasPermission('feature_institution_tag_read')"
           :filter-categories="allFilterCategories"
+          :search-applied="isSearchApplied"
           :raw-items="institutionList"
           @items-filtered="filteredItems = $event"
-          @reset="handleFilterReset" />
+          @reset="resetSearch" />
       </div>
 
       <div class="flex justify-end mt-4">
@@ -274,6 +275,10 @@ export default {
         .sort((a, b) => new Date(a.attributes.creationDate) - new Date(b.attributes.creationDate))
     },
 
+    isSearchApplied () {
+      return this.searchTerm !== ''
+    },
+
     selectableColumns () {
       return this.categoryFieldsAvailable.map(headerField => ([headerField.field, headerField.label]))
     },
@@ -477,7 +482,7 @@ export default {
         .map(el => el.name)
     },
 
-    resetSearch() {
+    resetSearch () {
       this.$refs.searchField.handleReset()
     },
 
@@ -487,7 +492,6 @@ export default {
     },
 
     handleSearch (searchTerm) {
-      this.isLoading = true
       this.searchTerm = searchTerm
 
       this.getInstitutionsByPage(1)

--- a/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
@@ -29,9 +29,10 @@ All rights reserved
         <client-side-tag-filter
           v-if="hasPermission('feature_institution_tag_read')"
           :filter-categories="allFilterCategories"
+          :search-applied="isSearchApplied"
           :raw-items="rowItems"
           @items-filtered="filteredItems = $event"
-          @reset="handleFilterReset" />
+          @reset="resetSearch" />
 
         <!-- Slot for bulk actions -->
       </div>
@@ -264,6 +265,10 @@ export default {
       return this.pagination.currentPage || 1
     },
 
+    isSearchApplied () {
+      return this.searchTerm !== ''
+    },
+
     itemsPerPage () {
       return this.pagination.perPage || this.defaultPagination.perPage
     },
@@ -467,7 +472,7 @@ export default {
       return this.institutionLocationContactItems[id]
     },
 
-    resetSearch() {
+    resetSearch () {
       this.$refs.searchField.handleReset()
     },
 

--- a/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
@@ -29,8 +29,8 @@ All rights reserved
         <client-side-tag-filter
           v-if="hasPermission('feature_institution_tag_read')"
           :filter-categories="allFilterCategories"
-          :search-applied="isSearchApplied"
           :raw-items="rowItems"
+          :search-applied="isSearchApplied"
           @items-filtered="filteredItems = $event"
           @reset="resetSearch" />
 
@@ -472,10 +472,6 @@ export default {
       return this.institutionLocationContactItems[id]
     },
 
-    resetSearch () {
-      this.$refs.searchField.handleReset()
-    },
-
     handleReset () {
       this.searchTerm = ''
       this.getInstitutionsWithContacts(1)
@@ -514,6 +510,10 @@ export default {
     resetQuery () {
       this.searchTerm = ''
       this.filterManager.reset()
+    },
+
+    resetSearch () {
+      this.$refs.searchField.handleReset()
     },
 
     returnPermissionChecksValuesArray (permissionChecks) {


### PR DESCRIPTION
### Ticket
[DPLAN-15898](https://demoseurope.youtrack.cloud/issue/DPLAN-15898/Das-Institutionen-verwalten-zurucksetzen-Button-setzt-die-Suche-nicht-zuruck-und-der-Button-bleibt-ausgegraut)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The button "Zurücksetzten" in the should set back not only the filters but also the applied search. This PR activates the button after a search was applied and sets it back when the button is clicked.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login to diplanbau as a user with fp-admin role and choose a procedure with added institutions or add some by your own
2. Switch to "Institutionen verwalten" and type something into the searchfield
3. The search text should be deletable through the x button at the searchfield and the "Zurücksetzen" button is inactive
4. Apply a search -> The search results are visible in the Table and the "Zurücksetzen" button is active
5. Click the "Zurücksetzen" button -> The initial values are shown in the table and the searchfield is cleared
6. Check this behavior also in combination with applied filters.
7. Check everything also as the mandanten-admin role in "Institutionen verschlagworten" 

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

