### PR TITLE
chore: bump demosplan-ui from v0.5.4 to v0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^15.0.0",
-    "@demos-europe/demosplan-ui": "^0.5.4",
+    "@demos-europe/demosplan-ui": "^0.5.5",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,9 +1997,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@demos-europe/demosplan-ui@npm:0.5.4"
+"@demos-europe/demosplan-ui@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@demos-europe/demosplan-ui@npm:0.5.5"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2053,7 +2053,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/c98f4efa56eb2c0ed2e2ce0ffdd36434ca67d4ab8c6107c68e684a7e1b3dd736a76d926e2b2dffa8f18f9830a42fb2e93a48f0a50982052bb6d1b241b80e3be6
+  checksum: 10c0/24e41ad9c952bc7f4fcc620be3526355adef1864fa9f1acadcaa92e543135aebfe0d1fc6477651b21dd9ead2caba405e4b6e1b9f8f0effc183e80bc63bd5a540
   languageName: node
   linkType: hard
 
@@ -12730,7 +12730,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^15.0.0"
-    "@demos-europe/demosplan-ui": "npm:^0.5.4"
+    "@demos-europe/demosplan-ui": "npm:^0.5.5"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"


### PR DESCRIPTION
New version contains
- DpNotification: option to allow non-error notifications to persist
- DpEditor: fix for prosemirror dependency conflicts
- DpIcon: new icon warning-circle
