### PR TITLE
refs DPLAN-16737: harden 404 page

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/404.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/404.html.twig
@@ -55,7 +55,7 @@
                 <h1 class="{{ 'u-mt-1_5'|prefixClass }}">{{ "error.404.title"|trans }}</h1>
 
                 <p>
-                    {{ "error.404"|trans({ path: currentPage })|wysiwyg }}
+                    {{ "error.404"|trans({ path: currentPage }) }}
                 </p>
 
                 <p>


### PR DESCRIPTION
## Ticket
DPLAN-16737

## Summary
Remove WYSIWYG filter from 404 error message to harden security by avoiding HTML rendering of the path variable.

## Changes
- Remove `|wysiwyg` filter from error message in 404.html.twig template
- Error message now displays as plain text instead of rendered HTML

## Test plan
- [ ] Verify 404 page displays correctly
- [ ] Confirm error message is shown as plain text
- [ ] Test with various invalid URLs