### PR TITLE
feat(refs DPLAN-14969): Increase duration of the local session

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakLogoutManager.php
@@ -30,7 +30,7 @@ class OzgKeycloakLogoutManager
     private const POST_LOGOUT_REDIRECT_URI = 'post_logout_redirect_uri=https://';
     private const ID_TOKEN_HINT = 'id_token_hint=';
 
-    /** @var int Session expiration time for testing (15 minutes) */
+    /** @var int Session expiration time for testing (120 minutes) */
     private const TEST_SESSION_LIFETIME_SECONDS = 7200;
 
     public function __construct(


### PR DESCRIPTION
<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
The timer implemented in [DPLAN-14969](https://demoseurope.youtrack.cloud/issue/DPLAN-14969/ADO-Issue-23560-Rechtzeitige-Ankundigung-Ausloggen-damit-gespeichert-werden-kann) was set to 15 min locally for testing purposes. This PR increases the session duration to 120 min.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Log in as admin -> the session duration should be 2h.

### Linked PRs (optional)
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
BE: https://github.com/demos-europe/demosplan-core/pull/4959
FE: https://github.com/demos-europe/demosplan-core/pull/4970

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

