### PR TITLE
fix(refs DPLAN-16591): import cookie banner styles

### DIFF
--- a/client/css/tailwind.css
+++ b/client/css/tailwind.css
@@ -8,6 +8,9 @@
 @import "tailwindcss/utilities.css" layer(utilities) source(none);
 @import "@demos-europe/demosplan-ui/styles/utilities.css";
 
+/* Import cookie consent CSS */
+@import "@demos-europe/dp-consent/src/css/style.css";
+
 /* Addons may contain Tailwind classes, too, so we need to include them here */
 @source "../../addons/vendor/demos-europe/demosplan-addon-*/client/**/*.{js,vue}";
 


### PR DESCRIPTION
### Ticket
[DPLAN-16591](https://demoseurope.youtrack.cloud/issue/DPLAN-16591/Design-Cookiebanner-kaputt)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The styles for the cookie banner were not applied, and importing them fixed this.
There should probably be a (better) way of fixing this in dp-consent, but I couldn't find it in the given time.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
- in the project's parameters.yml, set `piwik_enable` to `true`
- this should be enough to display the cookie banner, otherwise go to (chrome) dev tools -> Application -> Cookies -> delete dp-consent cookie or clear all cookies
- the styles for the cookie banner should be applied again (most notably, the buttons should have an outline and colors again)

### PR Checklist

- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
