### PR TITLE
f DPLAN-16397 use the right route to access file within procedure

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/notify_county_email.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/notify_county_email.html.twig
@@ -5,7 +5,7 @@ Die Stellungnahme(n) finden Sie im Anhang.
 Den Stellungnahmen waren folgende Dateien angehaengt:
 {% endif %}
 {% for file in templateVars.files %}
-{{ file|getFile("name") }} {{ url("core_file", { "hash":file|getFile("hash")}) }}
+{{ file|getFile("name") }} {{ url("core_file_procedure", { 'procedureId': templateVars.procedure.id, "hash":file|getFile("hash")}) }}
 {% endfor %}
 Mit freundlichem Gruß
 {{ templateVars.procedure.orgaName }}


### PR DESCRIPTION
Ticket : https://demoseurope.youtrack.cloud/issue/DPLAN-16397/Dataport-Extern-BOB-SH-ROBOB-Prod-und-Stage-Fehler-Links-zu-Anhangen-werden-unvollstandig-in-Mails-eingetragen-T36937
Description: use the right route to access file within procedure


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

