### PR TITLE
fix(DPLAN-17614): memory leak in StatementSegmentsEdit component

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -73,8 +73,8 @@
               <dp-editor
                 class="mr-4 pt-1"
                 :toolbar-items="{ linkButton: true, obscure: hasPermission('feature_obscure_text') }"
-                :value="segment.attributes.text"
-                @transform-obscure-tag="transformObscureTag"
+                :value="getSegmentInitialText(segment.id)"
+                @transform-obscure-tag="(val) => transformObscureTag(segment.id, val)"
                 @input="(val) => updateSegmentText(segment.id, val)"
               />
             </template>
@@ -108,8 +108,8 @@
           hidden-input="statementText"
           required
           :toolbar-items="{ linkButton: true}"
-          :value="statement.attributes.fullText || ''"
-          @transform-obscure-tag="transformObscureTag"
+          :value="getStatementInitialText()"
+          @transform-obscure-tag="transformObscureStatementTag"
           @input="updateStatementText"
         />
         <dp-button-row
@@ -216,7 +216,6 @@ export default {
       claimLoading: null,
       editingSegmentIds: [],
       isLoading: false,
-      obscuredText: '',
       defaultPagination: {
         currentPage: 1,
         limits: [10, 20, 50],
@@ -292,7 +291,15 @@ export default {
     }),
 
     addToEditing (id) {
-      this.editingSegmentIds.push(id)
+      this._localSegmentTexts[id] = this.segments[id]?.attributes?.text || ''
+
+      if (!this.editingSegmentIds.includes(id)) {
+        this.editingSegmentIds.push(id)
+      }
+    },
+
+    getSegmentInitialText (segmentId) {
+      return this.segments[segmentId]?.attributes?.text ?? ''
     },
 
     claimSegment (segment) {
@@ -351,33 +358,43 @@ export default {
     },
 
     reset (segmentId) {
-      // Restore initial text value
-      const initText = this.$store.state.StatementSegment.initial[segmentId].attributes.text
-      this.updateSegmentText(segmentId, initText)
+      delete this._localSegmentTexts[segmentId]
+
       if (this.$refs[`editField_${segmentId}`][0]) {
         this.$refs[`editField_${segmentId}`][0].loading = false
         this.$refs[`editField_${segmentId}`][0].editingEnabled = false
       }
+
       const segmentIdIndex = this.editingSegmentIds.indexOf(segmentId)
-      this.editingSegmentIds.splice(segmentIdIndex, 1)
+
+      if (segmentIdIndex > -1) {
+        this.editingSegmentIds.splice(segmentIdIndex, 1)
+      }
     },
 
     resetStatement () {
       this.restoreStatementAction(this.statement.id)
+
+      this._localStatementText = null
     },
 
     saveSegment (segmentId) {
-      if (!this.segments[segmentId].attributes.text) {
+      const textToSave = this._localSegmentTexts[segmentId] ?? ''
+
+      if (!textToSave) {
         this.$refs[`editField_${segmentId}`][0].loading = false
 
         return dplan.notify.error(Translator.trans('error.segment.empty.text'))
       }
 
-      // Use the transformed text if available
-      const textToSave = this.obscuredText || this.segments[segmentId].attributes.text
-
-      // Update the segment text with the transformed text
-      this.updateSegmentText(segmentId, textToSave)
+      const updated = {
+        ...this.segments[segmentId],
+        attributes: {
+          ...this.segments[segmentId].attributes,
+          text: textToSave,
+        },
+      }
+      this.setSegment({ ...updated, id: segmentId })
 
       this.saveSegmentAction(segmentId)
         .catch(() => {
@@ -386,7 +403,12 @@ export default {
         })
         .finally(() => {
           const segmentIdIndex = this.editingSegmentIds.indexOf(segmentId)
-          this.editingSegmentIds.splice(segmentIdIndex, 1)
+
+          if (segmentIdIndex > -1) {
+            this.editingSegmentIds.splice(segmentIdIndex, 1)
+          }
+
+          delete this._localSegmentTexts[segmentId]
 
           if (this.$refs[`editField_${segmentId}`][0]) {
             this.$refs[`editField_${segmentId}`][0].loading = false
@@ -396,7 +418,18 @@ export default {
     },
 
     saveStatement () {
-      this.$emit('saveStatement', this.statement)
+      const textToSave = this._localStatementText ?? this.statement.attributes.fullText
+
+      const updatedStatement = {
+        ...this.statement,
+        attributes: {
+          ...this.statement.attributes,
+          fullText: textToSave,
+        },
+      }
+
+      this.setStatement({ ...updatedStatement, id: this.statement.id })
+      this.$emit('saveStatement', updatedStatement)
     },
 
     scrollToSegment () {
@@ -453,34 +486,23 @@ export default {
     },
 
     updateSegmentText (segmentId, val) {
-      const fullText = this.obscuredText && this.obscuredText !== val ? this.obscuredText : val
-      const updated = {
-        ...this.segments[segmentId],
-        attributes: {
-          ...this.segments[segmentId].attributes,
-          text: fullText,
-        },
-      }
-      this.setSegment({ ...updated, id: segmentId })
+      this._localSegmentTexts[segmentId] = val
+    },
+
+    getStatementInitialText () {
+      return this.statement?.attributes?.fullText || ''
     },
 
     updateStatementText (val) {
-      const fullText = this.obscuredText && this.obscuredText !== val ? this.obscuredText : val
-
-      this.$emit('statementText:updated')
-
-      const updated = {
-        ...this.statement,
-        attributes: {
-          ...this.statement.attributes,
-          fullText,
-        },
-      }
-      this.setStatement({ ...updated, id: this.statement.id })
+      this._localStatementText = val
     },
 
-    transformObscureTag (val) {
-      this.obscuredText = val
+    transformObscureTag (segmentId, val) {
+      this._localSegmentTexts[segmentId] = val
+    },
+
+    transformObscureStatementTag (val) {
+      this._localStatementText = val
     },
 
     async fetchSegments (page = 1) {
@@ -578,6 +600,10 @@ export default {
   },
 
   created () {
+    // Non-reactive buffers for editor content (avoid controlled component issues)
+    this._localSegmentTexts = {}
+    this._localStatementText = null
+
     this.segmentNavigation = handleSegmentNavigation({
       statementId: this.statementId,
       storageKey: this.storageKeyPagination,
@@ -608,9 +634,10 @@ export default {
 
   beforeUnmount () {
     if (this.editingSegmentIds.length > 0 && hasPermission('area_statement_segmentation')) {
-      this.editingSegmentIds.forEach(segment => this.reset(segment.id))
+      this.editingSegmentIds.forEach(segmentId => this.reset(segmentId))
     }
-    if (this.hasSegments === false && this.segment) {
+
+    if (this.hasSegments === false && this.statement) {
       this.resetStatement()
     }
   },

--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -132,7 +132,8 @@
     <input
       type="hidden"
       name="r_oId"
-      :value="selectedOrgaId">
+      :value="selectedOrgaId"
+    >
 
     <!-- User fields that are specific to institutions: orga, department. These fields shall not be changeable in Bob-HH, but visible and present to submit their values when filled by autoFill function -->
     <template


### PR DESCRIPTION
### Ticket
[DPLAN-17614](https://demoseurope.youtrack.cloud/issue/DPLAN-17614) dev, release, stage: memory leak bei STN Text bearbeiten in Details

**Description:** This PR resolves memory leak in `StatementSegmentsEdit` component: 

Replace shared reactive state with local text buffers to prevent memory leaks when editing segments. Each editor instance now maintains its own untracked text state `_localSegmentTexts`, `_localStatementText` instead of using shared reactive properties that caused Vue reactivity issues.

- do not update the store state on every input event,; update it only when the user clicks Save.

### How to review/test
1. In the STN list, choose a non-split STN > Go to the STN Detail page > Edit the STN text > The page should not freeze.
2. In the STN list, choose a split STN > Go to the STN Detail page > Edit the segment text > The page should not freeze.

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
