### PR TITLE
fix: add Access-Control-Allow-Credentials header to TUS CORS middleware

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Middlewares/TusCors.php
+++ b/demosplan/DemosPlanCoreBundle/Middlewares/TusCors.php
@@ -35,6 +35,7 @@ class TusCors implements TusMiddleware
 
         $headers['Access-Control-Allow-Headers'] = $allowHeaders.', '.Header::FILE_HASH.', '.Header::FILE_ID;
         $headers['Access-Control-Expose-Headers'] = $exposeHeaders.', '.Header::FILE_HASH.', '.Header::FILE_ID;
+        $headers['Access-Control-Allow-Credentials'] = 'true';
 
         $response->replaceHeaders($headers);
     }


### PR DESCRIPTION
### Ticket
DPLAN-17517

File uploads via TUS fail in Firefox because the browser requires `withCredentials: true` on the XHR request (handled in demosplan-ui PR #1454). For that to work, the server must respond with `Access-Control-Allow-Credentials: true` — which was missing from the TUS CORS middleware.

### How to review/test
1. Apply demosplan-ui PR https://github.com/demos-europe/demosplan-ui/pull/1454
2. Log in as I-Ko in Firefox
3. Open a procedure and try to attach a file to a statement
4. Upload should succeed without error

### Linked PRs
- demosplan-ui https://github.com/demos-europe/demosplan-ui/pull/1454

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog