### PR TITLE
test: add missing mutation mock

### DIFF
--- a/tests/frontend/unit/DpAdminLayerList.spec.js
+++ b/tests/frontend/unit/DpAdminLayerList.spec.js
@@ -20,7 +20,8 @@ describe('AdminLayerList', () => {
 
   beforeEach(() => {
     mutations = {
-      setMinimapBaseLayer: jest.fn()
+      setMinimapBaseLayer: jest.fn(),
+      updateState: jest.fn()
     }
 
     actions = {


### PR DESCRIPTION
`yarn test` failed because the `updateState` mutation was missing in `AdminLayerList.spec.js`.

### How to review / test

Run `yarn test`, there should be no errors. :rocket: 