### PR TITLE
fix(refs DS-395): revert submitter data editability to manual-only with project-level override

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2233,6 +2233,11 @@ feature_statement_search_type_of_submission:
     expose: true
     label: 'Search for submission type in Assessment Table'
     loginRequired: true
+feature_statement_submitter_data_always_editable:
+    description: 'Allows editing submitter data fields (name, department, address, dates, phase, submit type) on all statements, not just manual ones. When disabled, these fields can only be edited on manual statements.'
+    expose: true
+    label: 'Allow editing submitter data on all statements'
+    loginRequired: true
 feature_statement_text_history_delete:
     description: 'Allow deletion of entity conent chances of the text field of statements.'
     expose: true

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -130,11 +130,11 @@ use Doctrine\Persistence\ManagerRegistry;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\Querying\Contracts\PathException;
 use Elastica\Aggregation\GlobalAggregation;
-use FOS\ElasticaBundle\Index\IndexManager;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\BoolQuery;
 use Exception;
+use FOS\ElasticaBundle\Index\IndexManager;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
@@ -2333,9 +2333,9 @@ class StatementService implements StatementServiceInterface
             static function ($value, string $key) {
                 if ('r_submitterEmailAddress' === $key) {
                     return str_starts_with($key, 'r_') && (\is_string($value) || (\is_array($value) && [] !== $value));
-                } else {
-                    return str_starts_with($key, 'r_') && ((\is_string($value) && '' !== $value) || (\is_array($value) && [] !== $value));
                 }
+
+                return str_starts_with($key, 'r_') && ((\is_string($value) && '' !== $value) || (\is_array($value) && [] !== $value));
             }
         )->mapWithKeys(
             static function ($stringOrArrayValue, string $key) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -1153,6 +1153,16 @@ class StatementService implements StatementServiceInterface
                 $this->logger->warning('Trying to update a locked by assignment statement.');
             }
 
+            // there are fields, which are only allowed to modify on a manual statement?
+            $hasManualStatementUpdateFields = $this->hasManualStatementUpdateFields($updatedStatement, $currentStatementObject);
+            $updateForbidden = ($hasManualStatementUpdateFields
+                && !$currentStatementObject->isManual())
+                && !$this->permissions->hasPermission('feature_statement_submitter_data_always_editable');
+            if ($updateForbidden) {
+                $this->messageBag->add('warning', 'warning.deny.update.manual.statement');
+                $this->logger->warning('Trying to update manualStatementUpdateFields on a normal statement.');
+            }
+
             // is a original statement?
             $lockedByOriginal = false;
             $isOriginal = $currentStatementObject->isOriginal();
@@ -1170,6 +1180,7 @@ class StatementService implements StatementServiceInterface
             if (!$lockedByAssignment
                 && !$lockedByAssignmentOfHeadStatement
                 && !$lockedByCluster
+                && !$updateForbidden
                 && !$lockedByOriginal
                 && !$currentStatementObject->isPlaceholder()) {
                 $preUpdatedStatement = clone $currentStatementObject;
@@ -1269,6 +1280,71 @@ class StatementService implements StatementServiceInterface
         }
 
         return $fileHashToFileContainerMapping;
+    }
+
+    /**
+     * Determines if one of the fields which only can be modified on a manual statement, should be updated.
+     *
+     * @param Statement|array $statement        - Statement as array or object
+     * @param Statement       $currentStatement - current unmodified statement object, to compare with incoming update data
+     *
+     * @return bool - true if one of the 'critical' fields should be updated, otherwise false
+     */
+    private function hasManualStatementUpdateFields($statement, Statement $currentStatement): bool
+    {
+        $currentAuthorName = $currentStatement->getAuthorName();
+        $currentSubmitterName = $currentStatement->getSubmitterName();
+        $currentSubmitterEmailAddress = $currentStatement->getSubmitterEmailAddress();
+        $currentDepartmentName = $currentStatement->getMeta()->getOrgaDepartmentName();
+        // orgaName is submitterType:
+        $currentSubmitterType = $currentStatement->getMeta()->getOrgaName();
+        $currentOrgaPostalCode = $currentStatement->getOrgaPostalCode();
+        $currentOrgaCity = $currentStatement->getOrgaCity();
+        $currentOrgaStreet = $currentStatement->getOrgaStreet();
+        $currentOrgaEmail = $currentStatement->getOrgaEmail();
+        $currentAuthoredDateString = $currentStatement->getAuthoredDateString();
+        $currentAuthoredDateTimeStamp = $currentStatement->getAuthoredDate();
+        $currentSubmittedDateString = $currentStatement->getSubmitDateString();
+        $currentSubmittedDateTimeStamp = $currentStatement->getSubmit();
+
+        if (\is_array($statement)) {
+            $statement = \collect($statement);
+            if (
+                ($statement->has('author_name') && $statement->get('author_name') != $currentAuthorName)
+                || ($statement->has('submit_name') && $statement->get('submit_name') != $currentSubmitterName)
+                || ($statement->has('submitterEmailAddress') && $statement->get('submitterEmailAddress') != $currentSubmitterEmailAddress)
+                || ($statement->has('departmentName') && $statement->get('departmentName') != $currentDepartmentName)
+                || ($statement->has('submitterType') && $statement->get('submitterType') != $currentSubmitterType)
+                || ($statement->has('orga_postalcode') && $statement->get('orga_postalcode') != $currentOrgaPostalCode)
+                || ($statement->has('orga_city') && $statement->get('orga_city') != $currentOrgaCity)
+                || ($statement->has('orga_street') && $statement->get('orga_street') != $currentOrgaStreet)
+                || ($statement->has('orga_email') && $statement->get('orga_email') != $currentOrgaEmail)
+                || ($statement->has('authoredDate') && $statement->get('authoredDate') != $currentAuthoredDateString)
+                || ($statement->has('submittedDate') && $statement->get('submittedDate') != $currentSubmittedDateString)
+            ) {
+                return true;
+            }
+        }
+
+        if ($statement instanceof Statement) {
+            if (
+                $statement->getAuthorName() != $currentAuthorName
+                || $statement->getSubmitterName() != $currentSubmitterName
+                || $statement->getMeta()->getOrgaDepartmentName() != $currentDepartmentName
+                || $statement->getMeta()->getOrgaName() != $currentSubmitterType
+                || $statement->getSubmitterEmailAddress() != $currentSubmitterEmailAddress
+                || $statement->getOrgaPostalCode() != $currentOrgaPostalCode
+                || $statement->getOrgaCity() != $currentOrgaCity
+                || $statement->getOrgaStreet() != $currentOrgaStreet
+                || $statement->getOrgaEmail() != $currentOrgaEmail
+                || $statement->getAuthoredDate() != $currentAuthoredDateTimeStamp
+                || $statement->getSubmit() != $currentSubmittedDateTimeStamp
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -18,12 +18,12 @@
             <h4 class="font-size-large">{{ "submitter.invitable_institution"|trans }}</h4>
 
             {# Submitted by #}
-            {# editable if orga is institution #}
+            {# editable if manualStatement and orga is institution #}
             {% if hasPermission('field_statement_meta_orga_name') %}
                 {% block submitOrga %}
                     {% if statement.meta.orgaName is defined %}
                         {% set orgaNameClass = 'u-mb-0_25 u-pr-0_5' %}
-                        {% if not readonly %}
+                        {% if manualStatement and not readonly %}
                             {% if statement.isSubmittedByCitizen == false%}
                                 {% set orgaNameValue = statement.meta.orgaName|default %}
                                 {% set labelHint = 'institution.name' %}
@@ -35,7 +35,7 @@
                                 {% endif %}
                                 {% set orgaNameDisabled = true %}
                             {% endif %}
-                        {% else %}
+                        {% elseif not manualStatement or readonly %}
                             {% if statement.isSubmittedByCitizen == false %}
                                 {% set orgaNameValue = statement.meta.orgaName|default('-') %}
                                 {% set orgaNameDisabled = true %}
@@ -47,17 +47,6 @@
                                 {% endif %}
                                 {% set orgaNameDisabled = true %}
                             {% endif %}
-                        {% endif %}
-                        {% if statement.isSubmittedByCitizen == false%}
-                            {% set orgaNameValue = statement.meta.orgaName|default %}
-                            {% set labelHint = 'institution.name' %}
-                        {% elseif statement.isSubmittedByCitizen %}
-                            {% if statement.meta.miscData.submitterRole|default == 'publicagency' %}
-                                {% set orgaNameValue = 'institution'|trans %}
-                            {% else %}
-                                {% set orgaNameValue = 'role.citizen'|trans %}
-                            {% endif %}
-                            {% set orgaNameDisabled = true %}
                         {% endif %}
 
                         {% if hasPermission('field_statement_meta_orga_department_name') and statement.isSubmittedByCitizen == false %}
@@ -91,10 +80,10 @@
             {% endif %}
 
             {# department #}
-            {# editable only if not readonly #}
+            {# editable only if manual statement #}
             {% if hasPermission('field_statement_meta_orga_department_name') %}
                 {% if statement.isSubmittedByCitizen == false %}
-                    {% if readonly %}
+                    {% if not manualStatement or readonly %}
                         {% set departmentDisabled = true %}
                     {% endif %}
 
@@ -148,11 +137,12 @@
             {% endif %}
 
             {# submitter name #}
-            {# editable only if not readonly #}
+            {# editable only if manualStatement #}
             {% if hasPermission('field_statement_meta_submit_name') and formDefinitions.name.enabled == true %}
-                {% if readonly %}
+                {% if not manualStatement or readonly %}
                     {% set submittedAuthorDisabled = true %}
                 {% endif %}
+
                 <div class="u-1-of-2 inline-block u-pr-0_5">
                     {% block submitted_author_label %}
                         {% if statement.gdprConsent and statement.gdprConsent.consentRevoked %}
@@ -355,8 +345,10 @@
             {% endif %}
 
             {% block address %}
-                {# Address block is not shown if it's postalcode is empty #}
-                {# editable if not readonly #}
+                {# Address block is not shown if it's not a manual statement and postalcode is empty or if it's a manual
+                   citizen statement and postalcode is empty #}
+                {# editable if manualStatement #}
+
                 {% if hasPermission('field_statement_meta_address') %}
 
                     {% set streetValue = statement.meta.orgaStreet|default %}
@@ -364,7 +356,7 @@
                     {% set postalCodeValue = statement.meta.orgaPostalCode|default %}
                     {% set cityValue = statement.meta.orgaCity|default %}
 
-                    {% if readonly %}
+                    {% if (manualStatement and readonly) or not manualStatement %}
                         {# disable input fields #}
                         {% set houseNumberDisabled = true %}
                         {% set streetDisabled = true %}
@@ -388,7 +380,6 @@
                             {% set cityValue = '-' %}
                         {% endif %}
                     {% endif %}
-
 
                     <div class="u-1-of-1">
                       {% if hasPermission('field_statement_meta_street') and (formDefinitions.streetAndHouseNumber.enabled == true or formDefinitions.street.enabled == true) %}
@@ -631,14 +622,14 @@
                 }) }}
 
                 {# Procedure phase
-                   editable if not readonly
+                   editable if manualStatement
                    display internal phases if submitter is not a citizen, otherwise display external phases
                 #}
                 {% if hasPermission('field_statement_phase') %}
                     {% set procedurePhaseOptGroups = {} %}
                     {% set procedurePhaseOptions = {} %}
 
-                    {% if readonly %}
+                    {% if not manualStatement or readonly %}
                         {# disable select #}
                         {% set procedurePhaseSelectDisabled = true %}
 
@@ -651,7 +642,7 @@
 
                         {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
 
-                    {% else %}
+                    {% elseif manualStatement and not readonly %}
                         {# set all options for optgroups only for edit-mode #}
                         {% if statement.isSubmittedByCitizen == false %}
                             {% set phases = templateVars.internalPhases|default %}
@@ -676,35 +667,35 @@
 
                         {% set procedurePhaseControlOptions = { name: 'r_phase', options: procedurePhaseOptions } %}
                     {% endif %}
-                    {{ uiComponent('form.row', {
-                        elements: [
-                            {
-                                label: { text: 'procedure.public.phase'|trans },
-                                control: procedurePhaseControlOptions,
-                                type: 'select',
-                                id: 'Phase',
-                                elementSize: 'large',
-                                elementClass: 'u-pr-0_5',
-                                disabledPlainText: true,
-                                disabled: procedurePhaseSelectDisabled|default(false),
-                                attributes: ['data-cy=statementDetail:Phase']
-                            }
-                        ]
-                    }) }}
+                        {{ uiComponent('form.row', {
+                            elements: [
+                                {
+                                    label: { text: 'procedure.public.phase'|trans },
+                                    control: procedurePhaseControlOptions,
+                                    type: 'select',
+                                    id: 'Phase',
+                                    elementSize: 'large',
+                                    elementClass: 'u-pr-0_5',
+                                    disabledPlainText: true,
+                                    disabled: procedurePhaseSelectDisabled|default(false),
+                                    attributes: ['data-cy=statementDetail:Phase']
+                                }
+                            ]
+                        }) }}
                 {% endif %}
 
                 {# elements for form.row component are merged into this object: date authored, date submitted and submit type #}
                 {% set authorDateRowElements = {} %}
 
-                {# date submitted - editable if not readonly #}
-                {% if readonly %}
+                {# date submitted - editable if manualStatement #}
+                {% if not manualStatement or readonly %}
                     {% set submitDateDisabled = true %}
                 {% endif %}
 
                 {# date authored #}
-                {# editable if not readonly #}
+                {# editable if manualStatement #}
                 {% if statement.meta.authoredDate is defined %}
-                    {% if readonly %}
+                    {% if not manualStatement or readonly %}
                         {% set authoredDateDisabled = true %}
                     {% endif %}
                     {% if statement.meta.authoredDate|dplanDate() != '' %}
@@ -752,10 +743,10 @@
                 }]) %}
 
                 {# show submit type, if feature is set and value differs from 'system' (-> manual statement) #}
-                {# editable only if not readonly #}
+                {# editable only if manualStatement #}
                 {% if hasPermission('field_statement_submit_type') %}
                     {% set submitTypeSelectOptions = {} %}
-                    {% if readonly %}
+                    {% if not manualStatement or readonly %}
                         {% set submitTypeSelectDisabled = true %}
 
                         {% for value, label in getFormOption('statement_submit_types.values', true) %}
@@ -764,7 +755,7 @@
                             {% endif %}
                         {% endfor %}
 
-                    {% else %}
+                    {% elseif manualStatement and not readonly %}
                         {# the default option is skipped in this case, since it is the value for "system" (submitted
                           by using the platform), which is no valid value for a manual statement #}
                         {% for value, label in getFormOption('statement_submit_types.values', true)|filter(value => value != 'system') %}
@@ -952,7 +943,7 @@
                                     :ignore-last-claimed="true"
                                 ></dp-select-statement-cluster>
                             </label>
-                            {# if not editable #}
+                        {# if not editable #}
                         {% else %}
                             <span class="layout__item u-3-of-4 u-mb-0_75 color--grey">{{ templateVars.table.statement.headStatement|default('statements.group.not.selected'|trans) }}</span>
                         {% endif %}
@@ -968,65 +959,65 @@
 
                     <div class="u-1-of-2 inline-block">
                         {% if statement.element.ident is defined %}
-                            {{ uiComponent('form.element', {
-                                label: { text: 'plandocument'|trans },
-                                control: { value: statement.element.title|default },
-                                type: 'text',
-                                id: 'elementTitle',
-                                elementClass: 'u-mb-0_25',
-                                disabled: true
-                            }) }}
-                            {% if not readonly %}
-                                {{ uiComponent('form.element', {
-                                    label: { text: 'delete'|trans },
-                                    control: { name: 'r_delete_element', value: '1' },
-                                    type: 'checkbox',
-                                    elementClass: 'u-mb-0_5',
-                                    id: 'r_delete_element',
-                                    attributes: ['data-cy=statementDetail:deleteElement']
-                                }) }}
-                            {% endif %}
-
-                            {% if statement.document.ident is defined and hasPermission('field_procedure_documents')%}
-                                {{ uiComponent('form.element', {
-                                    label: { text: 'file'|trans },
-                                    control: { value: statement.document.title|default },
-                                    type: 'text',
-                                    id: 'fileTitle',
-                                    elementClass: 'u-mb-0_25',
-                                    disabled: true
-                                }) }}
-                                {% if not readonly %}
                                     {{ uiComponent('form.element', {
-                                        label: { text: 'delete'|trans },
-                                        control: { name: 'r_delete_document', value: '1' },
-                                        type: 'checkbox',
-                                        elementClass: 'u-mb-0_5',
-                                        id: 'r_delete_document'
+                                        label: { text: 'plandocument'|trans },
+                                        control: { value: statement.element.title|default },
+                                        type: 'text',
+                                        id: 'elementTitle',
+                                        elementClass: 'u-mb-0_25',
+                                        disabled: true
                                     }) }}
-                                {% endif %}
-                            {% endif %}
+                                    {% if not readonly %}
+                                        {{ uiComponent('form.element', {
+                                            label: { text: 'delete'|trans },
+                                            control: { name: 'r_delete_element', value: '1' },
+                                            type: 'checkbox',
+                                            elementClass: 'u-mb-0_5',
+                                            id: 'r_delete_element',
+                                            attributes: ['data-cy=statementDetail:deleteElement']
+                                        }) }}
+                                    {% endif %}
 
-                            {% if statement.paragraph.ident is defined and hasPermission('field_procedure_paragraphs') %}
-                                {{ uiComponent('form.element', {
-                                    label: { text: 'paragraph'|trans },
-                                    control: { value: statement.paragraph.title|striptags|default },
-                                    type: 'text',
-                                    id: 'paragraphTitle',
-                                    elementClass: 'u-mb-0_25',
-                                    disabled: true
-                                }) }}
-
-                                {% if not readonly %}
+                                {% if statement.document.ident is defined and hasPermission('field_procedure_documents')%}
                                     {{ uiComponent('form.element', {
-                                        label: { text: 'delete'|trans },
-                                        control: { name: 'r_delete_paragraph', value: '1' },
-                                        type: 'checkbox',
-                                        elementClass: 'u-mb-0_5',
-                                        id: 'r_delete_paragraph'
+                                        label: { text: 'file'|trans },
+                                        control: { value: statement.document.title|default },
+                                        type: 'text',
+                                        id: 'fileTitle',
+                                        elementClass: 'u-mb-0_25',
+                                        disabled: true
                                     }) }}
+                                    {% if not readonly %}
+                                        {{ uiComponent('form.element', {
+                                            label: { text: 'delete'|trans },
+                                            control: { name: 'r_delete_document', value: '1' },
+                                            type: 'checkbox',
+                                            elementClass: 'u-mb-0_5',
+                                            id: 'r_delete_document'
+                                        }) }}
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
+
+                                {% if statement.paragraph.ident is defined and hasPermission('field_procedure_paragraphs') %}
+                                    {{ uiComponent('form.element', {
+                                        label: { text: 'paragraph'|trans },
+                                        control: { value: statement.paragraph.title|striptags|default },
+                                        type: 'text',
+                                        id: 'paragraphTitle',
+                                        elementClass: 'u-mb-0_25',
+                                        disabled: true
+                                    }) }}
+
+                                    {% if not readonly %}
+                                        {{ uiComponent('form.element', {
+                                            label: { text: 'delete'|trans },
+                                            control: { name: 'r_delete_paragraph', value: '1' },
+                                            type: 'checkbox',
+                                            elementClass: 'u-mb-0_5',
+                                            id: 'r_delete_paragraph'
+                                        }) }}
+                                    {% endif %}
+                                {% endif %}
                         {% else %} {# if statement.element.ident is not defined #}
                             {{ uiComponent('form.element', {
                                 label: { text: 'plandocument'|trans },
@@ -1224,14 +1215,14 @@
                         <div class="layout--flush">
                             <div class="layout__item u-1-of-1">
                                 {{
-                                fileupload(
-                                    "r_fileupload",
-                                    "documents.attach",
-                                    ['.jpg', '.png', '.bmp', '.jpeg', '.zip', '.docx', '.odt', '.pdf', '.txt', '.tiff', '.tif'],
-                                    "form.button.upload.files",
-                                    20,
-                                    true
-                                )
+                                    fileupload(
+                                        "r_fileupload",
+                                        "documents.attach",
+                                        ['.jpg', '.png', '.bmp', '.jpeg', '.zip', '.docx', '.odt', '.pdf', '.txt', '.tiff', '.tif'],
+                                        "form.button.upload.files",
+                                        20,
+                                        true
+                                    )
                                 }}
                             </div>
                         </div>


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-395/BOB-SH-Bauleitplanung-Abwagungstabelle-erlaubt-unzulassige-Modifikationen-Prio-mittel, https://demoseurope.youtrack.cloud/tickets/DS-409/BOB-SH-Planfeststellung-Abwagungstabelle-erlaubt-unzulassige-Modifikationen-Prio-mittel, https://demoseurope.youtrack.cloud/tickets/DS-408/BOB-SH-BImSchG-Abwagungstabelle-erlaubt-unzulassige-Modifikationen-Prio-mittel

Description: 
  Revert changes from eeeba8b in core: restore manualStatement guards in the assessment statement detail template and re-add the hasManualStatementUpdateFields check in StatementService.


- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly

