### PR TITLE
feat(refs BMDS-1551, DPLAN-16430): Allow project-overrides for client bundles

### DIFF
--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -184,12 +184,12 @@ function showErrorMessage (err, stats) {
 
 function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConfig, webpackRunner) {
   if (mode === 'build') {
-    log(chalk.green(`Begin ${chalk.bold('building')} frontend assets for ${project} in ${chalk.bold(webpackConfig[0].mode)} mode`))
+    log(chalk.green(`Begin ${chalk.bold('building')} frontend assets for ${chalk.bold(project)} in ${chalk.bold(webpackConfig[0].mode)} mode`))
     webpackRunner.run(userFeedbackCallback)
   }
 
   if (mode === 'watch') {
-    log(chalk.green(`Begin ${chalk.bold('watching')} frontend assets for ${project} in ${chalk.bold(webpackConfig[0].mode)} mode`))
+    log(chalk.green(`Begin ${chalk.bold('watching')} frontend assets for ${chalk.bold(project)} in ${chalk.bold(webpackConfig[0].mode)} mode`))
     webpackRunner.watch({
       aggregateTimeout: 1000
     }, userFeedbackCallback)

--- a/config.webpack.js
+++ b/config.webpack.js
@@ -81,11 +81,13 @@ const baseConfig = {
   }
 }
 
+const bundles = bundleEntryPoints(config)
+
 const bundlesConfig = merge(baseConfig, {
   name: 'main',
   entry: () => {
     return {
-      ...bundleEntryPoints(config.clientBundleGlob),
+      ...bundles,
       style: config.stylesEntryPoint,
       'style-public': config.publicStylesEntryPoint,
       preflight: resolveDir('./client/css/preflight.css'),
@@ -102,6 +104,7 @@ const bundlesConfig = merge(baseConfig, {
     extensions: ['...', '.js', '.vue', '.json', '.ts', '.tsx'],
     alias: {
       '@DpJs': config.absoluteRoot + 'client/js',
+      '@DpJsProject': config.projectRoot + '/client/js',
       vue: config.absoluteRoot + 'node_modules/@vue/compat/dist/vue.esm-bundler',
       // To Fix masterportal issues, we have to resolve some imports within olcs manually
       './olcs/olcsMap.js': config.absoluteRoot + 'node_modules/@masterportal/masterportalapi/src/maps/olcs/olcsMap.js',


### PR DESCRIPTION
### Ticket
DPLAN-16430

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Client bundles can now be overridden in project configurations in much the same way Twig overrides work. Essentially,
there needs to be a `<project>/client/js/bundle/<originalBundleName>.js` file and if that exists it will be used instead of the core one. 

To access components in the project's `client/js/components` directory, instead of `@DpJs` `@DpJsProject` can be used as an alias for imports.

### How to review/test

Create a bundle in a project, run the frontend build, see the bundle being used. I'd recommend `user/alternativeLogin.js` as that's very easy to reach.

<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->
