### PR TITLE
fix: Time based procedure phase switch (refs DPLAN-16177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Patch Version**: Incremented for bug fixes.
 
 ## UNRELEASED
+- Fix time based procedure phase switch
+
 ## v4.9.0 (2025-07-30)
 - Allow filtering of institution tags in AdminstrationMemberList / refactor twig
 - Add configurable feedback control for public participation statements

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -59,8 +59,8 @@
                 required
               />
               <!-- Hidden input with combined datetime for backend -->
-              <input 
-                type="hidden" 
+              <input
+                type="hidden"
                 :name="switchDateId"
                 :value="switchDate"
               />
@@ -139,8 +139,7 @@ import {
   DpDateRangePicker,
   DpInput,
   DpLabel,
-  DpSelect,
-  formatDate
+  DpSelect
 } from '@demos-europe/demosplan-ui'
 import { defineAsyncComponent } from 'vue'
 
@@ -288,7 +287,7 @@ export default {
       deep: false // Set default for migrating purpose. To know this occurrence is checked
     },
 
-    switchDateOnly() {
+    switchDateOnly () {
       this.updateSwitchDate()
     },
 
@@ -307,33 +306,36 @@ export default {
 
   methods: {
     // Helper function to convert German date format (DD.MM.YYYY) to ISO format (YYYY-MM-DD)
-    convertGermanToIsoDate(germanDate) {
-      if (!germanDate) return ''
-      
+    convertGermanToIsoDate (germanDate) {
+      if (!germanDate) {
+        return ''
+      }
+
       if (germanDate.includes('.')) {
         const [day, month, year] = germanDate.split('.')
         return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
       }
-      
+
       return germanDate // Already in ISO format
     },
 
     // Helper function to convert date object to German format (DD.MM.YYYY)
-    formatDateToGerman(date) {
+    formatDateToGerman (date) {
       const day = date.getDate().toString().padStart(2, '0')
       const month = (date.getMonth() + 1).toString().padStart(2, '0')
       const year = date.getFullYear()
       return `${day}.${month}.${year}`
     },
 
-    parseAndUpdateTime() {
-      const time = this.parseTimeInput(this.switchTime)
-      this.switchTime = time
+    parseAndUpdateTime () {
+      this.switchTime = this.parseTimeInput(this.switchTime)
       this.updateSwitchDate()
     },
 
-    parseTimeInput(input) {
-      if (!input) return '00:00'
+    parseTimeInput (input) {
+      if (!input) {
+        return '00:00'
+      }
 
       // Remove any non-digits and colons
       const cleaned = input.replace(/[^\d:]/g, '')
@@ -344,10 +346,12 @@ export default {
         const [hour, minute] = cleaned.split(':')
         const h = parseInt(hour) || 0
         const m = parseInt(minute) || 0
+
         return `${Math.min(h, 23).toString().padStart(2, '0')}:${Math.min(m, 59).toString().padStart(2, '0')}`
       } else {
         // 900, 0900, 9 formats
         const digits = cleaned.padStart(1, '0') // Don't force pad here
+
         if (digits.length === 1) {
           // Single digit (e.g., "9") -> 09:00
           return `${digits.padStart(2, '0')}:00`
@@ -361,6 +365,7 @@ export default {
           // Four digits (e.g., "0900") -> 09:00
           const h = Math.min(parseInt(digits.slice(0, 2)) || 0, 23)
           const m = Math.min(parseInt(digits.slice(2)) || 0, 59)
+
           return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`
         } else {
           // Fallback for other cases
@@ -369,11 +374,11 @@ export default {
       }
     },
 
-    updateSwitchDate() {
+    updateSwitchDate () {
       if (this.switchDateOnly && this.switchTime) {
         const isoDate = this.convertGermanToIsoDate(this.switchDateOnly)
         const dateObj = new Date(`${isoDate}T${this.switchTime}:00`)
-        
+
         if (!isNaN(dateObj.getTime())) {
           this.switchDate = dateObj.toISOString()
         }
@@ -392,7 +397,7 @@ export default {
       if (this.initSwitchDate) {
         this.autoSwitchPhase = true
         const date = new Date(this.initSwitchDate)
-        
+
         this.switchDateOnly = this.formatDateToGerman(date)
         this.switchTime = date.toTimeString().substring(0, 5)
         this.switchDate = this.initSwitchDate
@@ -400,9 +405,9 @@ export default {
         this.switchDateOnly = this.formatDateToGerman(new Date())
         this.switchTime = '00:00'
       }
-      
+
       this.switchDateMax = this.endDate
-      
+
       if (this.switchDate) {
         const date = new Date(this.switchDate)
         if (!isNaN(date.getTime())) {
@@ -437,4 +442,3 @@ export default {
   }
 }
 </script>
-

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -314,6 +314,7 @@ export default {
 
       if (germanDate.includes('.')) {
         const [day, month, year] = germanDate.split('.')
+        
         return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
       }
 

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -413,6 +413,7 @@ export default {
 
       if (this.switchDate) {
         const date = new Date(this.switchDate)
+        
         if (!isNaN(date.getTime())) {
           this.startDate = this.formatDateToGerman(date)
         }

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -65,7 +65,7 @@
                 :value="switchDate"
               />
             </div><!--
-         --><div class="layout__item u-1-of-3 u-pl-0_5">
+         --><div class="layout__item w-1/3 pl-2">
               <dp-label
                 :for="`${switchDateId}_time`"
                 :text="Translator.trans('time')"

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -405,7 +405,7 @@ export default {
         this.switchTime = date.toTimeString().substring(0, 5)
         this.switchDate = this.initSwitchDate
       } else {
-        this.switchDateOnly = this.formatDateToGerman(new Date())
+        this.switchDateOnly = this.minSwitchDate
         this.switchTime = '00:00'
       }
 

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -326,6 +326,7 @@ export default {
       const day = date.getDate().toString().padStart(2, '0')
       const month = (date.getMonth() + 1).toString().padStart(2, '0')
       const year = date.getFullYear()
+      
       return `${day}.${month}.${year}`
     },
 

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -40,7 +40,7 @@
 
      --><div class="layout__item u-1-of-3 u-1-of-1-lap-down">
           <div class="layout">
-            <div class="layout__item u-2-of-3 u-pr-0_5">
+            <div class="layout__item w-2/3 pr-2">
               <dp-label
                 :for="switchDateId"
                 :text="Translator.trans('phase.autoswitch.datetime')"

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -270,7 +270,7 @@ export default {
   watch: {
     autoSwitchPhase (newVal) {
       if (newVal && !this.switchDateOnly) {
-        this.switchDateOnly = this.formatDateToGerman(new Date())
+        this.switchDateOnly = this.minSwitchDate
         this.switchTime = '00:00'
         this.updateSwitchDate()
       }

--- a/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
+++ b/client/js/components/procedure/basicSettings/AutoSwitchProcedurePhaseForm.vue
@@ -295,6 +295,7 @@ export default {
       handler (newVal) {
         if (newVal) {
           const date = new Date(newVal)
+          
           if (!isNaN(date.getTime())) {
             this.startDate = this.formatDateToGerman(date)
           }

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250803194156 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T16177: Add designated_switch_date_timestamp to procedure_phase table for date comparison';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE procedure_phase ADD designated_switch_date_timestamp INT DEFAULT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE procedure_phase DROP designated_switch_date_timestamp');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250803194156.php
@@ -21,7 +21,7 @@ class Version20250803194156 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'refs T16177: Add designated_switch_date_timestamp to procedure_phase table for date comparison';
+        return 'refs DPLAN-16177: Add designated_switch_date_timestamp to procedure_phase table for date comparison';
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250805123542 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs T16177: fill designated_switch_date_timestamp for existing procedure phases';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        // Update designated_switch_date_timestamp for existing procedure phases
+        // that have a designated_switch_date but no designated_switch_date_timestamp
+        $this->addSql('
+            UPDATE procedure_phase 
+            SET designated_switch_date_timestamp = UNIX_TIMESTAMP(designated_switch_date)
+            WHERE designated_switch_date IS NOT NULL 
+            AND designated_switch_date_timestamp IS NULL
+        ');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        // Rollback: Clear designated_switch_date_timestamp values that were populated by this migration
+        // We can't perfectly rollback since we don't know which ones were originally null,
+        // but we can clear values that match the designated_switch_date timestamp
+        $this->addSql('
+            UPDATE procedure_phase 
+            SET designated_switch_date_timestamp = NULL
+            WHERE designated_switch_date IS NOT NULL 
+            AND designated_switch_date_timestamp = UNIX_TIMESTAMP(designated_switch_date)
+        ');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/08/Version20250805123542.php
@@ -21,7 +21,7 @@ class Version20250805123542 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'refs T16177: fill designated_switch_date_timestamp for existing procedure phases';
+        return 'refs DPLAN-16177: fill designated_switch_date_timestamp for existing procedure phases';
     }
 
     /**
@@ -34,9 +34,9 @@ class Version20250805123542 extends AbstractMigration
         // Update designated_switch_date_timestamp for existing procedure phases
         // that have a designated_switch_date but no designated_switch_date_timestamp
         $this->addSql('
-            UPDATE procedure_phase 
+            UPDATE procedure_phase
             SET designated_switch_date_timestamp = UNIX_TIMESTAMP(designated_switch_date)
-            WHERE designated_switch_date IS NOT NULL 
+            WHERE designated_switch_date IS NOT NULL
             AND designated_switch_date_timestamp IS NULL
         ');
     }
@@ -52,9 +52,9 @@ class Version20250805123542 extends AbstractMigration
         // We can't perfectly rollback since we don't know which ones were originally null,
         // but we can clear values that match the designated_switch_date timestamp
         $this->addSql('
-            UPDATE procedure_phase 
+            UPDATE procedure_phase
             SET designated_switch_date_timestamp = NULL
-            WHERE designated_switch_date IS NOT NULL 
+            WHERE designated_switch_date IS NOT NULL
             AND designated_switch_date_timestamp = UNIX_TIMESTAMP(designated_switch_date)
         ');
     }

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhase.php
@@ -101,6 +101,11 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
     protected ?DateTime $designatedSwitchDate = null;
 
     /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    protected ?int $designatedSwitchDateTimestamp = null;
+
+    /**
      * OnDelete set NULL at this site, will set the userID to null in case of the user will be deleted.
      * Doing this by a doctrine relation is not simply possible because,
      * the user has no defined relation in its class.
@@ -223,6 +228,16 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         $this->designatedSwitchDate = $designatedSwitchDate;
     }
 
+    public function getDesignatedSwitchDateTimestamp(): ?int
+    {
+        return $this->designatedSwitchDateTimestamp;
+    }
+
+    public function setDesignatedSwitchDateTimestamp(?int $designatedSwitchDateTimestamp): void
+    {
+        $this->designatedSwitchDateTimestamp = $designatedSwitchDateTimestamp;
+    }
+
     public function getDesignatedPhaseChangeUser(): ?UserInterface
     {
         return $this->designatedPhaseChangeUser;
@@ -260,6 +275,7 @@ class ProcedurePhase extends CoreEntity implements UuidEntityInterface, Procedur
         $this->name = $sourcePhase->name;
         $this->designatedEndDate = $sourcePhase->designatedEndDate;
         $this->designatedSwitchDate = $sourcePhase->designatedSwitchDate;
+        $this->designatedSwitchDateTimestamp = $sourcePhase->designatedSwitchDateTimestamp;
         $this->designatedPhase = $sourcePhase->designatedPhase;
         $this->permissionSet = $sourcePhase->permissionSet;
         $this->startDate = $sourcePhase->startDate;

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
@@ -920,6 +920,7 @@ class ProcedureSettings extends CoreEntity implements UuidEntityInterface, Proce
     public function setDesignatedSwitchDate(?DateTime $designatedSwitchDate): self
     {
         $this->procedure->getPhaseObject()->setDesignatedSwitchDate($designatedSwitchDate);
+        $this->procedure->getPhaseObject()->setDesignatedSwitchDateTimestamp($designatedSwitchDate?->getTimestamp());
 
         return $this;
     }
@@ -938,6 +939,7 @@ class ProcedureSettings extends CoreEntity implements UuidEntityInterface, Proce
     public function setDesignatedPublicSwitchDate(?DateTime $designatedPublicSwitchDate): self
     {
         $this->procedure->getPublicParticipationPhaseObject()->setDesignatedSwitchDate($designatedPublicSwitchDate);
+        $this->procedure->getPublicParticipationPhaseObject()->setDesignatedSwitchDateTimestamp($designatedPublicSwitchDate?->getTimestamp());
 
         return $this;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ServiceStorage.php
@@ -1062,8 +1062,8 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         $mandatoryErrors,
     ) {
         $this->logger->info('checkSwitchDateValidFields called', [
-            'startDate' => $startDate,
-            'endDate' => $endDate,
+            'startDate'         => $startDate,
+            'endDate'           => $endDate,
             'currentErrorCount' => count($mandatoryErrors),
         ]);
 
@@ -1075,17 +1075,17 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         $now = Carbon::now();
 
         $this->logger->info('Parsed dates for validation', [
-            'designatedSwitchDate' => $designatedSwitchDate->toISOString(),
+            'designatedSwitchDate'    => $designatedSwitchDate->toISOString(),
             'designatedSwitchEndDate' => $designatedSwitchEndDate->toISOString(),
-            'now' => $now->toISOString(),
+            'now'                     => $now->toISOString(),
         ]);
 
         // Check if end date is in the future
         if (!$designatedSwitchEndDate->greaterThan($now)) {
             $this->logger->warning('Switch date validation failed: end date is not in the future', [
                 'designatedSwitchEndDate' => $designatedSwitchEndDate->toISOString(),
-                'now' => $now->toISOString(),
-                'differenceInMinutes' => $now->diffInMinutes($designatedSwitchEndDate, false),
+                'now'                     => $now->toISOString(),
+                'differenceInMinutes'     => $now->diffInMinutes($designatedSwitchEndDate, false),
             ]);
 
             $mandatoryErrors[] = [
@@ -1099,9 +1099,9 @@ class ServiceStorage implements ProcedureServiceStorageInterface
         // Check if start date is before end date
         if ($designatedSwitchDate->startOfDay()->greaterThanOrEqualTo($designatedSwitchEndDate)) {
             $this->logger->warning('Switch date validation failed: start date is not before end date', [
-                'designatedSwitchDate' => $designatedSwitchDate->toISOString(),
+                'designatedSwitchDate'    => $designatedSwitchDate->toISOString(),
                 'designatedSwitchEndDate' => $designatedSwitchEndDate->toISOString(),
-                'differenceInMinutes' => $designatedSwitchDate->diffInMinutes($designatedSwitchEndDate, false),
+                'differenceInMinutes'     => $designatedSwitchDate->diffInMinutes($designatedSwitchEndDate, false),
             ]);
 
             $mandatoryErrors[] = [

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureRepository.php
@@ -1360,6 +1360,7 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
      */
     public function getProceduresReadyToSwitchPhases(): array
     {
+        $now = Carbon::now()->getTimestamp();
         $query = $this->createFluentQuery();
         $conditionDefinition = $query->getConditionDefinition()
             ->propertyHasValue(false, ['deleted'])
@@ -1368,15 +1369,15 @@ class ProcedureRepository extends SluggedRepository implements ArrayInterface, O
 
         $orCondition = $conditionDefinition->anyConditionApplies();
         $orCondition->allConditionsApply()
-            ->propertyIsNotNull(['phase', 'designatedSwitchDate'])
+            ->propertyIsNotNull(['phase', 'designatedSwitchDateTimestamp'])
             ->propertyIsNotNull(['phase', 'designatedPhase'])
             ->propertyIsNotNull(['phase', 'designatedEndDate'])
-            ->propertyHasValueBeforeNow(['phase', 'designatedSwitchDate']);
+            ->valueSmallerThan($now, ['phase', 'designatedSwitchDateTimestamp']);
         $orCondition->allConditionsApply()
-            ->propertyIsNotNull(['publicParticipationPhase', 'designatedSwitchDate'])
+            ->propertyIsNotNull(['publicParticipationPhase', 'designatedSwitchDateTimestamp'])
             ->propertyIsNotNull(['publicParticipationPhase', 'designatedPhase'])
             ->propertyIsNotNull(['publicParticipationPhase', 'designatedEndDate'])
-            ->propertyHasValueBeforeNow(['publicParticipationPhase', 'designatedSwitchDate']);
+            ->valueSmallerThan($now, ['publicParticipationPhase', 'designatedSwitchDateTimestamp']);
 
         return $query->getEntities();
     }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2526,7 +2526,7 @@ personal.data.usage.revoked.statement: "Aus verfahrensbezogenen Gründen werden 
 persons: "Personen"
 phase: "Phase"
 phase.autoswitch.date: "Tag der Umstellung"
-phase.autoswitch.datetime: "Zeitpunkt der Umstellung"
+phase.autoswitch.datetime: "Beginn"
 phase.autoswitch.value: "Wird umgestellt auf:"
 phase.changed: "Phase geändert"
 phase.public: "Phase Öffentlichkeit"


### PR DESCRIPTION
DPLAN-16177

## Summary
- Fix time-based procedure phase switching functionality
- Resolve issues with automated phase transitions based on scheduled dates
- Changed the interface from time picker to text field to avoid complex bugs and gain flexibility

## Test plan
- [ ] Test automated phase switching with configured dates
- [ ] Verify manual phase switching still works correctly
- [ ] Test edge cases with invalid/past dates

## Changes
- Updated procedure phase switching logic
- Enhanced date validation and scheduling
- Improved error handling for phase transitions

## Related Ticket
DPLAN-16177