### PR TITLE
f DPLAN-15662 refactor: use updateProcedure instead of updateProcedur…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -97,7 +97,7 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
         QueryProcedure $esQueryProcedure,
         ServiceOutput $serviceOutput,
         ServiceStorage $serviceStorage,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         parent::__construct($messageBag);
         $this->contentService = $contentService;
@@ -875,8 +875,8 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
             if (null !== $endedInternalProcedure->getEndDate()
                 && !$endedInternalProcedure->getMaster() && !$endedInternalProcedure->isDeleted()) {
                 $data = [
-                    'id' => $endedInternalProcedure->getId(),
-                    'phase' => $internalPhaseKey,
+                    'id'       => $endedInternalProcedure->getId(),
+                    'phase'    => $internalPhaseKey,
                     'customer' => $endedInternalProcedure->getCustomer(),
                 ];
                 $updatedProcedure = $this->procedureService->updateProcedure($data);
@@ -901,9 +901,9 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
             if (null !== $endedExternalProcedure->getPublicParticipationEndDate()
                 && !$endedExternalProcedure->getMaster() && !$endedExternalProcedure->isDeleted()) {
                 $data = [
-                    'id' => $endedExternalProcedure->getId(),
+                    'id'                       => $endedExternalProcedure->getId(),
                     'publicParticipationPhase' => $internalPhaseKey,
-                    'customer' => $endedExternalProcedure->getCustomer(),
+                    'customer'                 => $endedExternalProcedure->getCustomer(),
                 ];
                 $updatedProcedure = $this->procedureService->updateProcedure($data);
                 $changedExternalProcedures->push($updatedProcedure);


### PR DESCRIPTION
### Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-15662/ROBOB-Ubernahme-der-automatischen-Umstellung-in-Auswertung-bei-Fristende-wie-Regio-BLP-wird-nicht-ins-Protokoll-ubernommen

Description: refactor: use updateProcedure instead of updateProcedureObject: 
Replace direct entity manipulation with service method calls in ProcedureHandler for both internal and external procedure phase updates. The updateProcedure method generates report entries for phase changes initiated by MaintenanceController. This will ensure that automatic phase changes from the maintenance system are properly logged/tracked through report entries.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

