### PR TITLE
Make the container build respect project frontend dependencies

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,25 +2,52 @@
 
 cd "$(dirname "$0")" || exit
 
-if [ $# -lt 4 ]
-then
-  echo "Usage ./build.sh demosplan-production <IMAGE_NAME> <VERSION> <PROJECT_NAME> <?push> <?dev>"
-  echo "  <?push>: If 'push' is specified, images will be pushed to registry"
-  echo "  <?dev>: If 'dev' is specified, container will be built in dev mode, otherwise prod mode"
+function usage() {
+  echo "Usage: ./build.sh [-p] [-d] [-v] <IMAGE_NAME> <VERSION> <PROJECT_NAME>"
+  echo "  -p: If specified, images will be pushed to registry"
+  echo "  -d: If specified, container will be built in dev mode, otherwise prod mode"
+  echo "  -v: If specified, output logging for builds will be verbose"
+}
+
+# Parse arguments using getopts
+PUSH=""
+DEV=""
+VERBOSE=""
+while getopts "pdv" opt; do
+  case $opt in
+    p)
+      PUSH="push"
+      ;;
+    d)
+      DEV="dev"
+      ;;
+    v)
+      VERBOSE="--progress=plain"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [ $# -lt 3 ]; then
+  usage
   exit 2
 fi
 
-FOLDER=$1
-IMAGE_NAME=$2
-VERSION=$3
-PROJECT_NAME=$4
+FOLDER=demosplan-production
+IMAGE_NAME=$1
+VERSION=$2
+PROJECT_NAME=$3
 CONTEXT_DIR=.context
 BUILD_MODE="prod"
 PLATFORM="linux/amd64"
 
 # Check if dev environment is requested
-if [[ $6 == "dev" ]]
-then
+if [[ $DEV == "dev" ]]; then
   BUILD_MODE="dev"
   VERSION="${VERSION}-dev"
 fi
@@ -36,6 +63,7 @@ function docker_build() {
     shift 2
 
     DOCKER_BUILDKIT=1 docker build \
+        $VERBOSE \
         --platform $PLATFORM \
         --build-arg PROJECT_NAME=$PROJECT_NAME \
         --build-arg BUILD_MODE=$BUILD_MODE \
@@ -70,7 +98,7 @@ fi
 
 rm -rf $CONTEXT_DIR
 
-if [[ $5 == "push" ]]
+if [[ $PUSH == "push" ]]
 then
     docker push "$IMAGE_NAME:$VERSION"
     if [[ $PROJECT_NAME == *"diplan"* ]]

--- a/docker/demosplan-production/Dockerfile
+++ b/docker/demosplan-production/Dockerfile
@@ -47,14 +47,20 @@ RUN --mount=type=cache,target=/var/composer --mount=type=cache,target=/var/www,u
         composer install -o --prefer-dist --no-progress; \
     else \
         composer install -o --prefer-dist --no-dev --no-progress; \
-    fi && \
-    yarn install --immutable && \
-    yarn cache clean && \
-    rm -rf /srv/www/.cache/*
+    fi
 
 USER root
 COPY . /srv/www
 
+USER www-data
+# Now do the yarn workspace focus after files are copied
+RUN --mount=type=cache,target=/var/www,uid=33,gid=33 \
+    yarn workspaces list && \
+    yarn workspaces focus demosplan-core "$PROJECT_NAME" && \
+    yarn cache clean && \
+    rm -rf /srv/www/.cache/*
+
+USER root
 # Remove app_dev.php in production mode
 RUN if [ "$BUILD_MODE" = "prod" ]; then \
         rm -f /srv/www/projects/$PROJECT_NAME/web/app_dev.php; \


### PR DESCRIPTION
I'm sorry I rewrote everything. Adding more flags to the build script without it being getopt-ified seemed a little pointless so I did that. While on that I noticed that we always pass `demosplan-production` therefore that could be factored out of the argument list. And finally, the Dockerfile did the yarn install before the project code was available and was therefore missing the project dependencies.