### PR TITLE
fix(refs DPLAN-16329): load assessment table filters correctly

### DIFF
--- a/client/js/store/statement/Filter.js
+++ b/client/js/store/statement/Filter.js
@@ -288,10 +288,10 @@ const Filter = {
           let filtersToUpdateInStore
           // Update only options for one filter
           if (data.filterId) {
-            filtersToUpdateInStore = response.data.filter(filter => filter.id === data.filterId)
+            filtersToUpdateInStore = response.data.data.filter(filter => filter.id === data.filterId)
           } else {
             // Update options for all selected filters
-            filtersToUpdateInStore = response.data
+            filtersToUpdateInStore = response.data.data
           }
 
           commit('loadAvailableFilterListOptions', filtersToUpdateInStore)


### PR DESCRIPTION
### Ticket
[DPLAN-16329](https://demoseurope.youtrack.cloud/issue/DPLAN-16329/Abwagungstabelle-Filterung-funktioniert-nicht)

Since https://github.com/demos-europe/demosplan-ui/pull/1316, dpApi returns `response` instead of `response.data`, so we have to access the response data via `response.data.data` now

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
