### PR TITLE
DPLAN-DS-161: pick user soft delete via api to release_bobhh

### DIFF
--- a/client/js/components/user/DpUserList/DpUserList.vue
+++ b/client/js/components/user/DpUserList/DpUserList.vue
@@ -198,23 +198,35 @@ export default {
     }),
     ...mapActions('User', {
       userList: 'list',
-      deleteUser: 'delete'
+      deleteAdministratableUser: 'delete'
     }),
 
-    deleteItems (ids) {
-      if (this.selectedItems.length === 0) {
-        dplan.notify.notify('warning', Translator.trans('warning.select.entries'))
-      } else {
-        if (window.dpconfirm(Translator.trans('check.user.delete', { count: this.selectedItems.length }))) {
-          ids.forEach(id => {
-            this.deleteUser(id)
-              .then(() => {
-                // Remove deleted item from itemSelections
-                delete this.itemSelections[id]
-                dplan.notify.notify('confirm', Translator.trans('confirm.user.deleted'))
-              })
-          })
-        }
+    async deleteItems (ids) {
+      if (!this.selectedItems.length) {
+        return dplan.notify.notify('warning', Translator.trans('warning.select.entries'))
+      }
+
+      const isConfirmed = window.dpconfirm(
+        Translator.trans('check.user.delete', { count: this.selectedItems.length })
+      )
+
+      if (!isConfirmed) return
+
+      const deleteResults = await Promise.allSettled( /* ensures all deletions attempt to execute, even if one fails. Each deletion resolves to { status: 'fulfilled' | 'rejected', value | reason } */
+        ids.map(async id => {
+          try {
+            await this.deleteAdministratableUser(id)
+            delete this.itemSelections[id]
+            dplan.notify.notify('confirm', Translator.trans('confirm.user.deleted'))
+          } catch (error) {
+            console.error(`Failed to delete user with ID ${id}:`, error)
+          }
+        })
+      )
+
+      // Reload items only if at least one deletion was successful
+      if (deleteResults.some(result => result.status === 'fulfilled')) {
+        this.loadItems()
       }
     },
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2020,10 +2020,10 @@ class DemosPlanProcedureController extends BaseController
             }
         }
 
-        // Lösche gegebenenfalls Benachrichtigungen
+        // delete notification if required
         if (\array_key_exists('deleteSubscription', $requestPost)) {
             if (!isset($requestPost['region_selected']) || 0 === (is_countable($requestPost['region_selected']) ? count($requestPost['region_selected']) : 0)) {
-                $this->getMessageBag()->add('error', 'explanation.entries.noneselected');
+                $this->getMessageBag()->add('error', 'warning.select.entries');
             } else {
                 $deleteNotifications = $requestPost['region_selected'];
                 $actuallyDeletedCount = $this->procedureHandler->deleteSubscriptions($deleteNotifications);
@@ -2349,16 +2349,22 @@ class DemosPlanProcedureController extends BaseController
         $requestPost = $request->request;
         $procedureService = $this->procedureService;
 
-        // Lösche markierte Textbausteine und oder Textbausteingruppen
+        // Delete checked Boilerplates and or BoilerPlateGroups
         if ($requestPost->has('boilerplateDeleteChecked')) {
-            // Lösche markierte Textbausteine
+            // Delete checked Boilerplates
             if ($requestPost->has('boilerplate_delete')) {
                 $this->handleDeleteBoilerplates($procedureHandler, $requestPost->get('boilerplate_delete'));
             }
 
-            // Lösche markierte Textbausteingruppen
+            // Delete checked BoilerplateGroups
             if ($requestPost->has('boilerplateGroupIdsTo_delete')) {
                 $this->handleDeleteBoilerplateGroups($requestPost->get('boilerplateGroupIdsTo_delete'));
+            }
+
+            if (false === $requestPost->has('boilerplate_delete') ||
+                false === $requestPost->has('boilerplateGroupIdsTo_delete')
+            ) {
+                $this->getMessageBag()->add('warning', 'warning.select.entries');
             }
         }
 

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Role.php
@@ -193,4 +193,9 @@ class Role extends CoreEntity implements UuidEntityInterface, RoleInterface, Str
     {
         return $this->groupName;
     }
+
+    public function removeUserRoleInCustomer(UserRoleInCustomerInterface $userRoleInCustomer)
+    {
+        $this->userRoleInCustomers->removeElement($userRoleInCustomer);
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1085,6 +1085,19 @@ class User implements SamlUserInterface, AddonUserInterface
         }
     }
 
+    public function removeRoleInCustomer(RoleInterface $role, CustomerInterface $customer): UserRoleInCustomerInterface
+    {
+        $roleInCustomer = $this->getRoleInCustomers()->filter(
+            function (UserRoleInCustomerInterface $roleInCustomer) use ($role, $customer) {
+                return $roleInCustomer->getRole()->getId() === $role->getId() && $roleInCustomer->getCustomer()->getId() === $customer->getId();
+            }
+        )->first();
+
+        $this->roleInCustomers->removeElement($roleInCustomer);
+
+        return $roleInCustomer;
+    }
+
     /**
      * Unset Department.
      */

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -729,8 +729,8 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
 
             $this->getMessageBag()->add('confirm', 'confirm.users.invited', ['count' => $invitedUsersCount]);
         } else {
-            // wenn keine ausgewählt wurden, gebe eine info raus
-            $this->getMessageBag()->add('warning', 'explanation.entries.noneselected');
+            // if none were chosen - put out a warning
+            $this->getMessageBag()->add('warning', 'warning.select.entries');
         }
     }
 
@@ -799,38 +799,47 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
         if ($requestData->has('elementsToAdminister')
             && 0 < (is_countable($requestData->get('elementsToAdminister')) ? count($requestData->get('elementsToAdminister')) : 0)) {
             $usersToDelete = $requestData->get('elementsToAdminister');
-
-            foreach ($usersToDelete as $userId) {
-                $organisation = $this->getSingleUser($userId)->getOrga();
-                $numberOfOpenProcedures = $this->getUnerasedProceduresOfOrganisation($organisation)->count();
-
-                if ($this->isUserOnlyAdminOfItsOrganisation($userId) && $numberOfOpenProcedures > 0) {
-                    $this->logger->error("Failed to delete user with id {$userId}, because of user is the only administrator of organisation and there are open procedures.");
-
-                    $this->getMessageBag()->add(
-                        'error',
-                        'error.delete.last.admin.user.of.orga.with.open.procedures',
-                        [
-                            'organisationName'        => $organisation->getName(),
-                            '%numberOfOpenProcedures' => $numberOfOpenProcedures,
-                        ]
-                    );
-                } else {
-                    $result = $this->wipeUserData($userId);
-
-                    if (!$result instanceof User) {
-                        $this->logger->error("Failed to delete user with id {$userId}");
-                        $this->getMessageBag()->add('error', 'error.delete.user');
-
-                        return $userId;
-                    }
-
-                    $this->getMessageBag()->add('confirm', 'confirm.entries.marked.deleted');
-                }
-            }
+            $this->wipeUsersById($usersToDelete);
         } else {
-            // wenn keine ausgewählt wurden, gebe eine info raus
-            $this->getMessageBag()->add('warning', 'explanation.entries.noneselected');
+            // if nothing was selected - put out a warning
+            $this->getMessageBag()->add('warning', 'warning.select.entries');
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string|null will return a userId on Failure
+     */
+    public function wipeUsersById(array $userIdsToDelete): ?string
+    {
+        foreach ($userIdsToDelete as $userId) {
+            $organisation = $this->getSingleUser($userId)->getOrga();
+            $numberOfOpenProcedures = $this->getUnerasedProceduresOfOrganisation($organisation)->count();
+
+            if ($this->isUserOnlyAdminOfItsOrganisation($userId) && $numberOfOpenProcedures > 0) {
+                $this->logger->error("Failed to delete user with id {$userId}, because of user is the only administrator of organisation and there are open procedures.");
+
+                $this->getMessageBag()->add(
+                    'error',
+                    'error.delete.last.admin.user.of.orga.with.open.procedures',
+                    [
+                        'organisationName'        => $organisation->getName(),
+                        '%numberOfOpenProcedures' => $numberOfOpenProcedures,
+                    ]
+                );
+            } else {
+                $result = $this->wipeUserData($userId);
+
+                if (!$result instanceof User) {
+                    $this->logger->error("Failed to delete user with id {$userId}");
+                    $this->getMessageBag()->add('error', 'error.delete.user');
+
+                    return $userId;
+                }
+
+                $this->getMessageBag()->add('confirm', 'confirm.entries.marked.deleted');
+            }
         }
 
         return null;

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\DepartmentInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseUserResourceConfigBuilder;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
+use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
+use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
+use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $profileCompleted
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $accessConfirmed
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $invited
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $newsletter
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $noPiwik
+ * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,RoleInterface> $roles
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,DepartmentInterface> $department
+ * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga
+ */
+class UserResourceConfigBuilder extends BaseUserResourceConfigBuilder
+{
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\AiApiUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
@@ -21,10 +23,24 @@ use demosplan\DemosPlanCoreBundle\Entity\User\UserRoleInCustomer;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
+use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
+use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryUser;
+use EDT\JsonApi\ApiDocumentation\DefaultField;
+use EDT\JsonApi\ApiDocumentation\OptionalField;
+use EDT\JsonApi\RequestHandling\ModifiedEntity;
+use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
+use EDT\Wrapping\EntityDataInterface;
+use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
+use EDT\Wrapping\PropertyBehavior\FixedConstructorBehavior;
+use EDT\Wrapping\CreationDataInterface;
+use EDT\Wrapping\PropertyBehavior\Relationship\ToMany\CallbackToManyRelationshipSetBehavior;
+use EDT\Wrapping\PropertyBehavior\Relationship\ToOne\CallbackToOneRelationshipSetBehavior;
 use Elastica\Index;
+use InvalidArgumentException;
 
 /**
  * @template-implements ReadableEsResourceTypeInterface<User>
@@ -35,24 +51,19 @@ use Elastica\Index;
  * administrate the accessed resources. It does **not** mean that the {@link User}s covered by this
  * resource type are the only ones that are technically administratable.
  *
- * @property-read End $firstname
- * @property-read End $lastname
  * @property-read End $login
  * @property-read End $email
  * @property-read End $deleted
- * @property-read End $profileCompleted
- * @property-read End $accessConfirmed
- * @property-read End $invited
- * @property-read End $newsletter
- * @property-read End $noPiwik
- * @property-read DepartmentResourceType $department
  * @property-read OrgaResourceType $orga
  * @property-read UserRoleInCustomerResourceType $roleInCustomers
  * @property-read RoleResourceType $roles @deprecated use relation to {@link AdministratableUserResourceType::$roleInCustomers} instead
  */
 final class AdministratableUserResourceType extends DplanResourceType implements ReadableEsResourceTypeInterface
 {
-    public function __construct(private readonly QueryUser $esQuery, private readonly JsonApiEsService $jsonApiEsService)
+    public function __construct(private readonly QueryUser $esQuery,
+        private readonly JsonApiEsService $jsonApiEsService,
+        private readonly UserRepository $userRepository,
+        private readonly UserHandler $userHandler)
     {
     }
 
@@ -69,6 +80,21 @@ final class AdministratableUserResourceType extends DplanResourceType implements
     public function isAvailable(): bool
     {
         return $this->currentUser->hasPermission('feature_user_list');
+    }
+
+    public function isCreateAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('feature_user_add');
+    }
+
+    public function isUpdateAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('feature_user_edit');
+    }
+
+    public function isDeleteAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('area_manage_users');
     }
 
     protected function getAccessConditions(): array
@@ -127,42 +153,228 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         return [];
     }
 
-    protected function getProperties(): array
+    protected function getProperties(): ResourceConfigBuilderInterface
     {
-        return [
-            $this->createIdentifier()->readable()->filterable()->sortable(),
-            $this->createAttribute($this->firstname)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->lastname)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->login)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->email)->readable(true)->filterable()->sortable(),
-            $this->createAttribute($this->profileCompleted)
-                ->readable(true, static fn (User $user): bool => $user->isProfileCompleted()),
-            $this->createAttribute($this->accessConfirmed)
-                ->readable(true, static fn (User $user): bool => $user->isAccessConfirmed()),
-            $this->createAttribute($this->invited)
-                ->readable(true, static fn (User $user): bool => $user->isInvited()),
-            $this->createAttribute($this->newsletter)
-                ->readable(true, static fn (User $user): bool => $user->getNewsletter()),
-            $this->createAttribute($this->noPiwik)
-                ->readable(true, static fn (User $user): bool => $user->getNoPiwik()),
-            $this->createToManyRelationship($this->roles)
-                // Send only the user roles for the current customer.
-                ->readable(true, function (User $user): array {
-                    $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
+        $configBuilder = $this->getConfig(UserResourceConfigBuilder::class);
 
-                    return $user->getRoleInCustomers()
-                        ->filter(
-                            static fn (UserRoleInCustomer $roleInCustomer): bool => $currentCustomer === $roleInCustomer->getCustomer()
-                        )
-                        ->map(
-                            static fn (UserRoleInCustomer $roleInCustomer): Role => $roleInCustomer->getRole()
-                        )
-                        ->getValues();
-                }),
-            $this->createToOneRelationship($this->department)
-                ->readable(true, static fn (User $user): ?Department => $user->getDepartment()),
-            $this->createToOneRelationship($this->orga)
-                ->readable(true, static fn (User $user): ?Orga => $user->getOrga()),
-        ];
+        $configBuilder->id
+            ->readable()
+            ->sortable()
+            ->filterable();
+
+        $configBuilder->firstname
+            ->readable(true)
+            ->sortable()
+            ->updatable()
+            ->initializable()
+            ->filterable();
+
+        $configBuilder->lastname
+            ->readable(true)
+            ->sortable()
+            ->updatable()
+            ->initializable()
+            ->filterable();
+
+        $configBuilder->email
+            ->readable(true)
+            ->sortable()
+            ->updatable()
+            ->initializable()
+            ->filterable();
+
+        $configBuilder->profileCompleted
+            ->readable(true, static fn (User $user): bool => $user->isProfileCompleted())
+            ->sortable();
+
+        $configBuilder->accessConfirmed
+            ->readable(true, static fn (User $user): bool => $user->isAccessConfirmed())
+            ->sortable();
+
+        $configBuilder->invited
+            ->readable(true, static fn (User $user): bool => $user->isInvited())
+            ->sortable();
+
+        $configBuilder->newsletter
+            ->readable(true, static fn (User $user): bool => $user->getNewsletter())
+            ->sortable();
+
+        $configBuilder->noPiwik
+            ->readable(true, static fn (User $user): bool => $user->getNoPiwik())
+            ->sortable();
+
+        $configBuilder->roles
+            ->updatable([], [], function (User $user, array $newRoles): array {
+                    $this->updateRoles($user, $newRoles);
+
+                    return [];
+                }
+            )
+            ->setRelationshipType($this->getTypes()->getRoleResourceType())
+            ->readable(false, function (User $user): array {
+                $currentCustomer = $this->currentCustomerService->getCurrentCustomer();
+
+                return $user->getRoleInCustomers()
+                    ->filter(
+                        static fn (UserRoleInCustomer $roleInCustomer): bool => $currentCustomer === $roleInCustomer->getCustomer()
+                    )
+                    ->map(
+                        static fn (UserRoleInCustomer $roleInCustomer): Role => $roleInCustomer->getRole()
+                    )
+                    ->getValues();
+            })
+            ->sortable()
+            ->initializable(
+                false,
+                function (User $user, array $roles): array {
+                    $user->setDplanroles($roles, $this->currentCustomerService->getCurrentCustomer());
+
+                    return [];
+                }
+            );
+
+        $configBuilder->roleInCustomers
+            ->setRelationshipType($this->getTypes()->getUserRoleInCustomerResourceType())
+            ->readable();
+
+        $configBuilder->department
+            ->setRelationshipType($this->getTypes()->getDepartmentResourceType())
+            ->readable(true, static fn (User $user): ?Department => $user->getDepartment())
+            ->updatable(
+                [],
+                [],
+                function (User $user, Department $newDepartment): array {
+                    // Special logic for moving users from one department into another
+                    $originalDepartment = $user->getDepartment();
+                    if ($originalDepartment instanceof Department) {
+                        $originalDepartment->setGwId(null);
+                        $originalDepartment->removeUser($user);
+                    }
+                    $user->setDepartment($newDepartment);
+                    $newDepartment->addUser($user);
+
+                    return [];
+                }
+            )
+            ->initializable(
+                false,
+                static function (User $user, Department $department): array {
+                    $user->setDepartment($department);
+                    $department->addUser($user);
+
+                    return [];
+                }
+            );
+
+        $configBuilder->orga
+            ->setRelationshipType($this->getTypes()->getOrgaResourceType())
+            ->readable(true, static fn (User $user): ?Orga => $user->getOrga())
+            ->updatable(
+                [],
+                [],
+                function (User $user, Orga $newOrga): array {
+                    // Special logic for moving users from one organization into another
+                    $originalOrga = $user->getOrga();
+                    if ($originalOrga instanceof Orga) {
+                        $originalOrga->setGwId(null);
+                        $originalOrga->removeUser($user);
+                    }
+                    $user->setOrga($newOrga);
+                    $newOrga->addUser($user);
+
+                    return [];
+                }
+            )
+            ->initializable(
+                false,
+                static function (UserInterface $user, OrgaInterface $orga): array {
+                    $user->setOrga($orga);
+                    $orga->addUser($user);
+
+                    return [];
+                }
+            );
+
+        $configBuilder->addConstructorBehavior(
+            new FixedConstructorBehavior(
+                $this->email->getAsNamesInDotNotation(),
+                function (CreationDataInterface $entityData): array {
+                    $attributes = $entityData->getAttributes();
+                    $login = $attributes[$this->email->getAsNamesInDotNotation()];
+                    
+                    return [$login, []];
+                }
+            )
+        );
+
+        $configBuilder->addPostConstructorBehavior(new FixedSetBehavior(function (User $user, EntityDataInterface $entityData): array {
+            if ($this->currentUser->hasPermission('feature_organisation_own_users_list')) {
+                $orgaToSet = $entityData->getToOneRelationships()[$this->orga->getAsNamesInDotNotation()];
+                if ($this->currentUser->getUser()->getOrga()->getId() !== $orgaToSet['id']) {
+                    $this->messageBag->add('error', 'error.user.administration.limited.to.own.organisation');
+                    throw new InvalidArgumentException('User is only allowed to administrate users of their own organisation.');
+                }
+            }
+            
+            $this->userRepository->persistEntities([$user]);
+            $this->userHandler->inviteUser($user);
+
+            return [];
+        }));
+
+        return $configBuilder;
+    }
+
+    private function getAddedRoles(array $currentRoles, array $newRoles): array
+    {
+        return array_filter($newRoles, static fn (Role $newRole): bool => !in_array($newRole, $currentRoles, true));
+    }
+
+    private function getRemovedRoles(array $currentRoles, array $newRoles): array
+    {
+        return array_filter($currentRoles, static fn (Role $currentRole): bool => !in_array($currentRole, $newRoles, true));
+    }
+
+    public function updateEntity(string $entityId, EntityDataInterface $entityData): ModifiedEntity
+    {
+        $userAttributes = $entityData->getAttributes();
+
+        if (array_key_exists($this->email->getAsNamesInDotNotation(), $userAttributes)) {
+            $modifiedEntity = parent::updateEntity($entityId, $entityData);
+            $this->userHandler->inviteUser($modifiedEntity->getEntity());
+
+            return $modifiedEntity;
+        }
+
+        return parent::updateEntity($entityId, $entityData);
+    }
+
+    public function deleteEntity(string $userId): void
+    {
+        $nullEqualsSucceed = $this->userHandler->wipeUsersById([$userId]);
+        if (null !== $nullEqualsSucceed) {
+            // messageBag for errors has been filled already
+            throw new InvalidArgumentException(sprintf('Soft-deleting user with id %s failed via AdministratableUserResourceType', $userId));
+        }
+        // messageBag with confirmation has been filled already
+    }
+
+    private function updateRoles(UserInterface $user, array $newRoles): void
+    {
+        $roles = $user->getDplanroles($this->currentCustomerService->getCurrentCustomer())->toArray();
+
+        // Remove roles that are not in the new roles array
+        $removedRoles = $this->getRemovedRoles($roles, $newRoles);
+        foreach ($removedRoles as $role) {
+            $roleInCustomer = $user->removeRoleInCustomer($role, $this->currentCustomerService->getCurrentCustomer());
+            $role->removeUserRoleInCustomer($roleInCustomer);
+            $this->getTypes()->getUserRoleInCustomerResourceType()->deleteEntity($roleInCustomer->getId());
+        }
+
+        // Add new roles that the user does not already have
+        $addedRoles = $this->getAddedRoles($roles, $newRoles);
+        foreach ($addedRoles as $role) {
+            $user->addDplanrole($role, $this->currentCustomerService->getCurrentCustomer());
+        }
     }
 }


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/tickets/DS-161/BOP-Loschen-von-Nutzereintragen-nicht-moglich

Description:
This feature was implemented in https://github.com/demos-europe/demosplan-core/pull/4358 and developed for main.
Now this was needed in release_bobhh and had to be picked and adjusted due to an old edt version running for bobhh.

How to review/test:
You can locally set up the release_bobhh project and login as support and try to delete and or update a user.
.defaults.yml needs 
```
    development:
        version: "5.9"
    search7:
        enabled: true
```
for this old container to work.

Linked PRs (optional):
The original implementation: https://github.com/demos-europe/demosplan-core/pull/4358

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
