### PR TITLE
fix(DPLAN-12528): newly copied statements do not appear until the page refresh

### DIFF
--- a/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
+++ b/client/js/components/statement/assessmentTable/DpSelectedItemsStatements.vue
@@ -300,9 +300,9 @@ export default {
               dplan.notify.notify('warning', Translator.trans('statement.copy.to.assessment.table.error', { count: placeholderStatements.length, extids: JSON.stringify(placeholderStatements) }))
             }
 
+            dplan.notify.notify('confirm', Translator.trans('statement.copy.to.assessment.table.confirm', { count: params.statementIds.length }))
             this.$root.$emit('update:paginationAssessmentTable')
             this.$root.$emit('update:assessmentTable')
-            dplan.notify.notify('confirm', Translator.trans('statement.copy.to.assessment.table.confirm', { count: params.statementIds.length }))
           })
           .catch(() => {
             dplan.notify.notify('error', Translator.trans('error.copy'))


### PR DESCRIPTION
### Ticket
[DPLAN-12528](https://demoseurope.youtrack.cloud/issue/DPLAN-12528/Kopierte-STN-erscheint-erst-nach-einem-Reload)

**Description:**  This PR fixes an issue where newly copied statements did not appear until the page was manually refreshed.

The problem was a timing issue. The getStatementAction API call was running too soon. It would try to get the statements before the previous RPC call had finished saving the new statements to the database. This caused it to fetch the old list of statements instead of the updated one.

- place emit event at the end of the then() block

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly