### PR TITLE
fix(refs: DPLAN-16383): prevent duplicated custom field and option names

### DIFF
--- a/client/js/components/procedure/admin/AdministrationCustomFieldsList.vue
+++ b/client/js/components/procedure/admin/AdministrationCustomFieldsList.vue
@@ -384,7 +384,7 @@ export default {
     checkIfNameIsUnique (name) {
       const identicalNames = Object.values(this.customFields).filter(field => field.attributes.name === name)
 
-      return identicalNames.length <= 1
+      return identicalNames.length <= 0
     },
 
     /**
@@ -673,7 +673,11 @@ export default {
 
       let isAnyOptionNameDuplicated = false
       customFieldOptions.forEach(option => {
-        if (option.label !== '') {
+        if (isAnyOptionNameDuplicated) {
+          /* since the array function forEach does not accept continue in its arrow function we have to use return,
+          also see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_continue for further info */
+          return
+        } else if (option.label !== '') {
           isAnyOptionNameDuplicated = !this.checkIfOptionNameIsUnique(customFieldOptions, option.label)
         }
       })


### PR DESCRIPTION
### Ticket
DPLAN-16383

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

It was possible to create custom fields with the same name, or to change the name of a field to one that already existed. It was also possible to create an option, name it like an existing option, then create another option and give it a unique name and then save all this. In edit mode you got an error form the BE and when creating a new field the duplicated option names where saved.
This PR solves the duplicated name issues for both field and option name.  

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and open a procedure
2. Change to "Konfigurierbare Abschnittsfelder" and create a new field
3. Try to create another field with the same name
4. Check if there comes an error message popup and the duplicated field name can't be saved
5. When creating a new field, try to add two options with the same name followed by an option with a unique name
6. Check if there comes an error message popup and the duplicated options can't be saved
7. Check the same points for editing a field by changing the name to an existing name and add or rename options
8. Check if all error messages make sense for the specific case


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
