### PR TITLE
fix(refs dplan-16226): Add two-way data binding to email input in DpNewProcedure

### DIFF
--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -328,7 +328,10 @@ export default {
       // Do not copy mail from master blueprint otherwise fetch mail from selected blueprint
       const blueprintData = payload.value === this.masterBlueprintId ? this.emptyBlueprintData : await this.fetchBlueprintData(payload)
       this.description = blueprintData.description
-      this.mainEmail = blueprintData.agencyMainEmailAddress
+
+      if (blueprintData.agencyMainEmailAddress !== '') {
+        this.mainEmail = blueprintData.agencyMainEmailAddress
+      }
     },
 
     fetchBlueprintData (blueprintId) {

--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -145,7 +145,7 @@
         name="agencyMainEmailAddress[fullAddress]"
         required
         type="email"
-        :value="mainEmail" />
+        v-model="mainEmail" />
 
       <dp-text-area
         id="r_desc"


### PR DESCRIPTION
### Ticket
[DPLAN-16226](https://demoseurope.youtrack.cloud/issue/DPLAN-16226/E-Mail-Verfahrenstrager-wird-geloscht-wenn-ich-Verfahrenstyp-oder-Blaupause-wahle)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR adds v-model to the email address DpInput in DpNewProcedure, so that the email input doesn't get reset on changing other values in the form.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
create a new procedure --> type in an email address:
1. change 'Verfahrenstyp' --> the typed in email should persist
2. change 'Blaupause --> if the saved Blaupause email address is not an empty string, the typed in address will be overwritten by the one from the Blaupause

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
 
