### PR TITLE
f DPLAN-162343 remove filter by non-existent login field.

### DIFF
--- a/client/js/components/user/DpUserListExtended.vue
+++ b/client/js/components/user/DpUserListExtended.vue
@@ -103,7 +103,6 @@ export default {
       filterValue: '',
       headerItems: [
         { label: 'Name', width: 'u-1-of-4' },
-        { label: 'Login', width: 'u-1-of-4' },
         { label: 'E-Mail', width: 'u-1-of-4' }
       ],
       isFiltered: false,
@@ -224,9 +223,9 @@ export default {
             memberOf: 'name'
           }
         }
-        filter[`login_${idx}`] = {
+        filter[`email_${idx}`] = {
           condition: {
-            path: 'login',
+            path: 'email',
             value: subString,
             operator: 'STRING_CONTAINS_CASE_INSENSITIVE',
             memberOf: 'name'


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16343/BOBHH-Benutzer-Suche-funktioniert-nicht

Description: remove filter by non-existent login field and use email instead

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

