### PR TITLE
fix(DPLAN-12528): incorrect phase

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -653,7 +653,7 @@
 
                     {% else %}
                         {# set all options for optgroups only for edit-mode #}
-                        {% if statement.isSubmittedByCitizen == false and hasPermission('field_show_internal_procedure_phases_in_dropdown') %}
+                        {% if statement.isSubmittedByCitizen == false %}
                             {% set phases = templateVars.internalPhases|default %}
                         {% else %}
                             {% set phases = templateVars.externalPhases|default %}


### PR DESCRIPTION
### Ticket
[DPLAN-16535](https://demoseurope.youtrack.cloud/issue/DPLAN-16535) Falsche Verfahrensschritte in STN-Detailansicht nach dem ich eine Institution STN eingereicht habe

**Description:** This PR fixes an issue with displaying an incorrect phase.

The permission check (`field_show_internal_procedure_phases_in_dropdown`) was stopping the display of the internal phase instead of the external one when a statement was submitted by an institution. I could not find any usage of this permission, it was removed in this [commit](https://github.com/demos-europe/demosplan-core/commit/3d8804e3649c42dd6a9314f7fa4222f8d19a7577). 

As I see it, the permission check for creating a new STN [was removed there as well](https://github.com/demos-europe/demosplan-core/commit/3d8804e3649c42dd6a9314f7fa4222f8d19a7577#diff-aa4753a51a387143e832c7b31b422bb6be2c608b5d4ac5e87f862cfe9e658560L173). So probably they forgot to remove the check permission in this file.

### PR Checklist

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
