### PR TITLE
feat(refs DPLAN-16282): remove comments before segment patch

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -877,6 +877,8 @@ export default {
         }
       }
 
+      this.removeComments(updatedSegment.relationships)
+
       this.setSegment({
         ...updatedSegment,
         id: this.segment.id


### PR DESCRIPTION
### Ticket
[DPLAN-16282](https://demoseurope.youtrack.cloud/issue/DPLAN-16282/Fehler-nach-dem-hinzufugen-von-einen-Kommentar-zu-einem-Abschnitt-beim-andern-von-Bearbeitungsschritt)

Updating comments on the segment is not supported atm, so we need to remove them before sending the patch request. This had been implemented at some point but somehow got lost.

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
