### PR TITLE
fix(DPLAN-16347): unable to display fragments

### DIFF
--- a/client/js/store/statement/Fragment.js
+++ b/client/js/store/statement/Fragment.js
@@ -249,7 +249,7 @@ export default {
       }
 
       return dpApi.get(url)
-        .then(({ data }) => commit('loadFragmentsToStore', { fragments: data.data, statementId: data.statementId }))
+        .then(({ data: responseData  }) => commit('loadFragmentsToStore', { fragments: responseData.data, statementId: data.statementId }))
     },
 
     /**


### PR DESCRIPTION
### Ticket
[DPLAN-16347](https://demoseurope.youtrack.cloud/issue/DPLAN-16347) Wir zeigen keine Datensätze obwohl eine STN schon diese hat

**Description:** This PR fixes an issue where fragments were not displayed.

- two variables with the same name caused a variable shadowing effect (two different bindings sharing the same name)
- the inner variable is now destructured under a different name to avoid the conflict

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
