### PR TITLE
fix: replace double quotes with single quotes in migration SQL

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/07/Version20250723134332.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2025/07/Version20250723134332.php
@@ -68,7 +68,7 @@ class Version20250723134332 extends AbstractMigration
         // Step 2: Update segment values from labels to IDs
         $segments = $this->connection->fetchAllAssociative(
             'SELECT _st_id, custom_fields FROM _statement
-               WHERE entity_type = "Segment" AND custom_fields IS NOT NULL'
+               WHERE entity_type = \'Segment\' AND custom_fields IS NOT NULL'
         );
 
         foreach ($segments as $segment) {
@@ -133,7 +133,7 @@ class Version20250723134332 extends AbstractMigration
         // Step 2: Update segment values from IDs back to labels
         $segments = $this->connection->fetchAllAssociative(
             'SELECT _st_id, custom_fields FROM _statement
-               WHERE entity_type = "Segment" AND custom_fields IS NOT NULL'
+               WHERE entity_type = \'Segment\' AND custom_fields IS NOT NULL'
         );
 
         foreach ($segments as $segment) {


### PR DESCRIPTION
Replace double-quoted string literals with single-quoted ones in Version20250723134332
to ensure proper SQL syntax regardless of ANSI_QUOTES mode settings.

Branch is already tested on develop (migration was running)