### PR TITLE
fix(refs dplan-16236): Use Vue comps for email and phase number in procedure settings

### DIFF
--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -3,7 +3,6 @@
     <div class="flex gap-2">
       <dp-select
         v-model="selectedPhase"
-        class="w-8/12"
         :data-cy="`${dataCy}:select`"
         :label="{
           text: labelText,
@@ -11,8 +10,10 @@
         }"
         :name="fieldName"
         :options="phaseOptions"
+        class="w-8/12"
         required
-        @select="$emit('phase:select', $event)" />
+        @select="$emit('phase:select', $event)"
+      />
 
       <dp-input
         v-if="hasPermission('field_phase_iterator')"
@@ -26,14 +27,15 @@
         :name="iterator.name"
         pattern="^[1-9][0-9]*$"
         required
-        :value="iterator.value"
-        width="w-4/12" />
+        width="w-4/12"
+       />
     </div>
 
     <dp-inline-notification
-      class="mt-3 mb-2"
       :message="permissionMessageText"
-      type="warning" />
+      class="mt-3 mb-2"
+      type="warning"
+    />
 
     <div
       v-if="hasPermission('feature_auto_switch_to_procedure_end_phase') && !hasPermission('feature_auto_switch_procedure_phase') && isInParticipation"

--- a/client/js/components/procedure/basicSettings/ParticipationPhases.vue
+++ b/client/js/components/procedure/basicSettings/ParticipationPhases.vue
@@ -22,6 +22,7 @@
           text: iterator.label,
           tooltip: iterator.tooltip
         }"
+        :model-value="iterator.value"
         :name="iterator.name"
         pattern="^[1-9][0-9]*$"
         required

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -200,15 +200,15 @@
                                     showPlainHint: true
                                 } %}
                                 {{ form_errors(form.agencyMainEmailAddress) }}
-                                <input
+                                <dp-input
                                     id="{{ form.agencyMainEmailAddress.vars.id }}"
-                                    class="o-form__control-input w-full"
                                     data-cy="agencyMainEmailAddress"
                                     data-dp-validate-error-fieldname="{{ 'email.procedure.agency'|trans }}"
                                     name="agencyMainEmailAddress[fullAddress]"
                                     required
                                     type="email"
-                                    value="{{ form.agencyMainEmailAddress.vars.value.fullAddress }}">
+                                    model-value="{{ form.agencyMainEmailAddress.vars.value.fullAddress }}">
+                                </dp-input>
                             </div>
 
                             <div class="u-mb">
@@ -745,57 +745,25 @@
                                             permissionset: phase.permissionset,
                                         }]) %}
                                     {% endfor %}
-                                    
-                                    <div class="flex gap-2">
-                                        <div class="w-8/12">
-                                            <label for="r_phase">{{ "procedure.phase.institutions"|trans }}</label>
-                                            {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                helpText: 'text.procedure.edit.internal.change_phase'|trans,
-                                                cssClasses:'mb-1',
-                                                showPlainHint: true
-                                            } %}
-                                            <select class="o-form__control-select w-full" name="r_phase" id="r_phase" required>
-                                                {% for phase in templateVars.internalPhases %}
-                                                    <option value="{{ phase.key }}" {% if phase.key == proceduresettings.phase %}selected{% endif %}>
-                                                        {{ phase.name }}
-                                                    </option>
-                                                {% endfor %}
-                                            </select>
-                                        </div>
-                                        
-                                        {% if hasPermission('field_phase_iterator') %}
-                                            <div class="w-4/12">
-                                                <label for="r_phase_iteration">{{ 'procedure.phase.phasecounter'|trans }}</label>
-                                                {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                    helpText: 'text.procedure.phasecounter'|trans,
-                                                    cssClasses:'mb-1',
-                                                    showPlainHint: true
-                                                } %}
-                                                <input 
-                                                    class="o-form__control-input w-full" 
-                                                    type="number" 
-                                                    name="r_phase_iteration" 
-                                                    id="r_phase_iteration"
-                                                    pattern="^[1-9][0-9]*$"
-                                                    value="{{ proceduresettings.phaseObject.iteration }}"
-                                                    required>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                    
-                                    <div class="mt-3 mb-2 flash flash-warning">
-                                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                                        {{ 'explanation.procedure.internal.permissions'|trans }} 
-                                        {% set currentPhase = null %}
-                                        {% for phase in templateVars.internalPhases %}
-                                            {% if phase.key == proceduresettings.phase %}
-                                                {% set currentPhase = phase %}
-                                            {% endif %}
-                                        {% endfor %}
-                                        {% if currentPhase %}
-                                            {{ ('permissionset.' ~ currentPhase.permissionset)|trans }}
-                                        {% endif %}
-                                    </div>
+
+                                    <participation-phases
+                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: evaluatingPhase|trans|default('') }) }}"
+                                        data-cy="internalPhase"
+                                        field-name="r_phase"
+                                        help-text="{{ 'text.procedure.edit.internal.change_phase'|trans }}"
+                                        label-text="{{ "procedure.phase.institutions"|trans }}"
+                                        :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
+                                        permission-message="{{ 'explanation.procedure.internal.permissions'|trans }}"
+                                        :phase-options="JSON.parse('{{ internalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
+                                        init-selected-phase="{{ proceduresettings.phase }}"
+                                        :iterator="{
+                                            label: Translator.trans('procedure.phase.phasecounter'),
+                                            name: 'r_phase_iteration',
+                                            tooltip: Translator.trans('text.procedure.phasecounter'),
+                                            value: '{{ proceduresettings.phaseObject.iteration }}'
+                                            }"
+                                        @phase:select="setSelectedInternalPhase">
+                                    </participation-phases>
                                 {% endif %}
 
                                 {% if hasPermission('feature_procedure_legal_notice_read') %}
@@ -927,63 +895,25 @@
                                             permissionset: phase.permissionset,
                                         }]) %}
                                     {% endfor %}
-                                    
-                                    <div class="flex gap-2">
-                                        <div class="w-8/12">
-                                            <label for="r_publicParticipationPhase">{{ "procedure.public.phase"|trans }}</label>
-                                            {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                helpText: 'text.procedure.edit.external.change_phase'|trans,
-                                                cssClasses:'mb-1',
-                                                showPlainHint: true
-                                            } %}
-                                            <select class="o-form__control-select w-full" name="r_publicParticipationPhase" id="r_publicParticipationPhase" required>
-                                                {% for phase in templateVars.externalPhases %}
-                                                    <option value="{{ phase.key }}" {% if phase.key == proceduresettings.publicParticipationPhase %}selected{% endif %}>
-                                                        {{ phase.name }}
-                                                    </option>
-                                                {% endfor %}
-                                            </select>
-                                        </div>
-                                        
-                                        {% if hasPermission('field_phase_iterator') %}
-                                            <div class="w-4/12">
-                                                <label for="r_public_participation_phase_iteration">{{ 'procedure.phase.phasecounter'|trans }}</label>
-                                                {% include '@DemosPlanCore/Extension/contextual_help.html.twig' with {
-                                                    helpText: 'text.procedure.phasecounter'|trans,
-                                                    cssClasses:'mb-1',
-                                                    showPlainHint: true
-                                                } %}
-                                                <input 
-                                                    class="o-form__control-input w-full" 
-                                                    type="number" 
-                                                    name="r_public_participation_phase_iteration" 
-                                                    id="r_public_participation_phase_iteration"
-                                                    pattern="^[1-9][0-9]*$"
-                                                    value="{{ proceduresettings.publicParticipationPhaseObject.iteration }}"
-                                                    required>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                    
-                                    <div class="mt-3 mb-2 flash flash-warning">
-                                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                                        {{ 'explanation.procedure.external.permissions'|trans }} 
-                                        {% set currentPhase = null %}
-                                        {% for phase in templateVars.externalPhases %}
-                                            {% if phase.key == proceduresettings.publicParticipationPhase %}
-                                                {% set currentPhase = phase %}
-                                            {% endif %}
-                                        {% endfor %}
-                                        {% if currentPhase %}
-                                            {{ ('permissionset.' ~ currentPhase.permissionset)|trans }}
-                                        {% endif %}
-                                    </div>
-                                    
-                                    {% if hasPermission('feature_auto_switch_to_procedure_end_phase') and not hasPermission('feature_auto_switch_procedure_phase') %}
-                                        <div class="lbl__hint u-mt-0_25 u-mb-0">
-                                            {{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.external.evaluating'|trans }) }}
-                                        </div>
-                                    {% endif %}
+
+                                    <participation-phases
+                                        autoswitch-hint="{{ 'period.autoswitch.hint'|trans({ phase: 'procedure.phases.external.evaluating'|trans }) }}"
+                                        data-cy="publicPhase"
+                                        field-name="r_publicParticipationPhase"
+                                        help-text="{{ 'text.procedure.edit.external.change_phase'|trans }}"
+                                        label-text="{{ "procedure.public.phase"|trans }}"
+                                        :participation-phases="['participation', 'earlyparticipation', 'anotherparticipation']"
+                                        permission-message="{{ 'explanation.procedure.external.permissions'|trans }}"
+                                        :phase-options="JSON.parse('{{ externalPhaseOptions|json_encode|e('js', 'utf-8') }}')"
+                                        init-selected-phase="{{ proceduresettings.publicParticipationPhase }}"
+                                        :iterator="{
+                                            label: Translator.trans('procedure.phase.phasecounter'),
+                                            name: 'r_public_participation_phase_iteration',
+                                            tooltip: Translator.trans('text.procedure.phasecounter'),
+                                            value: '{{ proceduresettings.publicParticipationPhaseObject.iteration }}'
+                                            }"
+                                        @phase:select="setSelectedPublicPhase">
+                                    </participation-phases>
                                 {% endif %}
 
                                 {# start/end date for public participation #}


### PR DESCRIPTION
### Ticket
[DPLAN-16236](https://demoseurope.youtrack.cloud/issue/DPLAN-16236/Solution-using-vue-Der-Durchgangsnummer-und-E-Mail-des-Verfahrentragers-werden-nicht-gespeichert)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
