### PR TITLE
fix(refs dplan-16320): Use modelValue for DpInput in single-document_admin_edit

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/single_document_admin_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/single_document_admin_edit.html.twig
@@ -56,7 +56,7 @@
                 }"
                 name="r_title"
                 required
-                value="{{ document.title }}">
+                model-value="{{ document.title }}">
             </dp-input>
         {% else %}
             {% if document.document is defined and document.document != '' %}


### PR DESCRIPTION
### Ticket
[DPLAN-16320](https://demoseurope.youtrack.cloud/issue/DPLAN-16320/Beim-bearbeiten-von-Planungsdokument-nach-dem-hochladen-wird-das-hinzugefugte-Name-nicht-angezeigt-oder-wir-haben-ein-falsches)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- for v-model to work in Vue 3, we need to use modelValue
- DpInput has been updated to not support value anymore


### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Go to 'Planungsdokumente und Planzeichnung' --> upload new document --> click on edit in the list --> check if the 'Angezeigter Name' has the title rendered

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly

