### PR TITLE
fix DPLAN_16231 Show all map layer legends regardless of initial visibility 

### DIFF
--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -411,17 +411,17 @@ const LayersStore = {
 
         // Add each layer to GetLegendGraphic request
         layerParamSplit.forEach(item => {
-          if (layer.attributes.isEnabled) {
-            const legendUrl = legendUrlBase + 'Layer=' + item + '&Request=GetLegendGraphic&Format=image/png&version=1.1.1'
-            const legend = {
-              layerId: layer.id,
-              treeOrder: layer.attributes.treeOrder,
-              mapOrder: layer.attributes.mapOrder,
-              defaultVisibility: layer.attributes.hasDefaultVisibility,
-              url: legendUrl
-            }
-            commit('setLegend', legend)
+          // Always create legends for all layers, regardless of isEnabled status
+          const legendUrl = legendUrlBase + 'Layer=' + item + '&Request=GetLegendGraphic&Format=image/png&version=1.1.1'
+          const legend = {
+            layerId: layer.id,
+            treeOrder: layer.attributes.treeOrder,
+            mapOrder: layer.attributes.mapOrder,
+            defaultVisibility: layer.attributes.hasDefaultVisibility,
+            url: legendUrl
           }
+          commit('setLegend', legend)
+        }
         })
       }
     },

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -272,25 +272,23 @@
         {% set filtered_legends = all_layers|filter(layer => '//' in layer.url and (layer.legend|default|getFile('size')|length > 0 or layer.legend|default|getFile('mimeType')|length > 0)) %}
         {% set layers_with_legend_files = [] %}
         {% for layer in filtered_legends %}
-            {% if layer.defaultVisibility == true %}
-                {# Transform object to be consumable by vue component #}
-                {% set layers_with_legend_files = layers_with_legend_files|merge([{
-                    name: layer.name,
-                    legend: {
-                        hash: layer.legend|getFile('hash'),
-                        mimeType: layer.legend|getFile('mimeType'),
-                        fileSize: layer.legend|getFile('size')
-                    }
-                }]) %}
-            {%  endif %}
+            {# Include all layers with legend files, regardless of defaultVisibility #}
+            {% set layers_with_legend_files = layers_with_legend_files|merge([{
+                name: layer.name,
+                legend: {
+                    hash: layer.legend|getFile('hash'),
+                    mimeType: layer.legend|getFile('mimeType'),
+                    fileSize: layer.legend|getFile('size')
+                }
+            }]) %}
         {% endfor %}
         {% if false == display_legend_box %}
             {% set display_legend_box = layers_with_legend_files|length > 0 %}
         {% endif %}
 
-        {# When fetching legends dynamically via getLegendGraphic, we need to display the box anyhow, as we cannot know, whether we have legends or not #}
+        {# Always show legend box if any layers exist or if getLegendGraphic is available #}
         {% if false == display_legend_box %}
-            {% set display_legend_box = hasPermission('feature_participation_area_procedure_detail_map_use_get_legend_graphic') %}
+            {% set display_legend_box = hasPermission('feature_participation_area_procedure_detail_map_use_get_legend_graphic') or all_layers|length > 0 %}
         {% endif %}
 
         {# Statement tools #}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16231/ADO-37550-Stage-DiPlanBeteiligungBau-Legenden-werden-nicht-falsch-angezeigt

Description: Show all map layer legends regardless of initial visibility :
The 3 changes to fix the legend issue have been applied :

1. WMS legends for all layers

client/js/store/map/Layers.js:414
- Removed: if (layer.attributes.isEnabled) check
- Added: Comment "Always create legends for all layers, regardless of isEnabled status"

2. PDF legends for all layers

templates/.../map_public_participation_detail.html.twig:275
- Removed: {% if layer.defaultVisibility == true %} check
- Added: Comment "Include all layers with legend files, regardless of defaultVisibility"

3. Always show legend tab

templates/.../map_public_participation_detail.html.twig:291
- Enhanced: display_legend_box = ... or all_layers|length > 0
- Improved: Comment about display behavior

Result:

- ✅ All legends are displayed regardless of their initial visibility status
- ✅ The "Legends" tab is always available when map layers are configured
- ✅ PDF legends are loaded for all layers with legend files
- ✅ WMS legends are generated for all configured layers


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

