### PR TITLE
fix(refs dplan-16022): Use string values for checkbox in StatementModal

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1537,7 +1537,7 @@ export default {
         r_location_point: '',
         location_is_set: priorityAreaKey.length > 0 ? 'priority_area' : 'geometry',
         r_county: data.draftStatement.statementAttributes.county ?? '',
-        r_makePublic: !!data.draftStatement.publicAllowed
+        r_makePublic: data.draftStatement.publicAllowed ? 'on' : 'off'
       }
 
       if (draft.r_location === 'noLocation') draft.r_location = 'notLocated'


### PR DESCRIPTION
### Ticket
[DPLAN-16022](https://demoseurope.youtrack.cloud/issue/DPLAN-16022/Gesetzter-Haken-in-STN-Entwurf-wird-nicht-gespeichert)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
For the value of r_makePublic checkbox, the frontend expects a string value, but when loading previously saved statement drafts, was receiving a boolean value. This PR converts backend boolean to expected string format during draft loading.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
1. log in as a private person 
2. create and save a statement draft (check this checkbox: 'Ich möchte, dass meine Stellungnahme bei DiPlanBeteiligung online für andere Beteiligte einsehbar ist, damit diese meine Stellungnahme mitzeichnen können. Mein Name wird dabei nicht genannt.') 
3. go to saved drafts and check if the checkbox setting is saved in the draft

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

