### PR TITLE
chore: rector update SymfonySetList up to SYMFONY_64

### DIFF
--- a/config/linters/rector.php
+++ b/config/linters/rector.php
@@ -14,22 +14,24 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Set\SensiolabsSetList;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
     ->withSets([
         // Define what rule sets will be applied
-        // SetList::CODE_QUALITY,
-        // SymfonyLevelSetList::UP_TO_SYMFONY_44,
+        SetList::CODE_QUALITY,
+        SymfonySetList::SYMFONY_64,
         // SymfonyLevelSetList::UP_TO_SYMFONY_54,
-        // LevelSetList::UP_TO_PHP_53,
-        // LevelSetList::UP_TO_PHP_74,
         // LevelSetList::UP_TO_PHP_81,
         // TwigLevelSetList::UP_TO_TWIG_240,
         // SensiolabsSetList::ANNOTATIONS_TO_ATTRIBUTES,
-        SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
+        // SensiolabsSetList::ANNOTATIONS_TO_ATTRIBUTES,
+        // SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
+        // DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
         // PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
         // DoctrineSetList::DOCTRINE_DBAL_40,
     ])
@@ -42,7 +44,7 @@ return RectorConfig::configure()
     ->withPaths([__DIR__ . '/../../demosplan'])
     ->withPhpVersion(PhpVersion::PHP_81)
     ->withSymfonyContainerXml(
-        '/tmp/diplanbau/cache/dev/demosplan_DemosPlanCoreBundle_Application_DemosPlanKernelDevDebugContainer.xml'
+        '/srv/www/var/cache/dev/demosplan_DemosPlanCoreBundle_Application_DemosPlanKernelDevDebugContainer.xml'
     )
     ->withAutoloadPaths([__DIR__ . '/../../vendor/autoload.php'])
     ->withImportNames()

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonAutoinstallCommand.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+use Exception;
 use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
 use demosplan\DemosPlanCoreBundle\Command\CacheClearCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
@@ -22,11 +24,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:addon:autoinstall', description: 'Installs any addons defined in project configuration addons.yaml')]
 class AddonAutoinstallCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:addon:autoinstall';
-    protected static $defaultDescription = 'Installs any addons defined in project configuration addons.yaml';
-
     public function __construct(
         private readonly AddonInstallFromZipCommand $addonInstallCommand,
         private readonly AddonUninstallCommand $addonUninstallCommand,
@@ -102,7 +102,7 @@ class AddonAutoinstallCommand extends CoreCommand
                 ];
                 try {
                     $this->runCommand($this->addonInstallCommand, $arguments, $output);
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $output->error("Failed to install addon {$name} in Version {$addonConfig['version']}. {$e->getMessage()}");
                 }
             }

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonBuildFrontendCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -22,11 +23,9 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:addon:build-frontend', description: 'Build frontend assets for an addon')]
 class AddonBuildFrontendCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:addon:build-frontend';
-    protected static $defaultDescription = 'Build frontend assets for an addon';
-
     public function __construct(private readonly AddonRegistry $registry, ParameterBagInterface $parameterBag, ?string $name = null)
     {
         parent::__construct($parameterBag, $name);

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Composer\Package\BasePackage;
 use Composer\Package\CompleteAliasPackage;
 use Composer\Package\CompletePackage;
@@ -54,11 +55,9 @@ use ZipArchive;
  *
  * It does **NOT** handle addon activation!
  */
+#[AsCommand(name: 'dplan:addon:install', description: 'Installs an addon based on a given zip-file')]
 class AddonInstallFromZipCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:addon:install';
-    protected static $defaultDescription = 'Installs an addon based on a given zip-file';
-
     private string $zipSourcePath;
     private string $zipCachePath;
     private string $addonsDirectory;

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonListCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollectionWrapper;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use Symfony\Component\Console\Helper\Table;
@@ -17,11 +18,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:addon:list', description: 'List installed addons')]
 class AddonListCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:addon:list';
-    protected static $defaultDescription = 'List installed addons';
-
     public function __construct(
         private readonly AddonManifestCollectionWrapper $addonManifestCollectionWrapper,
         ParameterBagInterface $parameterBag,

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonUninstallCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonUninstallCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
@@ -36,11 +37,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(name: 'dplan:addon:uninstall', description: 'Uninstall installed addons')]
 class AddonUninstallCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:addon:uninstall';
-    protected static $defaultDescription = 'Uninstall installed addons';
-
     public function __construct(
         private readonly AddonRegistry $registry,
         private readonly Registrator $registrator,

--- a/demosplan/DemosPlanCoreBundle/Command/ApplyProcedureTypeTemplateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ApplyProcedureTypeTemplateCommand.php
@@ -31,13 +31,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(
-    name: 'dplan:procedure-type:apply-template',
-    description: 'Apply predefined configuration templates to procedure types'
-)]
+#[AsCommand(name: 'dplan:procedure-type:apply-template', description: 'Apply predefined configuration templates to procedure types')]
 class ApplyProcedureTypeTemplateCommand extends Command
 {
-    protected static $defaultName = 'dplan:procedure-type:apply-template';
     private const TEMPLATE_CONFIGURATIONS = [
         'ewm' => [
             'name'        => 'Einwendungsmanagement',

--- a/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/CacheClearCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Logic\DemosFilesystem;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
@@ -28,12 +29,10 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * Update current project
  */
+#[AsCommand(name: 'dplan:cache:clear', description: 'Clear apcu and op caches')]
 class CacheClearCommand extends CoreCommand
 {
     final public const APCU_CLEAR_SCHEDULE_FILE = 'web/uploads/scheduled-apcu-clear';
-
-    protected static $defaultName = 'dplan:cache:clear';
-    protected static $defaultDescription = 'Clear apcu and op caches';
 
     public function configure(): void
     {

--- a/demosplan/DemosPlanCoreBundle/Command/ClassGenerator/EntityCompanionGeneratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ClassGenerator/EntityCompanionGeneratorCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\ClassGenerator;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FaqCategoryInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FaqInterface;
 use DemosEurope\DemosplanAddon\EntityPath\Paths;
@@ -53,12 +54,10 @@ use Webmozart\Assert\Assert;
  * * easy access to resource: {@link ResourceTypeStore}
  * * resource property schema config classes: e.g. {@link BaseStatementResourceConfigBuilder}, needs to be moved into `demosplan-addon` after generation
  */
+#[AsCommand(name: 'dplan:generator:entity:companion', description: 'Generate companion classes for entities.')]
 class EntityCompanionGeneratorCommand extends CoreCommand
 {
     use EntityClassGeneratorTrait;
-
-    protected static $defaultName = 'dplan:generator:entity:companion';
-    protected static $defaultDescription = 'Generate companion classes for entities.';
 
     private readonly ClassOrInterfaceType $sortingClass;
     private readonly ClassOrInterfaceType $conditionClass;

--- a/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ContainerInitCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\DependencyInjection\Configuration\CustomerConfiguration;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -33,12 +34,10 @@ use Symfony\Component\Yaml\Yaml;
 
 use function is_string;
 
+#[AsCommand(name: 'dplan:container:init', description: 'Perform startup tasks that may be used e.g. as an init container in kubernetes setup')]
 class ContainerInitCommand extends CoreCommand
 {
     private const OPTION_CUSTOMER_CONFIG = 'customerConfig';
-
-    protected static $defaultName = 'dplan:container:init';
-    protected static $defaultDescription = 'Perform startup tasks that may be used e.g. as an init container in kubernetes setup';
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,

--- a/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/CopyFaqCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FaqCategoryInterface;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
@@ -28,11 +29,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:data:copy-faq', description: 'Copies the FAQ from one customer to another.')]
 class CopyFaqCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:data:copy-faq';
-    protected static $defaultDescription = 'Copies the FAQ from one customer to another.';
-
     protected QuestionHelper $helper;
 
     public function __construct(

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DeleteCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DeleteCustomerCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Logic\Customer\CustomerDeleter;
@@ -28,11 +29,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 use function is_string;
 
+#[AsCommand(name: 'dplan:customer:delete', description: 'Deletes a customer including all related content like procedure, orgaTypes, statements, tags, News, etc.')]
 class DeleteCustomerCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:customer:delete';
-    protected static $defaultDescription =
-        'Deletes a customer including all related content like procedure, orgaTypes, statements, tags, News, etc.';
     public const OPTION_DRY_RUN = 'dry-run';
     public const OPTION_WITHOUT_ES_REPOPULATE = 'without-repopulate';
 
@@ -65,7 +64,7 @@ class DeleteCustomerCommand extends CoreCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output = new SymfonyStyle($input, $output);
         $isDryRun = $input->getOption(self::OPTION_DRY_RUN);

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DeleteOrgaCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DeleteOrgaCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Logic\Orga\OrgaDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
@@ -23,11 +24,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:organisation:delete', description: 'Deletes an organisation including all related content like procedure, statements, tags, News, etc.')]
 class DeleteOrgaCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:organisation:delete';
-    protected static $defaultDescription = 'Deletes an organisation including all related content like procedure, statements, tags, News, etc.';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly OrgaDeleter $orgaDeleter,
@@ -67,7 +66,7 @@ class DeleteOrgaCommand extends CoreCommand
         $isDryRun = (bool) $input->getOption('dry-run');
         $withoutRepopulate = (bool) $input->getOption('without-repopulate');
         $orgaIds = $input->getArgument('orgaIds');
-        $orgaIds = explode(',', $orgaIds);
+        $orgaIds = explode(',', (string) $orgaIds);
         try {
             $retrievedOrgaIds = array_column(
                 $this->queriesService->fetchFromTableByParameter(['_o_id'], '_orga', '_o_id', $orgaIds),

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DeleteProcedureCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DeleteProcedureCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
@@ -25,11 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:procedure:delete', description: 'Deletes a procedure including all related content like statements, tags, News, etc.')]
 class DeleteProcedureCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:procedure:delete';
-    protected static $defaultDescription = 'Deletes a procedure including all related content like statements, tags, News, etc.';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly ProcedureDeleter $procedureDeleter,
@@ -69,7 +68,7 @@ class DeleteProcedureCommand extends CoreCommand
         $isDryRun = (bool) $input->getOption('dry-run');
         $withoutRepopulate = (bool) $input->getOption('without-repopulate');
         $procedureIds = $input->getArgument('procedureIds');
-        $procedureIds = explode(',', $procedureIds);
+        $procedureIds = explode(',', (string) $procedureIds);
         try {
             $retrievedProceduresIds = array_column(
                 $this->queriesService->fetchFromTableByParameter(['_p_id'], '_procedure', '_p_id', $procedureIds),

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateCustomerCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
@@ -41,6 +42,7 @@ use Webmozart\Assert\Assert;
 use function in_array;
 use function is_string;
 
+#[AsCommand(name: 'dplan:data:generate-customer', description: 'Creates a new customer')]
 class GenerateCustomerCommand extends CoreCommand
 {
     private const OPTION_NAME = 'name';
@@ -48,9 +50,6 @@ class GenerateCustomerCommand extends CoreCommand
     private const MAP_PARAMETERS = 'map-parameters'; // use value 'default' to automatically insert default values
     private const CHOICE_DEFAULT = 'use default';
     private const CHOICE_CUSTOMIZE = 'customize';
-
-    protected static $defaultName = 'dplan:data:generate-customer';
-    protected static $defaultDescription = 'Creates a new customer';
 
     protected QuestionHelper $helper;
 

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateOrganisationCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateOrganisationCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Entity\Slug;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
@@ -31,10 +32,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:data:generate:organisation', description: 'Generate a (number of) Organisation(s)')]
 class GenerateOrganisationCommand extends DataProviderCommand
 {
-    protected static $defaultName = 'dplan:data:generate:organisation';
-    protected static $defaultDescription = 'Generate a (number of) Organisation(s)';
     /**
      * @var ManagerRegistry
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateStatementCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateStatementCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\DataGenerator\CustomFactory\StatementFactory;
 use demosplan\DemosPlanCoreBundle\Exception\DataProviderException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidUserDataException;
@@ -20,10 +21,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:data:generate:statement', description: 'Generate a (number of) statement(s) by a user')]
 class GenerateStatementCommand extends DataProviderCommand
 {
-    public static $defaultName = 'dplan:data:generate:statement';
-    protected static $defaultDescription = 'Generate a (number of) statement(s) by a user';
     /**
      * @var LoggerInterface
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateStatementFragmentCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateStatementFragmentCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use demosplan\DemosPlanCoreBundle\DataGenerator\CustomFactory\StatementFragmentFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
@@ -26,11 +27,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:data:generate:statement-fragment', description: 'Generate Fragments on a Statement')]
 class GenerateStatementFragmentCommand extends DataProviderCommand
 {
-    public static $defaultName = 'dplan:data:generate:statement-fragment';
-    protected static $defaultDescription = 'Generate Fragments on a Statement';
-
     public function __construct(
         private readonly CurrentUserInterface $currentUser,
         ParameterBagInterface $parameterBag,

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ModifyTestuserDefaultPasswordCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ModifyTestuserDefaultPasswordCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
@@ -24,10 +25,9 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Throwable;
 
+#[AsCommand(name: 'dplan:data:modify-testuser-default-password', description: 'Update default password for test users')]
 class ModifyTestuserDefaultPasswordCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:data:modify-testuser-default-password';
-    protected static $defaultDescription = 'Update default password for test users';
     /**
      * @var QuestionHelper
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ModifyUserCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ModifyUserCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -23,12 +24,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * dplan:data:modify-user.
  */
+#[AsCommand(name: 'dplan:data:modify-user', description: 'Reset passwords of users for each allowed role to allow login.')]
 class ModifyUserCommand extends CoreCommand
 {
-    // lazy load command
-    protected static $defaultName = 'dplan:data:modify-user';
-    protected static $defaultDescription = 'Reset passwords of users for each allowed role to allow login.';
-
     /** @var UserService */
     protected $userService;
 

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterUserForCustomerCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
@@ -30,10 +31,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:data:register-user-for-customer', description: 'Registers an existing user to an existing customer')]
 class RegisterUserForCustomerCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:data:register-user-for-customer';
-    protected static $defaultDescription = 'Registers an existing user to an existing customer';
     /**
      * @var QuestionHelper
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RemoveUserDataCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\EmailAddress;
@@ -54,12 +55,9 @@ use function strlen;
 /**
  * dplan:data:remove-user-data.
  */
+#[AsCommand(name: 'dplan:data:remove-user-data', description: 'Deletes sensitive/personal data from DB.')]
 class RemoveUserDataCommand extends CoreCommand
 {
-    // lazy load command
-    protected static $defaultName = 'dplan:data:remove-user-data';
-    protected static $defaultDescription = 'Deletes sensitive/personal data from DB.';
-
     /** @var UserService */
     protected $userService;
 

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ReplaceFilesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ReplaceFilesCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\DataGenerator\CustomFactory\DataGeneratorInterface;
 use demosplan\DemosPlanCoreBundle\DataGenerator\CustomFactory\FakeDataGeneratorFactory;
@@ -35,10 +36,9 @@ use function is_dir;
 use function strrpos;
 use function substr;
 
+#[AsCommand(name: 'dplan:data:replace-files')]
 class ReplaceFilesCommand extends CoreCommand
 {
-    public static $defaultName = 'dplan:data:replace-files';
-
     public function __construct(
         private readonly FakeDataGeneratorFactory $generatorFactory,
         private readonly FileRepository $fileRepository,

--- a/demosplan/DemosPlanCoreBundle/Command/Db/DumpCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/DumpCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,11 +20,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'dplan:db:dump', description: 'Dump the currently configured db into a sql file')]
 class DumpCommand extends DatabaseManagementCommand
 {
-    protected static $defaultName = 'dplan:db:dump';
-    protected static $defaultDescription = 'Dump the currently configured db into a sql file';
-
     public function configure(): void
     {
         parent::configure();

--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -28,11 +29,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * sf doctrine:migrate:migrate && sf doctrine:migrate:migrate -C /vendor/demosplan/DemosPlanCoreBundle/Resources/config/project_migrations.yml
  */
+#[AsCommand(name: 'dplan:migrate', description: 'Run core and project migrations in correct order')]
 class MigrateCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:migrate';
-    protected static $defaultDescription = 'Run core and project migrations in correct order';
-
     public function configure(): void
     {
         $this->addOption('db', null, InputOption::VALUE_REQUIRED, 'Use Database configuration');

--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrationsCacheCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrationsCacheCommand.php
@@ -10,17 +10,16 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'dplan:migrations:cache', description: 'Clears the Doctrine cache')]
 class MigrationsCacheCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:migrations:cache';
-    protected static $defaultDescription = 'Clears the Doctrine cache';
-
     /**
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Db/MigrationsDiffCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/MigrationsDiffCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Exception;
@@ -21,11 +22,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Creates doctrine migration diffs with pruned cache
  */
+#[AsCommand(name: 'dplan:migrations:diff', description: 'Creates doctrine diffs with pruned cache')]
 class MigrationsDiffCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:migrations:diff';
-    protected static $defaultDescription = 'Creates doctrine diffs with pruned cache';
-
     /**
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Command/Db/RestoreCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Db/RestoreCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Db;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,11 +18,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'dplan:db:restore', description: 'Restores the currently configured db from a sql file')]
 class RestoreCommand extends DatabaseManagementCommand
 {
-    protected static $defaultName = 'dplan:db:restore';
-    protected static $defaultDescription = 'Restores the currently configured db from a sql file';
-
     public function configure(): void
     {
         parent::configure();

--- a/demosplan/DemosPlanCoreBundle/Command/Debug/DplanProcedureTypeFieldsCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Debug/DplanProcedureTypeFieldsCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Debug;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedureType;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureTypeService;
@@ -24,14 +25,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:debug:procedure-type-fields', description: 'Shows info regarding the fields for the different ProcedureTypes')]
 class DplanProcedureTypeFieldsCommand extends CoreCommand
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = 'dplan:debug:procedure-type-fields';
-    protected static $defaultDescription = 'Shows info regarding the fields for the different ProcedureTypes';
-
     public function __construct(
         private readonly ProcedureTypeService $procedureTypeService,
         ParameterBagInterface $parameterBag,

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/EventFinder.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/EventFinder.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Documentation;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
@@ -29,11 +30,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'dplan:documentation:generate:event-list', description: '')]
 class EventFinder extends CoreCommand
 {
-    protected static $defaultName = 'dplan:documentation:generate:event-list';
-    protected static $defaultDescription = '';
-
     private const OPTION_START_PATHS = 'startPaths';
     private const OPTION_PARENTS = 'parents';
 

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Documentation;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
@@ -28,11 +29,9 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 use Illuminate\Support\Collection;
 
+#[AsCommand(name: 'documentation:generate:permission-list', description: 'Update the permissions information in dplandocs')]
 class PermissionListCommand extends CoreCommand
 {
-    protected static $defaultName = 'documentation:generate:permission-list';
-    protected static $defaultDescription = 'Update the permissions information in dplandocs';
-
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $loaderOutput = new NullOutput();

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/ProjectPermissionsDocumentationCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/ProjectPermissionsDocumentationCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\Documentation;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
@@ -29,11 +30,9 @@ use function array_flip;
 use function array_map;
 use function collect;
 
+#[AsCommand(name: 'dplan:documentation:project-permissions', description: 'Extend the permissions documentation with project information')]
 class ProjectPermissionsDocumentationCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:documentation:project-permissions';
-    protected static $defaultDescription = 'Extend the permissions documentation with project information';
-
     public function __construct(ParameterBagInterface $parameterBag, private readonly PermissionsInterface $permissions, string $name = null)
     {
         parent::__construct($parameterBag, $name);

--- a/demosplan/DemosPlanCoreBundle/Command/ElasticsearchPopulateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ElasticsearchPopulateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
@@ -28,11 +29,9 @@ use Illuminate\Support\Collection;
  *
  * @see https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/doc/cookbook/speed-up-populate-command.md
  */
+#[AsCommand(name: 'dplan:elasticsearch:populate', description: 'Run elasticsearch populate with many workers')]
 class ElasticsearchPopulateCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:elasticsearch:populate';
-    protected static $defaultDescription = 'Run elasticsearch populate with many workers';
-
     protected $elasticsearchIndexingPoolSize;
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Command/FilesListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FilesListCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\Console\Command\Command;
@@ -19,12 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:files:list', description: 'List files known to flysystem. Supports "local" and "s3" storage')]
 class FilesListCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:files:list';
-
-    protected static $defaultDescription = 'List files known to flysystem. Supports "local" and "s3" storage';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly FilesystemOperator $s3Storage,

--- a/demosplan/DemosPlanCoreBundle/Command/FrontendBuildinfoCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendBuildinfoCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
@@ -24,11 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * This command fetches all required data and runs necessary sub commands to feed
  * the frontend toolchain with required information.
  */
+#[AsCommand(name: 'dplan:frontend:buildinfo', description: 'This command outputs a bunch of data needed by the FE build tooling')]
 class FrontendBuildinfoCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:frontend:buildinfo';
-    protected static $defaultDescription = 'This command outputs a bunch of data needed by the FE build tooling';
-
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $data = $this->getParameters();

--- a/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
@@ -10,6 +10,10 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+use EDT\JsonApi\ApiDocumentation\GetActionConfig;
+use EDT\JsonApi\ApiDocumentation\ListActionConfig;
+use EDT\JsonApi\ApiDocumentation\OpenApiWording;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\Writer;
@@ -42,14 +46,12 @@ use function str_replace;
  * This command fetches all required data and runs necessary sub commands to feed
  * the frontend toolchain with required information.
  */
+#[AsCommand(name: 'dplan:frontend:integrator', description: 'This command outputs a bunch of data needed by the FE tooling')]
 class FrontendIntegratorCommand extends CoreCommand
 {
     private const OPEN_API_JSON_FILE = 'client/js/generated/openApi.json';
 
     private const RESOURCE_TYPES_FILE = 'client/js/generated/ResourceTypes.js';
-
-    protected static $defaultName = 'dplan:frontend:integrator';
-    protected static $defaultDescription = 'This command outputs a bunch of data needed by the FE tooling';
 
     public function __construct(
         private readonly CurrentUserInterface $currentUser,
@@ -152,13 +154,13 @@ class FrontendIntegratorCommand extends CoreCommand
         $schemaGenerator = $this->manager->createOpenApiDocumentBuilder();
 
         $schemaGenerator->setGetActionConfig(
-            new \EDT\JsonApi\ApiDocumentation\GetActionConfig($this->router, $this->translator)
+            new GetActionConfig($this->router, $this->translator)
         );
         $schemaGenerator->setListActionConfig(
-            new \EDT\JsonApi\ApiDocumentation\ListActionConfig($this->router, $this->translator)
+            new ListActionConfig($this->router, $this->translator)
         );
 
-        $openApiSpec = $schemaGenerator->buildDocument(new \EDT\JsonApi\ApiDocumentation\OpenApiWording($this->translator));
+        $openApiSpec = $schemaGenerator->buildDocument(new OpenApiWording($this->translator));
 
         // just to be safe, reset permissions after getting everything we want
         $this->currentUser->getPermissions()->initPermissions($user);

--- a/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/InitDbCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use DomainException;
 use EFrane\ConsoleAdditions\Batch\Batch;
@@ -24,12 +25,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
+#[AsCommand(name: 'dplan:db:init', description: 'Initialize a db for the project')]
 class InitDbCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:db:init';
-
-    protected static $defaultDescription = 'Initialize a db for the project';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly SessionHandlerInterface $sessionHandler,

--- a/demosplan/DemosPlanCoreBundle/Command/InitializeWorkflowPlacesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/InitializeWorkflowPlacesCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Workflow\Place;
 use Doctrine\ORM\EntityManagerInterface;
@@ -27,11 +28,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * Initialize default workflow places for procedures that don't have any places.
  */
+#[AsCommand(name: 'dplan:workflow:init-places', description: 'Add default workflow places to procedures that have none')]
 class InitializeWorkflowPlacesCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:workflow:init-places';
-    protected static $defaultDescription = 'Add default workflow places to procedures that have none';
-
     /**
      * Default places that will be created (same as in LoadWorkflowPlaceData fixture).
      */

--- a/demosplan/DemosPlanCoreBundle/Command/LocationUpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/LocationUpdateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Logic\LocationUpdateService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,11 +21,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * Update Location table with current data.
  */
+#[AsCommand(name: 'dplan:location:repopulate', description: 'Repopulate location table with current Data')]
 class LocationUpdateCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:location:repopulate';
-    protected static $defaultDescription = 'Repopulate location table with current Data';
-
     public function configure(): void
     {
         $this->addOption(

--- a/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/MaintenanceCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Bazinga\GeocoderBundle\ProviderFactory\NominatimFactory;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\AddonMaintenanceEventInterface;
@@ -55,6 +56,7 @@ use Wrep\Daemonizable\Exception\ShutdownEndlessCommandException;
  *
  * Class MaintenanceCommand
  */
+#[AsCommand(name: 'dplan:maintenance', aliases: ['demos:maintenance'])]
 class MaintenanceCommand extends EndlessContainerAwareCommand
 {
     protected static $defaultDescription = 'DemosPlan Maintenance daemon';
@@ -151,8 +153,7 @@ class MaintenanceCommand extends EndlessContainerAwareCommand
     {
         // Since this command has an alias this command **cannot** be lazyfied at the moment!
         // Add an alias until we have reconfigured the dev services
-        $this->setName('dplan:maintenance')
-            ->setAliases(['demos:maintenance'])
+        $this
             ->setTimeout(5); // Set the timeout in seconds between two calls to the "execute" method
         parent::configure();
     }

--- a/demosplan/DemosPlanCoreBundle/Command/MoveFilesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/MoveFilesCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\Console\Command\Command;
@@ -20,12 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:files:move', description: 'Move files from one flysystem storage to another. Supports "local" and "s3" storage')]
 class MoveFilesCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:files:move';
-
-    protected static $defaultDescription = 'Move files from one flysystem storage to another. Supports "local" and "s3" storage';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         private readonly FilesystemOperator $s3Storage,

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/DisablePermissionForCustomerOrgaRoleCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Permission;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
@@ -22,11 +23,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * This Command is used to disable a specific permission for a given customer, organization, and role.
  */
+#[AsCommand(name: 'dplan:permission:disable:customer-orga-role', description: 'Disables a specific permission for a given customer, organization, and role')]
 class DisablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOrgaRoleCommand
 {
-    protected static $defaultName = 'dplan:permission:disable:customer-orga-role';
-    protected static $defaultDescription = 'Disables a specific permission for a given customer, organization, and role';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         CustomerService $customerService,

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/EnablePermissionForCustomerOrgaRoleCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Permission;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
@@ -22,11 +23,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 /**
  * This Command is used to enable a specific permission for a given customer, organization, and role.
  */
+#[AsCommand(name: 'dplan:permission:enable:customer-orga-role', description: 'Enables a specific permission for a given customer, organization, and role')]
 class EnablePermissionForCustomerOrgaRoleCommand extends PermissionForCustomerOrgaRoleCommand
 {
-    protected static $defaultName = 'dplan:permission:enable:customer-orga-role';
-    protected static $defaultDescription = 'Enables a specific permission for a given customer, organization, and role';
-
     public function __construct(
         ParameterBagInterface $parameterBag,
         CustomerService $customerService,

--- a/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Permission/PermissionForCustomerOrgaRoleCommand.php
@@ -99,8 +99,8 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
         $orgaId = $input->getArgument('orgaId');
         $dryRun = $input->getOption('dry-run');
 
-        $roleIds = explode(',', $roleIdsString);
-        $customerIds = explode(',', $customerIdsString);
+        $roleIds = explode(',', (string) $roleIdsString);
+        $customerIds = explode(',', (string) $customerIdsString);
         foreach ($roleIds as $roleId) {
             foreach ($customerIds as $customerId) {
                 $customerChoice = $this->customerService->findCustomerById(trim($customerId));
@@ -112,7 +112,7 @@ abstract class PermissionForCustomerOrgaRoleCommand extends CoreCommand
                     throw new RoleNotFoundException('Role not found');
                 }
 
-                $updatedOrgas = $this->doExecuteAction($permissionChoice, $customerChoice, $roleChoice, $dryRun, $orgaId ? trim($orgaId) : null);
+                $updatedOrgas = $this->doExecuteAction($permissionChoice, $customerChoice, $roleChoice, $dryRun, $orgaId ? trim((string) $orgaId) : null);
 
                 $this->displayUpdatedOrgas($output, $updatedOrgas);
 

--- a/demosplan/DemosPlanCoreBundle/Command/PermissionFixCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PermissionFixCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Symfony\Component\Console\Command\Command;
@@ -23,11 +24,9 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * Tries to autofix file permission issues
  */
+#[AsCommand(name: 'dplan:permission:fix', description: 'Tries to autofix file permission issues')]
 class PermissionFixCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:permission:fix';
-    protected static $defaultDescription = 'Tries to autofix file permission issues';
-
     public function configure(): void
     {
         $this

--- a/demosplan/DemosPlanCoreBundle/Command/PhpStanCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PhpStanCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,12 +19,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'dplan:phpstan', description: 'Run PHPStan')]
 class PhpStanCommand extends CoreCommand
 {
     private const PHPSTAN_CONFIG_PATH = 'config/linters/phpstan.template.neon';
-
-    protected static $defaultName = 'dplan:phpstan';
-    protected static $defaultDescription = 'Run PHPStan';
 
     public function configure(): void
     {

--- a/demosplan/DemosPlanCoreBundle/Command/PreflightCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PreflightCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,11 +26,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @see readme.md#Updating-a-project
  */
+#[AsCommand(name: 'dplan:preflight', description: 'Manages Git branches, updating code and composer+npm updates')]
 class PreflightCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:preflight';
-    protected static $defaultDescription = 'Manages Git branches, updating code and composer+npm updates';
-
     public function configure(): void
     {
         $this->addOption(

--- a/demosplan/DemosPlanCoreBundle/Command/PsalmCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/PsalmCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,12 +21,10 @@ use Symfony\Component\Process\Process;
  * Runs psalm checks https://psalm.dev
  * Class PsalmCommand.
  */
+#[AsCommand(name: 'dplan:psalm', description: 'Run psalm code analysis')]
 class PsalmCommand extends CoreCommand
 {
     private const PSALM_CONFIG_PATH = 'config/linters/psalm.template.xml';
-
-    protected static $defaultName = 'dplan:psalm';
-    protected static $defaultDescription = 'Run psalm code analysis';
 
     public function configure(): void
     {

--- a/demosplan/DemosPlanCoreBundle/Command/TranslationsDumpCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/TranslationsDumpCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use EFrane\ConsoleAdditions\Batch\Batch;
@@ -22,11 +23,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
+#[AsCommand(name: 'dplan:translations:dump', description: 'Dump translations into a ES6 importable JS module')]
 class TranslationsDumpCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:translations:dump';
-    protected static $defaultDescription = 'Dump translations into a ES6 importable JS module';
-
     protected function configure(): void
     {
         $this->addOption('target', 't', InputOption::VALUE_REQUIRED);

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserCreateCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\User;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
@@ -29,10 +30,9 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:user:create', description: 'Creates a new user with customer, orga, department and roles')]
 class UserCreateCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:user:create';
-    protected static $defaultDescription = 'Creates a new user with customer, orga, department and roles';
     /**
      * @var mixed|QuestionHelper
      */

--- a/demosplan/DemosPlanCoreBundle/Command/User/UserListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/User/UserListCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command\User;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -27,11 +28,9 @@ use Illuminate\Support\Collection;
  *
  * List users with their roles
  */
+#[AsCommand(name: 'dplan:user:list', description: 'List users with roles')]
 class UserListCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:user:list';
-    protected static $defaultDescription = 'List users with roles';
-
     public function __construct(ParameterBagInterface $parameterBag, private readonly UserService $userService, string $name = null)
     {
         parent::__construct($parameterBag, $name);

--- a/demosplan/DemosPlanCoreBundle/Command/UserPermissionGrantCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UserPermissionGrantCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use Exception;
 use Symfony\Component\Console\Command\Command;
@@ -19,13 +20,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'dplan:user:permission:grant', description: 'Grant a specific permission to a user')]
 class UserPermissionGrantCommand extends UserPermissionBaseCommand
 {
     protected function configure(): void
     {
         $this
-            ->setName('dplan:user:permission:grant')
-            ->setDescription('Grant a specific permission to a user')
             ->setHelp('This command allows you to grant a specific permission to a user beyond their role-based permissions.');
 
         $this->addCommonArguments();

--- a/demosplan/DemosPlanCoreBundle/Command/UserPermissionListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UserPermissionListCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Logic\Permission\UserAccessControlService;
@@ -26,6 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'dplan:user:permission:list', description: 'List all user-specific permissions for a user')]
 class UserPermissionListCommand extends CoreCommand
 {
     public function __construct(
@@ -39,8 +41,6 @@ class UserPermissionListCommand extends CoreCommand
     protected function configure(): void
     {
         $this
-            ->setName('dplan:user:permission:list')
-            ->setDescription('List all user-specific permissions for a user')
             ->setHelp('This command lists all user-specific permissions that have been granted to a specific user.')
             ->addArgument('user-id', InputArgument::REQUIRED, 'User ID (UUID)')
             ->addOption(

--- a/demosplan/DemosPlanCoreBundle/Command/UserPermissionRevokeCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/UserPermissionRevokeCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use Exception;
 use Symfony\Component\Console\Command\Command;
@@ -19,13 +20,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'dplan:user:permission:revoke', description: 'Revoke a specific permission from a user')]
 class UserPermissionRevokeCommand extends UserPermissionBaseCommand
 {
     protected function configure(): void
     {
         $this
-            ->setName('dplan:user:permission:revoke')
-            ->setDescription('Revoke a specific permission from a user')
             ->setHelp('This command allows you to revoke a user-specific permission from a user.');
 
         $this->addCommonArguments();

--- a/demosplan/DemosPlanCoreBundle/Command/VendorlistUpdateCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/VendorlistUpdateCommand.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Carbon\Carbon;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'dplan:vendorlist:update', description: 'Update the list of external dependencies')]
 class VendorlistUpdateCommand extends CoreCommand
 {
     /**
@@ -42,9 +44,6 @@ class VendorlistUpdateCommand extends CoreCommand
      * @const string[] Elements should be given as `vendor/package`
      */
     private const PHP_PACKAGE_DENYLIST = [];
-
-    protected static $defaultName = 'dplan:vendorlist:update';
-    protected static $defaultDescription = 'Update the list of external dependencies';
 
     final public const JS_PATH_JSON = 'demosplan/DemosPlanCoreBundle/Resources/static/js_licenses.json';
     final public const JS_PATH_TEXT = 'licenses/js_licenses.txt';

--- a/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Admin/DemosPlanAdminController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Platform\Statistics\StatisticsGenerator;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\NameGenerator;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Twig\Environment;
 use Twig\Extension\EscaperExtension;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -56,7 +56,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function array_key_exists;

--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanStatementFragmentUpdateAPIController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Response\EmptyResponse;
 use demosplan\DemosPlanCoreBundle\ValueObject\Statement\StatementFragmentUpdate;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Base/APIDocumentationController.php
@@ -12,12 +12,15 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Base;
 
+use EDT\JsonApi\ApiDocumentation\GetActionConfig;
+use EDT\JsonApi\ApiDocumentation\ListActionConfig;
+use EDT\JsonApi\ApiDocumentation\OpenApiWording;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\Writer;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use EDT\JsonApi\Manager;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -51,13 +54,13 @@ class APIDocumentationController extends BaseController
         $schemaGenerator = $manager->createOpenApiDocumentBuilder();
 
         $schemaGenerator->setGetActionConfig(
-            new \EDT\JsonApi\ApiDocumentation\GetActionConfig($router, $translator)
+            new GetActionConfig($router, $translator)
         );
         $schemaGenerator->setListActionConfig(
-            new \EDT\JsonApi\ApiDocumentation\ListActionConfig($router, $translator)
+            new ListActionConfig($router, $translator)
         );
 
-        $openApi = $schemaGenerator->buildDocument(new \EDT\JsonApi\ApiDocumentation\OpenApiWording($translator));
+        $openApi = $schemaGenerator->buildDocument(new OpenApiWording($translator));
 
         return new Response(
             Writer::writeToJson($openApi),

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -64,7 +64,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\String\UnicodeString;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentDashboardAPIController.php
@@ -39,7 +39,7 @@ use Exception;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanDocumentDashboardAPIController extends APIController
@@ -55,7 +55,7 @@ class DemosPlanDocumentDashboardAPIController extends APIController
         MessageBagInterface $messageBag,
         MessageFormatter $messageFormatter,
         SchemaPathProcessor $schemaPathProcessor,
-        private ManagerRegistry $managerRegistry
+        private readonly ManagerRegistry $managerRegistry
     ) {
         parent::__construct(
             $apiLogger,

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsAPIController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Services\ApiResourceService;
 use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanElementsAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsBulkEditController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanElementsBulkEditController.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanElementsBulkEditController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqApiController.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Faq\FaqHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Logger\ApiLogger;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class FaqApiController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqCategoryApiController.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\FaqCategory;
 use demosplan\DemosPlanCoreBundle\Logic\Faq\FaqHandler;
 use demosplan\DemosPlanCoreBundle\Transformers\FaqCategoryTransformer;
 use Exception;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class FaqCategoryApiController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Faq/FaqController.php
@@ -29,7 +29,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Forum/DemosPlanReleaseController.php
@@ -23,7 +23,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Extension\EscaperExtension;

--- a/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/GenericApiController.php
@@ -33,7 +33,7 @@ use EDT\Wrapping\Contracts\TypeRetrievalAccessException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Webmozart\Assert\Assert;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/GenericRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/GenericRpcController.php
@@ -22,7 +22,7 @@ use JsonException;
 use JsonSchema\Exception\InvalidSchemaException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class GenericRpcController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Help/DemosPlanHelpController.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanHelpController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapApiController.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Logic\Map\MapService;
 use demosplan\DemosPlanCoreBundle\Transformers\Map\MapOptionsTransformer;
 use Exception;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanMapApiController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -37,7 +37,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -413,7 +413,7 @@ class DemosPlanMapController extends BaseController
         if (array_key_exists('manualsort', $requestPost)) {
             $manualSort = $requestPost['manualsort'];
             if ('' !== $manualSort && 'delete' !== $manualSort) {
-                $layerIds = explode(', ', $requestPost['manualsort']);
+                $layerIds = explode(', ', (string) $requestPost['manualsort']);
                 $mapService->reOrder($layerIds);
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanXplanboxController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanXplanboxController.php
@@ -18,7 +18,7 @@ use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use demosplan\DemosPlanCoreBundle\Logic\Maps\Xplanbox;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanXplanboxController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/MiscContent/DemosPlanMiscContentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/MiscContent/DemosPlanMiscContentController.php
@@ -34,7 +34,7 @@ use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use UnexpectedValueException;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/News/DemosPlanNewsController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/News/DemosPlanNewsController.php
@@ -33,7 +33,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/AzureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/AzureController.php
@@ -16,7 +16,7 @@ use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class AzureController extends AbstractController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/EntrypointController.php
@@ -26,7 +26,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/FileController.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class FileController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/HttpErrorController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/HttpErrorController.php
@@ -15,7 +15,7 @@ use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class HttpErrorController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/KeycloakController.php
@@ -16,7 +16,7 @@ use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class KeycloakController extends AbstractController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/LocationSearchController.php
@@ -18,7 +18,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class LocationSearchController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/MaintenanceController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/MaintenanceController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/AuthorizedUsersController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Consultation\ConsultationTokenService;
 use demosplan\DemosPlanCoreBundle\Logic\FileResponseGenerator\FileResponseGeneratorStrategy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AuthorizedUsersController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ConsultationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ConsultationController.php
@@ -21,7 +21,7 @@ use Doctrine\ORM\EntityNotFoundException;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class ConsultationController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanBoilerplateAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanBoilerplateAPIController.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\BoilerplateGroupResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\BoilerplateResourceType;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanBoilerplateAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanMailController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanPlisController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanPlisController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\Plis;
 use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanPlisController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureAPIController.php
@@ -46,7 +46,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanProcedureAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -111,7 +111,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Exception\ValidatorException;

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureExportController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanProcedureExportController extends DemosPlanProcedureController

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayerCategoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureLayerCategoryAPIController.php
@@ -17,7 +17,7 @@ use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Logic\Map\MapService;
 use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class DemosPlanProcedureLayerCategoryAPIController.

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -44,7 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 use function array_key_exists;

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureTypeController.php
@@ -37,7 +37,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanProcedureTypeController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanSubmitterController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanSubmitterController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
@@ -24,7 +24,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 use function array_key_exists;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureStatisticsRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureStatisticsRpcController.php
@@ -18,7 +18,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use demosplan\DemosPlanCoreBundle\Transformers\PercentageDistributionTransformer;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class ProcedureStatisticsRpcController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/WerDenktWasAPIController.php
@@ -19,7 +19,7 @@ use proj4php\Proj;
 use proj4php\Proj4php;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportAPIController.php
@@ -30,7 +30,7 @@ use EDT\JsonApi\RequestHandling\PaginatorFactory;
 use Exception;
 use League\Fractal\Resource\Collection;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Webmozart\Assert\Assert;
 
 class DemosPlanReportAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Report/DemosPlanReportController.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Seitenausgabe Protokolldaten.

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoApiController.php
@@ -34,7 +34,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DraftsInfoApiController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/DraftsInfoController.php
@@ -23,7 +23,7 @@ use demosplan\DemosPlanCoreBundle\Validator\SegmentableStatementValidator;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DraftsInfoController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentBulkEditController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentBulkEditController.php
@@ -14,7 +14,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class SegmentBulkEditController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentController.php
@@ -35,7 +35,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentRpcController.php
@@ -18,7 +18,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\StoredQuery\SegmentListQuery;
 use EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class SegmentRpcController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -30,7 +30,7 @@ use Exception;
 use PhpOffice\PhpWord\IOFactory;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use ZipStream\ZipStream;
 
 class SegmentsExportController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
@@ -21,7 +21,7 @@ use demosplan\DemosPlanCoreBundle\Transformers\SlugDraftTransformer;
 use demosplan\DemosPlanCoreBundle\ValueObject\SlugDraftValueObject;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class SlugDraftApiController.

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -39,7 +39,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function array_key_exists;

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
@@ -28,7 +28,7 @@ use Exception;
 use Psr\Log\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 use function array_key_exists;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
@@ -40,7 +40,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanClaimAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanClaimAPIController.php
@@ -34,7 +34,7 @@ use EDT\Wrapping\TypeProviders\PrefilledTypeProvider;
 use EDT\Wrapping\Utilities\SchemaPathProcessor;
 use Exception;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use UnexpectedValueException;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Transformers\EntityContentChangeComparisonTran
 use demosplan\DemosPlanCoreBundle\Transformers\HistoryDayTransformer;
 use Doctrine\ORM\EntityNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class DemosPlanEntityContentChangeAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanSimplifiedStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanSimplifiedStatementController.php
@@ -20,7 +20,7 @@ use demosplan\DemosPlanCoreBundle\Exception\UserNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\SimplifiedStatement\ManualSimplifiedStatementCreator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Takes care of actions related to the simplified version of a Statement.

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -55,7 +55,7 @@ use League\Fractal\Resource\Collection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -82,7 +82,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
@@ -2495,7 +2495,7 @@ class DemosPlanStatementController extends BaseController
                 );
             }
             throw new DemosException(self::STATEMENT_IMPORT_ENCOUNTERED_ERRORS);
-        } catch (DuplicateInternIdException $e) {
+        } catch (DuplicateInternIdException) {
             $this->getMessageBag()->add(
                 'error',
                 'statements.import.error.document.duplicate.internid'

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementTagController.php
@@ -24,7 +24,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/GdprConsentRevokeTokenController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/GdprConsentRevokeTokenController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\GdprConsentRevokeTokenService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class GdprConsentRevokeTokenController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/SegmentHistoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/SegmentHistoryAPIController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\SegmentService;
 use demosplan\DemosPlanCoreBundle\Transformers\HistoryDayTransformer;
 use Exception;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class SegmentHistoryAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class StatementAnonymizeController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeRpcController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementAnonymizeRpcController.php
@@ -22,7 +22,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class StatementAnonymizeRpcController extends RpcController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementExportController.php
@@ -26,7 +26,7 @@ use Doctrine\ORM\Query\QueryException;
 use Exception;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StatementExportController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
@@ -22,7 +22,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementFragmentResourceType;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Handles changes to {@link StatementFragment} resources.

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementHistoryAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementHistoryAPIController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\EntityContentChangeDisplayHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Transformers\HistoryDayTransformer;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class StatementHistoryAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementListController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureCoupleTokenFetcher;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class StatementListController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/TagTopicAPIController.php
@@ -23,7 +23,7 @@ use demosplan\DemosPlanCoreBundle\Exception\DuplicatedTagTopicTitleException;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\TagTopicResourceType;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class TagTopicAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanCustomerController.php
@@ -29,7 +29,7 @@ use EDT\Wrapping\Contracts\AccessException;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentAPIController.php
@@ -16,7 +16,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaHandler;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\DepartmentResourceType;
 use demosplan\DemosPlanCoreBundle\Services\ApiResourceService;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanDepartmentAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
@@ -24,7 +24,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class DemosPlanDepartmentController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanInvitableToebAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanInvitableToebAPIController.php
@@ -15,7 +15,7 @@ use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\InvitablePublicAgencyResourceType;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanInvitableToebAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
@@ -36,7 +36,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanMasterToebController extends BaseController

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrganisationAPIController.php
@@ -55,7 +55,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use UnexpectedValueException;
 use Webmozart\Assert\Assert;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanRoleAPIController.php
@@ -18,7 +18,7 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\RoleResourceType;
 use Exception;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DemosPlanRoleAPIController extends APIController
 {

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAPIController.php
@@ -53,7 +53,7 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DemosPlanUserAPIController extends APIController

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
 use Symfony\Contracts\Cache\CacheInterface;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -48,7 +48,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
@@ -19,7 +19,7 @@ use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class DemosPlanUserListController

--- a/demosplan/DemosPlanCoreBundle/Controller/User/InstitutionTagController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/InstitutionTagController.php
@@ -15,7 +15,7 @@ namespace demosplan\DemosPlanCoreBundle\Controller\User;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Controller\Base\BaseController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class InstitutionTagController extends BaseController
 {

--- a/demosplan/DemosPlanCoreBundle/Entity/Permission/UserAccessControl.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Permission/UserAccessControl.php
@@ -45,12 +45,12 @@ class UserAccessControl extends CoreEntity implements UuidEntityInterface, UserA
     protected string $id;
 
     /**
-     * @Assert\NotBlank
      *
-     * @Assert\Length(min=1, max=255)
      *
      * @ORM\Column(name="permission", type="string", length=255, nullable=false)
      */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 1, max: 255)]
     protected string $permission = '';
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Form/AbstractBaseResourceFormType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/AbstractBaseResourceFormType.php
@@ -47,7 +47,7 @@ abstract class AbstractBaseResourceFormType extends AbstractType implements Data
      * @throws ReflectionException
      * @throws UserNotFoundException
      */
-    public function mapDataToForms($viewData, iterable $forms): void
+    public function mapDataToForms($viewData, Traversable $forms): void
     {
         if (null === $viewData) {
             return;
@@ -74,7 +74,7 @@ abstract class AbstractBaseResourceFormType extends AbstractType implements Data
      * @throws ReflectionException
      * @throws UserNotFoundException
      */
-    public function mapFormsToData(iterable $forms, &$viewData): void
+    public function mapFormsToData(Traversable $forms, &$viewData): void
     {
         /** @var FormInterface[] $forms */
         $forms = iterator_to_array($forms);

--- a/demosplan/DemosPlanCoreBundle/Form/AbstractProcedureFormType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/AbstractProcedureFormType.php
@@ -43,7 +43,7 @@ abstract class AbstractProcedureFormType extends AbstractType
     {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We can't simply disable the email address fields as a whole because this would require
         // adjustments in the FE. Instead, we simply do not validate to avoid errors when the
@@ -129,7 +129,7 @@ abstract class AbstractProcedureFormType extends AbstractType
             ->all();
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/demosplan/DemosPlanCoreBundle/Form/BoilerplateCategoryType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/BoilerplateCategoryType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BoilerplateCategoryType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -32,7 +32,7 @@ class BoilerplateCategoryType extends AbstractType
             ->setDataLocked(true);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => BoilerplateCategoryVO::class]);
     }

--- a/demosplan/DemosPlanCoreBundle/Form/BoilerplateGroupType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/BoilerplateGroupType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BoilerplateGroupType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -41,7 +41,7 @@ class BoilerplateGroupType extends AbstractType
             ->setDataLocked(true);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => BoilerplateGroupVO::class]);
     }

--- a/demosplan/DemosPlanCoreBundle/Form/BoilerplateType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/BoilerplateType.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Form;
 
+use Traversable;
 use demosplan\DemosPlanCoreBundle\ValueObject\Procedure\BoilerplateVO;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BoilerplateType extends AbstractType implements DataMapperInterface
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -77,7 +78,7 @@ class BoilerplateType extends AbstractType implements DataMapperInterface
             ->setDataLocked(true);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(['data_class' => BoilerplateVO::class]);
     }
@@ -85,7 +86,7 @@ class BoilerplateType extends AbstractType implements DataMapperInterface
     /**
      * @param BoilerplateVO $data
      */
-    public function mapDataToForms($data, iterable $forms)
+    public function mapDataToForms($data, Traversable $forms)
     {
         $forms = \iterator_to_array($forms);
         /* @var FormInterface[] $forms */
@@ -99,7 +100,7 @@ class BoilerplateType extends AbstractType implements DataMapperInterface
     /**
      * @param BoilerplateVO $boilerplateVO
      */
-    public function mapFormsToData(iterable $forms, &$boilerplateVO)
+    public function mapFormsToData(Traversable $forms, &$boilerplateVO)
     {
         $forms = \iterator_to_array($forms);
         /** @var FormInterface[] $forms */

--- a/demosplan/DemosPlanCoreBundle/Form/EmailAddressType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/EmailAddressType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EmailAddressType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add(
             'fullAddress',
@@ -30,7 +30,7 @@ class EmailAddressType extends AbstractType
         );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/demosplan/DemosPlanCoreBundle/Form/PreparationMailType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/PreparationMailType.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Form;
 
+use Traversable;
 use demosplan\DemosPlanCoreBundle\ValueObject\Procedure\PreparationMailVO;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Form\FormInterface;
 
 class PreparationMailType extends AbstractType implements DataMapperInterface
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -53,7 +54,7 @@ class PreparationMailType extends AbstractType implements DataMapperInterface
             ->setDataMapper($this);
     }
 
-    public function mapDataToForms($data, iterable $forms)
+    public function mapDataToForms($data, Traversable $forms)
     {
         $forms = iterator_to_array($forms);
         /* @var FormInterface[] $forms */
@@ -62,7 +63,7 @@ class PreparationMailType extends AbstractType implements DataMapperInterface
         $forms['r_email_address']->setData($data ? $data->getSendMail() : true);
     }
 
-    public function mapFormsToData(iterable $forms, &$data)
+    public function mapFormsToData(Traversable $forms, &$data)
     {
         $forms = iterator_to_array($forms);
         /** @var FormInterface[] $forms */

--- a/demosplan/DemosPlanCoreBundle/Form/StatementBulkEditType.php
+++ b/demosplan/DemosPlanCoreBundle/Form/StatementBulkEditType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class StatementBulkEditType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/demosplan/DemosPlanCoreBundle/Logic/ArrayObject.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ArrayObject.php
@@ -22,10 +22,7 @@ class ArrayObject extends \ArrayObject
         parent::__construct($mergedValues, $flags, $iterator_class);
     }
 
-    /**
-     * @param mixed $offset
-     */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         if (0 == parent::count()) {
             return false;
@@ -34,10 +31,7 @@ class ArrayObject extends \ArrayObject
         return array_key_exists($offset, parent::getArrayCopy()) ? true : property_exists($this, $offset);
     }
 
-    /**
-     * @param mixed $offset
-     */
-    public function offsetGet($offset): mixed
+    public function offsetGet(mixed $offset): mixed
     {
         $getterMethod = 'get'.ucfirst((string) $offset);
         if (method_exists($this, $getterMethod)) {
@@ -56,11 +50,7 @@ class ArrayObject extends \ArrayObject
         return null;
     }
 
-    /**
-     * @param mixed $offset
-     * @param mixed $value
-     */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         parent::offsetSet($offset, $value);
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/SingleDocumentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/SingleDocumentService.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Document;
 
+use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Contracts\Entities\SingleDocumentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Services\SingleDocumentServiceInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
@@ -290,7 +291,7 @@ class SingleDocumentService implements SingleDocumentServiceInterface
      * @throws ORMException
      * @throws OptimisticLockException
      * @throws ReflectionException
-     * @throws \DemosEurope\DemosplanAddon\Exception\JsonException
+     * @throws JsonException
      */
     public function updateSingleDocument($data): array
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityHelper.php
@@ -87,7 +87,7 @@ class EntityHelper
      *
      * @return string|null the first tested method name that exists in $object or null if none matched
      */
-    public function findGetterMethodForPropertyName($key, $object): ?string
+    public function findGetterMethodForPropertyName($key, mixed $object): ?string
     {
         $method = 'get'.ucfirst($key);
         if (method_exists($object, $method)) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ExcelImporter.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Import\Statement;
 
+use DemosEurope\DemosplanAddon\Contracts\Exceptions\AddonResourceNotFoundException;
 use Carbon\Carbon;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
@@ -186,7 +187,7 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
      * @throws StatementElementNotFoundException
      * @throws UnexpectedWorksheetNameException
      * @throws UserNotFoundException
-     * @throws \DemosEurope\DemosplanAddon\Contracts\Exceptions\AddonResourceNotFoundException
+     * @throws AddonResourceNotFoundException
      */
     public function processSegments(SplFileInfo $fileInfo): SegmentExcelImportResult
     {
@@ -403,7 +404,7 @@ class ExcelImporter extends AbstractStatementSpreadsheetImporter
     /**
      * @throws DuplicatedTagTitleException
      * @throws PathException
-     * @throws \DemosEurope\DemosplanAddon\Contracts\Exceptions\AddonResourceNotFoundException
+     * @throws AddonResourceNotFoundException
      */
     public function generateSegment(
         Statement $statement,

--- a/demosplan/DemosPlanCoreBundle/Logic/TestMailer.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/TestMailer.php
@@ -88,7 +88,7 @@ EOT;
                 ->html(nl2br($testMailbody).$message->getHtmlBody());
 
             foreach ($message->getAttachments() as $attachment) {
-                $testMessage->attachPart($attachment);
+                $testMessage->addPart($attachment);
             }
             // overwrite Original Object with Testmail
             $message = $testMessage;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomFieldResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/CustomFieldResourceType.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use EDT\Wrapping\Utilities\SchemaPathProcessor;
 use DemosEurope\DemosplanAddon\Contracts\ApiRequest\ApiPaginationInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
@@ -243,7 +244,7 @@ final class CustomFieldResourceType extends AbstractResourceType implements Json
         return $this->getResourceConfig()->getUpdatability();
     }
 
-    protected function getSchemaPathProcessor(): \EDT\Wrapping\Utilities\SchemaPathProcessor
+    protected function getSchemaPathProcessor(): SchemaPathProcessor
     {
         return $this->getJsonApiResourceTypeService()->getSchemaPathProcessor();
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGatewayHH;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +34,7 @@ final class OsiHHAuthenticator extends OsiAuthenticator
     protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('Token');
-        $request->getSession()->set(Security::LAST_USERNAME, $osiToken);
+        $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $osiToken);
         $credentialsVO = new Credentials();
         $credentialsVO->setToken($osiToken);
         $credentialsVO->lock();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHStaticAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiHHStaticAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGatewayHHStatic;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,7 +35,7 @@ final class OsiHHStaticAuthenticator extends OsiAuthenticator
     protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('TokenTest');
-        $request->getSession()->set(Security::LAST_USERNAME, $osiToken);
+        $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $osiToken);
         $credentialsVO = new Credentials();
         $credentialsVO->setToken($osiToken);
         $credentialsVO->lock();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGatewaySH;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +34,7 @@ final class OsiSHAuthenticator extends OsiAuthenticator
     protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('Token');
-        $request->getSession()->set(Security::LAST_USERNAME, $osiToken);
+        $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $osiToken);
         $credentialsVO = new Credentials();
         $credentialsVO->setToken($osiToken);
         $credentialsVO->lock();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHStaticAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OsiSHStaticAuthenticator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperDataportGatewaySHStatic;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +34,7 @@ final class OsiSHStaticAuthenticator extends OsiAuthenticator
     protected function getCredentials(Request $request): Credentials
     {
         $osiToken = $request->query->get('TokenTest');
-        $request->getSession()->set(Security::LAST_USERNAME, $osiToken);
+        $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $osiToken);
         $credentialsVO = new Credentials();
         $credentialsVO->setToken($osiToken);
         $credentialsVO->lock();

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Provider/SecurityUserProvider.php
@@ -31,7 +31,7 @@ class SecurityUserProvider implements UserProviderInterface, PasswordUpgraderInt
     ) {
     }
 
-    public function refreshUser(UserInterface $user): ?UserInterface
+    public function refreshUser(UserInterface $user): \Symfony\Component\Security\Core\User\UserInterface
     {
         if (!$user instanceof SecurityUser) {
             throw new UnsupportedUserException(sprintf('Invalid user class %s', $user::class));

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/Strategy/SegmentCustomFieldUsageRemovalStrategy.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/Strategy/SegmentCustomFieldUsageRemovalStrategy.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Utils\CustomField\Strategy;
 
+use Doctrine\DBAL\Exception;
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValue;
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValuesList;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
@@ -27,7 +28,7 @@ class SegmentCustomFieldUsageRemovalStrategy implements EntityCustomFieldUsageRe
 
     /**
      * @throws PersistResourceException
-     * @throws \Doctrine\DBAL\Exception
+     * @throws Exception
      */
     public function removeUsages(string $customFieldId): void
     {


### PR DESCRIPTION
### Ticket
efa-64

This PR applies rector SymfonySetLists up to SYMFONY_64

### How to review/test

code review and app should work as before

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
