### PR TITLE
fix(refs dplan-16165): Use modelValue for DpInput in StatementModal

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -357,7 +357,7 @@
                 }"
                 name="r_represents"
                 :placeholder="Translator.trans('institution.represents')"
-                :value="formData.r_represents"
+                :model-value="formData.r_represents"
                 @input="val => setStatementData({r_represents: val})" />
             </div>
           </fieldset>


### PR DESCRIPTION
### Ticket
[DPLAN-16165](https://demoseurope.youtrack.cloud/issue/DPLAN-16165/Nicht-moglich-etwas-in-der-Die-Stellungnahme-im-Namen-folgender-Institution-zu-reinschreiben)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- for v-model to work in Vue 3, we need to use modelValue
- DpInput has been updated to not support value anymore

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
log in as admin --> submit a STN --> type something into "Die Stellungnahme im Namen folgender Institution" input 

### Linked PRs (optional)
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
Some of the dp-input instances in the code base were adjusted in:
https://github.com/demos-europe/demosplan-core/pull/4976
https://github.com/demos-europe/demosplan-core/pull/4984

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

