### PR TITLE
fix(DPLAN-16347): unable to display fragments - v2

### DIFF
--- a/client/js/store/statement/Fragment.js
+++ b/client/js/store/statement/Fragment.js
@@ -249,7 +249,7 @@ export default {
       }
 
       return dpApi.get(url)
-        .then((response) => commit('loadFragmentsToStore', { fragments: response.data.data, statementId: data.statementId }))
+        .then(response => commit('loadFragmentsToStore', { fragments: response.data.data, statementId: data.statementId }))
     },
 
     /**

--- a/client/js/store/statement/Fragment.js
+++ b/client/js/store/statement/Fragment.js
@@ -249,7 +249,7 @@ export default {
       }
 
       return dpApi.get(url)
-        .then(({ data: responseData  }) => commit('loadFragmentsToStore', { fragments: responseData.data, statementId: data.statementId }))
+        .then((response) => commit('loadFragmentsToStore', { fragments: response.data.data, statementId: data.statementId }))
     },
 
     /**


### PR DESCRIPTION
### Ticket
[DPLAN-16347](https://demoseurope.youtrack.cloud/issue/DPLAN-16347) Wir zeigen keine Datensätze obwohl eine STN schon diese hat

**Description:** This PR fixes an issue where fragments were not displayed.

The [first PR](https://github.com/demos-europe/demosplan-core/pull/5167) has to be changed!

- destructing `{ data: responseData }` --> it creates a new variable called 'responseData' from the data property of the response, but somehow it does not work on the server (maybe some differences in the configuration), so refactor it and rename the variable to test it on the server

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly