### PR TITLE
fix: add page size limit to JsonAPI pagination for security

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/JsonApiPaginationParser.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JsonApiPaginationParser.php
@@ -25,14 +25,14 @@ class JsonApiPaginationParser
     final public const MAX_PAGE_SIZE = 1000;
 
     public function __construct(
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
     ) {
     }
 
     public function parseApiPaginationProfile(
         array $profile,
         string $sortString,
-        int $defaultSize = self::DEFAULT_PAGE_SIZE
+        int $defaultSize = self::DEFAULT_PAGE_SIZE,
     ): APIPagination {
         if (0 >= $defaultSize) {
             $defaultSize = self::DEFAULT_PAGE_SIZE;
@@ -58,10 +58,12 @@ class JsonApiPaginationParser
                 if ('size' === $key && $intValue > self::MAX_PAGE_SIZE) {
                     $this->logger->warning('JsonAPI: Large page size requested ({requested}), limited to {max}', [
                         'requested' => $intValue,
-                        'max' => self::MAX_PAGE_SIZE
+                        'max'       => self::MAX_PAGE_SIZE,
                     ]);
+
                     return self::MAX_PAGE_SIZE;
                 }
+
                 return $intValue;
             }
         }


### PR DESCRIPTION
## Summary
* Add MAX_PAGE_SIZE constant with 1000 item limit to prevent DoS attacks
* Add constructor injection for LoggerInterface with proper dependency injection
* Log when large page sizes are requested and automatically limit them
* Use PSR-3 structured logging with context for better monitoring

## Security Impact
Prevents DoS attacks through unlimited page size requests that could cause:
- Memory exhaustion from loading massive datasets
- Database timeouts from complex queries
- API timeouts from large response serialization

## Test plan
- [ ] Verify requests with page size <= 1000 work normally
- [ ] Confirm requests with page size > 1000 are limited and logged
- [ ] Test that logging includes proper context (requested vs limited size)
- [ ] Validate dependency injection works correctly for the logger