### PR TITLE
F dplan-14969 validate keycloak in env

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
@@ -46,12 +46,8 @@ class ExpirationTimestampRequestListener implements EventSubscriberInterface
 
     public function onKernelController(ControllerEvent $event): void
     {
-        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()) {
-            return;
-        }
-
-        // If Keycloak is not configured, do nothing regardless of environment
-        if (!$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
+        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission() &&
+            !$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
             return;
         }
 

--- a/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
@@ -50,6 +50,11 @@ class ExpirationTimestampRequestListener implements EventSubscriberInterface
             return;
         }
 
+        // If Keycloak is not configured, do nothing regardless of environment
+        if (!$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
+            return;
+        }
+
         // Only handle main requests
         if (!$event->isMainRequest()) {
             return;

--- a/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
@@ -46,8 +46,8 @@ class ExpirationTimestampRequestListener implements EventSubscriberInterface
 
     public function onKernelController(ControllerEvent $event): void
     {
-        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission() &&
-            !$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
+        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()
+            && !$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
             return;
         }
 

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -64,7 +64,7 @@ class LogoutSubscriber implements EventSubscriberInterface
         }
 
         // let oauth identity provider handle logout when defined
-        if ('' !== $this->parameterBag->get('oauth_keycloak_logout_route')) {
+        if ($this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
             $keycloakToken = $event->getRequest()->getSession()->get(OzgKeycloakLogoutManager::KEYCLOAK_TOKEN);
             $event->getRequest()->getSession()->invalidate();
             $logoutRoute = $this->parameterBag->get('oauth_keycloak_logout_route');

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -30,7 +30,7 @@ class OzgKeycloakLogoutManager
     private const POST_LOGOUT_REDIRECT_URI = 'post_logout_redirect_uri=https://';
     private const ID_TOKEN_HINT = 'id_token_hint=';
 
-    /** @var int Session expiration time for testing (120 minutes) */
+    /** @var int Session expiration time for testing (15 minutes) */
     private const TEST_SESSION_LIFETIME_SECONDS = 900;
 
     public function __construct(

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -50,7 +50,6 @@ class OzgKeycloakLogoutManager
         return '' !== $this->parameterBag->get('oauth_keycloak_logout_route');
     }
 
-
     /**
      * Determines if test token expiration should be injected in dev/test environments.
      *

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -31,7 +31,7 @@ class OzgKeycloakLogoutManager
     private const ID_TOKEN_HINT = 'id_token_hint=';
 
     /** @var int Session expiration time for testing (120 minutes) */
-    private const TEST_SESSION_LIFETIME_SECONDS = 7200;
+    private const TEST_SESSION_LIFETIME_SECONDS = 900;
 
     public function __construct(
         private readonly KernelInterface $kernel,

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -43,23 +43,22 @@ class OzgKeycloakLogoutManager
     }
 
     /**
+     * Check if Keycloak logout is configured for this environment.
+     */
+    public function isKeycloakConfigured(): bool
+    {
+        return '' !== $this->parameterBag->get('oauth_keycloak_logout_route');
+    }
+
+
+    /**
      * Determines if test token expiration should be injected in dev/test environments.
-     * Skips injection when Keycloak logout is configured since real tokens handle expiration.
      *
      * @return bool True if injection should occur, false otherwise
      */
     public function shouldInjectTestExpiration(): bool
     {
-        $isTestOrDev = DemosPlanKernel::ENVIRONMENT_TEST === $this->kernel->getEnvironment() || DemosPlanKernel::ENVIRONMENT_DEV === $this->kernel->getEnvironment();
-
-        if (!$isTestOrDev) {
-            return false;
-        }
-
-        // If env is test or dev, and  keycloak logout is configured then do not inject
-        $keycloakLogoutRoute = $this->parameterBag->get('oauth_keycloak_logout_route');
-
-        return '' === $keycloakLogoutRoute;
+        return DemosPlanKernel::ENVIRONMENT_TEST === $this->kernel->getEnvironment() || DemosPlanKernel::ENVIRONMENT_DEV === $this->kernel->getEnvironment();
     }
 
     public function hasLogoutWarningPermission(): bool


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-14969/ADO-Issue-23560-Rechtzeitige-Ankundigung-Ausloggen-damit-gespeichert-werden-kann

Validate that when prod env and not keycloak set up, then skip the lifetimestamp expiration token