### PR TITLE
Add commands to list/detach organisations from customers

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
@@ -12,11 +12,11 @@ namespace demosplan\DemosPlanCoreBundle\Command\Data;
 
 use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
 use demosplan\DemosPlanCoreBundle\Command\Helpers\CustomerSelectionTrait;
-use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
+use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -99,7 +99,7 @@ class DetachOrganisationFromCustomerCommand extends CoreCommand
             }
 
             $this->entityManager->flush();
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $io->error('Failed to detach organisations: '.$exception->getMessage());
 
             return Command::FAILURE;

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Data;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Command\Helpers\CustomerSelectionTrait;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityNotFoundException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+use function array_map;
+use function count;
+
+#[AsCommand(name: 'dplan:customer:detach-organisation', description: 'Detaches one or more organisations from a customer without deleting them')]
+class DetachOrganisationFromCustomerCommand extends CoreCommand
+{
+    use CustomerSelectionTrait;
+
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly CustomerRepository $customerRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly QuestionHelper $helper = new QuestionHelper(),
+        ?string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    public function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            '',
+            InputOption::VALUE_NONE,
+            'Show what would be done without making changes.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $isDryRun = (bool) $input->getOption('dry-run');
+
+        if ($isDryRun) {
+            $io->note('Running in dry-run mode — no changes will be made.');
+        }
+
+        $customer = $this->askForCustomer($input, $io);
+        $orgaStatuses = $customer->getOrgaStatuses();
+
+        $selectedStatuses = 0 === count($orgaStatuses) ? null : $this->askForOrganisations($input, $io, $orgaStatuses);
+
+        if (null === $selectedStatuses || [] === $selectedStatuses) {
+            $io->info(null === $selectedStatuses
+                ? 'No detachable organisations available for this customer.'
+                : 'No organisations selected.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->printSelectedOrganisations($io, $selectedStatuses);
+
+        if ($isDryRun) {
+            $io->success('Dry run complete — no changes were made.');
+
+            return Command::SUCCESS;
+        }
+
+        $confirm = new ConfirmationQuestion('Do you want to proceed? (y/N) ', false);
+        if (!$this->helper->ask($input, $io, $confirm)) {
+            $io->info('Aborted.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            foreach ($selectedStatuses as $status) {
+                $this->entityManager->remove($status);
+            }
+
+            $this->entityManager->flush();
+        } catch (\Exception $exception) {
+            $io->error('Failed to detach organisations: '.$exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success(count($selectedStatuses).' organisation entry/entries detached from customer "'.$customer->getName().'".');
+
+        return Command::SUCCESS;
+    }
+
+    protected function getCustomerRepository(): CustomerRepository
+    {
+        return $this->customerRepository;
+    }
+
+    protected function getQuestionHelper(): QuestionHelper
+    {
+        return $this->helper;
+    }
+
+    /**
+     * @param OrgaStatusInCustomer[] $selectedStatuses
+     */
+    private function printSelectedOrganisations(SymfonyStyle $io, array $selectedStatuses): void
+    {
+        $io->section('The following organisation entries will be detached:');
+        foreach ($selectedStatuses as $status) {
+            try {
+                $orgaName = $status->getOrga()->getName();
+                $orgaId = $status->getOrga()->getId();
+            } catch (EntityNotFoundException) {
+                $orgaName = 'ORPHANED';
+                $orgaId = $status->getId();
+            }
+            $io->writeln(sprintf(
+                '  - %s (ID: %s, Type: %s, Status: %s)',
+                $orgaName,
+                $orgaId,
+                $status->getOrgaType()->getLabel(),
+                $status->getStatus()
+            ));
+        }
+    }
+
+    /**
+     * @param iterable<OrgaStatusInCustomer> $orgaStatuses
+     *
+     * @return OrgaStatusInCustomer[]|null null if no detachable organisations available
+     */
+    private function askForOrganisations(InputInterface $input, SymfonyStyle $output, iterable $orgaStatuses): ?array
+    {
+        $statusMap = [];
+        $choices = [];
+
+        /** @var OrgaStatusInCustomer $orgaStatus */
+        foreach ($orgaStatuses as $orgaStatus) {
+            try {
+                $orga = $orgaStatus->getOrga();
+                $orgaName = $orga->getName();
+                $orgaId = $orga->getId();
+
+                // Never allow detaching the default citizen organisation
+                if ($orga->isDefaultCitizenOrganisation()) {
+                    continue;
+                }
+            } catch (EntityNotFoundException) {
+                $orgaName = 'ORPHANED';
+                $orgaId = $orgaStatus->getId();
+            }
+
+            $label = sprintf(
+                '%s | Type: %s | Status: %s | ID: %s',
+                $orgaName,
+                $orgaStatus->getOrgaType()->getLabel(),
+                $orgaStatus->getStatus(),
+                $orgaId
+            );
+            $choices[] = $label;
+            $statusMap[$label] = $orgaStatus;
+        }
+
+        if ([] === $choices) {
+            return null;
+        }
+
+        $question = new ChoiceQuestion(
+            'Select organisation(s) to detach (comma-separated for multiple):',
+            $choices
+        );
+        $question->setMultiselect(true);
+
+        $answers = $this->helper->ask($input, $output, $question);
+
+        return array_map(
+            static fn (string $answer): OrgaStatusInCustomer => $statusMap[$answer],
+            $answers
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/DetachOrganisationFromCustomerCommand.php
@@ -130,6 +130,9 @@ class DetachOrganisationFromCustomerCommand extends CoreCommand
             try {
                 $orgaName = $status->getOrga()->getName();
                 $orgaId = $status->getOrga()->getId();
+                if ('' === $orgaName || null === $orgaName) {
+                    $orgaName = '(no name)';
+                }
             } catch (EntityNotFoundException) {
                 $orgaName = 'ORPHANED';
                 $orgaId = $status->getId();
@@ -161,9 +164,13 @@ class DetachOrganisationFromCustomerCommand extends CoreCommand
                 $orgaName = $orga->getName();
                 $orgaId = $orga->getId();
 
-                // Never allow detaching the default citizen organisation
-                if ($orga->isDefaultCitizenOrganisation()) {
+                // Never allow detaching the default citizen organisation or soft-deleted orgas
+                if ($orga->isDefaultCitizenOrganisation() || $orga->isDeleted()) {
                     continue;
+                }
+
+                if ('' === $orgaName || null === $orgaName) {
+                    $orgaName = '(no name)';
                 }
             } catch (EntityNotFoundException) {
                 $orgaName = 'ORPHANED';
@@ -184,6 +191,8 @@ class DetachOrganisationFromCustomerCommand extends CoreCommand
         if ([] === $choices) {
             return null;
         }
+
+        usort($choices, static fn (string $a, string $b): int => strnatcasecmp($a, $b));
 
         $question = new ChoiceQuestion(
             'Select organisation(s) to detach (comma-separated for multiple):',

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ListCustomerOrganisationsCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ListCustomerOrganisationsCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Data;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Command\Helpers\CustomerSelectionTrait;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use Doctrine\ORM\EntityNotFoundException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(name: 'dplan:customer:list-organisations', description: 'Lists all organisations registered for a customer')]
+class ListCustomerOrganisationsCommand extends CoreCommand
+{
+    use CustomerSelectionTrait;
+
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly CustomerRepository $customerRepository,
+        private readonly QuestionHelper $helper = new QuestionHelper(),
+        ?string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $customer = $this->askForCustomer($input, $io);
+        $orgaStatuses = $customer->getOrgaStatuses();
+
+        if (0 === count($orgaStatuses)) {
+            $io->info('No organisations found for customer "'.$customer->getName().'".');
+
+            return Command::SUCCESS;
+        }
+
+        $io->title('Organisations for customer "'.$customer->getName().'" ('.$customer->getSubdomain().')');
+
+        $table = new Table($output);
+        $table->setHeaders(['Orga Name', 'Orga ID', 'Orga Type', 'Status']);
+
+        $orphanedCount = 0;
+        $displayedCount = 0;
+
+        /** @var OrgaStatusInCustomer $orgaStatus */
+        foreach ($orgaStatuses as $orgaStatus) {
+            try {
+                $orga = $orgaStatus->getOrga();
+                // Force proxy initialization to detect missing entities
+                $orgaName = $orga->getName();
+                $orgaId = $orga->getId();
+
+                if ($orga->isDefaultCitizenOrganisation()) {
+                    continue;
+                }
+            } catch (EntityNotFoundException) {
+                ++$orphanedCount;
+                ++$displayedCount;
+                $table->addRow([
+                    '<error>ORPHANED</error>',
+                    $orgaStatus->getId(),
+                    $orgaStatus->getOrgaType()->getLabel(),
+                    $orgaStatus->getStatus(),
+                ]);
+                continue;
+            }
+
+            ++$displayedCount;
+            $table->addRow([
+                $orgaName,
+                $orgaId,
+                $orgaStatus->getOrgaType()->getLabel(),
+                $orgaStatus->getStatus(),
+            ]);
+        }
+
+        if (0 === $displayedCount) {
+            $io->info('No organisations found for customer "'.$customer->getName().'".');
+
+            return Command::SUCCESS;
+        }
+
+        $table->render();
+
+        $io->info($displayedCount.' organisation(s) found.');
+        if ($orphanedCount > 0) {
+            $io->warning($orphanedCount.' orphaned entry/entries found (organisation no longer exists in database).');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    protected function getCustomerRepository(): CustomerRepository
+    {
+        return $this->customerRepository;
+    }
+
+    protected function getQuestionHelper(): QuestionHelper
+    {
+        return $this->helper;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Data/ListCustomerOrganisationsCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/ListCustomerOrganisationsCommand.php
@@ -57,7 +57,7 @@ class ListCustomerOrganisationsCommand extends CoreCommand
         $table->setHeaders(['Orga Name', 'Orga ID', 'Orga Type', 'Status']);
 
         $orphanedCount = 0;
-        $displayedCount = 0;
+        $rows = [];
 
         /** @var OrgaStatusInCustomer $orgaStatus */
         foreach ($orgaStatuses as $orgaStatus) {
@@ -67,29 +67,34 @@ class ListCustomerOrganisationsCommand extends CoreCommand
                 $orgaName = $orga->getName();
                 $orgaId = $orga->getId();
 
-                if ($orga->isDefaultCitizenOrganisation()) {
+                if ($orga->isDefaultCitizenOrganisation() || $orga->isDeleted()) {
                     continue;
                 }
+
+                $rows[] = [
+                    '' !== $orgaName && null !== $orgaName ? $orgaName : '<comment>(no name)</comment>',
+                    $orgaId,
+                    $orgaStatus->getOrgaType()->getLabel(),
+                    $orgaStatus->getStatus(),
+                ];
             } catch (EntityNotFoundException) {
                 ++$orphanedCount;
-                ++$displayedCount;
-                $table->addRow([
+                $rows[] = [
                     '<error>ORPHANED</error>',
                     $orgaStatus->getId(),
                     $orgaStatus->getOrgaType()->getLabel(),
                     $orgaStatus->getStatus(),
-                ]);
-                continue;
+                ];
             }
-
-            ++$displayedCount;
-            $table->addRow([
-                $orgaName,
-                $orgaId,
-                $orgaStatus->getOrgaType()->getLabel(),
-                $orgaStatus->getStatus(),
-            ]);
         }
+
+        usort($rows, static fn (array $a, array $b): int => strnatcasecmp(strip_tags($a[0]), strip_tags($b[0])));
+
+        foreach ($rows as $row) {
+            $table->addRow($row);
+        }
+
+        $displayedCount = count($rows);
 
         if (0 === $displayedCount) {
             $io->info('No organisations found for customer "'.$customer->getName().'".');

--- a/demosplan/DemosPlanCoreBundle/Command/Helpers/CustomerSelectionTrait.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Helpers/CustomerSelectionTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Helpers;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+use function array_filter;
+use function array_map;
+
+trait CustomerSelectionTrait
+{
+    abstract protected function getCustomerRepository(): CustomerRepository;
+
+    abstract protected function getQuestionHelper(): QuestionHelper;
+
+    private function askForCustomer(InputInterface $input, OutputInterface $output): Customer
+    {
+        $availableCustomers = $this->getCustomerRepository()->findAll();
+        $choices = array_map(
+            static fn (Customer $customer): string => $customer->getSubdomain().' id: '.$customer->getId(),
+            $availableCustomers
+        );
+
+        $question = new ChoiceQuestion('Please select a customer:', $choices);
+        $answer = $this->getQuestionHelper()->ask($input, $output, $question);
+
+        $chosenCustomer = array_filter(
+            $availableCustomers,
+            static fn (Customer $customer): bool => $customer->getSubdomain().' id: '.$customer->getId() === $answer
+        );
+
+        $chosenCustomer = reset($chosenCustomer);
+        if (!$chosenCustomer instanceof Customer) {
+            throw new InvalidArgumentException('Given customer is not available.');
+        }
+
+        return $chosenCustomer;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/User/OrgaStatusInCustomer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/OrgaStatusInCustomer.php
@@ -52,7 +52,7 @@ class OrgaStatusInCustomer extends CoreEntity implements UuidEntityInterface, Or
      *
      * @var OrgaInterface
      *
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Orga", inversedBy="statusInCustomers", cascade={"remove"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Orga", inversedBy="statusInCustomers")
      *
      * @ORM\JoinColumn(name="_o_id", referencedColumnName="_o_id", nullable=false, onDelete="CASCADE")
      */
@@ -63,7 +63,7 @@ class OrgaStatusInCustomer extends CoreEntity implements UuidEntityInterface, Or
      *
      * @var OrgaTypeInterface
      *
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\OrgaType", inversedBy="orgaStatusInCustomers", cascade={"remove"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\OrgaType", inversedBy="orgaStatusInCustomers")
      *
      * @ORM\JoinColumn(name="_ot_id", referencedColumnName="_ot_id", nullable=false)
      */
@@ -74,7 +74,7 @@ class OrgaStatusInCustomer extends CoreEntity implements UuidEntityInterface, Or
      *
      * @var CustomerInterface
      *
-     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer", inversedBy="orgaStatuses", cascade={"remove"})
+     * @ORM\ManyToOne(targetEntity="demosplan\DemosPlanCoreBundle\Entity\User\Customer", inversedBy="orgaStatuses")
      *
      * @ORM\JoinColumn(name="_c_id", referencedColumnName="_c_id", nullable=false)
      */

--- a/tests/backend/core/Core/Functional/Command/CustomerCommandTestHelper.php
+++ b/tests/backend/core/Core/Functional/Command/CustomerCommandTestHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional\Command;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+
+trait CustomerCommandTestHelper
+{
+    private function createOrga(string $name, string $id): MockObject&Orga
+    {
+        $orga = $this->createMock(Orga::class);
+        $orga->method('getName')->willReturn($name);
+        $orga->method('getId')->willReturn($id);
+
+        return $orga;
+    }
+
+    private function createOrgaType(string $name): MockObject&OrgaType
+    {
+        $orgaType = $this->createMock(OrgaType::class);
+        $orgaType->method('getLabel')->willReturn($name);
+
+        return $orgaType;
+    }
+
+    private function createOrgaStatusInCustomer(
+        MockObject&Orga $orga,
+        MockObject&OrgaType $orgaType,
+        string $status,
+    ): MockObject&OrgaStatusInCustomer {
+        $orgaStatus = $this->createMock(OrgaStatusInCustomer::class);
+        $orgaStatus->method('getOrga')->willReturn($orga);
+        $orgaStatus->method('getOrgaType')->willReturn($orgaType);
+        $orgaStatus->method('getStatus')->willReturn($status);
+
+        return $orgaStatus;
+    }
+
+    private function createCustomerWithOrgaStatuses(
+        string $name,
+        string $subdomain,
+        string $id,
+        array $orgaStatuses,
+    ): MockObject&Customer {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getName')->willReturn($name);
+        $customer->method('getSubdomain')->willReturn($subdomain);
+        $customer->method('getId')->willReturn($id);
+        $customer->method('getOrgaStatuses')->willReturn(new ArrayCollection($orgaStatuses));
+
+        return $customer;
+    }
+}

--- a/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
@@ -174,7 +174,7 @@ class DetachOrganisationFromCustomerCommandTest extends FunctionalTestCase
         $regularLabel = 'Regular Org | Type: Planning Agency | Status: accepted | ID: regular-orga-id';
         $callCount = 0;
         $this->questionHelperMock->method('ask')
-            ->willReturnCallback(function ($askInput, $askOutput, $question) use (&$capturedChoices, &$callCount, $regularLabel) {
+            ->willReturnCallback(function ($_askInput, $_askOutput, $question) use (&$capturedChoices, &$callCount, $regularLabel) {
                 ++$callCount;
 
                 if (1 === $callCount) {

--- a/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
@@ -234,5 +234,4 @@ class DetachOrganisationFromCustomerCommandTest extends FunctionalTestCase
 
         return $commandTester;
     }
-
 }

--- a/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional\Command;
+
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Data\DetachOrganisationFromCustomerCommand;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+
+class DetachOrganisationFromCustomerCommandTest extends FunctionalTestCase
+{
+    private const CUSTOMER_NAME = 'Test Customer';
+    private const CUSTOMER_SUBDOMAIN = 'test-sub';
+    private const CUSTOMER_ID = 'test-id';
+    private const CUSTOMER_SELECTION = 'test-sub id: test-id';
+    private const ORGA_NAME = 'Test Organisation';
+    private const ORGA_ID = 'test-orga-id';
+    private const ORGA_TYPE_LABEL = 'Planning Agency';
+    private const ORGA_LABEL = 'Test Organisation | Type: Planning Agency | Status: accepted | ID: test-orga-id';
+
+    private ?MockObject $parameterBagMock;
+    private ?MockObject $customerRepositoryMock;
+    private ?MockObject $entityManagerMock;
+    private ?MockObject $questionHelperMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->parameterBagMock = $this->createMock(ParameterBagInterface::class);
+        $this->customerRepositoryMock = $this->createMock(CustomerRepository::class);
+        $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $this->questionHelperMock = $this->createMock(QuestionHelper::class);
+    }
+
+    public function testDryRunMakesNoChanges(): void
+    {
+        $this->setUpDefaultCustomerWithOrga();
+
+        $this->questionHelperMock->method('ask')
+            ->willReturnOnConsecutiveCalls(
+                self::CUSTOMER_SELECTION,
+                [self::ORGA_LABEL]
+            );
+
+        $this->entityManagerMock->expects(self::never())->method('remove');
+        $this->entityManagerMock->expects(self::never())->method('flush');
+
+        $commandTester = $this->executeCommand(['--dry-run' => true]);
+        $output = $commandTester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('Dry run complete', $output);
+        self::assertStringContainsString(self::ORGA_NAME, $output);
+    }
+
+    public function testDetachOrganisationWithConfirmation(): void
+    {
+        [$orgaStatus] = $this->setUpDefaultCustomerWithOrga();
+
+        $this->questionHelperMock->method('ask')
+            ->willReturnOnConsecutiveCalls(
+                self::CUSTOMER_SELECTION,
+                [self::ORGA_LABEL],
+                true
+            );
+
+        $this->entityManagerMock->expects(self::once())->method('remove')->with($orgaStatus);
+        $this->entityManagerMock->expects(self::once())->method('flush');
+
+        $commandTester = $this->executeCommand();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('1 organisation entry/entries detached', $commandTester->getDisplay());
+    }
+
+    public function testAbortOnDeniedConfirmation(): void
+    {
+        $this->setUpDefaultCustomerWithOrga();
+
+        $this->questionHelperMock->method('ask')
+            ->willReturnOnConsecutiveCalls(
+                self::CUSTOMER_SELECTION,
+                [self::ORGA_LABEL],
+                false
+            );
+
+        $this->entityManagerMock->expects(self::never())->method('remove');
+        $this->entityManagerMock->expects(self::never())->method('flush');
+
+        $commandTester = $this->executeCommand();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('Aborted', $commandTester->getDisplay());
+    }
+
+    public function testNoOrganisationsForCustomer(): void
+    {
+        $customer = $this->createCustomerWithOrgaStatuses('Empty Customer', 'empty-sub', 'empty-id', []);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+        $this->questionHelperMock->method('ask')->willReturn('empty-sub id: empty-id');
+
+        $commandTester = $this->executeCommand();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('No detachable organisations available', $commandTester->getDisplay());
+    }
+
+    public function testDetachMultipleOrganisations(): void
+    {
+        $orgaType = $this->createOrgaType(self::ORGA_TYPE_LABEL);
+        $orga1 = $this->createOrga('First Org', 'orga-id-1');
+        $orga2 = $this->createOrga('Second Org', 'orga-id-2');
+        $orgaStatus1 = $this->createOrgaStatusInCustomer($orga1, $orgaType, 'accepted');
+        $orgaStatus2 = $this->createOrgaStatusInCustomer($orga2, $orgaType, 'accepted');
+        $customer = $this->createCustomerWithOrgaStatuses(self::CUSTOMER_NAME, self::CUSTOMER_SUBDOMAIN, self::CUSTOMER_ID, [$orgaStatus1, $orgaStatus2]);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+
+        $label1 = 'First Org | Type: Planning Agency | Status: accepted | ID: orga-id-1';
+        $label2 = 'Second Org | Type: Planning Agency | Status: accepted | ID: orga-id-2';
+        $this->questionHelperMock->method('ask')
+            ->willReturnOnConsecutiveCalls(
+                self::CUSTOMER_SELECTION,
+                [$label1, $label2],
+                true
+            );
+
+        $this->entityManagerMock->expects(self::exactly(2))->method('remove');
+        $this->entityManagerMock->expects(self::once())->method('flush');
+
+        $commandTester = $this->executeCommand();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('2 organisation entry/entries detached', $commandTester->getDisplay());
+    }
+
+    public function testCitizenOrganisationNotSelectable(): void
+    {
+        $orgaType = $this->createOrgaType(self::ORGA_TYPE_LABEL);
+        $citizenOrga = $this->createOrga('Privatperson', UserInterface::ANONYMOUS_USER_ORGA_ID);
+        $citizenOrga->method('isDefaultCitizenOrganisation')->willReturn(true);
+        $regularOrga = $this->createOrga('Regular Org', 'regular-orga-id');
+        $regularOrga->method('isDefaultCitizenOrganisation')->willReturn(false);
+
+        $citizenStatus = $this->createOrgaStatusInCustomer($citizenOrga, $orgaType, 'accepted');
+        $regularStatus = $this->createOrgaStatusInCustomer($regularOrga, $orgaType, 'accepted');
+        $customer = $this->createCustomerWithOrgaStatuses(self::CUSTOMER_NAME, self::CUSTOMER_SUBDOMAIN, self::CUSTOMER_ID, [$citizenStatus, $regularStatus]);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+
+        $capturedChoices = [];
+        $regularLabel = 'Regular Org | Type: Planning Agency | Status: accepted | ID: regular-orga-id';
+        $callCount = 0;
+        $this->questionHelperMock->method('ask')
+            ->willReturnCallback(function ($askInput, $askOutput, $question) use (&$capturedChoices, &$callCount, $regularLabel) {
+                ++$callCount;
+
+                if (1 === $callCount) {
+                    return self::CUSTOMER_SELECTION;
+                }
+                if ($question instanceof ChoiceQuestion) {
+                    $capturedChoices = $question->getChoices();
+
+                    return [$regularLabel];
+                }
+
+                return true;
+            });
+
+        $commandTester = $this->executeCommand();
+
+        foreach ($capturedChoices as $choice) {
+            self::assertStringNotContainsString('Privatperson', $choice);
+            self::assertStringNotContainsString(UserInterface::ANONYMOUS_USER_ORGA_ID, $choice);
+        }
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('1 organisation entry/entries detached', $commandTester->getDisplay());
+    }
+
+    /**
+     * @return array{OrgaStatusInCustomer&MockObject}
+     */
+    private function setUpDefaultCustomerWithOrga(): array
+    {
+        $orgaType = $this->createOrgaType(self::ORGA_TYPE_LABEL);
+        $orga = $this->createOrga(self::ORGA_NAME, self::ORGA_ID);
+        $orgaStatus = $this->createOrgaStatusInCustomer($orga, $orgaType, 'accepted');
+        $customer = $this->createCustomerWithOrgaStatuses(self::CUSTOMER_NAME, self::CUSTOMER_SUBDOMAIN, self::CUSTOMER_ID, [$orgaStatus]);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+
+        return [$orgaStatus];
+    }
+
+    private function executeCommand(array $additionalParameters = []): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+        $application->add(
+            new DetachOrganisationFromCustomerCommand(
+                $this->parameterBagMock,
+                $this->customerRepositoryMock,
+                $this->entityManagerMock,
+                $this->questionHelperMock
+            )
+        );
+        $command = $application->find(DetachOrganisationFromCustomerCommand::getDefaultName());
+        $execute = ['command' => $command->getName()];
+        foreach ($additionalParameters as $parameter => $value) {
+            $execute[$parameter] = $value;
+        }
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($execute);
+
+        return $commandTester;
+    }
+
+    private function createOrga(string $name, string $id): MockObject&Orga
+    {
+        $orga = $this->createMock(Orga::class);
+        $orga->method('getName')->willReturn($name);
+        $orga->method('getId')->willReturn($id);
+
+        return $orga;
+    }
+
+    private function createOrgaType(string $name): MockObject&OrgaType
+    {
+        $orgaType = $this->createMock(OrgaType::class);
+        $orgaType->method('getLabel')->willReturn($name);
+
+        return $orgaType;
+    }
+
+    private function createOrgaStatusInCustomer(
+        MockObject&Orga $orga,
+        MockObject&OrgaType $orgaType,
+        string $status,
+    ): MockObject&OrgaStatusInCustomer {
+        $orgaStatus = $this->createMock(OrgaStatusInCustomer::class);
+        $orgaStatus->method('getOrga')->willReturn($orga);
+        $orgaStatus->method('getOrgaType')->willReturn($orgaType);
+        $orgaStatus->method('getStatus')->willReturn($status);
+
+        return $orgaStatus;
+    }
+
+    private function createCustomerWithOrgaStatuses(
+        string $name,
+        string $subdomain,
+        string $id,
+        array $orgaStatuses,
+    ): MockObject&Customer {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getName')->willReturn($name);
+        $customer->method('getSubdomain')->willReturn($subdomain);
+        $customer->method('getId')->willReturn($id);
+        $customer->method('getOrgaStatuses')->willReturn(new ArrayCollection($orgaStatuses));
+
+        return $customer;
+    }
+}

--- a/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
@@ -10,13 +10,13 @@
 
 namespace Tests\Core\Core\Functional\Command;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
 use demosplan\DemosPlanCoreBundle\Command\Data\DetachOrganisationFromCustomerCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
-use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -24,7 +24,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Tests\Base\FunctionalTestCase;

--- a/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/DetachOrganisationFromCustomerCommandTest.php
@@ -13,12 +13,7 @@ namespace Tests\Core\Core\Functional\Command;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
 use demosplan\DemosPlanCoreBundle\Command\Data\DetachOrganisationFromCustomerCommand;
-use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Command\Command;
@@ -30,6 +25,8 @@ use Tests\Base\FunctionalTestCase;
 
 class DetachOrganisationFromCustomerCommandTest extends FunctionalTestCase
 {
+    use CustomerCommandTestHelper;
+
     private const CUSTOMER_NAME = 'Test Customer';
     private const CUSTOMER_SUBDOMAIN = 'test-sub';
     private const CUSTOMER_ID = 'test-id';
@@ -238,48 +235,4 @@ class DetachOrganisationFromCustomerCommandTest extends FunctionalTestCase
         return $commandTester;
     }
 
-    private function createOrga(string $name, string $id): MockObject&Orga
-    {
-        $orga = $this->createMock(Orga::class);
-        $orga->method('getName')->willReturn($name);
-        $orga->method('getId')->willReturn($id);
-
-        return $orga;
-    }
-
-    private function createOrgaType(string $name): MockObject&OrgaType
-    {
-        $orgaType = $this->createMock(OrgaType::class);
-        $orgaType->method('getLabel')->willReturn($name);
-
-        return $orgaType;
-    }
-
-    private function createOrgaStatusInCustomer(
-        MockObject&Orga $orga,
-        MockObject&OrgaType $orgaType,
-        string $status,
-    ): MockObject&OrgaStatusInCustomer {
-        $orgaStatus = $this->createMock(OrgaStatusInCustomer::class);
-        $orgaStatus->method('getOrga')->willReturn($orga);
-        $orgaStatus->method('getOrgaType')->willReturn($orgaType);
-        $orgaStatus->method('getStatus')->willReturn($status);
-
-        return $orgaStatus;
-    }
-
-    private function createCustomerWithOrgaStatuses(
-        string $name,
-        string $subdomain,
-        string $id,
-        array $orgaStatuses,
-    ): MockObject&Customer {
-        $customer = $this->createMock(Customer::class);
-        $customer->method('getName')->willReturn($name);
-        $customer->method('getSubdomain')->willReturn($subdomain);
-        $customer->method('getId')->willReturn($id);
-        $customer->method('getOrgaStatuses')->willReturn(new ArrayCollection($orgaStatuses));
-
-        return $customer;
-    }
 }

--- a/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
@@ -130,5 +130,4 @@ class ListCustomerOrganisationsCommandTest extends FunctionalTestCase
 
         return $commandTester;
     }
-
 }

--- a/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
@@ -13,12 +13,8 @@ namespace Tests\Core\Core\Functional\Command;
 use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
 use demosplan\DemosPlanCoreBundle\Command\Data\ListCustomerOrganisationsCommand;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
-use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
-use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -28,6 +24,8 @@ use Tests\Base\FunctionalTestCase;
 
 class ListCustomerOrganisationsCommandTest extends FunctionalTestCase
 {
+    use CustomerCommandTestHelper;
+
     private const ORGA_TYPE_LABEL = 'Planning Agency';
 
     private ?MockObject $parameterBagMock;
@@ -133,48 +131,4 @@ class ListCustomerOrganisationsCommandTest extends FunctionalTestCase
         return $commandTester;
     }
 
-    private function createOrga(string $name, string $id): MockObject&Orga
-    {
-        $orga = $this->createMock(Orga::class);
-        $orga->method('getName')->willReturn($name);
-        $orga->method('getId')->willReturn($id);
-
-        return $orga;
-    }
-
-    private function createOrgaType(string $name): MockObject&OrgaType
-    {
-        $orgaType = $this->createMock(OrgaType::class);
-        $orgaType->method('getLabel')->willReturn($name);
-
-        return $orgaType;
-    }
-
-    private function createOrgaStatusInCustomer(
-        MockObject&Orga $orga,
-        MockObject&OrgaType $orgaType,
-        string $status,
-    ): MockObject&OrgaStatusInCustomer {
-        $orgaStatus = $this->createMock(OrgaStatusInCustomer::class);
-        $orgaStatus->method('getOrga')->willReturn($orga);
-        $orgaStatus->method('getOrgaType')->willReturn($orgaType);
-        $orgaStatus->method('getStatus')->willReturn($status);
-
-        return $orgaStatus;
-    }
-
-    private function createCustomerWithOrgaStatuses(
-        string $name,
-        string $subdomain,
-        string $id,
-        array $orgaStatuses,
-    ): MockObject&Customer {
-        $customer = $this->createMock(Customer::class);
-        $customer->method('getName')->willReturn($name);
-        $customer->method('getSubdomain')->willReturn($subdomain);
-        $customer->method('getId')->willReturn($id);
-        $customer->method('getOrgaStatuses')->willReturn(new ArrayCollection($orgaStatuses));
-
-        return $customer;
-    }
 }

--- a/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
+++ b/tests/backend/core/Core/Functional/Command/ListCustomerOrganisationsCommandTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional\Command;
+
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\Data\ListCustomerOrganisationsCommand;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
+use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Tests\Base\FunctionalTestCase;
+
+class ListCustomerOrganisationsCommandTest extends FunctionalTestCase
+{
+    private const ORGA_TYPE_LABEL = 'Planning Agency';
+
+    private ?MockObject $parameterBagMock;
+    private ?MockObject $customerRepositoryMock;
+    private ?MockObject $questionHelperMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->parameterBagMock = $this->createMock(ParameterBagInterface::class);
+        $this->customerRepositoryMock = $this->createMock(CustomerRepository::class);
+        $this->questionHelperMock = $this->createMock(QuestionHelper::class);
+    }
+
+    public function testListsOrganisationsForCustomer(): void
+    {
+        $orgaType = $this->createOrgaType(self::ORGA_TYPE_LABEL);
+        $orga = $this->createOrga('Test Organisation', 'test-orga-id');
+        $customer = $this->createCustomerWithOrgaStatuses('Test Customer', 'test-subdomain', 'test-customer-id', [
+            $this->createOrgaStatusInCustomer($orga, $orgaType, 'accepted'),
+        ]);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+        $this->questionHelperMock->method('ask')->willReturn('test-subdomain id: test-customer-id');
+
+        $commandTester = $this->executeCommand();
+        $output = $commandTester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('Test Organisation', $output);
+        self::assertStringContainsString('test-orga-id', $output);
+        self::assertStringContainsString(self::ORGA_TYPE_LABEL, $output);
+        self::assertStringContainsString('accepted', $output);
+        self::assertStringContainsString('1 organisation(s) found', $output);
+    }
+
+    public function testEmptyOrganisationList(): void
+    {
+        $customer = $this->createCustomerWithOrgaStatuses('Empty Customer', 'empty-subdomain', 'empty-customer-id', []);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+        $this->questionHelperMock->method('ask')->willReturn('empty-subdomain id: empty-customer-id');
+
+        $commandTester = $this->executeCommand();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('No organisations found', $commandTester->getDisplay());
+    }
+
+    public function testInvalidCustomerSelection(): void
+    {
+        $customers = $this->getEntries(Customer::class);
+        $this->customerRepositoryMock->method('findAll')->willReturn($customers);
+
+        $customer = reset($customers);
+        $this->questionHelperMock->method('ask')->willReturn($customer->getSubdomain().' id: NOT_FOUND');
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Given customer is not available.');
+
+        $this->executeCommand();
+    }
+
+    public function testMultipleOrganisations(): void
+    {
+        $orgaType1 = $this->createOrgaType(self::ORGA_TYPE_LABEL);
+        $orgaType2 = $this->createOrgaType('Municipality');
+        $orga1 = $this->createOrga('First Org', 'orga-id-1');
+        $orga2 = $this->createOrga('Second Org', 'orga-id-2');
+
+        $customer = $this->createCustomerWithOrgaStatuses('Multi Customer', 'multi-sub', 'multi-id', [
+            $this->createOrgaStatusInCustomer($orga1, $orgaType1, 'accepted'),
+            $this->createOrgaStatusInCustomer($orga2, $orgaType2, 'pending'),
+        ]);
+
+        $this->customerRepositoryMock->method('findAll')->willReturn([$customer]);
+        $this->questionHelperMock->method('ask')->willReturn('multi-sub id: multi-id');
+
+        $commandTester = $this->executeCommand();
+        $output = $commandTester->getDisplay();
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('First Org', $output);
+        self::assertStringContainsString('Second Org', $output);
+        self::assertStringContainsString('2 organisation(s) found', $output);
+    }
+
+    private function executeCommand(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new ConsoleApplication($kernel, false);
+        $application->add(
+            new ListCustomerOrganisationsCommand(
+                $this->parameterBagMock,
+                $this->customerRepositoryMock,
+                $this->questionHelperMock
+            )
+        );
+        $command = $application->find(ListCustomerOrganisationsCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        return $commandTester;
+    }
+
+    private function createOrga(string $name, string $id): MockObject&Orga
+    {
+        $orga = $this->createMock(Orga::class);
+        $orga->method('getName')->willReturn($name);
+        $orga->method('getId')->willReturn($id);
+
+        return $orga;
+    }
+
+    private function createOrgaType(string $name): MockObject&OrgaType
+    {
+        $orgaType = $this->createMock(OrgaType::class);
+        $orgaType->method('getLabel')->willReturn($name);
+
+        return $orgaType;
+    }
+
+    private function createOrgaStatusInCustomer(
+        MockObject&Orga $orga,
+        MockObject&OrgaType $orgaType,
+        string $status,
+    ): MockObject&OrgaStatusInCustomer {
+        $orgaStatus = $this->createMock(OrgaStatusInCustomer::class);
+        $orgaStatus->method('getOrga')->willReturn($orga);
+        $orgaStatus->method('getOrgaType')->willReturn($orgaType);
+        $orgaStatus->method('getStatus')->willReturn($status);
+
+        return $orgaStatus;
+    }
+
+    private function createCustomerWithOrgaStatuses(
+        string $name,
+        string $subdomain,
+        string $id,
+        array $orgaStatuses,
+    ): MockObject&Customer {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getName')->willReturn($name);
+        $customer->method('getSubdomain')->willReturn($subdomain);
+        $customer->method('getId')->willReturn($id);
+        $customer->method('getOrgaStatuses')->willReturn(new ArrayCollection($orgaStatuses));
+
+        return $customer;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dplan:customer:list-organisations` command to interactively list all orgas for a selected customer
- Add `dplan:customer:detach-organisation` command to remove orga-customer relationships without deleting the organisation
- Fix dangerous `cascade={"remove"}` on `OrgaStatusInCustomer` ManyToOne relations that would cascade-delete Orga, OrgaType, and Customer entities (separate commit, cherry-pickable)
- Both commands skip the default citizen organisation (Privatperson)
- Extracted shared `CustomerSelectionTrait` for interactive customer selection

## Test plan
- [x] 10 unit tests pass (4 list, 6 detach including citizen org protection)
- [ ] Manually verify `dplan:customer:list-organisations` shows correct orgas
- [ ] Manually verify `dplan:customer:detach-organisation` removes relationship without deleting the org
- [ ] Verify Privatperson is not listed or selectable in either command
- [ ] Verify graceful handling when only Privatperson exists for a customer