### PR TITLE
feat: modify webpack warning behaviour

### DIFF
--- a/client/fe/webpack/moduleRules.js
+++ b/client/fe/webpack/moduleRules.js
@@ -10,6 +10,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const config = require('../config/config').config
 const resolveDir = require('./util').resolveDir
 const { purgeCSSPlugin } = require('@fullhuman/postcss-purgecss')
+const sass = require('sass-embedded')
 
 /**
  * List of modules which need to be transpiled with Babel
@@ -129,8 +130,10 @@ const moduleRules =
         {
           loader: 'sass-loader',
           options: {
-            implementation: require('sass-embedded'),
+            implementation: sass,
             sassOptions: {
+              logger: sass.Logger.silent,
+              quietDeps: true,
               additionalData: `$url-path-prefix: '${config.urlPathPrefix}';`,
               loadPaths: [
                 config.projectRoot + 'web/',

--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -179,6 +179,12 @@ function showErrorMessage (err, stats) {
         log(chalk.yellow(warning.message))
       }
     }
+  } else if (stats.hasWarnings()) {
+    // Always show warnings, even when there are no errors
+    const info = stats.toJson()
+    for (const warning of info.warnings) {
+      log(chalk.yellow(warning.message))
+    }
   }
 }
 


### PR DESCRIPTION
Sass Loader warnings are now never emitted, but Vue Template Compiler warnings and all others that might appear will be printed on every build.

**Testplan**

Run the webpack build for any project, Vue Template Compiler warnings should be displayed.