### PR TITLE
Add logout button to IDP error page

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/login_idp_error.html.twig
@@ -39,6 +39,16 @@
                     </dp-support-card>
                 </div>
             {% endif %}
+
+            <div class="u-mt-2">
+                <a
+                    class="btn btn--primary"
+                    href="{{ path("DemosPlan_user_logout") }}"
+                    data-cy="logout">
+                    <i class="fa fa-sign-out u-mr-0_25" aria-hidden="true"></i>
+                    {{ "logout.idp"|trans }}
+                </a>
+            </div>
         </div>
     </div>
 {% endblock component_part %}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -2180,6 +2180,7 @@ logo.of.bundesland: "Logo-Bild des Bundeslandes"
 logo.delete: "Logo löschen"
 logo.upload.new: "Neues Logo hochladen"
 logout: "Abmelden"
+logout.idp: "Vom Identity Provider abmelden"
 # map.attribution.default supports both {linkImprint} and {currentYear} placeholders.
 map.attribution.default: "© basemap.de / BKG {currentYear}"
 map.attribution.exports: "© basemap.de BKG (www.basemap.de) / LVermGeo SH (www.LVermGeoSH.schleswig-holstein.de)"


### PR DESCRIPTION
### Ticket
No specific ticket - user improvement

### Description
Users who reach the IDP error page (`core_login_idp_error`) due to missing permissions are currently unable to log out from their Identity Provider (Keycloak) session. This creates a poor user experience where they remain logged in to the IDP but cannot access the platform.

This PR adds a logout button to the error page with descriptive German text ("Vom Identity Provider abmelden") that clarifies the button logs out from the IDP, not from dplan itself.

<img width="1496" height="628" alt="image" src="https://github.com/user-attachments/assets/0fa2417a-6cfe-4aa2-ab7e-f0bcabc2abbd" />


### How to review/test
1. Navigate to the IDP error page at `/idp/login/error`
2. Verify the logout button is visible and properly styled
3. Click the logout button and verify it uses the `DemosPlan_user_logout` route
4. Confirm the button text displays "Vom Identity Provider abmelden"
5. Check that the button follows the same styling as other primary buttons in the application

### PR Checklist
- [ ] Create/Update tests (not needed - template change only)
- [ ] Update documentation (not needed)
- [ ] Add/Update data-cy attributes (added `data-cy="logout"`)
- [ ] Run `yarn lint` (no JS/CSS changes)
- [ ] Run `yarn test` (no JS changes)
- [ ] Link all relevant tickets (no specific ticket)
- [ ] Move the tickets on the board accordingly (no specific ticket)
- [ ] Update changelog (minor UX improvement)