### PR TITLE
f DPLAN-16042 : Add proceduresettings.publicParticipationFeedbackEnabled check to feedback block

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -520,6 +520,7 @@
           :form-fields="formFields"
           :statement="formData"
           :public-participation-publication-enabled="publicParticipationPublicationEnabled"
+          :public-participation-feedback-enabled="publicParticipationFeedbackEnabled"
           :statement-feedback-definitions="statementFeedbackDefinitions"
           :statement-form-hint-recheck="statementFormHintRecheck" />
 

--- a/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModalRecheck.vue
@@ -153,7 +153,7 @@
     </div>
 
     <div
-      v-if="statementFeedbackDefinitions.length > 0"
+      v-if="statementFeedbackDefinitions.length > 0 && publicParticipationFeedbackEnabled"
       :class="prefixClass('flow-root border--top u-pt-0_25')">
       <p
         v-if="hasPermission('feature_statements_feedback_postal')"
@@ -250,6 +250,12 @@ export default {
     },
 
     publicParticipationPublicationEnabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    publicParticipationFeedbackEnabled: {
       type: Boolean,
       required: false,
       default: false


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16042/Ado-Issue-32485-Ruckmeldung-zu-Stellungnahme-steuerbar
Description: 

- Add publicParticipationFeedbackEnabled prop to StatementModalRecheck component
- Update v-if condition to check both statementFeedbackDefinitions.length > 0 AND publicParticipationFeedbackEnabled
- Pass publicParticipationFeedbackEnabled prop from StatementModal to StatementModalRecheck component
- Ensures feedback block is only displayed when procedure setting is enabled

The feedback section in the statement recheck modal now properly respects the proceduresettings.publicParticipationFeedbackEnabled setting, preventing the feedback UI from appearing when the feature is disabled at the procedure level.



- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

