### PR TITLE
feat (refs: DPLAN-14969): Add shouldSkipInProductionWithoutKeycloak a…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
@@ -46,11 +46,13 @@ class ExpirationTimestampRequestListener implements EventSubscriberInterface
 
     public function onKernelController(ControllerEvent $event): void
     {
-        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()
-            && !$this->ozgKeycloakLogoutManager->isKeycloakConfigured()) {
+        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()){
             return;
         }
 
+        if($this->ozgKeycloakLogoutManager->shouldSkipInProductionWithoutKeycloak()) {
+            return;
+        }
         // Only handle main requests
         if (!$event->isMainRequest()) {
             return;

--- a/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
+++ b/demosplan/DemosPlanCoreBundle/EventListener/ExpirationTimestampRequestListener.php
@@ -46,11 +46,11 @@ class ExpirationTimestampRequestListener implements EventSubscriberInterface
 
     public function onKernelController(ControllerEvent $event): void
     {
-        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()){
+        if (!$this->ozgKeycloakLogoutManager->hasLogoutWarningPermission()) {
             return;
         }
 
-        if($this->ozgKeycloakLogoutManager->shouldSkipInProductionWithoutKeycloak()) {
+        if ($this->ozgKeycloakLogoutManager->shouldSkipInProductionWithoutKeycloak()) {
             return;
         }
         // Only handle main requests

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -47,12 +47,14 @@ class OzgKeycloakLogoutManager
      */
     public function isKeycloakConfigured(): bool
     {
-        $this->logger->info('Logging oauth_keycloak_logout_route', [
-            'oauth_keycloak_logout_route'  => $this->parameterBag->get('oauth_keycloak_logout_route'),
-            'isKeycloakConfigured'         => '' !== $this->parameterBag->get('oauth_keycloak_logout_route'),
-        ]);
-
         return '' !== $this->parameterBag->get('oauth_keycloak_logout_route');
+    }
+
+
+    public function shouldSkipInProductionWithoutKeycloak()
+    {
+        return DemosPlanKernel::ENVIRONMENT_PROD === $this->kernel->getEnvironment() &&
+            !$this->isKeycloakConfigured();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -50,11 +50,10 @@ class OzgKeycloakLogoutManager
         return '' !== $this->parameterBag->get('oauth_keycloak_logout_route');
     }
 
-
     public function shouldSkipInProductionWithoutKeycloak()
     {
-        return DemosPlanKernel::ENVIRONMENT_PROD === $this->kernel->getEnvironment() &&
-            !$this->isKeycloakConfigured();
+        return DemosPlanKernel::ENVIRONMENT_PROD === $this->kernel->getEnvironment()
+            && !$this->isKeycloakConfigured();
     }
 
     /**


### PR DESCRIPTION
Ticket https://demoseurope.youtrack.cloud/issue/DPLAN-14969/ADO-Issue-23560-Rechtzeitige-Ankundigung-Ausloggen-damit-gespeichert-werden-kann

Split validation that in case it is in prod and no keycloak set up, then skip it

Because the 2 validations were together, and the user has permissions, then the execution was happening.
but because the env is prod, and it is not keycloak, then the method handleExpiredToken was executed, causing that after the user logs in , then immediately gets loggout
