### PR TITLE
 fix (refs: DPLAN-16670): fix method reference 

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
@@ -16,11 +16,11 @@
 
         <div class="layout__item u-1-of-6 u-pl-0">
             <label for="active-filters" class="u-mv-0_25">{{ "filter.active"|trans }}:</label>
-        </div><!--
-
-     --><div
+        </div>
+        <div
+            id="active-filters"
             class="layout__item u-5-of-6 u-mt-0_25"
-            @click.prevent="$refs.filterModal.toggleModal"
+            @click.prevent="$refs.filterModal.openModal()"
             aria-label="{{ "aria.maximize_filters"|trans }}"
            >
             {{ filtersSet|default([])|join(", ") }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/dhtml/v1/assessment_table_original_filter.html.twig
@@ -12,21 +12,20 @@
 
 {# show active filters #}
 {% if filtersSet is defined %}
-    <fieldset class="u-mt-0_5 u-pb-0_5 border--bottom">
+    <div class="u-mt-0_5 u-pb-0_5 border--bottom">
 
         <div class="layout__item u-1-of-6 u-pl-0">
-            <label for="active-filters" class="u-mv-0_25">{{ "filter.active"|trans }}:</label>
+            <div class="u-mv-0_25">{{ "filter.active"|trans }}:</div>
         </div>
-        <div
-            id="active-filters"
-            class="layout__item u-5-of-6 u-mt-0_25"
+        <button
+            class="btn--blank o-link--default inline-block u-mt-0_25"
             @click.prevent="$refs.filterModal.openModal()"
             aria-label="{{ "aria.maximize_filters"|trans }}"
            >
             {{ filtersSet|default([])|join(", ") }}
-        </div>
+        </button>
 
-    </fieldset>
+    </div>
 {%  endif %}
 
 <div class="c-at__controls o-sticky o-sticky--border space-stack-xs u-pt-0_5 u-pb-0_25" data-sticky="lap-up">


### PR DESCRIPTION
### Ticket
[DPLAN-16670](https://demoseurope.youtrack.cloud/issue/DPLAN-16670)

The bug was caused by a wrong method reference to the filter modal 'toggleModal'. I changed it to the correct 'openModal'. I also changed the html and css to reflect that there is a button that can do something and not a form.

### How to review/test
1. Login as admin, select a procedure, go to Abwaegungstabelle and then original statements.
2. Click on filter and select some filters.
3. Check that the site shows correctly.
4. Check that there is now an "Aktive Filter" layout element with a clickable button that opens the filter modal again with your active filters selected.

