### PR TITLE
fix(refs DPLAN-16414): provide index again

### DIFF
--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -171,7 +171,7 @@
         :form-definitions="formDefinitions" />
       <!-- Loop statements in default viewMode -->
       <dp-assessment-table-card
-        v-for="statement in statements"
+        v-for="(statement, _, index) in statements"
         v-else
         :ref="'itemdisplay_' + statement.id"
         :key="`statement:${statement.id}`"


### PR DESCRIPTION
### Ticket
[DPLAN-16414](https://demoseurope.youtrack.cloud/issue/DPLAN-16414/Undefined-fur-eine-datacy-Hook-index)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

`index` had been accidentally removed, so the data-cy attribute always ended in `undefined`. This PR restores the `index`.

### PR Checklist

- [x] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
