### PR TITLE
f DPLAN-16227 Fallback to 'analysis' if 'evaluating' phase not found:

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -1396,11 +1396,21 @@ class DemosPlanProcedureController extends BaseController
                 $template = '@DemosPlanCore/DemosPlanProcedure/administration_edit.html.twig';
                 $title = 'procedure.adjustments';
 
+                $evaluatingPhase = null;
                 foreach ($templateVars['internalPhases'] as $internalPhase) {
                     if ('evaluating' === $internalPhase['key']) {
                         $evaluatingPhase = $internalPhase['name'];
-
                         break;
+                    }
+                }
+                
+                // Fallback to 'analysis' if 'evaluating' phase not found
+                if (null === $evaluatingPhase) {
+                    foreach ($templateVars['internalPhases'] as $internalPhase) {
+                        if ('analysis' === $internalPhase['key']) {
+                            $evaluatingPhase = $internalPhase['name'];
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16227/ROBOB-Anzeige-im-Phasenumschaltkasten-zeigt-englische-Phasenbeschreibung


Description: Fallback to 'analysis' if 'evaluating' phase not found:
- Initialize $evaluatingPhase to null before the first loop
- Keep the original logic to look for 'evaluating' phase first
- Add a fallback section that checks for 'analysis' phase if 'evaluating' was not found


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
