### PR TITLE
f DPLAN-16398 improve email footer replacement

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_member_email.html.twig
@@ -123,7 +123,17 @@
 
         {% set emailText = templateVars.procedure.settings.emailText|default %}
         {% if hasPermission('feature_email_invitable_institution_additional_invitation_text') and templateVars.emailTextAdded is defined %}
-            {% set emailText = emailText ~ '<br/><br/>' ~ templateVars.emailTextAdded|wysiwyg|nl2br %}
+            {# Remove existing footer to replace with updated one #}
+            {% set footerMarker = '---------' %}
+            {% set hasExistingFooter = false %}
+            {% if emailText and footerMarker in emailText %}
+                {% set emailTextParts = emailText|split(footerMarker) %}
+                {% set emailText = emailTextParts[0]|trim %}
+                {% set hasExistingFooter = true %}
+            {% endif %}
+            {# Add current footer with selected TÖBs - no br/br if footer existed #}
+            {% set spacing = hasExistingFooter ? '' : '<br/><br/>' %}
+            {% set emailText = emailText ~ spacing ~ templateVars.emailTextAdded|wysiwyg|nl2br %}
         {% endif %}
 
         <div class="{{ 'u-mb-0_75'|prefixClass }}">


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16398/BOB-SH-Bauleitplanung-Prod-Stage-Mit-jedem-Speichern-einer-Einladungsmail-wird-die-TOB-Liste-neu-angehangt-T36935

Description:
improve email footer replacement with smart spacing to avoid having duplicated footer in emails.

- Remove existing footer (marked by '---------') before adding new content
- Skip br/br spacing when replacing existing footer to prevent extra whitespace
- Add br/br spacing only when appending to email text without existing footer
- Ensures clean email formatting for TÖB invitation text updates

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
