### PR TITLE
chore(refs DPLAN-17432, #AB51419): bump demosplan-ui to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.15.0",
+    "@demos-europe/demosplan-ui": "0.16.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.15.0"
+"@demos-europe/demosplan-ui@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.16.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2868,7 +2868,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/2466a7eeeba7333299085f0e87752df7df6225e34b58838dc5bbb5b3cf77a23574ce9d7b95c3cd07fbd410daeabc3af8361fa1f8d1a4cf24409fa33969ca1c73
+  checksum: 10c0/d74c40afaf18823d2578736f98245fa8882882a02bdcccc9e95957b7b690f405740294122ea9bfbf3d35215394f721a6a507ca42e8eb2553b533f6be6a68abc0
   languageName: node
   linkType: hard
 
@@ -8289,7 +8289,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.15.0"
+    "@demos-europe/demosplan-ui": "npm:0.16.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
Needed for DPLAN-17432