### PR TITLE
feat: Make build script more platform independent

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,59 +1,84 @@
 #!/usr/bin/env bash
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
 
 if [ $# -lt 4 ]
 then
-  echo "Usage ./build.sh demosplan-production <imagename> <version> <projectname> <?push> <?dev>"
+  echo "Usage ./build.sh demosplan-production <IMAGE_NAME> <VERSION> <PROJECT_NAME> <?push> <?dev>"
   echo "  <?push>: If 'push' is specified, images will be pushed to registry"
   echo "  <?dev>: If 'dev' is specified, container will be built in dev mode, otherwise prod mode"
   exit 2
 fi
 
-projectsfolder="projects"
-
-folder=$1
-imagename=$2
-version=$3
-projectname=$4
-context=.context
-build_mode="prod"
+FOLDER=$1
+IMAGE_NAME=$2
+VERSION=$3
+PROJECT_NAME=$4
+CONTEXT_DIR=.context
+BUILD_MODE="prod"
+PLATFORM="linux/amd64"
 
 # Check if dev environment is requested
 if [[ $6 == "dev" ]]
 then
-  build_mode="dev"
-  version="${version}-dev"
+  BUILD_MODE="dev"
+  VERSION="${VERSION}-dev"
 fi
 
-printf "Building %s in %s mode...\n" $folder $build_mode
+printf "Building %s in %s mode...\n" $FOLDER $BUILD_MODE
 
-if [ -d $context ]
+function docker_build() {
+    # extract named arguments
+    image=$1
+    target=$2
+
+    # remove those to append remaining arguments as extra to docker build command
+    shift 2
+
+    DOCKER_BUILDKIT=1 docker build \
+        --platform $PLATFORM \
+        --build-arg PROJECT_NAME=$PROJECT_NAME \
+        --build-arg BUILD_MODE=$BUILD_MODE \
+        -t $image:$VERSION \
+        -f $FOLDER/Dockerfile \
+        --target "$target" \
+        "$@" \
+        $CONTEXT_DIR
+}
+
+if [ -d $CONTEXT_DIR ]
 then
-rm -rf $context
+rm -rf $CONTEXT_DIR
 fi
 
-mkdir -p $context/{bin,projects}
+mkdir -p $CONTEXT_DIR/{bin,projects}
 
-rsync --files-from=rsyncInclude.txt -arz .. $context
-rsync -az ../bin/$projectname $context/bin/$projectname
-rsync --exclude-from=rsyncExcludeProject.txt -az ../projects/$projectname $context/projects
-cp -r $folder/* $context
-cp -r $folder/.dockerignore $context
-# use --progress=plain to see all build output
-DOCKER_BUILDKIT=1 docker build --build-arg PROJECT_NAME=$projectname --build-arg BUILD_MODE=$build_mode --secret id=envlocal,src=../.env.local -t $imagename:$version -f $folder/Dockerfile --target fpm $context
-DOCKER_BUILDKIT=1 docker build --build-arg PROJECT_NAME=$projectname --build-arg BUILD_MODE=$build_mode -t $imagename/nginx:$version -f $folder/Dockerfile --target nginx $context
-DOCKER_BUILDKIT=1 docker build --build-arg PROJECT_NAME=$projectname --build-arg BUILD_MODE=$build_mode -t $imagename-nginx:$version -f $folder/Dockerfile --target nginx $context
+rsync --files-from=rsyncInclude.txt -arz .. $CONTEXT_DIR
+rsync -az "../bin/$PROJECT_NAME" "$CONTEXT_DIR/bin/$PROJECT_NAME"
+rsync --exclude-from=rsyncExcludeProject.txt -az "../projects/$PROJECT_NAME" $CONTEXT_DIR/projects
+cp -r "$FOLDER"/* $CONTEXT_DIR
+cp -r "$FOLDER"/.dockerignore $CONTEXT_DIR
 
-rm -rf $context
+docker_build "$IMAGE_NAME" fpm --secret id=envlocal,src=../.env.local
+
+if [[ $PROJECT_NAME == *"diplan"* ]]
+then
+    docker_build "$IMAGE_NAME/nginx" nginx
+else
+    docker_build "$IMAGE_NAME-nginx" nginx
+fi
+
+rm -rf $CONTEXT_DIR
 
 if [[ $5 == "push" ]]
 then
-docker push $imagename:$version
-if [[ $projectname == *"diplan"* ]]
-then
-docker push $imagename/nginx:$version
-else
-docker push $imagename-nginx:$version
+    docker push "$IMAGE_NAME:$VERSION"
+    if [[ $PROJECT_NAME == *"diplan"* ]]
+    then
+        docker push "$IMAGE_NAME/nginx:$VERSION"
+    else
+        docker push $IMAGE_NAME-nginx:$VERSION
+    fi
 fi
-fi
+
+printf "Build of %s in %s mode completed.\n" $FOLDER $BUILD_MODE

--- a/docker/rsyncInclude.txt
+++ b/docker/rsyncInclude.txt
@@ -10,13 +10,11 @@ babel.config.js
 composer.json
 composer.lock
 config.webpack.js
-eslintrc.js
+eslint.config.js
 fe
 jest.config.js
 package.json
 stylelint.config.js
 symfony.lock
-tailwind.config.js
 yarn.lock
 .yarnrc.yml
-tailwind.preflight.config.js


### PR DESCRIPTION
### Ticket

DPLAN-16555


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The container build is now a little more performant because only one of the nginx containers is being built
depending on the project. Also, it defaults to build linux/amd64 containers regardless of the host platform.

The includes/excludes were updated to reflect recent stack changes.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
