### PR TITLE
fix(refs DPLAN-16415): change cancel button in add organisation dialog

### DIFF
--- a/client/js/components/procedure/admin/DpAddOrganisationList.vue
+++ b/client/js/components/procedure/admin/DpAddOrganisationList.vue
@@ -30,12 +30,13 @@
         rounded
         @click="addPublicInterestBodies(selectedItems)"
       />
-      <a
+      <dp-button
         :href="Routing.generate('DemosPlan_procedure_member_index', { procedure: procedureId })"
+        :text="Translator.trans('abort.and.back')"
+        color="secondary"
         data-cy="organisationList:abortAndBack"
-        class="btn btn--secondary">
-        {{ Translator.trans('abort.and.back') }}
-      </a>
+        rounded
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Ticket
[DPLAN-16415](https://demoseurope.youtrack.cloud/issue/DPLAN-16415)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

In "Institution hinzufügen" dialog, the add and the cancel button where not in one line and had different size. This PR changes the cancel button in position and size, by making a dp-button of it.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and open a procedure.
2. Go to "Institutionen verwalten" and from there to "Institution hinzufügen".
3. Check if the button at the bottom are in the same line and have nearly the same size


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
