### PR TITLE
fix DPLAN-16735 Add validation for map extent boundaries

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
@@ -12,13 +12,22 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Map;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Validates map extent boundaries to ensure they contain the initial viewport.
  */
 class MapExtentValidator
 {
+    public function __construct(
+        private readonly MessageBagInterface $messageBag,
+        private readonly LoggerInterface $logger
+    )
+    {
+    }
+
     /**
      * Validates that the map extent (boundaries) fully contains the initial viewport (bounding box).
      *
@@ -52,6 +61,10 @@ class MapExtentValidator
             || $boxMaxX > $extentMaxX
             || $boxMaxY > $extentMaxY
         ) {
+            $this->messageBag->add('error', 'Der Startkartenausschnitt muss vollständig innerhalb der Kartenbegrenzung liegen.');
+
+            $this->logger->error('The starting map section (bounding box) must be completely within the map extent. MapExtent: ['.implode(', ', $flatMapExtent).'], BoundingBox: ['.implode(', ', $flatBoundingBox).']');
+
             throw new InvalidArgumentException('Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen. MapExtent: ['.implode(', ', $flatMapExtent).'], BoundingBox: ['.implode(', ', $flatBoundingBox).']');
         }
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
@@ -61,7 +61,7 @@ class MapExtentValidator
             || $boxMaxX > $extentMaxX
             || $boxMaxY > $extentMaxY
         ) {
-            $this->messageBag->add('error', 'Der Startkartenausschnitt muss vollständig innerhalb der Kartenbegrenzung liegen.');
+            $this->messageBag->add('error', 'error.map.viewport.outside_extent');
 
             $this->logger->error('The starting map section (bounding box) must be completely within the map extent. MapExtent: ['.implode(', ', $flatMapExtent).'], BoundingBox: ['.implode(', ', $flatBoundingBox).']');
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapExtentValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Map;
+
+use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+
+/**
+ * Validates map extent boundaries to ensure they contain the initial viewport.
+ */
+class MapExtentValidator
+{
+    /**
+     * Validates that the map extent (boundaries) fully contains the initial viewport (bounding box).
+     *
+     * @param array|null $mapExtent      The maximum extent boundaries [minX, minY, maxX, maxY]
+     * @param array|null $boundingBox    The initial map viewport [minX, minY, maxX, maxY]
+     *
+     * @throws InvalidArgumentException if the bounding box is not fully contained within the map extent
+     */
+    public function validateExtentContainsBoundingBox(?array $mapExtent, ?array $boundingBox): void
+    {
+        // Skip validation if either is null or empty
+        if (null === $mapExtent || null === $boundingBox || [] === $mapExtent || [] === $boundingBox) {
+            return;
+        }
+
+        // Convert to flat arrays if they are in coordinate format
+        $flatMapExtent = $this->convertToFlatArray($mapExtent);
+        $flatBoundingBox = $this->convertToFlatArray($boundingBox);
+
+        // Need exactly 4 values for each
+        if (4 !== count($flatMapExtent) || 4 !== count($flatBoundingBox)) {
+            return;
+        }
+
+        [$extentMinX, $extentMinY, $extentMaxX, $extentMaxY] = $flatMapExtent;
+        [$boxMinX, $boxMinY, $boxMaxX, $boxMaxY] = $flatBoundingBox;
+
+        // Check if bounding box is fully contained within map extent
+        if ($boxMinX < $extentMinX
+            || $boxMinY < $extentMinY
+            || $boxMaxX > $extentMaxX
+            || $boxMaxY > $extentMaxY
+        ) {
+            throw new InvalidArgumentException(
+                'Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen. '
+                .'MapExtent: ['.implode(', ', $flatMapExtent).'], '
+                .'BoundingBox: ['.implode(', ', $flatBoundingBox).']'
+            );
+        }
+    }
+
+    /**
+     * Converts coordinate format to flat array if needed.
+     *
+     * @param array $coordinates Either flat [minX, minY, maxX, maxY] or structured ['start' => [...], 'end' => [...]]
+     *
+     * @return array Flat array [minX, minY, maxX, maxY]
+     */
+    private function convertToFlatArray(array $coordinates): array
+    {
+        // Already flat format
+        if (isset($coordinates[0]) && is_numeric($coordinates[0])) {
+            return array_values($coordinates);
+        }
+
+        // Structured format with 'start' and 'end'
+        if (isset($coordinates['start'], $coordinates['end'])) {
+            $start = $coordinates['start'];
+            $end = $coordinates['end'];
+
+            return [
+                $start['latitude'] ?? $start[0] ?? 0,
+                $start['longitude'] ?? $start[1] ?? 0,
+                $end['latitude'] ?? $end[0] ?? 0,
+                $end['longitude'] ?? $end[1] ?? 0,
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/backend/core/Map/Unit/MapExtentValidatorTest.php
+++ b/tests/backend/core/Map/Unit/MapExtentValidatorTest.php
@@ -18,7 +18,6 @@ use Tests\Base\UnitTestCase;
 
 class MapExtentValidatorTest extends UnitTestCase
 {
-
     /** @var MapExtentValidator */
     private $validator;
 
@@ -43,11 +42,11 @@ class MapExtentValidatorTest extends UnitTestCase
     {
         $mapExtent = [
             'start' => ['latitude' => 1000000, 'longitude' => 6000000],
-            'end' => ['latitude' => 1500000, 'longitude' => 6500000],
+            'end'   => ['latitude' => 1500000, 'longitude' => 6500000],
         ];
         $boundingBox = [
             'start' => ['latitude' => 1100000, 'longitude' => 6100000],
-            'end' => ['latitude' => 1400000, 'longitude' => 6400000],
+            'end'   => ['latitude' => 1400000, 'longitude' => 6400000],
         ];
 
         $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);

--- a/tests/backend/core/Map/Unit/MapExtentValidatorTest.php
+++ b/tests/backend/core/Map/Unit/MapExtentValidatorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Map\Unit;
+
+use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+use demosplan\DemosPlanCoreBundle\Logic\Map\MapExtentValidator;
+use Tests\Base\UnitTestCase;
+
+class MapExtentValidatorTest extends UnitTestCase
+{
+
+    /** @var MapExtentValidator */
+    private $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = new MapExtentValidator();
+    }
+
+    public function testValidExtentContainsBoundingBox(): void
+    {
+        $mapExtent = [1000000, 6000000, 1500000, 6500000];
+        $boundingBox = [1100000, 6100000, 1400000, 6400000];
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+
+        // If no exception is thrown, the test passes
+        $this->assertTrue(true);
+    }
+
+    public function testValidExtentContainsBoundingBoxWithStructuredFormat(): void
+    {
+        $mapExtent = [
+            'start' => ['latitude' => 1000000, 'longitude' => 6000000],
+            'end' => ['latitude' => 1500000, 'longitude' => 6500000],
+        ];
+        $boundingBox = [
+            'start' => ['latitude' => 1100000, 'longitude' => 6100000],
+            'end' => ['latitude' => 1400000, 'longitude' => 6400000],
+        ];
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+
+        $this->assertTrue(true);
+    }
+
+    public function testBoundingBoxMinXOutOfBounds(): void
+    {
+        $mapExtent = [1000000, 6000000, 1500000, 6500000];
+        $boundingBox = [999999, 6100000, 1400000, 6400000];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen');
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+    }
+
+    public function testBoundingBoxMaxXOutOfBounds(): void
+    {
+        $mapExtent = [1000000, 6000000, 1500000, 6500000];
+        $boundingBox = [1100000, 6100000, 1500001, 6400000];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen');
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+    }
+
+    public function testBoundingBoxMinYOutOfBounds(): void
+    {
+        $mapExtent = [1000000, 6000000, 1500000, 6500000];
+        $boundingBox = [1100000, 5999999, 1400000, 6400000];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen');
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+    }
+
+    public function testBoundingBoxMaxYOutOfBounds(): void
+    {
+        $mapExtent = [1000000, 6000000, 1500000, 6500000];
+        $boundingBox = [1100000, 6100000, 1400000, 6500001];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Der Startkartenausschnitt (boundingBox) muss vollständig innerhalb der Kartenbegrenzung (mapExtent) liegen');
+
+        $this->validator->validateExtentContainsBoundingBox($mapExtent, $boundingBox);
+    }
+
+    public function testNullExtentSkipsValidation(): void
+    {
+        $this->validator->validateExtentContainsBoundingBox(null, [1100000, 6100000, 1400000, 6400000]);
+        $this->assertTrue(true);
+    }
+
+    public function testNullBoundingBoxSkipsValidation(): void
+    {
+        $this->validator->validateExtentContainsBoundingBox([1000000, 6000000, 1500000, 6500000], null);
+        $this->assertTrue(true);
+    }
+
+    public function testEmptyArraysSkipValidation(): void
+    {
+        $this->validator->validateExtentContainsBoundingBox([], []);
+        $this->assertTrue(true);
+    }
+
+    public function testBoundingBoxEqualToExtent(): void
+    {
+        $extent = [1000000, 6000000, 1500000, 6500000];
+
+        // Bounding box exactly equals extent (edge case - should be valid)
+        $this->validator->validateExtentContainsBoundingBox($extent, $extent);
+
+        $this->assertTrue(true);
+    }
+}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1187,6 +1187,7 @@ error.news.description.toolong: "Der Kurztext für die Mitteilung ist zu lang. B
 error.map.getcapabilities: "Fehler beim Abruf der Layerdaten. Ist die URL korrekt eingegeben?"
 error.map.layer.projections.none: "Die Projektionen der URL ({projectionsFromSource}) stehen nicht zur Verfügung. (Verfügbare Projektionen: {availableProjectionsFromSystem})"
 error.map.layer.service.unknown: "Der angegebene Service ist ungültig: {service}. Bitte wählen Sie den Service unter \"Typ\" aus und entfernen Sie die Angabe des Services aus der URL."
+error.map.viewport.outside_extent: "Der Startkartenausschnitt muss vollständig innerhalb der Kartenbegrenzung liegen."
 warning.map.getcapabilities.of.layer: "Fehler beim Abruf der Layerdaten des Layers \"{layerName}\"."
 error.master.generate: "Bitte eine Blaupause anlegen."
 error.missing.emailAddress: "E-Mail-Adresse muss ausgefüllt sein."


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-16735/Startkartenausschnitt-boundingBox-muss-vollstandig-innerhalb-der-Kartenbegrenzung-mapExtent-liegen

Description: 
Ensures that the initial map viewport (Startkartenausschnitt/boundingBox) is fully contained within the map boundaries (Kartenbegrenzung/mapExtent). The validation is triggered when either value is updated via the ProcedureMapSetting API.

- Add MapExtentValidator service to validate coordinate boundaries
- Integrate validation into ProcedureMapSettingResourceType
- Throw InvalidArgumentException with German error message when validation fails
- Support both flat array and structured coordinate formats


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

