### PR TITLE
fix some build warnings

### DIFF
--- a/client/js/components/addon/AddonWrapper.vue
+++ b/client/js/components/addon/AddonWrapper.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <component
+      v-bind="{ demosplanUi, ...addonProps }"
       :is="addon.component"
       v-for="addon in loadedAddons"
       :key="`addon:${addon.name}`"
       :ref="`${addon.name}${refComponent}`"
       :data-cy="`addon:${addon.name}`"
-      v-bind="{ demosplanUi, ...addonProps }"
       @addonEvent:emit="(event) => $emit(event.name, event.payload)" />
   </div>
 </template>

--- a/client/js/components/statement/statement/DpVersionHistory.vue
+++ b/client/js/components/statement/statement/DpVersionHistory.vue
@@ -30,36 +30,40 @@
       :class="{'u-mr': days.length === 0}"
       style="height: 88vh;">
       <table class="u-mb">
-        <tr class="sr-only">
-          <th>
-            {{ Translator.trans('history') }}
-          </th>
-        </tr>
-        <tr>
+        <thead class="sr-only">
+          <tr>
+            <th>
+              {{ Translator.trans('history') }}
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
           <!-- if history is empty -->
-          <td
-            v-if="days === null || typeof days === 'undefined' || days.length === 0"
-            data-cy="noEntries"
-            colspan="4"
-            class="u-mr">
-            <dp-inline-notification
-              class="mt-3 mb-2"
-              :message="Translator.trans('explanation.noentries')"
-              type="info" />
-          </td>
-        </tr>
-        <!-- if there are history items -->
-        <!-- for each day -->
-        <template v-if="days.length">
-          <dp-version-history-day
-            v-for="(day, idx) in days"
-            :key="idx"
-            :procedure-id="procedureId"
-            :date="day.attributes.day"
-            :day="day"
-            :all-times="times"
-            :entity="entity" />
-        </template>
+          <tr v-if="!days || days.length === 0">
+            <td
+              data-cy="noEntries"
+              colspan="4"
+              class="u-mr">
+              <dp-inline-notification
+                class="mt-3 mb-2"
+                :message="Translator.trans('explanation.noentries')"
+                type="info" />
+            </td>
+          </tr>
+          <!-- if there are history items -->
+          <!-- for each day -->
+          <template v-if="days.length">
+            <dp-version-history-day
+              v-for="(day, idx) in days"
+              :key="idx"
+              :procedure-id="procedureId"
+              :date="day.attributes.day"
+              :day="day"
+              :all-times="times"
+              :entity="entity" />
+          </template>
+        </tbody>
       </table>
     </div>
   </div>


### PR DESCRIPTION
**Description:** 

- COMPILER_V_BIND_OBJECT_ORDER issue: place the v-bind attribute to the top
- <tr> cannot be child of <table>, according to HTML specifications: add thead and tbody tags
