### PR TITLE
refactor: Make webpack error handling less annoying

### DIFF
--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -202,7 +202,7 @@ function showErrorMessage (err, stats) {
  * Prints a list of log messages using the given color function
  *
  * @param {Array} messageList Array of webpack stats messages to print
- * @param {Function} colorFunction Chalk color function
+ * @param {chalk.Chalk} colorFunction Chalk color function
  */
 function printStatsMessageList(messageList, colorFunction) {
   messageList.forEach(message => {


### PR DESCRIPTION
Webpack used to dump the stats object at every opportunity it found. Unfortunately, the stats object is stupidly large and mostly useless for debugging.

This change adds error handling for webpack config which should drastically reduce the config object dump(ster fire) occurrences. Additionally, Some refactoring for readability and reuse were done along the way.

Overall, webpack build stability should be increased, along with debuggability especially of the config.

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Make the webpack config fail, for instance by adding a non-existent variable to any of the plugin lists in moduleRules.
- Build and be happy that there is no stats object dump.
