### PR TITLE
fix(refs DPLAN-16190): add reset of selection after deleting elements

### DIFF
--- a/client/js/components/procedure/admin/AdministrationMemberList.vue
+++ b/client/js/components/procedure/admin/AdministrationMemberList.vue
@@ -153,7 +153,7 @@ export default {
       })
         .then(response => {
           this.$refs.organisationTable.getInstitutionsWithContacts()
-          dplan.notify.notify('confirm', Translator.trans('confirm.invitable_institutions.deleted', { count: organisationIds.length }))
+          this.$refs.organisationTable.resetSelection()
           this.selectedItems = []
         })
         .catch(() => {

--- a/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/OrganisationTable.vue
@@ -515,6 +515,12 @@ export default {
       this.$refs.searchField.handleReset()
     },
 
+    resetSelection () {
+      this.$refs.DpDataTable.resetSelection()
+      this.$refs.DpDataTable.elementSelections = {}
+      this.$refs.DpDataTable.selectedElements = []
+    },
+
     returnPermissionChecksValuesArray (permissionChecks) {
       return permissionChecks.reduce((acc, check) => {
         if (hasPermission(check.permission)) {


### PR DESCRIPTION
### Ticket
[DPLAN-16190](https://demoseurope.youtrack.cloud/issue/DPLAN-16190/Wenn-man-eine-Institution-loscht-bekommt-man-das-Erfolgspopup-zweimal)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

When deleting institutions from the institution list in the "Institutionen verwalten" dialog, the success message appears two times instead of one. Solving this behavior leads to an error message, when deleting another institution from the list. This PR solves both behaviors, by completely reset the selection after deleting an element.  

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and choose a procedure
2. Go to "Institutionen verwalten" dialog and add some institutions
3. Select some of the institutions and click on the delete button
4. Check if there is only one success message
5. Try the same with the select all checkbox and delete all visible and checked entries
6. Check if there is no error message when deleting entries two or more times in a row, without reloading the page between it

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
