### PR TITLE
fix(refs DPLAN-16711): correct grammar mistake in cf delete msg

### DIFF
--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -4152,7 +4152,7 @@ warning.changed.organisation_name: "Der Master-User Ihrer Organisation hat im Se
 warning.char.removed: "Das Zeichen {character} wurde entfernt."
 warning.char.replaced.by: "Das Zeichen {character} wurde durch {replacement} ersetzt."
 warning.consolidate.only.clusters.selected: "Sie haben nur Stellungnahmengruppen ausgewählt. Für eine Gruppierung muss mindestens eine einzelne Stellungnahme ausgewählt werden, damit diese als Hauptstellungnahme genutzt werden kann."
-warning.custom_field.delete.message: "Beim Löschen dieses Feldes wird das Feld und dessen zugewiesene Optionen auch von den Abschnitten entfernt, an denen das Feld verwendet wird."
+warning.custom_field.delete.message: "Beim Löschen dieses Feldes werden das Feld und dessen zugewiesene Optionen auch von den Abschnitten entfernt, an denen das Feld verwendet wird."
 warning.custom_field.edit.message: "Ihre Änderung wird automatisch für alle Abschnitte übernommen, an denen dieses Feld verwendet wird. Entfernte Optionen werden auch in allen Abschnitten entfernt, denen sie zugewiesen wurden."
 warning.edit.selection.fragments.not.claimed: "Sie können die aktuelle Auswahl nicht bearbeiten, weil Ihnen nicht alle Datensätze zugewiesen sind"
 warning.edit.selection.statements.not.claimed: "Sie können die aktuelle Auswahl nicht bearbeiten, weil Ihnen nicht alle Stellungnahmen zugewiesen sind"


### PR DESCRIPTION
### Ticket
[DPLAN-16711](https://demoseurope.youtrack.cloud/issue/DPLAN-16711)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR corrects a grammar mistake in the custom field delete warning message.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as Admin and choose a procedure with custom fields
2. Change to the custom fields dialog and click at a delete button next to a custom field in the list
3. Check the warning message at the part "...dieses Feldes werden das Feld und dessen..."  there should be "werden" not "wird"

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
