### PR TITLE
chore(refs dplan-15846): Fix linting errors in LayerSettings

### DIFF
--- a/client/js/components/map/admin/LayerSettings.vue
+++ b/client/js/components/map/admin/LayerSettings.vue
@@ -87,7 +87,6 @@
       @selectAll="selectAllLayers"
       @deselectAll="deselectAllLayers"
     >
-
       <template v-slot:tag="{ props }">
         <span class="multiselect__tag">
           {{ props.option.label }}
@@ -183,7 +182,7 @@ export default {
     DpSelect
   },
 
-  mixins: [ prefixClassMixin ],
+  mixins: [prefixClassMixin],
 
   props: {
     availableProjections: {
@@ -605,7 +604,7 @@ export default {
       } else {
         this.unavailableLayers = []
       }
-    },
+    }
   },
 
   mounted () {


### PR DESCRIPTION
<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR fixes linting errors connected to the changes made in the PR listed below.
1 warning remains - using a self-closing button-tag is bad practice and can lead to rendering problems in some browsers.

### Linked PRs (optional)
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
[DPLAN-15846](https://demoseurope.youtrack.cloud/issue/DPLAN-15846/ADO-30421-Veraltete-Layer-automatisch-erkennen-und-Nutzer-informieren): https://github.com/demos-europe/demosplan-core/pull/5068


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
