### PR TITLE
fix(refs DPLAN-16987, DS-487): allow overriding demosplan-ui tailwind defaults

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/_custom-properties.dplan.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/_custom-properties.dplan.scss
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  (c) 2010-present DEMOS plan GmbH.
+//
+//  This file is part of the package demosplan,
+//  for more information see the license file.
+//
+//  All rights reserved
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//  Map SCSS color tokens to CSS custom properties.
+//
+//  The Tailwind utilities defined in demosplan-ui reference CSS custom properties
+//  (e.g. `bg-interactive` → `var(--dp-color-interactive, ...)`). In order to be able
+//  to override the defaults from demosplan-ui in the projects, we need to map the css
+//  properties to the SCSS variables that are defined in the project _settings-*.scss files
+//
+// Temporary fix until demosplan-ui theming is implemented
+
+:root {
+  // Brand colors
+  --dp-color-main: #{$dp-color-main};
+  --dp-color-main-contrast: #{$dp-color-main-contrast};
+  --dp-color-alt: #{$dp-color-alt};
+  --dp-color-alt-contrast: #{$dp-color-alt-contrast};
+  --dp-color-highlight: #{$dp-color-highlight};
+  --dp-color-highlight-contrast: #{$dp-color-highlight-contrast};
+
+  // Interactive colors (buttons, links, etc.)
+  --dp-color-interactive: #{$dp-color-interactive-default};
+  --dp-color-interactive-hover: #{$dp-color-interactive-hover};
+  --dp-color-interactive-active: #{$dp-color-interactive-active};
+  --dp-color-interactive-subtle-hover: #{$dp-color-interactive-subtle-hover};
+  --dp-color-interactive-subtle-active: #{$dp-color-interactive-subtle-active};
+}

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/core_style.scss
@@ -74,6 +74,9 @@
 // Generic
 @import 'inuit-5/generic.shared';
 
+// CSS Custom Properties (map SCSS tokens to CSS variables for Tailwind-based components)
+@import 'custom-properties.dplan';
+
 // Base (Elements)
 @import 'inuit-5/base.page';
 @import 'base.dplan';


### PR DESCRIPTION
### Ticket
DPLAN-16987

The css properties used in demosplan-ui are now mapped to the scss variables used in the projects for overrides so that the overrides now actually take effect for demosplan-ui components that are using tailwind classes, like DpButton.
This is a temporary fix to restore interface consistency (without it, components like DpButton use the defaults defined in demosplan-ui, while buttons not using DpButton have the correct project styles).
Long-term, project theming should be handled directly by demosplan-ui tailwind config.

### How to review/test
Buttons and links should now always use the project colors instead of demosplan-ui defaults.

### PR Checklist

- [x] Run `yarn test`
- [x] Link all relevant tickets
