### PR TITLE
fix(refs DPLAN-16550): adjust autocomplete usages

### DIFF
--- a/client/js/components/map/map/DpOlMap.vue
+++ b/client/js/components/map/map/DpOlMap.vue
@@ -71,6 +71,7 @@
           <div :class="prefixClass('float-right')">
             <dp-autocomplete
               v-if="_options.autoSuggest.enabled"
+              id="ol_map_autosuggest"
               :class="prefixClass('u-mb inline-block w-11 bg-color--white')"
               :options="autoCompleteOptions"
               :route-generator="(searchString) => {

--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -11,6 +11,7 @@
   <div aria-hidden="true">
     <dp-autocomplete
       v-if="hasPermission('feature_map_search_location')"
+      id="map_autosuggest"
       :class="prefixClass('c-map__autocomplete')"
       :options="autocompleteOptions"
       :model-value="selectedValue"

--- a/client/js/components/procedure/listSubscriptions/ListSubscriptions.vue
+++ b/client/js/components/procedure/listSubscriptions/ListSubscriptions.vue
@@ -26,6 +26,7 @@
     <div class="flex space-inline-s">
       <dp-autocomplete
         v-if="dplan.settings.useOpenGeoDb"
+        id="subscriptions_autosuggest"
         class="u-nojs-hide inline-block w-11 bg-color--white"
         height="32px"
         label="value"

--- a/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
+++ b/client/js/components/procedure/publicindex/DpSearchProcedureMap.vue
@@ -28,7 +28,7 @@
             query: searchString
           })
         }"
-        search-button
+        @reset="currentAutocompleteSearch = ''; form.search = currentAutocompleteSearch; submitForm();"
         @search-changed="updateSuggestions"
         @searched="search => setValueAndSubmitForm({ target: { value: search } }, 'search')"
         @selected="search => setValueAndSubmitForm({ target: { value: search.value } }, 'search')"
@@ -49,17 +49,15 @@
           width="auto"
           @enter="form.search = currentAutocompleteSearch; submitForm();"
         />
+        <button
+          type="button"
+          data-cy="searchProcedureMapForm:procedureSearchSubmit"
+          :class="[dplan.settings.useOpenGeoDb ? prefixClass('hidden md:block') : '', prefixClass('c-proceduresearch__search-btn btn btn--primary weight--bold')]"
+          @click.prevent="form.search = currentAutocompleteSearch; submitForm();"
+        >
+          {{ Translator.trans('searching') }}
+        </button>
       </template>
-
-      <!-- Search button, if dp-autocomplete is used only displayed on lap-up screens -->
-      <button
-        type="button"
-        data-cy="searchProcedureMapForm:procedureSearchSubmit"
-        :class="[dplan.settings.useOpenGeoDb ? prefixClass('hidden md:block') : '', prefixClass('c-proceduresearch__search-btn btn btn--primary weight--bold')]"
-        @click.prevent="form.search = currentAutocompleteSearch; submitForm();"
-      >
-        {{ Translator.trans('searching') }}
-      </button>
     </div>
 
     <div :class="prefixClass('layout__item u-mb-0_75')">

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_proceduresearch.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_proceduresearch.scss
@@ -54,7 +54,7 @@
         &__search-field {
             flex-grow: 1;
             max-width: calc(100% - 24px);
-            min-width: calc(37.5% - 24px); // Does not solve the "jumpy" behavior of DpAutocomplete/vue-omnibox, but diminishes it.
+            min-width: calc(37.5% - 24px);
         }
 
         &__search-btn {


### PR DESCRIPTION
### Ticket
[DPLAN-16550](https://demoseurope.youtrack.cloud/issue/DPLAN-16550/Abweichungen-vom-Sucherverhalten-von-DiPlanPortal)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

- since DpAutocomplete has been refactored to use DpResettableInput under the hood in https://github.com/demos-europe/demosplan-ui/pull/1358, we now need to pass an `id` to it (for the input)
- since DpAutocomplete now has an icon-only search button integrated, we don't need the search button in DpSearchProcedureMap anymore when using autocomplete

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

- Go to the public index page and search for a city in the search field
- try to navigate and select a suggestion using the keyboard
- Go to the public detail page and search for a city in the search field in the map
- Go to Grundeinstellungen > Verortung des Verfahrens and search for a city in the search field above the map

### Linked PRs
- [ ] https://github.com/demos-europe/demosplan-ui/pull/1358

### Tasks
- [ ] Merge https://github.com/demos-europe/demosplan-ui/pull/1358
- [ ] Release new demosplan-ui version
- [ ] Bump demosplan-ui version in demosplan
- [ ] Merge this PR

### PR Checklist

- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
