### PR TITLE
fix: handle promise rejections in DpDashboardTaskCard

### DIFF
--- a/client/js/components/procedure/DpDashboardTaskCard.vue
+++ b/client/js/components/procedure/DpDashboardTaskCard.vue
@@ -76,9 +76,11 @@ export default {
 
     // Get count of segments assigned to the current user
     const segmentUrl = Routing.generate('api_resource_list', { resourceType: 'StatementSegment' })
-    dpApi.get(segmentUrl, { filter: filterQuery }).then(response => {
-      this.assignedSegmentCount = response.data.data.length
-    })
+    dpApi.get(segmentUrl, { filter: filterQuery })
+      .then(response => {
+        this.assignedSegmentCount = response.data.data.length
+      })
+      .catch(e => console.error('Failed to fetch assigned segments count', e))
 
     /*
      * It is currently difficult to get the default filter hash but a filter hash is needed to retrieve an updated hash.
@@ -101,13 +103,14 @@ export default {
 
         // Get the actual filter hash
         const url = Routing.generate('dplan_rpc_segment_list_query_update', { queryHash })
-        dpApi.patch(url, {}, filterData)
+        return dpApi.patch(url, {}, filterData)
           .then(({ data }) => {
             if (data) {
               this.userHash = data
             }
           })
       })
+      .catch(e => console.error('Failed to fetch segment filter hash', e))
   },
 }
 </script>


### PR DESCRIPTION
## Summary
- Add `.catch()` handlers to all API calls in `DpDashboardTaskCard.vue` to prevent unhandled promise rejections on the procedure dashboard
- Chain inner `dpApi.patch()` rejection to the outer promise via `return` so errors propagate to a single `.catch()`
- Component gracefully degrades to its defaults (0 segments, no filter link) on failure

## Test plan
- [ ] Open a procedure dashboard (`/verfahren/{id}/uebersicht`)
- [ ] Verify the task card loads correctly with assigned segments
- [ ] Simulate a network failure and confirm no unhandled rejection appears in the console