### PR TITLE
chore: bump demosplan-ui from 0.5.5 to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^15.0.0",
-    "@demos-europe/demosplan-ui": "^0.5.5",
+    "@demos-europe/demosplan-ui": "^0.5.6",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,9 +1997,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "@demos-europe/demosplan-ui@npm:0.5.5"
+"@demos-europe/demosplan-ui@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@demos-europe/demosplan-ui@npm:0.5.6"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2053,7 +2053,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/24e41ad9c952bc7f4fcc620be3526355adef1864fa9f1acadcaa92e543135aebfe0d1fc6477651b21dd9ead2caba405e4b6e1b9f8f0effc183e80bc63bd5a540
+  checksum: 10c0/f188845a7183139678fe3b8e36059e7b47e64eadcd92890baed1057606fc942f89132b13e571a87879218118c29829aff1b9359bae47dd37325f8f3fa965a97f
   languageName: node
   linkType: hard
 
@@ -12730,7 +12730,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
     "@cesium/engine": "npm:^15.0.0"
-    "@demos-europe/demosplan-ui": "npm:^0.5.5"
+    "@demos-europe/demosplan-ui": "npm:^0.5.6"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@fullhuman/postcss-purgecss": "npm:^7.0.2"


### PR DESCRIPTION
### Ticket
[DPLAN-16247](https://demoseurope.youtrack.cloud/issue/DPLAN-16247/Originalstellungnahmen-Nach-dem-Klick-auf-Exportieren-springt-der-Button-nach-links)

New version contains a focus style fix for DpButton and a few dependency updates (globals, ts-loader, typescript).