### PR TITLE
fix(DPLAN-17358): Reset to page 1 when changing page size in assessme…

### DIFF
--- a/client/js/components/statement/assessmentTable/DpTable.vue
+++ b/client/js/components/statement/assessmentTable/DpTable.vue
@@ -543,7 +543,8 @@ export default {
       const tmpPager = {
         ...this.pagination,
         count: newSize,
-        per_page: newSize
+        per_page: newSize,
+        current_page: 1
       }
       this.updatePagination(tmpPager)
       this.changeUrl(tmpPager)


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17358/BOB-SH-Paginierung-in-Abwagungstabelle-funktioniert-nur-bei-2.-Klick
Description: Reset to page 1 when changing page size in assessment table                                                                                                               
                                                                                                                                                                                              
When changing page size while on a page beyond page 1, the current page number was preserved in the request. If the new page size made the total number of pages smaller than the current page, Pagerfanta threw an OutOfRangeCurrentPageException. For example: 27 items, on page 2 with size 25, changing size to 27 requested page 2 which no longer exists.


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
 
