### PR TITLE
f DPLAN-16340 remove join on strings

### DIFF
--- a/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
+++ b/client/js/components/user/DpOrganisationList/DpOrganisationList.vue
@@ -455,10 +455,10 @@ export default {
         sort: 'name',
         filter: filterObject,
         fields: {
-          Customer: orgaFields.Customer.join(),
-          Orga: orgaFields.Orga.join(),
-          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer.join(),
-          ...(orgaFields.Branding ? { Branding: orgaFields.Branding.join() } : {})
+          Customer: orgaFields.Customer,
+          Orga: orgaFields.Orga,
+          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer,
+          ...(orgaFields.Branding ? { Branding: orgaFields.Branding } : {})
         },
         include: includeFields.join()
       })
@@ -473,10 +473,10 @@ export default {
           number: page
         },
         fields: {
-          Customer: orgaFields.Customer.join(),
-          Orga: orgaFields.Orga.join(),
-          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer.join(),
-          ...(orgaFields.Branding ? { Branding: orgaFields.Branding.join() } : {})
+          Customer: orgaFields.Customer,
+          Orga: orgaFields.Orga,
+          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer,
+          ...(orgaFields.Branding ? { Branding: orgaFields.Branding } : {})
         },
         sort: 'name',
         filter: {
@@ -509,10 +509,10 @@ export default {
           number: page
         },
         fields: {
-          Customer: orgaFields.Customer.join(),
-          Orga: orgaFields.Orga.join(),
-          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer.join(),
-          ...(orgaFields.Branding ? { Branding: orgaFields.Branding.join() } : {})
+          Customer: orgaFields.Customer,
+          Orga: orgaFields.Orga,
+          OrgaStatusInCustomer: orgaFields.OrgaStatusInCustomer,
+          ...(orgaFields.Branding ? { Branding: orgaFields.Branding } : {})
         },
         sort: 'name',
         include: includeFields.join()


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16340/Organisationliste-ladt-nicht


Description: 
orgaFields is defined as an object where each property is already a joined string (e.g., Customer: orgaFieldsArrays.Customer.join()). But a join() is called again on orgaFields.Customer, which it's already a string, not an array. Same with the other calls

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

