### PR TITLE
fix(refs:DPLAN-16246): fix TW class syntax

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/TagListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <form
-    class="grid grid-cols-[1fr,auto,auto] items-center gap-1"
+    class="grid grid-cols-[1fr_auto_auto] items-center gap-1"
     data-dp-validate="editTagOrCategoryForm">
     <div class="flex space-x-1">
       <dp-icon


### PR DESCRIPTION
### Ticket
[DPLAN-16246](https://demoseurope.youtrack.cloud/issue/DPLAN-16246/Schlagworte-verwalten-Icons-sind-nach-links-verrutscht)

The tailwind class for the grid columns failed because the syntax was not longer correct in tailwind 4. This PR changes the class to use the correct syntax, as seen [here](https://tailwindcss.com/docs/grid-template-columns#using-a-custom-value) in the tailwind docs.

### How to review/test
log in as Mandantenadmin > go to institution tags page > edit tags page > check if icons are on the same line as headings

