### PR TITLE
chore: add GitHub Action for automated JS SBOM generation

### DIFF
--- a/.github/workflows/sbom-js.yml
+++ b/.github/workflows/sbom-js.yml
@@ -36,7 +36,7 @@ jobs:
       - run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
 
       - name: Generate JS SBOM
-        run: npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate --production
+        run: npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4

--- a/.github/workflows/sbom-js.yml
+++ b/.github/workflows/sbom-js.yml
@@ -36,7 +36,7 @@ jobs:
       - run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
 
       - name: Generate JS SBOM
-        run: npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate
+        run: npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate --production
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4

--- a/.github/workflows/sbom-js.yml
+++ b/.github/workflows/sbom-js.yml
@@ -1,0 +1,45 @@
+name: Generate JS SBOM
+
+on:
+  schedule:
+    - cron: 0 7 * * 1
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - yarn.lock
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.11.1'
+
+      - run: npm install --ignore-scripts -g corepack && corepack enable && yarn set version 4.2.2
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/.yarn/cache
+            .yarn/cache
+            node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+
+      - name: Generate JS SBOM
+        run: npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-js
+          path: sbom-js.cdx.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sbom-js.yml` that generates a CycloneDX JS SBOM using OWASP `cdxgen`
- Triggers weekly (Monday 7 AM UTC), on manual dispatch, and on push to main when `yarn.lock` changes
- Uploads the SBOM as a workflow artifact

Uses `@cyclonedx/cdxgen` instead of `@cyclonedx/cyclonedx-npm` because the latter relies on `npm ls` which doesn't work with yarn-managed `node_modules`.

Companion to #6144 (PHP SBOM).

## Test plan
- [x] Verified locally: `npx @cyclonedx/cdxgen -t yarn -o sbom-js.cdx.json --spec-version 1.5 --validate` generates a valid 3.4MB SBOM
- [ ] Trigger workflow manually via Actions tab after merge
- [ ] Verify SBOM artifact is generated and downloadable