### PR TITLE
fix(refs: DPLAN-16161): change internal note textarea to dp-text-area

### DIFF
--- a/client/js/bundles/procedure/administrationEdit.js
+++ b/client/js/bundles/procedure/administrationEdit.js
@@ -11,7 +11,7 @@
  * This is the entry point for administration_edit.html.twig
  */
 
-import { DpCheckbox, DpDateRangePicker, dpValidate } from '@demos-europe/demosplan-ui'
+import { DpCheckbox, DpDateRangePicker, DpTextArea, dpValidate } from '@demos-europe/demosplan-ui'
 import AdministrationMaster from '@DpJs/lib/procedure/AdministrationMaster'
 import DpBasicSettings from '@DpJs/components/procedure/basicSettings/DpBasicSettings'
 // Import this separately because Planfest has a separate twig template which does not use DpBasicSettings
@@ -20,7 +20,7 @@ import DPWizard from '@DpJs/lib/procedure/DPWizard'
 import { initialize } from '@DpJs/InitVue'
 import UrlPreview from '@DpJs/lib/shared/UrlPreview'
 
-const components = { DpBasicSettings, DpCheckbox, DpDateRangePicker, DpEmailList }
+const components = { DpBasicSettings, DpCheckbox, DpDateRangePicker, DpEmailList, DpTextArea }
 
 initialize(components).then(() => {
   UrlPreview()

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -338,19 +338,17 @@
                                     showPlainHint: true
                                 } %}
                                 {# Bei textareas muss der Inhalt ohne Leerzeichen zwischen den Tags stehen, sonst werden die Leerzeichen ausgegeben und multiplizieren sich im Frontend. #}
-                                <textarea
-                                    class="o-form__control-textarea h-7"
+                                <dp-text-area
+                                    class="bg-surface"
                                     data-cy="internal:internalNote"
+                                    grow-to-parent
                                     id="r_desc"
-                                    name="r_desc">
-                                    {%- if proceduresettings.desc is defined %}
-                                        {{- proceduresettings.desc -}}
-                                    {% else %}
-                                        {{- 'notspecified'|trans -}}
-                                    {% endif -%}
-                                </textarea>
+                                    name="r_desc"
+                                    reduced-height
+                                    value="{{ proceduresettings.desc is defined ? proceduresettings.desc
+                                    : 'notspecified'|trans }}"
+                                />
                             </div>
-
                         </div>
 
                         <label class="o-wizard__mark u-mb-0">


### PR DESCRIPTION
### Ticket
[DPLAN-16161](https://demoseurope.youtrack.cloud/issue/DPLAN-16161/Interne-Notiz-bleibt-ausgegraut-obwohl-es-editierbar-ist)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The tailwind preflight.css sets the background-color of textareas to transparent. In the "Grundeinstellungen" of a procedure there is an internal note textarea and the background of the parent element is gray. Because of the transparent background of the textarea und the dark gray text color it looks as if the textarea is disabled. I changed the textarea to dp-text-area and also changed the background-color of it to tailwind class bg-surface (this is also used for the other elements in this dialog, it is white)

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and choose a procedure
2. Change to the "Grundeinstellungen" and open "Intern"
3. Check if the internal note text area has a white background 

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
