### PR TITLE
fix(refs DPLAN-16206): put v-model to name input

### DIFF
--- a/client/js/components/procedure/admin/NewBlueprintForm.vue
+++ b/client/js/components/procedure/admin/NewBlueprintForm.vue
@@ -36,6 +36,7 @@
         class="sr-only"
         v-text="Translator.trans('blueprint.data')" />
       <dp-input
+        v-model="name"
         id="r_name"
         data-cy="newMasterName"
         :label="{
@@ -237,6 +238,7 @@ export default {
     return {
       isLoading: false,
       mainEmail: this.agencyMainEmailFullAddress || '',
+      name: '',
       selectedBlueprint: this.masterBlueprintId,
       emailAddresses: this.initEmailAddresses
     }

--- a/client/js/components/procedure/admin/NewBlueprintForm.vue
+++ b/client/js/components/procedure/admin/NewBlueprintForm.vue
@@ -38,13 +38,14 @@
       <dp-input
         v-model="name"
         id="r_name"
-        data-cy="newMasterName"
         :label="{
           text: Translator.trans('name')
         }"
+        data-cy="newMasterName"
         maxlength="200"
         name="r_name"
-        required />
+        required
+      />
 
       <dp-select
         id="r_copymaster"


### PR DESCRIPTION
### Ticket
[DPLAN-16206](https://demoseurope.youtrack.cloud/issue/DPLAN-16206/Blaupause-Name-verschwindet-sobald-man-Blaupause-auswahlt-oder-Verfahrenstrager-E-Mail-eingibt)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

When adding a new blueprint, name input was cleared after choosing a template blueprint or typing in an e-mail address. This PR adds a v-model to the name input, that prevents the field from being cleared. 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and open the Blueprint list
2. Click on the add blueprint button
3. Type in a name in the input field and check if the name is still there, when a template blueprint is chosen or an e-mail address was written into the e-mail input field

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
