### PR TITLE
feat(refs dplan-14969, #AB23560): Change timer format

### DIFF
--- a/client/js/components/shared/SessionTimer.vue
+++ b/client/js/components/shared/SessionTimer.vue
@@ -59,7 +59,7 @@ export default {
     },
 
     isWarning () {
-      return this.timeLeft <= 10 * millisecondsPerMinute
+      return this.timeLeft <= 3 * millisecondsPerMinute
     },
 
     shouldShowTimer () {
@@ -92,9 +92,13 @@ export default {
     formatTimeString ({ hours, minutes, seconds }) {
       const pad = (num) => String(num).padStart(2, '0')
 
-      return hours > 0
-        ? `${ hours }:${ pad(minutes) }:${ pad(seconds) }`
-        : `${ pad(minutes) }:${ pad(seconds) }`
+      if (hours > 0) {
+        return `${ hours } h ${ pad(minutes) } min`
+      } else if (minutes >= 3) {
+        return `${ pad(minutes) } min`
+      } else {
+        return `${ pad(minutes) } min ${ pad(seconds) } sec`
+      }
     },
 
     getTimeUnits (milliseconds) {
@@ -115,8 +119,8 @@ export default {
 
     initializeTimer () {
       const timestampInMsecs = this.dplan.expirationTimestamp * millisecondsPerSecond
-      this.tenMinutesThreshold = timestampInMsecs - (10 * millisecondsPerMinute)
-      this.threeMinutesThreshold = timestampInMsecs - (3 * millisecondsPerMinute)
+      this.tenMinutesThreshold = timestampInMsecs - (11 * millisecondsPerMinute) // only MIN are rendered (10 min), so warning comes at 10:59
+      this.threeMinutesThreshold = timestampInMsecs - (4 * millisecondsPerMinute)
       this.updateTimer()
       this.intervalId = setInterval(this.updateTimer, millisecondsPerSecond)
     },


### PR DESCRIPTION
This PR is related to [DPLAN-14969](https://demoseurope.youtrack.cloud/issue/DPLAN-14969/ADO-Issue-23560-Rechtzeitige-Ankundigung-Ausloggen-damit-gespeichert-werden-kann)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
1. It changes the formatting of the timer from **01:59:45** to **01 h 59 min** (not rendering seconds anymore).
2. The text turns red 3 (and not 10) min. before logout.
3. Seconds are shown only when the timer hits 3 min.
4. Since only min. are rendered, warning MSGs now appear 11 and 4 minutes before logout (when **10 min** and **3 min** are rendered).

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Log in as admin, the timer should appear int he right upper corner, warning notifications in the right bottom one.

### Linked PRs (optional)
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
Linked PR: https://github.com/demos-europe/demosplan-core/pull/4970


