### PR TITLE
fix(refs DPLAN-16399): initialize custom field values on stmt segment

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -737,6 +737,18 @@ export default {
       dplan.notify.notify('confirm', Translator.trans('recommendation.pasted'))
     },
 
+    getCurrentSelectedOption (fieldId) {
+      const selectedOption = this.customFields[fieldId].attributes.options?.find(
+        option => option.id === this.segment.attributes.customFields?.find(
+          customFieldIdValue => customFieldIdValue.id === fieldId)?.value)
+
+      if (!selectedOption) {
+        return
+      }
+
+      return selectedOption
+    },
+
     handleTabChange (id) {
       this.activeId = id
     },
@@ -770,6 +782,20 @@ export default {
         .then(() => {
           this.setSelectedAssignee()
         })
+    },
+
+    initCustomFieldValues () {
+      Object.values(this.customFields).map((field) => {
+        const selectedOption = this.getCurrentSelectedOption(field.id)
+
+        if (selectedOption) {
+          this.customFieldValues[field.id] = {
+            fieldId: field.id,
+            id: selectedOption.id + ":" + selectedOption.label,
+            name: selectedOption.label,
+          }
+        }
+      })
     },
 
     initPlaces () {
@@ -1139,6 +1165,7 @@ export default {
   mounted () {
     this.initPlaces()
     this.initAssignableUsers()
+    this.initCustomFieldValues()
 
     if (hasPermission('field_segments_custom_fields') && this.segment.attributes.customFields?.length > 0) {
       this.setInitiallySelectedCustomFieldValues()


### PR DESCRIPTION
### Ticket
[DPLAN-16399](https://demoseurope.youtrack.cloud/issue/DPLAN-16399/Custom-Fields-wenn-der-Option-geandert-ist-wird-es-nicht-richtig-im-Abschnitt-Erwiderungsansicht-ubergenommen)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

When editing a statment segment form the statement segement list it is possible to choose values for custom field for the segment. After saving the values they where not preselected when reloading the page. This PR initializes the custom field multiselects with the last saved values.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and open a procedure with custom fields and with a statement, that have segments
2. Open the segment list and edit (click on the three little dots ... next to the segment) a segment
3. Click on "Erwiederung" and then check the checkbox "Weitere Felder bearbeiten"
4. Choose a value for a custom field and save
5. Leave the dialog and visit it again
6. Check if the saved value is selected in the multiselect field of the custom field  

- [x] Move the tickets on the board accordingly
