### PR TITLE
fix(refs DPLAN-16170): access response correctly

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -893,7 +893,7 @@ export default {
 
     this.fetchLayers(this.procedureId)
       .then(response => {
-        this.procedureMapSettings.layers = response.data
+        this.procedureMapSettings.layers = response.data.data
           .filter(layer => layer.attributes.isEnabled && layer.attributes.hasDefaultVisibility)
           .map(layer => layer.attributes)
       })

--- a/client/js/components/statement/statement/DpVersionHistoryItem.vue
+++ b/client/js/components/statement/statement/DpVersionHistoryItem.vue
@@ -238,7 +238,7 @@ export default {
       if (this.time.displayChange) {
         this.loadHistory()
           .then((response) => {
-            this.history = response.data
+            this.history = response.data.data
             this.isLoading = false
           })
       } else {


### PR DESCRIPTION
### Ticket
[DPLAN-16170](https://demoseurope.youtrack.cloud/issue/DPLAN-16170/Abschnitt-Versionsverlauf-Accordion-Toggles-funktionieren-nicht)

Since https://github.com/demos-europe/demosplan-ui/pull/1316, dpApi returns `response` instead of `response.data`, so where we used `response.data` before, we now have to use `response.data.data`

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly