### PR TITLE
fix: reset padding only for layout__item

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_proceduresearch.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_proceduresearch.scss
@@ -16,7 +16,10 @@
 @if not index($dp-skip-components, 'c-proceduresearch') {
     .c-proceduresearch {
         &__heading {
-            padding-left: 0; // this erases the padding-left of .layout__item but not the one on .o-page__padded
+            // Reset padding for layout__item, but not for o-page__padded
+            &.layout__item:not(.o-page__padded) {
+                padding-left: 0;
+            }
             color: $dp-color-highlight !important;
 
             @include media-query('palm') {


### PR DESCRIPTION
After the tailwind 4 migration, the specificity order of styles has changed, and `c-proceduresearch__heading` was also overriding the padding for `o-page__padded`, which it was not intended to do. I restored the previous styling so the heading on the index page is aligned with the content again.
