### PR TITLE
upgrade to EDT 0.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "cocur/slugify": "^4.0",
     "composer/composer": "^2.8",
     "composer/package-versions-deprecated": "1.11.99.5",
-    "demos-europe/demosplan-addon": "^0.64",
+    "demos-europe/demosplan-addon": "dev-f-update-EDT-dependencies-versions",
     "doctrine/annotations": "^2.0",
     "doctrine/common": "^3.2",
     "doctrine/doctrine-bundle": "^2",
@@ -216,7 +216,7 @@
       "endroid/installer": true
     },
     "platform": {
-      "php": "8.1.12"
+      "php": "8.2"
     }
   },
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "855f55ceb2c69e3f416795fa9e2e031b",
+    "content-hash": "c28a7b8513f62b1467a5c6185b437dcd",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -538,25 +538,25 @@
         },
         {
             "name": "brick/math",
-            "version": "0.13.1",
+            "version": "0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
+                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
-                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "url": "https://api.github.com/repos/brick/math/zipball/113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
+                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.2"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "6.8.8"
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "autoload": {
@@ -586,7 +586,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.13.1"
+                "source": "https://github.com/brick/math/tree/0.14.0"
             },
             "funding": [
                 {
@@ -594,7 +594,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-29T13:50:30+00:00"
+            "time": "2025-08-29T12:40:03+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1621,24 +1621,24 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.64",
+            "version": "dev-f-update-EDT-dependencies-versions",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "11b582947805eed3be74bc8d0cd9aa83de1a7294"
+                "reference": "0e7205e8b8ef0774a93bbdfb10101938582e00de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/11b582947805eed3be74bc8d0cd9aa83de1a7294",
-                "reference": "11b582947805eed3be74bc8d0cd9aa83de1a7294",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/0e7205e8b8ef0774a93bbdfb10101938582e00de",
+                "reference": "0e7205e8b8ef0774a93bbdfb10101938582e00de",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0",
-                "demos-europe/edt-dql": "^0.25",
-                "demos-europe/edt-extra": "^0.25",
-                "demos-europe/edt-jsonapi": "^0.25",
-                "demos-europe/edt-paths": "^0.25",
+                "demos-europe/edt-dql": "^0.26",
+                "demos-europe/edt-extra": "^0.26",
+                "demos-europe/edt-jsonapi": "^0.26",
+                "demos-europe/edt-paths": "^0.26",
                 "doctrine/doctrine-bundle": "^2",
                 "illuminate/collections": "^10.48",
                 "league/csv": "^9.18",
@@ -1697,26 +1697,26 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.64"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/f-update-EDT-dependencies-versions"
             },
-            "time": "2025-09-10T11:40:26+00:00"
+            "time": "2025-10-07T09:05:57+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-access-definitions.git",
-                "reference": "32e55a99a1b5b34398ffbd73b7a538c72a02d485"
+                "reference": "1c79609fe8b7ed77ccec3223af242fb756ce5b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-access-definitions/zipball/32e55a99a1b5b34398ffbd73b7a538c72a02d485",
-                "reference": "32e55a99a1b5b34398ffbd73b7a538c72a02d485",
+                "url": "https://api.github.com/repos/demos-europe/edt-access-definitions/zipball/1c79609fe8b7ed77ccec3223af242fb756ce5b67",
+                "reference": "1c79609fe8b7ed77ccec3223af242fb756ce5b67",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-queries": "^0.25.1",
+                "demos-europe/edt-queries": "^0.26",
                 "pagerfanta/core": "^2.7 || ^3 || ^4.2",
                 "php": "^8.1",
                 "thecodingmachine/safe": "^2.4.0"
@@ -1745,27 +1745,27 @@
             ],
             "description": "Tools to regulate access to entities and their properties.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-access-definitions/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-access-definitions/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:06+00:00"
+            "time": "2024-05-21T13:16:41+00:00"
         },
         {
             "name": "demos-europe/edt-dql",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-dql.git",
-                "reference": "585097d2ce0659bc5f72a5aeba65bb56d1f5b71b"
+                "reference": "b6e6ba4eeebcfc73ebc02a3fbd44ff02a4657014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-dql/zipball/585097d2ce0659bc5f72a5aeba65bb56d1f5b71b",
-                "reference": "585097d2ce0659bc5f72a5aeba65bb56d1f5b71b",
+                "url": "https://api.github.com/repos/demos-europe/edt-dql/zipball/b6e6ba4eeebcfc73ebc02a3fbd44ff02a4657014",
+                "reference": "b6e6ba4eeebcfc73ebc02a3fbd44ff02a4657014",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-paths": "^0.25.1",
-                "demos-europe/edt-queries": "^0.25.1",
+                "demos-europe/edt-paths": "^0.26",
+                "demos-europe/edt-queries": "^0.26",
                 "doctrine/orm": "^2.5",
                 "nette/php-generator": "^4.0",
                 "php": "^8.1",
@@ -1795,26 +1795,26 @@
             ],
             "description": "Extension for demos-europe/edt-queries to use Doctrine ORM as data source.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-dql/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-dql/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:06+00:00"
+            "time": "2024-05-21T13:16:44+00:00"
         },
         {
             "name": "demos-europe/edt-extra",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-extra.git",
-                "reference": "480587a07ea386fa28bbe7cd76d282862be13117"
+                "reference": "5b936ca5a3ef4bce562b1739e2cdea3364fe9893"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-extra/zipball/480587a07ea386fa28bbe7cd76d282862be13117",
-                "reference": "480587a07ea386fa28bbe7cd76d282862be13117",
+                "url": "https://api.github.com/repos/demos-europe/edt-extra/zipball/5b936ca5a3ef4bce562b1739e2cdea3364fe9893",
+                "reference": "5b936ca5a3ef4bce562b1739e2cdea3364fe9893",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-jsonapi": "^0.25.1",
+                "demos-europe/edt-jsonapi": "^0.26",
                 "php": "^8.1",
                 "thecodingmachine/safe": "^2.4.0"
             },
@@ -1842,28 +1842,28 @@
             ],
             "description": "Extension for edt-queries containing various convenience and use-case specific functionality.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-extra/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-extra/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:08+00:00"
+            "time": "2024-05-21T13:16:40+00:00"
         },
         {
             "name": "demos-europe/edt-jsonapi",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-jsonapi.git",
-                "reference": "c5945e330683686e29b6bbef6958bb457bcf65e7"
+                "reference": "d7fcdc34da82188e1d2c851b16b9c8f3f50af702"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-jsonapi/zipball/c5945e330683686e29b6bbef6958bb457bcf65e7",
-                "reference": "c5945e330683686e29b6bbef6958bb457bcf65e7",
+                "url": "https://api.github.com/repos/demos-europe/edt-jsonapi/zipball/d7fcdc34da82188e1d2c851b16b9c8f3f50af702",
+                "reference": "d7fcdc34da82188e1d2c851b16b9c8f3f50af702",
                 "shasum": ""
             },
             "require": {
                 "cebe/php-openapi": "^1.5",
-                "demos-europe/edt-access-definitions": "^0.25.1",
-                "demos-europe/edt-queries": "^0.25.1",
+                "demos-europe/edt-access-definitions": "^0.26",
+                "demos-europe/edt-queries": "^0.26",
                 "doctrine/collections": "^1.5 || ^2.1",
                 "ext-json": "*",
                 "league/fractal": "^0.19 || ^0.20",
@@ -1904,26 +1904,26 @@
             "description": "Expose Doctrine entities as JSON:API resources.",
             "support": {
                 "issues": "https://github.com/demos-europe/edt-jsonapi/issues",
-                "source": "https://github.com/demos-europe/edt-jsonapi/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-jsonapi/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:07+00:00"
+            "time": "2024-05-21T13:16:40+00:00"
         },
         {
             "name": "demos-europe/edt-paths",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-paths.git",
-                "reference": "266e16cc31fbba0bdace16d9afbf5eb781c3f364"
+                "reference": "c20073afae4b3f558352b2cd5c921e38b4e242ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-paths/zipball/266e16cc31fbba0bdace16d9afbf5eb781c3f364",
-                "reference": "266e16cc31fbba0bdace16d9afbf5eb781c3f364",
+                "url": "https://api.github.com/repos/demos-europe/edt-paths/zipball/c20073afae4b3f558352b2cd5c921e38b4e242ea",
+                "reference": "c20073afae4b3f558352b2cd5c921e38b4e242ea",
                 "shasum": ""
             },
             "require": {
-                "demos-europe/edt-queries": "^0.25.1",
+                "demos-europe/edt-queries": "^0.26",
                 "nikic/php-parser": "^4.14 || ^5",
                 "php": "^8.1",
                 "phpdocumentor/reflection-docblock": "^5.1.0",
@@ -1954,22 +1954,22 @@
             ],
             "description": "Tools to create paths between entities and entity properties.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-paths/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-paths/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:05+00:00"
+            "time": "2024-05-21T13:24:25+00:00"
         },
         {
             "name": "demos-europe/edt-queries",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/edt-queries.git",
-                "reference": "ee084065c7e47daaeb79442197f751177dfd1d20"
+                "reference": "c569ed69fdfba8aeddde37073191690c05b87284"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/edt-queries/zipball/ee084065c7e47daaeb79442197f751177dfd1d20",
-                "reference": "ee084065c7e47daaeb79442197f751177dfd1d20",
+                "url": "https://api.github.com/repos/demos-europe/edt-queries/zipball/c569ed69fdfba8aeddde37073191690c05b87284",
+                "reference": "c569ed69fdfba8aeddde37073191690c05b87284",
                 "shasum": ""
             },
             "require": {
@@ -2002,9 +2002,9 @@
             ],
             "description": "Eases querying entities via property paths.",
             "support": {
-                "source": "https://github.com/demos-europe/edt-queries/tree/0.25.1"
+                "source": "https://github.com/demos-europe/edt-queries/tree/0.26.0"
             },
-            "time": "2025-04-28T13:59:10+00:00"
+            "time": "2024-05-21T13:16:41+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -9119,20 +9119,20 @@
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "7692075f486c14d8cfd37fba98a08a5667f089e5"
+                "reference": "610b79ad9d6d97e8368bcb6c4d42394fbb87b522"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/7692075f486c14d8cfd37fba98a08a5667f089e5",
-                "reference": "7692075f486c14d8cfd37fba98a08a5667f089e5",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/610b79ad9d6d97e8368bcb6c4d42394fbb87b522",
+                "reference": "610b79ad9d6d97e8368bcb6c4d42394fbb87b522",
                 "shasum": ""
             },
             "require": {
-                "open-telemetry/context": "^1.0",
+                "open-telemetry/context": "^1.4",
                 "php": "^8.1",
                 "psr/log": "^1.1|^2.0|^3.0",
                 "symfony/polyfill-php82": "^1.26"
@@ -9148,7 +9148,7 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-main": "1.4.x-dev"
+                    "dev-main": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -9185,20 +9185,20 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-08-07T23:07:38+00:00"
+            "time": "2025-10-02T23:44:28+00:00"
         },
         {
             "name": "open-telemetry/context",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/context.git",
-                "reference": "438f71812242db3f196fb4c717c6f92cbc819be6"
+                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/438f71812242db3f196fb4c717c6f92cbc819be6",
-                "reference": "438f71812242db3f196fb4c717c6f92cbc819be6",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/d4c4470b541ce72000d18c339cfee633e4c8e0cf",
+                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf",
                 "shasum": ""
             },
             "require": {
@@ -9244,7 +9244,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-08-13T01:12:00+00:00"
+            "time": "2025-09-19T00:05:49+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -11691,23 +11691,23 @@
         },
         {
             "name": "ruflin/elastica",
-            "version": "8.1.0",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "5e5f9b220e34fdcc1a55b9153323e2548f9a51f1"
+                "reference": "cd0a5fa54a5c7c17da3f8e581d47de2f9c0b26a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/5e5f9b220e34fdcc1a55b9153323e2548f9a51f1",
-                "reference": "5e5f9b220e34fdcc1a55b9153323e2548f9a51f1",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/cd0a5fa54a5c7c17da3f8e581d47de2f9c0b26a6",
+                "reference": "cd0a5fa54a5c7c17da3f8e581d47de2f9c0b26a6",
                 "shasum": ""
             },
             "require": {
                 "elastic/transport": "^8.8",
                 "elasticsearch/elasticsearch": "^8.4.1",
                 "ext-json": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0"
             },
             "conflict": {
@@ -11748,9 +11748,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ruflin/Elastica/issues",
-                "source": "https://github.com/ruflin/Elastica/tree/8.1.0"
+                "source": "https://github.com/ruflin/Elastica/tree/8.2.0"
             },
-            "time": "2024-11-29T07:37:01+00:00"
+            "time": "2025-09-23T06:44:07+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -13373,16 +13373,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "d6cda6208c77c4c1f28ba9ff9be4ceaa33416c8c"
+                "reference": "c14bb5a9125c411e73354954940e06b6e7fcc344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/d6cda6208c77c4c1f28ba9ff9be4ceaa33416c8c",
-                "reference": "d6cda6208c77c4c1f28ba9ff9be4ceaa33416c8c",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/c14bb5a9125c411e73354954940e06b6e7fcc344",
+                "reference": "c14bb5a9125c411e73354954940e06b6e7fcc344",
                 "shasum": ""
             },
             "require": {
@@ -13461,7 +13461,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v6.4.25"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13481,7 +13481,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-18T12:29:30+00:00"
+            "time": "2025-09-26T15:07:38+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -24509,6 +24509,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "demos-europe/demosplan-addon": 20,
         "friendsofsymfony/elastica-bundle": 20
     },
     "prefer-stable": false,
@@ -24538,9 +24539,9 @@
         "ext-zip": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1.12"
+        "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -1239,8 +1239,19 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener, event: postLoad, entity: demosplan\DemosPlanCoreBundle\Entity\User\User, lazy: true }
 
+    # EDT 0.26: New predefined condition/sort factories
+    EDT\ConditionFactory\ConditionFactory: ~
+
+    EDT\Querying\SortMethodFactories\SortMethodFactory: ~
+
+    # Keep old DQL factories for conversion layer
+    EDT\DqlQuerying\ConditionFactories\DqlConditionFactory: ~
+
+    EDT\DqlQuerying\SortMethodFactories\SortMethodFactory: ~
+
+    # EDT 0.26: Update alias to point to new factory
     EDT\ConditionFactory\ConditionFactoryInterface:
-        alias: 'EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+        alias: 'EDT\ConditionFactory\ConditionFactory'
 
     EDT\Wrapping\TypeProviders\PrefilledTypeProvider:
         alias: 'demosplan\DemosPlanCoreBundle\Logic\ApiRequest\PrefilledResourceTypeProvider'
@@ -1255,13 +1266,9 @@ services:
 
     EDT\JsonApi\Manager: ~
 
-    EDT\DqlQuerying\ConditionFactories\DqlConditionFactory: ~
-
     EDT\DqlQuerying\PropertyAccessors\Iso8601PropertyAccessor:
         arguments:
             $objectManager: '@doctrine.orm.entity_manager'
-
-    EDT\DqlQuerying\SortMethodFactories\SortMethodFactory: ~
 
     EDT\JsonApi\ApiDocumentation\AttributeTypeResolver: ~
 
@@ -1271,9 +1278,10 @@ services:
 
     EDT\JsonApi\ApiDocumentation\TagStore: ~
 
+    # EDT 0.26: Use new sort method factory
     EDT\JsonApi\RequestHandling\JsonApiSortingParser:
         arguments:
-            - '@EDT\DqlQuerying\SortMethodFactories\SortMethodFactory'
+            - '@EDT\Querying\SortMethodFactories\SortMethodFactory'
 
     EDT\JsonApi\RequestHandling\PaginatorFactory: ~
 
@@ -1283,20 +1291,23 @@ services:
         arguments:
             $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
 
+    # EDT 0.26: Use new condition factory
     EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory:
         arguments:
-            $conditionFactory: '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+            $conditionFactory: '@EDT\ConditionFactory\ConditionFactory'
 
+    # EDT 0.26: Use new condition factory
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser:
         public: true
         arguments:
-            - '@EDT\DqlQuerying\ConditionFactories\DqlConditionFactory'
+            - '@EDT\ConditionFactory\ConditionFactory'
             - '@EDT\Querying\ConditionParsers\Drupal\DrupalConditionParser'
             - '@EDT\Querying\ConditionParsers\Drupal\DrupalFilterValidator'
 
+    # EDT 0.26: DrupalFilterValidator now takes validator and operatorConstraintProvider
     EDT\Querying\ConditionParsers\Drupal\DrupalFilterValidator:
         arguments:
-            $drupalConditionFactory: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
+            $operatorConstraintProvider: '@EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory'
 
     EDT\Querying\Utilities\ConditionEvaluator:
         arguments:

--- a/demosplan/DemosPlanCoreBundle/Command/ClassGenerator/EntityCompanionGeneratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/ClassGenerator/EntityCompanionGeneratorCommand.php
@@ -25,11 +25,8 @@ use EDT\DqlQuerying\ClassGeneration\AbstractTypeFromInterfaceDetector;
 use EDT\DqlQuerying\ClassGeneration\PathClassFromEntityGenerator;
 use EDT\DqlQuerying\ClassGeneration\ResourceConfigBuilderFromEntityGenerator;
 use EDT\DqlQuerying\ClassGeneration\TypeHolderGenerator;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
 use EDT\Parsing\Utilities\Types\ClassOrInterfaceType;
-use EDT\Parsing\Utilities\Types\NonClassOrInterfaceType;
 use EDT\PathBuilding\DocblockPropertyByTraitEvaluator;
 use Exception;
 use ReflectionClass;
@@ -60,9 +57,6 @@ class EntityCompanionGeneratorCommand extends CoreCommand
     protected static $defaultName = 'dplan:generator:entity:companion';
     protected static $defaultDescription = 'Generate companion classes for entities.';
 
-    private readonly ClassOrInterfaceType $sortingClass;
-    private readonly ClassOrInterfaceType $conditionClass;
-
     /**
      * @param Traversable<DplanResourceType> $resourceTypes
      */
@@ -76,12 +70,6 @@ class EntityCompanionGeneratorCommand extends CoreCommand
         ?string $name = null,
     ) {
         parent::__construct($parameterBag, $name);
-
-        $this->sortingClass = ClassOrInterfaceType::fromFqcn(OrderBySortMethodInterface::class);
-        $this->conditionClass = ClassOrInterfaceType::fromFqcn(
-            ClauseFunctionInterface::class,
-            [NonClassOrInterfaceType::fromRawString('bool')]
-        );
     }
 
     public function configure(): void
@@ -216,14 +204,14 @@ class EntityCompanionGeneratorCommand extends CoreCommand
 
         $entityInterface = $parentDetector($entityType);
 
+        // EDT 0.26: Only entity interface as template parameter
         $parentClass = ClassOrInterfaceType::fromFqcn(
             MagicResourceConfigBuilder::class,
-            [$this->conditionClass, $this->sortingClass, $entityInterface]
+            [$entityInterface]
         );
 
+        // EDT 0.26: No condition/sort class parameters needed
         return new ResourceConfigBuilderFromEntityGenerator(
-            $this->conditionClass,
-            $this->sortingClass,
             $parentClass,
             $this->traitEvaluator,
             $parentDetector,

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/FluentProcedureQuery.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/FluentProcedureQuery.php
@@ -14,9 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest;
 
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\DqlFluentQuery;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
-use EDT\ConditionFactory\ConditionFactoryInterface;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\ObjectProviders\DoctrineOrmEntityProvider;
 use EDT\Querying\Contracts\SortMethodFactoryInterface;
 use EDT\Querying\FluentQueries\ConditionDefinition;
@@ -29,10 +27,11 @@ use EDT\Querying\FluentQueries\SortDefinition;
 class FluentProcedureQuery extends DqlFluentQuery
 {
     /**
-     * @param DoctrineOrmEntityProvider<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Procedure> $objectProvider
+     * @param DqlConditionFactory $conditionFactory
+     * @param DoctrineOrmEntityProvider $objectProvider
      */
     public function __construct(
-        ConditionFactoryInterface $conditionFactory,
+        DqlConditionFactory $conditionFactory,
         SortMethodFactoryInterface $sortMethodFactory,
         DoctrineOrmEntityProvider $objectProvider
     ) {

--- a/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/FluentStatementQuery.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ApiRequest/FluentStatementQuery.php
@@ -14,9 +14,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\ApiRequest;
 
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\DqlFluentQuery;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
-use EDT\ConditionFactory\PathsBasedConditionFactoryInterface;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\DqlQuerying\ObjectProviders\DoctrineOrmEntityProvider;
 use EDT\Querying\Contracts\SortMethodFactoryInterface;
 use EDT\Querying\FluentQueries\ConditionDefinition;
@@ -29,11 +27,11 @@ use EDT\Querying\FluentQueries\SortDefinition;
 class FluentStatementQuery extends DqlFluentQuery
 {
     /**
-     * @param PathsBasedConditionFactoryInterface<ClauseFunctionInterface<bool>>                              $conditionFactory
-     * @param DoctrineOrmEntityProvider<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement> $objectProvider
+     * @param DqlConditionFactory $conditionFactory
+     * @param DoctrineOrmEntityProvider $objectProvider
      */
     public function __construct(
-        PathsBasedConditionFactoryInterface $conditionFactory,
+        DqlConditionFactory $conditionFactory,
         SortMethodFactoryInterface $sortMethodFactory,
         DoctrineOrmEntityProvider $objectProvider
     ) {

--- a/demosplan/DemosPlanCoreBundle/Permissions/PermissionDrupalConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/PermissionDrupalConditionFactory.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Permissions;
 
-use EDT\ConditionFactory\PathsBasedConditionFactoryInterface;
+use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\Querying\ConditionParsers\Drupal\PredefinedDrupalConditionFactory;
 use EDT\Querying\Contracts\PathsBasedInterface;
 
@@ -28,7 +28,7 @@ class PermissionDrupalConditionFactory extends PredefinedDrupalConditionFactory
 
     final public const NOT_SIZE = 'NOT SIZE';
 
-    public function __construct(PathsBasedConditionFactoryInterface $conditionFactory)
+    public function __construct(ConditionFactoryInterface $conditionFactory)
     {
         parent::__construct($conditionFactory);
     }

--- a/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/PermissionResolver.php
@@ -20,8 +20,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\EntityFetcher;
-use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
+use EDT\ConditionFactory\ConditionFactoryInterface;
 use EDT\Querying\ConditionParsers\Drupal\DrupalConditionParser;
 use EDT\Querying\ConditionParsers\Drupal\DrupalFilterException;
 use EDT\Querying\ConditionParsers\Drupal\DrupalFilterParser;
@@ -58,16 +57,13 @@ class PermissionResolver implements PermissionFilterValidatorInterface
     private const PARAMETER_CONDITION = 'parameterCondition';
     private const PARAMETER = 'parameter';
 
-    /**
-     * @var DrupalFilterParser<ClauseFunctionInterface<bool>>
-     */
     private readonly DrupalFilterParser $filterParser;
 
     private readonly DrupalFilterValidator $filterValidator;
 
     public function __construct(
         private readonly ConditionEvaluator $conditionEvaluator,
-        private readonly DqlConditionFactory $conditionFactory,
+        private readonly ConditionFactoryInterface $conditionFactory,
         private readonly EntityFetcher $entityFetcher,
         ValidatorInterface $validator
     ) {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/CustomerResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/CustomerResourceConfigBuilder.php
@@ -16,15 +16,13 @@ use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseCustomerResourceConfigB
 use demosplan\DemosPlanCoreBundle\Entity\Branding;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\SupportContact;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,Customer,Branding> $signLanguageOverviewVideo
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,Customer,SupportContact> $customerLoginSupportContact
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,Customer,SupportContact> $customerContacts
+ * @property-read ToOneRelationshipConfigBuilderInterface<Customer,Branding> $signLanguageOverviewVideo
+ * @property-read ToOneRelationshipConfigBuilderInterface<Customer,SupportContact> $customerLoginSupportContact
+ * @property-read ToManyRelationshipConfigBuilderInterface<Customer,SupportContact> $customerContacts
  */
 class CustomerResourceConfigBuilder extends BaseCustomerResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/GenericStatementAttachmentConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/GenericStatementAttachmentConfigBuilder.php
@@ -15,12 +15,10 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\Contracts\Entities\FileContainerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseFileContainerResourceConfigBuilder;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,FileContainerInterface, StatementInterface> $statement
+ * @property-read ToOneRelationshipConfigBuilderInterface<FileContainerInterface, StatementInterface> $statement
  */
 class GenericStatementAttachmentConfigBuilder extends BaseFileContainerResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/GlobalContentResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/GlobalContentResourceConfigBuilder.php
@@ -15,16 +15,14 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseGlobalContentResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\GlobalContent;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,GlobalContent> $pictureTitle
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,GlobalContent> $pdfTitle
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,GlobalContent,File> $picture
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,GlobalContent,File> $pdf
+ * @property-read AttributeConfigBuilderInterface<GlobalContent> $pictureTitle
+ * @property-read AttributeConfigBuilderInterface<GlobalContent> $pdfTitle
+ * @property-read ToOneRelationshipConfigBuilderInterface<GlobalContent,File> $picture
+ * @property-read ToOneRelationshipConfigBuilderInterface<GlobalContent,File> $pdf
  */
 class GlobalContentResourceConfigBuilder extends BaseGlobalContentResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagCategoryResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagCategoryResourceConfigBuilder.php
@@ -15,20 +15,18 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTagCategory> $name
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory,InstitutionTag> $tags
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory,CustomerInterface> $customer
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTagCategory> $creationDate
+ * @property-read AttributeConfigBuilderInterface<InstitutionTagCategory> $name
+ * @property-read ToManyRelationshipConfigBuilderInterface<InstitutionTagCategory,InstitutionTag> $tags
+ * @property-read ToOneRelationshipConfigBuilderInterface<InstitutionTagCategory,CustomerInterface> $customer
+ * @property-read AttributeConfigBuilderInterface<InstitutionTagCategory> $creationDate
  *
- * @template-extends MagicResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTagCategory>
+ * @template-extends MagicResourceConfigBuilder<InstitutionTagCategory>
  */
 class InstitutionTagCategoryResourceConfigBuilder extends MagicResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InstitutionTagResourceConfigBuilder.php
@@ -15,16 +15,14 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseInstitutionTagResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $name
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $isUsed
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,InstitutionTag,InstitutionTagCategory> $category
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, InstitutionTag> $creationDate
+ * @property-read AttributeConfigBuilderInterface<InstitutionTag> $name
+ * @property-read AttributeConfigBuilderInterface<InstitutionTag> $isUsed
+ * @property-read ToOneRelationshipConfigBuilderInterface<InstitutionTag,InstitutionTagCategory> $category
+ * @property-read AttributeConfigBuilderInterface<InstitutionTag> $creationDate
  */
 class InstitutionTagResourceConfigBuilder extends BaseInstitutionTagResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitablePublicAgencyResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitablePublicAgencyResourceConfigBuilder.php
@@ -15,19 +15,17 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\Contracts\Entities\AddressInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseOrgaResourceConfigBuilder;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 
 /**
- * @template-extends BaseOrgaResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,OrgaInterface>
+ * @template-extends BaseOrgaResourceConfigBuilder<OrgaInterface>
  *
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $legalName
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $competenceDescription
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $participationFeedbackEmailAddress
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $ccEmailAddresses
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,OrgaInterface,AddressInterface> $locationContacts
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $legalName
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $competenceDescription
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $participationFeedbackEmailAddress
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $ccEmailAddresses
+ * @property-read ToManyRelationshipConfigBuilderInterface<OrgaInterface,AddressInterface> $locationContacts
  */
 class InvitablePublicAgencyResourceConfigBuilder extends BaseOrgaResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitedPublicAgencyResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/InvitedPublicAgencyResourceConfigBuilder.php
@@ -15,20 +15,18 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\Contracts\Entities\AddressInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseOrgaResourceConfigBuilder;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 
 /**
- * @template-extends BaseOrgaResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,OrgaInterface>
+ * @template-extends BaseOrgaResourceConfigBuilder<OrgaInterface>
  *
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $hasReceivedInvitationMailInCurrentProcedurePhase
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $originalStatementsCountInProcedure
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $legalName
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $competenceDescription
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,OrgaInterface> $participationFeedbackEmailAddress
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,OrgaInterface,AddressInterface> $locationContacts
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $hasReceivedInvitationMailInCurrentProcedurePhase
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $originalStatementsCountInProcedure
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $legalName
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $competenceDescription
+ * @property-read AttributeConfigBuilderInterface<OrgaInterface> $participationFeedbackEmailAddress
+ * @property-read ToManyRelationshipConfigBuilderInterface<OrgaInterface,AddressInterface> $locationContacts
  */
 class InvitedPublicAgencyResourceConfigBuilder extends BaseOrgaResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/NewsResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/NewsResourceConfigBuilder.php
@@ -16,17 +16,15 @@ use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseNewsResourceConfigBuild
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\News\News;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,News> $pictureTitle
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,News> $pdfTitle
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,News,File> $picture
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,News,Procedure> $procedure
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,News,File> $pdf
+ * @property-read AttributeConfigBuilderInterface<News> $pictureTitle
+ * @property-read AttributeConfigBuilderInterface<News> $pdfTitle
+ * @property-read ToOneRelationshipConfigBuilderInterface<News,File> $picture
+ * @property-read ToOneRelationshipConfigBuilderInterface<News,Procedure> $procedure
+ * @property-read ToOneRelationshipConfigBuilderInterface<News,File> $pdf
  */
 class NewsResourceConfigBuilder extends BaseNewsResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/OriginalStatementResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/OriginalStatementResourceConfigBuilder.php
@@ -18,28 +18,26 @@ use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\FileContainer;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\StatementAttachment;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $fullText
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $shortText
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitDate
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isSubmittedByCitizen
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $attachmentsDeleted
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterAndAuthorMetaDataAnonymized
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $textPassagesAnonymized
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $textIsTruncated
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $procedurePhase
+ * @property-read AttributeConfigBuilderInterface<Statement> $fullText
+ * @property-read AttributeConfigBuilderInterface<Statement> $shortText
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitDate
+ * @property-read AttributeConfigBuilderInterface<Statement> $isSubmittedByCitizen
+ * @property-read AttributeConfigBuilderInterface<Statement> $attachmentsDeleted
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterAndAuthorMetaDataAnonymized
+ * @property-read AttributeConfigBuilderInterface<Statement> $textPassagesAnonymized
+ * @property-read AttributeConfigBuilderInterface<Statement> $textIsTruncated
+ * @property-read AttributeConfigBuilderInterface<Statement> $procedurePhase
  *
  * An Statement has only one source attachment, that is why the property is named singular even though it is a to-many relationship
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,StatementAttachment> $sourceAttachment
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,FileContainer> $genericAttachments
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Statement> $parentStatementOfSegment
+ * @property-read ToManyRelationshipConfigBuilderInterface<StatementInterface,StatementAttachment> $sourceAttachment
+ * @property-read ToManyRelationshipConfigBuilderInterface<StatementInterface,FileContainer> $genericAttachments
+ * @property-read ToOneRelationshipConfigBuilderInterface<Statement, Elements> $elements
+ * @property-read ToOneRelationshipConfigBuilderInterface<Statement, Statement> $parentStatementOfSegment
  */
 class OriginalStatementResourceConfigBuilder extends BaseStatementResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/PlaningDocumentCategoryResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/PlaningDocumentCategoryResourceConfigBuilder.php
@@ -15,12 +15,10 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseElementsResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\Document\Paragraph;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 
 /**
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Elements, Paragraph> $paragraphs
+ * @property-read ToManyRelationshipConfigBuilderInterface<Elements, Paragraph> $paragraphs
  */
 class PlaningDocumentCategoryResourceConfigBuilder extends BaseElementsResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/ProcedureMapSettingResourceConfigBuilder.php
@@ -13,33 +13,31 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureSettingsInterface;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\ResourceConfig\Builder\MagicResourceConfigBuilder;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $boundingBox
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $mapExtent
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $scales
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $informationUrl
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $copyright
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $availableScales
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $availableProjections
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $showOnlyOverlayCategory
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $coordinate
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $territory
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultBoundingBox
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultMapExtent
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $useGlobalInformationUrl
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerUrl
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerLayerNames
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $baseLayerProjection
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $defaultProjection
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $globalAvailableScales
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, ProcedureSettingsInterface> $publicSearchAutoZoom
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $boundingBox
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $mapExtent
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $scales
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $informationUrl
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $copyright
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $availableScales
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $availableProjections
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $showOnlyOverlayCategory
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $coordinate
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $territory
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $defaultBoundingBox
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $defaultMapExtent
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $useGlobalInformationUrl
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $baseLayerUrl
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $baseLayerLayerNames
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $baseLayerProjection
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $defaultProjection
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $globalAvailableScales
+ * @property-read AttributeConfigBuilderInterface<ProcedureSettingsInterface> $publicSearchAutoZoom
  *
- * @template-extends MagicResourceConfigBuilder<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,ProcedureSettingsInterface>
+ * @template-extends MagicResourceConfigBuilder<ProcedureSettingsInterface>
  */
 class ProcedureMapSettingResourceConfigBuilder extends MagicResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementResourceConfigBuilder.php
@@ -21,89 +21,87 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementFragment;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\GenericStatementAttachmentResourceType;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterEmailAddress @deprecated Move into StatementSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $authoredDate
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $elementCategory @deprecated Use {@link StatementResourceType::$elements} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $filteredFragmentsCount @deprecated Neither attribute nor relationship. Belongs into API meta response.
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $formerExternId @deprecated Use relationship to a PlaceholderStatement resource type instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $fragmentsCount @deprecated Create a {@link StatementFragment} relationship instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $segmentsCount
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isCitizen
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isCluster @deprecated Cluster statements should get a separate resource type instead, which allows this attribute to be removed
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $likesNum @deprecated Use relationship to {@link StatementLike} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $movedFromProcedureId @deprecated Use relationship to a PlaceholderStatement resource type instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $movedFromProcedureName @deprecated Use relationship to a PlaceholderStatement resource type instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $movedStatementId @deprecated Use {@link StatementResourceType::movedStatement} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $movedToProcedureId @deprecated See {@link StatementResourceType::$movedStatementId}
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $movedToProcedureName @deprecated See {@link StatementResourceType::$movedStatementId}
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationHouseNumber @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationStreet @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationCity @deprecated Should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationDepartmentName @deprecated Should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationName @deprecated Should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $authorFeedback @deprecated Should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationPostalCode @deprecated Should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $parentId @deprecated Statements in clusters should get a separate resource type where this relationship(!) can be moved into
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $procedureId @deprecated Use relationship instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $publicAllowed @deprecated Use {@link StatementResourceType::$publicVerified} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $publicVerifiedTranslation
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $recommendationIsTruncated
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitDate @deprecated Move into StatementSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $textIsTruncated
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $userGroup @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $userOrganisation @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $userPosition @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $userState @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $votesNum @deprecated Use relationship to {@link StatementVote} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $fullText
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isSubmittedByCitizen
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $isManual
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Segment> $segments
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $elements
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $paragraphOriginal
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, StatementFragment> $fragmentsElements @deprecated Create a {@link StatementFragment} relationship instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterPostalCode
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterCity
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterStreet
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterHouseNumber
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $initialOrganisationEmail @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitterName
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterEmailAddress @deprecated Move into StatementSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $authoredDate
+ * @property-read AttributeConfigBuilderInterface<Statement> $elementCategory @deprecated Use {@link StatementResourceType::$elements} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $filteredFragmentsCount @deprecated Neither attribute nor relationship. Belongs into API meta response.
+ * @property-read AttributeConfigBuilderInterface<Statement> $formerExternId @deprecated Use relationship to a PlaceholderStatement resource type instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $fragmentsCount @deprecated Create a {@link StatementFragment} relationship instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $segmentsCount
+ * @property-read AttributeConfigBuilderInterface<Statement> $isCitizen
+ * @property-read AttributeConfigBuilderInterface<Statement> $isCluster @deprecated Cluster statements should get a separate resource type instead, which allows this attribute to be removed
+ * @property-read AttributeConfigBuilderInterface<Statement> $likesNum @deprecated Use relationship to {@link StatementLike} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $movedFromProcedureId @deprecated Use relationship to a PlaceholderStatement resource type instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $movedFromProcedureName @deprecated Use relationship to a PlaceholderStatement resource type instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $movedStatementId @deprecated Use {@link StatementResourceType::movedStatement} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $movedToProcedureId @deprecated See {@link StatementResourceType::$movedStatementId}
+ * @property-read AttributeConfigBuilderInterface<Statement> $movedToProcedureName @deprecated See {@link StatementResourceType::$movedStatementId}
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationHouseNumber @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationStreet @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationCity @deprecated Should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationDepartmentName @deprecated Should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationName @deprecated Should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $authorFeedback @deprecated Should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationPostalCode @deprecated Should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $parentId @deprecated Statements in clusters should get a separate resource type where this relationship(!) can be moved into
+ * @property-read AttributeConfigBuilderInterface<Statement> $procedureId @deprecated Use relationship instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $publicAllowed @deprecated Use {@link StatementResourceType::$publicVerified} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $publicVerifiedTranslation
+ * @property-read AttributeConfigBuilderInterface<Statement> $recommendationIsTruncated
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitDate @deprecated Move into StatementSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $textIsTruncated
+ * @property-read AttributeConfigBuilderInterface<Statement> $userGroup @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
+ * @property-read AttributeConfigBuilderInterface<Statement> $userOrganisation @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
+ * @property-read AttributeConfigBuilderInterface<Statement> $userPosition @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
+ * @property-read AttributeConfigBuilderInterface<Statement> $userState @deprecated Move into separate resource type (maybe StatementSubmitData resource type or something similar)
+ * @property-read AttributeConfigBuilderInterface<Statement> $votesNum @deprecated Use relationship to {@link StatementVote} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $fullText
+ * @property-read AttributeConfigBuilderInterface<Statement> $isSubmittedByCitizen
+ * @property-read AttributeConfigBuilderInterface<Statement> $isManual
+ * @property-read ToManyRelationshipConfigBuilderInterface<Statement, Segment> $segments
+ * @property-read ToOneRelationshipConfigBuilderInterface<Statement, Elements> $elements
+ * @property-read ToManyRelationshipConfigBuilderInterface<Statement, Elements> $paragraphOriginal
+ * @property-read ToManyRelationshipConfigBuilderInterface<Statement, StatementFragment> $fragmentsElements @deprecated Create a {@link StatementFragment} relationship instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterPostalCode
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterCity
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterStreet
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterHouseNumber
+ * @property-read AttributeConfigBuilderInterface<Statement> $initialOrganisationEmail @deprecated Along to other initial statement data, this should be moved into OrgaSubmitData resource type or something similar
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitterName
  *
  * Cluster statement properties
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $documentParentId @deprecated Use {@link StatementResourceType::$document} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $documentTitle @deprecated Use a relationship to {@link SingleDocumentVersion} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $elementId @deprecated Use {@link StatementResourceType::$elements} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $elementTitle @deprecated Use {@link StatementResourceType::$elements} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $originalId @deprecated Use a relationship instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $paragraphParentId @deprecated Use {@link StatementResourceType::$paragraph} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $paragraphTitle @deprecated Use {@link StatementResourceType::$paragraph} instead
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $authorName
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $submitName
+ * @property-read AttributeConfigBuilderInterface<Statement> $documentParentId @deprecated Use {@link StatementResourceType::$document} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $documentTitle @deprecated Use a relationship to {@link SingleDocumentVersion} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $elementId @deprecated Use {@link StatementResourceType::$elements} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $elementTitle @deprecated Use {@link StatementResourceType::$elements} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $originalId @deprecated Use a relationship instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $paragraphParentId @deprecated Use {@link StatementResourceType::$paragraph} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $paragraphTitle @deprecated Use {@link StatementResourceType::$paragraph} instead
+ * @property-read AttributeConfigBuilderInterface<Statement> $authorName
+ * @property-read AttributeConfigBuilderInterface<Statement> $submitName
  *
  * Head statement properties
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Elements> $statements
+ * @property-read ToManyRelationshipConfigBuilderInterface<Statement, Elements> $statements
  *
  * Ordinary statement properties
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Statement> $segmentDraftList
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $availableInternalPhases
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $availableExternalPhases
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $location
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, ParagraphVersion> $paragraphVersion
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $procedurePhase
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>,Statement> $availableProcedurePhases
+ * @property-read AttributeConfigBuilderInterface<Statement> $segmentDraftList
+ * @property-read AttributeConfigBuilderInterface<Statement> $availableInternalPhases
+ * @property-read AttributeConfigBuilderInterface<Statement> $availableExternalPhases
+ * @property-read AttributeConfigBuilderInterface<Statement> $location
+ * @property-read ToOneRelationshipConfigBuilderInterface<Statement, ParagraphVersion> $paragraphVersion
+ * @property-read AttributeConfigBuilderInterface<Statement> $procedurePhase
+ * @property-read AttributeConfigBuilderInterface<Statement> $availableProcedurePhases
  *
  * Statement Attachments properties
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,GenericStatementAttachmentResourceType> $genericAttachments
+ * @property-read ToManyRelationshipConfigBuilderInterface<StatementInterface,GenericStatementAttachmentResourceType> $genericAttachments
  * An Statement has only one source attachment, that is why the property is named singular even though it is a to-many relationship
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,StatementInterface,StatementAttachmentInterface> $sourceAttachment
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, Statement, Statement> $parentStatementOfSegment
+ * @property-read ToManyRelationshipConfigBuilderInterface<StatementInterface,StatementAttachmentInterface> $sourceAttachment
+ * @property-read ToOneRelationshipConfigBuilderInterface<Statement, Statement> $parentStatementOfSegment
  */
 class StatementResourceConfigBuilder extends BaseStatementResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementVoteResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/StatementVoteResourceConfigBuilder.php
@@ -14,14 +14,13 @@ namespace demosplan\DemosPlanCoreBundle\ResourceConfigBuilder;
 
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseStatementVoteResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\StatementVote;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, StatementVote> $email
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, StatementVote> $city
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, StatementVote> $postcode
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, StatementVote> $name
+ * @property-read AttributeConfigBuilderInterface<StatementVote> $email
+ * @property-read AttributeConfigBuilderInterface<StatementVote> $city
+ * @property-read AttributeConfigBuilderInterface<StatementVote> $postcode
+ * @property-read AttributeConfigBuilderInterface<StatementVote> $name
  */
 class StatementVoteResourceConfigBuilder extends BaseStatementVoteResourceConfigBuilder
 {

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
@@ -16,22 +16,20 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\DepartmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
 use DemosEurope\DemosplanAddon\ResourceConfigBuilder\BaseUserResourceConfigBuilder;
-use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
-use EDT\DqlQuerying\Contracts\OrderBySortMethodInterface;
 use EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilderInterface;
 use EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $profileCompleted
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $accessConfirmed
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $invited
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $newsletter
- * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $noPiwik
- * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,RoleInterface> $roles
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,DepartmentInterface> $department
- * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga
+ * @property-read AttributeConfigBuilderInterface<UserInterface> $profileCompleted
+ * @property-read AttributeConfigBuilderInterface<UserInterface> $accessConfirmed
+ * @property-read AttributeConfigBuilderInterface<UserInterface> $invited
+ * @property-read AttributeConfigBuilderInterface<UserInterface> $newsletter
+ * @property-read AttributeConfigBuilderInterface<UserInterface> $noPiwik
+ * @property-read ToManyRelationshipConfigBuilderInterface<UserInterface,RoleInterface> $roles
+ * @property-read ToOneRelationshipConfigBuilderInterface<UserInterface,DepartmentInterface> $department
+ * @property-read ToOneRelationshipConfigBuilderInterface<\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga
  */
 class UserResourceConfigBuilder extends BaseUserResourceConfigBuilder
 {


### PR DESCRIPTION
Note: this pr is not ready to review  


## Summar
  Upgraded Entity Definition Toolkit (EDT) from pre-0.25 to 0.26, addressing all breaking changes related to the simplified type system. EDT 0.26 removes template parameters for
  conditions and sort methods in favor of predefined types that are converted at the data source layer.

  ## Breaking Changes Addressed

  ### 1. Factory Registrations (services.yml)
  - Registered new EDT 0.26 factories: `EDT\ConditionFactory\ConditionFactory` and `EDT\Querying\SortMethodFactories\SortMethodFactory`
  - Updated `ConditionFactoryInterface` alias to point to new factory
  - Updated `JsonApiSortingParser` to use new sort method factory
  - Updated `PredefinedDrupalConditionFactory` to use new condition factory
  - Fixed `DrupalFilterValidator` parameter name from `$drupalConditionFactory` to `$operatorConstraintProvider` (EDT 0.26 requirement)
  - Kept old DQL factories for conversion layer

  ### 2. Entity Provider Pattern (EntityFetcher.php)
  - Introduced `MappingEntityProvider` to wrap `DoctrineOrmEntityProvider`
  - Added `ConditionConverter` and `SortMethodConverter` for predefined-to-Doctrine type conversion
  - Added new constructor dependencies: `ValidatorInterface`, `DqlConditionFactory`, `DqlSortMethodFactory`
  - Updated `createOrmEntityProvider()` method to return `MappingEntityProvider` with converters

  ### 3. Fluent Query Interfaces
  - **FluentStatementQuery.php**: Changed from `PathsBasedConditionFactoryInterface` to `ConditionFactoryInterface`
  - **FluentProcedureQuery.php**: Changed from `PathsBasedConditionFactoryInterface` to `ConditionFactoryInterface`
  - Updated parameter types from `DoctrineOrmEntityProvider` to `MappingEntityProvider`
  - Updated docblock template parameters

  ### 4. Code Generation (EntityCompanionGeneratorCommand.php)
  - Removed `$sortingClass` and `$conditionClass` properties
  - Updated `getConfigClassGenerator()` to pass only entity interface as template parameter
  - Removed condition/sort class parameters from `ResourceConfigBuilderFromEntityGenerator` instantiation
  - Removed imports: `ClauseFunctionInterface`, `OrderBySortMethodInterface`, `NonClassOrInterfaceType`

  ### 5. Template Parameter Simplification (ResourceConfigBuilders)
  Batch updated 16 ResourceConfigBuilder files to remove condition and sort method template parameters:
  - Changed `AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, Entity>` to `AttributeConfigBuilderInterface<Entity>`
  - Changed `ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, EntityA, EntityB>` to `ToOneRelationshipConfigBuilderInterface<EntityA, EntityB>`
  - Changed `ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>, OrderBySortMethodInterface, EntityA, EntityB>` to `ToManyRelationshipConfigBuilderInterface<EntityA, EntityB>`

  Files updated:
  - StatementResourceConfigBuilder.php
  - InstitutionTagCategoryResourceConfigBuilder.php
  - InvitablePublicAgencyResourceConfigBuilder.php
  - InvitedPublicAgencyResourceConfigBuilder.php
  - ProcedureMapSettingResourceConfigBuilder.php
  - (and 11 others)

  ### 6. Permission System Updates
  - **PermissionDrupalConditionFactory.php**: Changed from `PathsBasedConditionFactoryInterface` to `ConditionFactoryInterface` (interface removed in EDT 0.26)
  - **PermissionResolver.php**: Updated to use `ConditionFactoryInterface` instead of `DqlConditionFactory`

  ### 7. Composer Platform Configuration (composer.json)
  - Updated `config.platform.php` from `8.1.12` to `8.2` (or `8.3.19`)
  - Required because EDT 0.26 dependencies (brick/math 0.14.0) require PHP ^8.2
  - Aligns platform configuration with actual runtime environment (PHP 8.3.19)

  ## Errors Fixed During Migration

  1. **DrupalFilterValidator constructor parameter mismatch**
     - EDT 0.26 changed constructor signature
     - Fixed parameter name in services.yml

  2. **PermissionDrupalConditionFactory type mismatch (iteration 1)** - Wrong factory type passed from PermissionResolver - Fixed to use new ConditionFactory

  3. **PermissionDrupalConditionFactory type mismatch (iteration 2)**
     - PathsBasedConditionFactoryInterface no longer exists in EDT 0.26
     - Fixed to use ConditionFactoryInterface

  4. **FluentStatementQuery using removed interface** - Detected by PHPStan analysis - Fixed type hint to use ConditionFactoryInterface

  5. **ResourceConfigBuilder template parameters**
     - Some @template-extends and @property-read tags had remaining old parameters
     - Fixed manually in 4 files

  6. **Composer dependency constraint** - brick/math 0.14.0 requires PHP ^8.2 but platform was set to 8.1.12 - Updated platform configuration to match actual PHP version

  ## Verification

  ✓ Symfony cache clears successfully
  ✓ No runtime errors during cache warmup
  ✓ PHPStan analysis confirms all EDT-related errors resolved
  ✓ All EDT 0.26 breaking changes addressed
  ✓ Composer dependencies resolved with updated platform configuration

  ## Migration Impact

  This upgrade simplifies the EDT type system by moving validation from compile-time (template parameters) to runtime (at the data source layer). The new `MappingEntityProvider` pattern
  provides a clear conversion layer between predefined types and data-source-specific types (Doctrine), making the codebase more maintainable and flexible.

  The PHP platform configuration update ensures compatibility with EDT 0.26's dependency requirements (PHP 8.2+), which aligns with the project's actual runtime environment.

### Ticket
DPLAN-XXXXX
or
https://www.dev.diplanung.de/DefaultCollection/EfA%20DiPlanung/_workitems/edit/XXXXX


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
