### PR TITLE
BMDS-3870: prepare implementation of TagServiceInterface, ntroduce new Statement method - prepare usage in StatementInterface

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -4181,4 +4181,9 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
 
         return $this;
     }
+
+    public function getStatementsCreatedFromOriginal(): ArrayCollection|Collection
+    {
+        return $this->statementsCreatedFromOriginal;
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/TagService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/TagService.php
@@ -10,6 +10,9 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\TagInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\TagTopicInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\UpdateTagEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Boilerplate;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
@@ -84,7 +87,7 @@ class TagService
      *
      * @throws DuplicatedTagTitleException
      */
-    public function createTag(string $title, TagTopic $topic, bool $persistAndFlush = true): Tag
+    public function createTag(string $title, TagTopicInterface $topic, bool $persistAndFlush = true): TagInterface
     {
         $procedureId = $topic->getProcedure()->getId();
         if ('' === $title) {
@@ -112,7 +115,7 @@ class TagService
      * @throws DuplicatedTagTopicTitleException
      * @throws Exception
      */
-    public function createTagTopic($title, Procedure $procedure, bool $persistAndFlush = true): TagTopic
+    public function createTagTopic($title, ProcedureInterface $procedure, bool $persistAndFlush = true): TagTopic
     {
         $this->assertTitleNotDuplicated($title, $procedure);
         $toCreate = new TagTopic($title, $procedure);
@@ -129,7 +132,7 @@ class TagService
      *
      * @throws DuplicatedTagTopicTitleException
      */
-    public function assertTitleNotDuplicated($title, Procedure $procedure): void
+    public function assertTitleNotDuplicated($title, ProcedureInterface $procedure): void
     {
         $titleCount = $this->tagTopicRepository->count(['procedure' => $procedure, 'title' => $title]);
         if (0 !== $titleCount) {
@@ -255,7 +258,7 @@ class TagService
     /**
      * @return array<int,TagTopic>
      */
-    public function getTagTopicsByTitle(Procedure $procedure, string $tagTopicTitle): array
+    public function getTagTopicsByTitle(ProcedureInterface $procedure, string $tagTopicTitle): array
     {
         return $this->tagTopicRepository->findBy([
             'procedure' => $procedure->getId(),


### PR DESCRIPTION
Ticket:
https://d3.ce.capgemini.com/jira/browse/BMDS-3870
https://demoseurope.youtrack.cloud/issue/EWM-162/BMDS-KI-Capg-Zeiterfassungsticket

Description:
prepare implementation of TagServiceInterface and introduce new Statement method to gather assignableStatements of an original and prepare usage in StatementInterface

This PR is preparing a direct version jump to v0.63 bypassing -non-breaking-changes- made by https://github.com/demos-europe/demosplan-addon/pull/150 and https://github.com/demos-europe/demosplan-addon/pull/151 which will be implemented later in https://github.com/demos-europe/demosplan-core/pull/5193
This is to prevent breaking changes that would occur if the main branch would not adjust to the in v0.63 introduced adjustments. https://github.com/demos-europe/demosplan-addon/pull/152

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
