### PR TITLE
fix(refs DPLAN-16010): Add check for data before using it

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsList.vue
@@ -887,7 +887,9 @@ export default {
     this.setContent({ prop: 'commentsList', val: { ...this.commentsList, procedureId: this.procedure.id, statementId: this.statementId } })
     this.fetchProcedureMapSettings({ procedureId: this.procedure.id })
       .then(response => {
-        this.procedureMapSettings = { ...this.procedureMapSettings, ...response.attributes }
+        if (response?.attributes) {
+          this.procedureMapSettings = { ...this.procedureMapSettings, ...response.attributes }
+        }
       })
 
     this.fetchLayers(this.procedureId)


### PR DESCRIPTION
### Ticket
[DPLAN-16010](https://demoseurope.youtrack.cloud/issue/DPLAN-16010/Fehlermeldung-in-Konsole-wenn-man-auf-das-MID-in-Erfolgspopup-nach-dem-Erstellen-von-STN-klickt-Uncaught-in-promise-TypeError)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR adds a check for the API response in the mounted hook to make sure data is there before using it.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Create a new STN --> click on MID in the success popup --> check the console for 'Uncaught (in promise) TypeError: can't access property "attributes", response is undefined error.'

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

