### PR TITLE
fix(refs:DPLAN-16180): increase icon css specificity

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_procedurelist.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_procedurelist.scss
@@ -115,13 +115,13 @@
             position: absolute;
 
             &-icon {
-                &,
-                .is-done:hover & {
-                    display: none;
+                &.fa.fa-check-circle,
+                .is-done:hover &.fa.fa-check-circle {
+                    display: none !important;
                 }
 
-                .is-done & {
-                    display: block;
+                .is-done &.fa.fa-check-circle {
+                    display: block !important;
                 }
             }
 


### PR DESCRIPTION
### Ticket
[DPLAN-16180](https://demoseurope.youtrack.cloud/issue/DPLAN-16180)

This PR increases the specificity of the CSS selectors for the checkmark icon, so that it is displayed correctly again after the Tailwind 4 update.
 
### How to review/test

1. Login as private person and go to the homepage.
2. Look at a procedure in the procedure list - there should be no checkmark icon.
3. Hover over the left side of a procedure and check the checkbox.
4. The procedure should now appear light grey and have a checkmark icon.
