### PR TITLE
fix (refs: DPLAN-16383) Validate options are unique when creating custom fields

### DIFF
--- a/demosplan/DemosPlanCoreBundle/CustomField/AbstractCustomField.php
+++ b/demosplan/DemosPlanCoreBundle/CustomField/AbstractCustomField.php
@@ -43,7 +43,7 @@ abstract class AbstractCustomField implements CustomFieldInterface
         }
 
         // Check for duplicate labels using Collections
-        $labels = collect($newOptions)->map(fn($option) => $option->getLabel())->map('trim');
+        $labels = collect($newOptions)->map(fn ($option) => $option->getLabel())->map('trim');
         if ($labels->count() !== $labels->unique()->count()) {
             throw new InvalidArgumentException('Option labels must be unique');
         }
@@ -53,7 +53,7 @@ abstract class AbstractCustomField implements CustomFieldInterface
     {
         collect($newOptions)
             ->filter(fn ($option) => $option->getId())
-            ->map(fn($option) => $option->getId())
+            ->map(fn ($option) => $option->getId())
             ->each(function ($id) {
                 if (null === $this->getCustomOptionValueById($id)) {
                     throw new InvalidArgumentException("Invalid option ID: {$id}");

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldFactory.php
@@ -37,6 +37,7 @@ class CustomFieldFactory
         if (isset($attributes['options']) && method_exists($customField, 'setOptions')) {
             // Transform options to the new format if they come as strings
             $options = $this->normalizeOptions($attributes['options']);
+            $customField->validateBasicStructure($options);
             $customField->setOptions($options);
         }
 

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldUpdater.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldUpdater.php
@@ -17,7 +17,6 @@ use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldOption;
 use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
-use Illuminate\Support\Collection;
 use Ramsey\Uuid\Uuid;
 
 class CustomFieldUpdater
@@ -73,9 +72,7 @@ class CustomFieldUpdater
         $updatedOptions = $this->processOptionsUpdate($currentOptions, $newOptions);
         $customField->validate($updatedOptions);
         $customField->setOptions($updatedOptions);
-
     }
-
 
     /**
      * @param CustomFieldOption[] $currentOptions

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldUpdater.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldUpdater.php
@@ -14,8 +14,10 @@ namespace demosplan\DemosPlanCoreBundle\Utils\CustomField;
 
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldInterface;
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldOption;
+use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
+use Illuminate\Support\Collection;
 use Ramsey\Uuid\Uuid;
 
 class CustomFieldUpdater
@@ -66,12 +68,14 @@ class CustomFieldUpdater
         }
 
         $newOptions = $attributes['options'];
-        $customField->validate($newOptions);
-
         $currentOptions = $customField->getOptions();
+
         $updatedOptions = $this->processOptionsUpdate($currentOptions, $newOptions);
+        $customField->validate($updatedOptions);
         $customField->setOptions($updatedOptions);
+
     }
+
 
     /**
      * @param CustomFieldOption[] $currentOptions


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-16383


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
