### PR TITLE
fix(refs DPLAN-16193): change buttons in layer and organisation lists

### DIFF
--- a/client/js/components/map/admin/AdminLayerList.vue
+++ b/client/js/components/map/admin/AdminLayerList.vue
@@ -205,22 +205,27 @@
         class="text-right mt-5 space-x-2"
         v-if="!isLoading">
         <dp-button
-          data-cy="adminLayerList:save"
           :busy="!isEditable"
           :text="Translator.trans('save')"
-          @click="saveOrder" />
+          data-cy="adminLayerList:save"
+          rounded
+          @click="saveOrder"
+        />
         <dp-button
-          data-cy="adminLayerList:saveAndReturn"
           :busy="!isEditable"
           :text="Translator.trans('save.and.return.to.list')"
-          @click="saveOrder(true)" />
-        <button
-          class="btn btn--secondary"
+          data-cy="adminLayerList:saveAndReturn"
+          rounded
+          @click="saveOrder(true)"
+        />
+        <dp-button
+          :text="Translator.trans('reset.order')"
+          color="secondary"
           data-cy="adminLayerList:resetOrder"
+          rounded
           type="reset"
-          @click.prevent="resetOrder">
-          {{ Translator.trans('reset.order') }}
-        </button>
+          @click.prevent="resetOrder"
+        />
       </div>
     </div>
   </div>

--- a/client/js/components/procedure/admin/AdministrationMemberList.vue
+++ b/client/js/components/procedure/admin/AdministrationMemberList.vue
@@ -56,11 +56,12 @@ All rights reserved
         </button>
 
         <dp-button
-          class="btn btn--primary float-right"
-          data-cy="addPublicAgency"
           :href="addMemberPath"
           :text="Translator.trans('invitable_institution.add')"
-          variant="primary" />
+          class="btn btn--primary float-right"
+          data-cy="addPublicAgency"
+          rounded
+        />
       </div>
     </template>
   </organisation-table>

--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -28,7 +28,8 @@
         :text="Translator.trans('invitable_institution.add')"
         data-cy="addPublicAgency"
         rounded
-        @click="addPublicInterestBodies(selectedItems)" />
+        @click="addPublicInterestBodies(selectedItems)"
+      />
       <a
         :href="Routing.generate('DemosPlan_procedure_member_index', { procedure: procedureId })"
         data-cy="organisationList:abortAndBack"

--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -27,6 +27,7 @@
       <dp-button
         :text="Translator.trans('invitable_institution.add')"
         data-cy="addPublicAgency"
+        rounded
         @click="addPublicInterestBodies(selectedItems)" />
       <a
         :href="Routing.generate('DemosPlan_procedure_member_index', { procedure: procedureId })"


### PR DESCRIPTION
### Ticket
[DPLAN-16193](https://demoseurope.youtrack.cloud/issue/DPLAN-16193/Falsches-Buttonstil-Institution-hinzufugen-und-bei-Kartenebenen)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Some buttons in the "Kartenebenen definieren" dialog and the "Institution hinzufügen" dialog has a wrong style. This PR changes the style of the buttons to the design as it is in our figma design template.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and change to open a procedure
2. Change to "Kartenebenen definieren" and "Institution hinzufügen"
3. Check in each dialog, if the buttons at the bottom of the dialog have rounded borders and a pill like style 

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
