### PR TITLE
add showPhases prop to AdministrationProceduresList and fix header alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Patch Version**: Incremented for bug fixes.
 
 ## UNRELEASED
+- add showPhases prop to AdministrationProceduresList and fix header alignment
 
 ### Fixed
 - Fix redirect to split-view after claiming statement and correct unclaim behavior to prevent false assignee confirmation dialog

--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -115,12 +115,14 @@
         v-if="showStatementCount"
         v-slot:header-count
       >
-        {{ Translator.trans('quantity') }}
-        <dp-icon
-          v-tooltip="Translator.trans('procedures.statements.count')"
-          icon="info"
-          size="small"
-        />
+        <div class="text-center">
+          {{ Translator.trans('quantity') }}
+          <dp-icon
+            v-tooltip="Translator.trans('procedures.statements.count')"
+            icon="info"
+            size="small"
+          />
+        </div>
       </template>
 
       <template
@@ -210,6 +212,11 @@ export default {
       default: false,
     },
 
+    showPhases: {
+      type: Boolean,
+      default: true,
+    },
+
     showStatementCount: {
       type: Boolean,
       default: false,
@@ -251,12 +258,12 @@ export default {
         {
           colClass: 'w-10',
           field: 'internalPhase',
-          isVisible: this.showInternalPhases,
+          isVisible: this.showInternalPhases && this.showPhases,
         },
         {
           colClass: this.showInternalPhases ? 'w-10' : 'u-1-of-4',
           field: 'externalPhase',
-          isVisible: true,
+          isVisible: this.showPhases,
           label: !this.showInternalPhases && Translator.trans('procedure.public.phase'),
         },
       ]

--- a/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
+++ b/client/js/components/procedure/admin/DpNewProcedure/DpNewProcedure.vue
@@ -181,7 +181,10 @@
         reduced-height
       />
 
-      <fieldset class="pb-0">
+      <fieldset
+        v-if="showDateRange"
+        class="pb-0"
+      >
         <legend class="weight--bold">
           {{ Translator.trans('period') }}
           <dp-contextual-help :text="Translator.trans('explanation.date.format')" />
@@ -317,6 +320,11 @@ export default {
     procedureTypes: {
       type: Array,
       required: true,
+    },
+
+    showDateRange: {
+      type: Boolean,
+      default: true,
     },
 
     token: {


### PR DESCRIPTION
Description: 
Add a new boolean prop `showPhases` (default: true) to the AdministrationProceduresList component. When set to false, both the internal and external phase columns (Verfahrensschritt Institution / Öffentlichkeit) are hidden from the procedure list. This allows projects that don't use phases to opt out of displaying them without affecting other projects.

 Additionally, center the quantity (Anzahl) column header to align with the centered count values in the table body.

- [x] Update changelog 
