### PR TITLE
fix DS-426 use File ident instead of hash for FileContainer FK in sta…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementCopier.php
@@ -365,7 +365,7 @@ class StatementCopier
                 if ($file instanceof File) {
                     $this->fileService->addStatementFileContainer(
                         $copiedStatement->getId(),
-                        $file->getHash(),
+                        $file->getId(),
                         $file->getFileString()
                     );
                 }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-426/hoch-PROD-Landesplanung-Fehlermeldung-beim-Verschieben-von-STN
Description:
 Fixes a foreign key constraint violation when copying statements between procedures. The `file_container.file_id` column references `_files._f_ident` (the File entity's primary key), but `copyStatementFiles()` was passing `$file->getHash()` instead of `$file->getIdent()` to `addStatementFileContainer()`.                                                                      
                                                                                                                                                                                              
  When `FileService::copy()` creates a new File during statement copy, it generates a fresh storage hash (`createHash()`) and Doctrine generates a separate UUID for the entity primary key (`ident` via `NCNameGenerator`). These are always different values. The `addFileContainer()` method uses `getReference(File::class, $fileId)` which expects the primary key — passing the
  hash instead created a proxy with a non-existent identifier, causing the FK constraint to fail on flush.     

The file_container table has a foreign key column file_id that references _files._f_ident (the File entity's primary key).

  When addStatementFileContainer is called, it does this:

  $file = $this->doctrine->getManager()->getReference(File::class, $fileId);
  $fileContainer->setFile($file);

  getReference(File::class, $fileId) creates a Doctrine proxy that says "there's a File entity with this primary key." When the FileContainer is flushed, Doctrine writes $fileId into the
  file_id FK column.

  Here's the problem:

  ┌─────────┬─────────────────────────────────────┬───────────────────────────────────┐
  │         │              getHash()              │       getIdent() / getId()        │
  ├─────────┼─────────────────────────────────────┼───────────────────────────────────┤
  │ Returns │ The storage hash (filename on disk) │ The entity primary key (_f_ident) │
  ├─────────┼─────────────────────────────────────┼───────────────────────────────────┤
  │ Column  │ _f_hash                             │ _f_ident                          │
  ├─────────┼─────────────────────────────────────┼───────────────────────────────────┤
  │ Example │ a1b2c3d4e5f6...                     │ x9y8z7w6v5u4...                   │
  └─────────┴─────────────────────────────────────┴───────────────────────────────────┘

  When copy() creates a new File, it generates a fresh hash (createHash()) and Doctrine generates a separate UUID for ident (via NCNameGenerator). They are always different values.

  So with getHash():
  file_container.file_id = "a1b2c3d4..."  (the hash)
  _files._f_ident        = "x9y8z7w6..."  (the actual PK)
  → FK constraint fails: no _files row with _f_ident = "a1b2c3d4..."

  With getIdent():
  file_container.file_id = "x9y8z7w6..."  (the PK)
  _files._f_ident        = "x9y8z7w6..."  (matches)
  → FK constraint satisfied ✅

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

