### PR TITLE
chore: add GitHub Action for automated PHP SBOM generation

### DIFF
--- a/.github/workflows/sbom-php.yml
+++ b/.github/workflows/sbom-php.yml
@@ -1,0 +1,54 @@
+name: Generate PHP SBOM
+
+on:
+  schedule:
+    - cron: 0 7 * * 1
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - composer.lock
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup PHP with composer v2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: gd soap sockets zip
+          tools: composer:v2
+
+      - name: Cache php modules
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-build-php-${{ hashFiles('**/composer-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-php-
+
+      - name: Install composer dependencies
+        run: |
+          composer --version
+          composer install --no-interaction
+
+      - name: Generate PHP SBOM
+        run: |
+          composer CycloneDX:make-sbom \
+            --output-format=JSON \
+            --output-file=sbom-php.cdx.json \
+            --spec-version=1.5 \
+            --output-reproducible \
+            --validate
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-php
+          path: sbom-php.cdx.json

--- a/.github/workflows/sbom-php.yml
+++ b/.github/workflows/sbom-php.yml
@@ -14,17 +14,17 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP with composer v2
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
           php-version: '8.2'
           extensions: gd soap sockets zip
           tools: composer:v2
 
       - name: Cache php modules
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.composer/cache
@@ -48,7 +48,7 @@ jobs:
             --validate
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-php
           path: sbom-php.cdx.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sbom-php.yml` that generates a CycloneDX PHP SBOM
- Triggers weekly (Monday 7 AM UTC), on manual dispatch, and on push to main when `composer.lock` changes
- Uploads the SBOM as a workflow artifact

## Test plan
- [ ] Trigger workflow manually via Actions tab after merge
- [ ] Verify SBOM artifact is generated and downloadable