### PR TITLE
DPLAN-17218: sync entity_type when statements join or leave a cluster…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementHandler.php
@@ -3778,6 +3778,11 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
                 $successfulAddedStatement =
                     $this->statementService->updateStatementFromObject($statementToAdd, $ignoreAssignmentOfStatement, true);
                 if ($successfulAddedStatement instanceof Statement) {
+                    $this->entityManager->getConnection()->executeStatement(
+                        "UPDATE _statement SET entity_type = 'StatementMember' WHERE _st_id = :id",
+                        ['id' => $statementToAdd->getId()]
+                    );
+
                     return $successfulAddedStatement->getHeadStatement();
                 }
             }
@@ -3963,6 +3968,11 @@ class StatementHandler extends CoreHandler implements StatementHandlerInterface
                 $this->getMessageBag()->add(
                     'error', 'error.statement.cluster.resolve',
                     ['clusterId' => $headStatement->getExternId()]
+                );
+            } else {
+                $this->entityManager->getConnection()->executeStatement(
+                    "UPDATE _statement SET entity_type = 'Statement' WHERE _st_id = :id",
+                    ['id' => $statement->getId()]
                 );
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -168,6 +168,13 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
                 $headStatement->setCluster($statements);
                 $manager->persist($headStatement);
                 $manager->flush();
+
+                foreach ($statements as $statement) {
+                    $this->getEntityManager()->getConnection()->executeStatement(
+                        "UPDATE _statement SET entity_type = 'StatementMember' WHERE _st_id = :id",
+                        ['id' => $statement->getId()]
+                    );
+                }
             }
 
             return $headStatement;
@@ -1767,6 +1774,10 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
                 $notDetachedStatements->push($statement);
                 throw new Exception('error.statement.cluster.resolve'.$headStatement->getId());
             }
+            $this->getEntityManager()->getConnection()->executeStatement(
+                "UPDATE _statement SET entity_type = 'Statement' WHERE _st_id = :id",
+                ['id' => $statement->getId()]
+            );
         }
 
         if (0 === $notDetachedStatements->count()) {


### PR DESCRIPTION
  - StatementRepository line 174 — members get StatementMember when added to a cluster                                                                                                        
  - StatementRepository line 1778 — members revert to Statement when cluster is resolved (deletion path)                                                                                      
  - StatementHandler line 3782 — member gets StatementMember when added to existing cluster                                                                                                   
  - StatementHandler line 3974 — members revert to Statement when cluster is resolved (normal flow)                                                                                           
                                                                                                                                                                                              
                                                                                                    
                                                                                                                                                                                              
 sync entity_type when statements join or leave a cluster  