### PR TITLE
DPLAN-17244 Display custom fields in pdf export in draft statements

### DIFF
--- a/demosplan/DemosPlanCoreBundle/CustomField/CustomFieldInterface.php
+++ b/demosplan/DemosPlanCoreBundle/CustomField/CustomFieldInterface.php
@@ -57,4 +57,10 @@ interface CustomFieldInterface
     public function getCustomOptionValueById(string $customFieldOptionValueId): ?CustomFieldOption;
 
     public function getApiAttributes(): array;
+
+    /**
+     * Returns the human-readable representation of a stored value for display purposes (e.g. PDF export).
+     * Each field type is responsible for resolving its own value format.
+     */
+    public function formatValueForDisplay(mixed $value): string;
 }

--- a/demosplan/DemosPlanCoreBundle/CustomField/MultiSelectField.php
+++ b/demosplan/DemosPlanCoreBundle/CustomField/MultiSelectField.php
@@ -94,6 +94,18 @@ class MultiSelectField extends AbstractCustomField
         return null;
     }
 
+    public function formatValueForDisplay(mixed $value): string
+    {
+        if (!is_array($value)) {
+            return '';
+        }
+
+        return collect($value)
+            ->map(fn (string $optionId) => $this->getCustomOptionValueById($optionId)?->getLabel())
+            ->filter()
+            ->implode(', ');
+    }
+
     protected function validateFieldSpecific(array $options): void
     {
         if (count($options) < 2) {

--- a/demosplan/DemosPlanCoreBundle/CustomField/RadioButtonField.php
+++ b/demosplan/DemosPlanCoreBundle/CustomField/RadioButtonField.php
@@ -84,7 +84,7 @@ class RadioButtonField extends AbstractCustomField
             return '';
         }
 
-        return $this->getCustomOptionValueById($value)?->getLabel() ?? $value;
+        return $this->getCustomOptionValueById($value)?->getLabel() ?? '';
     }
 
     protected function validateFieldSpecific(array $options): void

--- a/demosplan/DemosPlanCoreBundle/CustomField/RadioButtonField.php
+++ b/demosplan/DemosPlanCoreBundle/CustomField/RadioButtonField.php
@@ -78,6 +78,15 @@ class RadioButtonField extends AbstractCustomField
         return null;
     }
 
+    public function formatValueForDisplay(mixed $value): string
+    {
+        if (!is_string($value) || '' === $value) {
+            return '';
+        }
+
+        return $this->getCustomOptionValueById($value)?->getLabel() ?? $value;
+    }
+
     protected function validateFieldSpecific(array $options): void
     {
         if (count($options) < 2) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -873,16 +873,7 @@ class DraftStatementService
                 $filenameSuffix = $this->translator->trans('export.filenames.statement.single.suffix');
                 // Die Stellungnahme kann nicht übergeben werden, rufe sie ab
                 $statement = $this->getSingleDraftStatement($itemsToExport[0]);
-                if ($this->currentUser->hasPermission('feature_statements_custom_fields')
-                    && $statement['customFields'] instanceof CustomFieldValuesList
-                ) {
-                    $statement['resolvedCustomFields'] = $this->customFieldDisplayResolver->resolveForDisplay(
-                        $statement['customFields'],
-                        CustomFieldSupportedEntity::procedure,
-                        $procedureId,
-                        CustomFieldSupportedEntity::statement
-                    );
-                }
+                $statement = $this->attachResolvedCustomFields($statement, $procedureId);
                 $templateVars['statement'] = $statement;
                 $itemsToExport = null;
                 break;
@@ -2168,19 +2159,26 @@ class DraftStatementService
                 $statementArray['documentlist'] = $this->paragraphService
                     ->getParaDocumentObjectList($procedureId, $statementArray['elementId']);
 
-                if ($this->currentUser->hasPermission('feature_statements_custom_fields')
-                    && $statementArray['customFields'] instanceof CustomFieldValuesList
-                ) {
-                    $statementArray['resolvedCustomFields'] = $this->customFieldDisplayResolver->resolveForDisplay(
-                        $statementArray['customFields'],
-                        CustomFieldSupportedEntity::procedure,
-                        $procedureId,
-                        CustomFieldSupportedEntity::statement
-                    );
-                }
+                $statementArray = $this->attachResolvedCustomFields($statementArray, $procedureId);
 
                 return $this->checkMapScreenshotFile($statementArray, $procedureId);
             }
         );
+    }
+
+    private function attachResolvedCustomFields(array $statement, string $procedureId): array
+    {
+        if ($this->currentUser->hasPermission('feature_statements_custom_fields')
+            && $statement['customFields'] instanceof CustomFieldValuesList
+        ) {
+            $statement['resolvedCustomFields'] = $this->customFieldDisplayResolver->resolveForDisplay(
+                $statement['customFields'],
+                CustomFieldSupportedEntity::procedure,
+                $procedureId,
+                CustomFieldSupportedEntity::statement
+            );
+        }
+
+        return $statement;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -50,6 +50,7 @@ use demosplan\DemosPlanCoreBundle\Repository\SingleDocumentVersionRepository;
 use demosplan\DemosPlanCoreBundle\Repository\StatementAttributeRepository;
 use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
+use demosplan\DemosPlanCoreBundle\Utils\CustomField\CustomFieldDisplayResolver;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\CustomFieldValueCreator;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\Enum\CustomFieldPropertyName;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\Enum\CustomFieldSupportedEntity;
@@ -154,6 +155,7 @@ class DraftStatementService
         private readonly ManagerRegistry $doctrine,
         private readonly ProfilerService $profilerService,
         private readonly CustomFieldValueCreator $customFieldValueCreator,
+        private readonly CustomFieldDisplayResolver $customFieldDisplayResolver,
     ) {
         $this->currentUser = $currentUser;
         $this->elementsService = $elementsService;
@@ -870,9 +872,18 @@ class DraftStatementService
 
                 $filenameSuffix = $this->translator->trans('export.filenames.statement.single.suffix');
                 // Die Stellungnahme kann nicht übergeben werden, rufe sie ab
-                $templateVars['statement'] = $this->getSingleDraftStatement(
-                    $itemsToExport[0]
-                );
+                $statement = $this->getSingleDraftStatement($itemsToExport[0]);
+                if ($this->currentUser->hasPermission('feature_statements_custom_fields')
+                    && $statement['customFields'] instanceof CustomFieldValuesList
+                ) {
+                    $statement['resolvedCustomFields'] = $this->customFieldDisplayResolver->resolveForDisplay(
+                        $statement['customFields'],
+                        CustomFieldSupportedEntity::procedure,
+                        $procedureId,
+                        CustomFieldSupportedEntity::statement
+                    );
+                }
+                $templateVars['statement'] = $statement;
                 $itemsToExport = null;
                 break;
             case 'list_final_group_citizen':
@@ -2156,6 +2167,17 @@ class DraftStatementService
             function (array $statementArray) use ($procedureId) {
                 $statementArray['documentlist'] = $this->paragraphService
                     ->getParaDocumentObjectList($procedureId, $statementArray['elementId']);
+
+                if ($this->currentUser->hasPermission('feature_statements_custom_fields')
+                    && $statementArray['customFields'] instanceof CustomFieldValuesList
+                ) {
+                    $statementArray['resolvedCustomFields'] = $this->customFieldDisplayResolver->resolveForDisplay(
+                        $statementArray['customFields'],
+                        CustomFieldSupportedEntity::procedure,
+                        $procedureId,
+                        CustomFieldSupportedEntity::statement
+                    );
+                }
 
                 return $this->checkMapScreenshotFile($statementArray, $procedureId);
             }

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -38,7 +38,7 @@ class CustomFieldDisplayResolver
             return [];
         }
 
-        $fieldDefinitions = $this->customFieldProvider->getCustomFieldsByCriteria(
+        $customFieldDefinitions = $this->customFieldProvider->getCustomFieldsByCriteria(
             $sourceEntity->value,
             $sourceEntityId,
             $targetEntity->value
@@ -46,34 +46,20 @@ class CustomFieldDisplayResolver
 
         $resolved = [];
         foreach ($values->getCustomFieldsValues() as $fieldValue) {
-            $definition = $fieldDefinitions->filter(
+            $customFieldDefinition = $customFieldDefinitions->filter(
                 fn (CustomFieldInterface $field) => $field->getId() === $fieldValue->getId()
             )->first();
 
-            if (!$definition instanceof CustomFieldInterface) {
+            if (!$customFieldDefinition instanceof CustomFieldInterface) {
                 continue;
             }
 
             $resolved[] = [
-                'name'  => $definition->getName(),
-                'value' => $this->resolveValueLabel($definition, $fieldValue->getValue()),
+                'name'  => $customFieldDefinition->getName(),
+                'value' => $customFieldDefinition->formatValueForDisplay($fieldValue->getValue()),
             ];
         }
 
         return $resolved;
-    }
-
-    private function resolveValueLabel(CustomFieldInterface $definition, mixed $rawValue): string
-    {
-        if (is_array($rawValue)) {
-            $labels = array_filter(array_map(
-                fn (string $optionId) => $definition->getCustomOptionValueById($optionId)?->getLabel(),
-                $rawValue
-            ));
-
-            return implode(', ', $labels);
-        }
-
-        return $definition->getCustomOptionValueById((string) $rawValue)?->getLabel() ?? (string) $rawValue;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -15,11 +15,13 @@ namespace demosplan\DemosPlanCoreBundle\Utils\CustomField;
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldInterface;
 use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValuesList;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\Enum\CustomFieldSupportedEntity;
+use Psr\Log\LoggerInterface;
 
 class CustomFieldDisplayResolver
 {
     public function __construct(
         private readonly CustomFieldProvider $customFieldProvider,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -51,6 +53,15 @@ class CustomFieldDisplayResolver
             )->first();
 
             if (!$customFieldDefinition instanceof CustomFieldInterface) {
+                $this->logger->warning(
+                    'CustomFieldDisplayResolver: no definition found for field value ID "{fieldValueId}". '
+                    . 'The field configuration may have been deleted while values still reference it.',
+                    [
+                        'fieldValueId'   => $fieldValue->getId(),
+                        'sourceEntityId' => $sourceEntityId,
+                        'targetEntity'   => $targetEntity->value,
+                    ]
+                );
                 continue;
             }
 

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -55,7 +55,7 @@ class CustomFieldDisplayResolver
             if (!$customFieldDefinition instanceof CustomFieldInterface) {
                 $this->logger->warning(
                     'CustomFieldDisplayResolver: no definition found for field value ID "{fieldValueId}". '
-                    . 'The field configuration may have been deleted while values still reference it.',
+                    .'The field configuration may have been deleted while values still reference it.',
                     [
                         'fieldValueId'   => $fieldValue->getId(),
                         'sourceEntityId' => $sourceEntityId,

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -32,7 +32,7 @@ class CustomFieldDisplayResolver
         CustomFieldValuesList $values,
         CustomFieldSupportedEntity $sourceEntity,
         string $sourceEntityId,
-        CustomFieldSupportedEntity $targetEntity
+        CustomFieldSupportedEntity $targetEntity,
     ): array {
         if ($values->isEmpty()) {
             return [];

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -19,6 +19,9 @@ use Psr\Log\LoggerInterface;
 
 class CustomFieldDisplayResolver
 {
+    /** @var array<string, true> Keyed by field value ID to suppress duplicate warnings per request */
+    private array $loggedMissingDefinitions = [];
+
     public function __construct(
         private readonly CustomFieldProvider $customFieldProvider,
         private readonly LoggerInterface $logger,
@@ -53,15 +56,21 @@ class CustomFieldDisplayResolver
             )->first();
 
             if (!$customFieldDefinition instanceof CustomFieldInterface) {
-                $this->logger->warning(
-                    'CustomFieldDisplayResolver: no definition found for field value ID "{fieldValueId}". '
-                    .'The field configuration may have been deleted while values still reference it.',
-                    [
-                        'fieldValueId'   => $fieldValue->getId(),
-                        'sourceEntityId' => $sourceEntityId,
-                        'targetEntity'   => $targetEntity->value,
-                    ]
-                );
+                if (!isset($this->loggedMissingDefinitions[$fieldValue->getId()])) {
+                    $this->loggedMissingDefinitions[$fieldValue->getId()] = true;
+                    $this->logger->warning(
+                        sprintf(
+                            'CustomFieldDisplayResolver: no definition found for field value ID "%s". '
+                            .'The field configuration may have been deleted while values still reference it.',
+                            $fieldValue->getId()
+                        ),
+                        [
+                            'fieldValueId'   => $fieldValue->getId(),
+                            'sourceEntityId' => $sourceEntityId,
+                            'targetEntity'   => $targetEntity->value,
+                        ]
+                    );
+                }
                 continue;
             }
 

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDisplayResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Utils\CustomField;
+
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldInterface;
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValuesList;
+use demosplan\DemosPlanCoreBundle\Utils\CustomField\Enum\CustomFieldSupportedEntity;
+
+class CustomFieldDisplayResolver
+{
+    public function __construct(
+        private readonly CustomFieldProvider $customFieldProvider,
+    ) {
+    }
+
+    /**
+     * Resolves a list of custom field values to display-ready name/value pairs.
+     *
+     * @return array<int, array{name: string, value: string}>
+     */
+    public function resolveForDisplay(
+        CustomFieldValuesList $values,
+        CustomFieldSupportedEntity $sourceEntity,
+        string $sourceEntityId,
+        CustomFieldSupportedEntity $targetEntity
+    ): array {
+        if ($values->isEmpty()) {
+            return [];
+        }
+
+        $fieldDefinitions = $this->customFieldProvider->getCustomFieldsByCriteria(
+            $sourceEntity->value,
+            $sourceEntityId,
+            $targetEntity->value
+        );
+
+        $resolved = [];
+        foreach ($values->getCustomFieldsValues() as $fieldValue) {
+            $definition = $fieldDefinitions->filter(
+                fn (CustomFieldInterface $field) => $field->getId() === $fieldValue->getId()
+            )->first();
+
+            if (!$definition instanceof CustomFieldInterface) {
+                continue;
+            }
+
+            $resolved[] = [
+                'name'  => $definition->getName(),
+                'value' => $this->resolveValueLabel($definition, $fieldValue->getValue()),
+            ];
+        }
+
+        return $resolved;
+    }
+
+    private function resolveValueLabel(CustomFieldInterface $definition, mixed $rawValue): string
+    {
+        if (is_array($rawValue)) {
+            $labels = array_filter(array_map(
+                fn (string $optionId) => $definition->getCustomOptionValueById($optionId)?->getLabel(),
+                $rawValue
+            ));
+
+            return implode(', ', $labels);
+        }
+
+        return $definition->getCustomOptionValueById((string) $rawValue)?->getLabel() ?? (string) $rawValue;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldProvider.php
@@ -17,6 +17,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 class CustomFieldProvider
 {
+    /** @var array<string, ArrayCollection> */
+    private array $cache = [];
+
     public function __construct(
         private readonly CustomFieldConfigurationRepository $customFieldConfigurationRepository,
     ) {
@@ -24,6 +27,12 @@ class CustomFieldProvider
 
     public function getCustomFieldsByCriteria(string $sourceEntity, string $sourceEntityId, string $targetEntity): ArrayCollection
     {
-        return $this->customFieldConfigurationRepository->getCustomFields($sourceEntity, $sourceEntityId, $targetEntity);
+        $cacheKey = $sourceEntity.'|'.$sourceEntityId.'|'.$targetEntity;
+
+        if (!isset($this->cache[$cacheKey])) {
+            $this->cache[$cacheKey] = $this->customFieldConfigurationRepository->getCustomFields($sourceEntity, $sourceEntityId, $targetEntity);
+        }
+
+        return $this->cache[$cacheKey];
     }
 }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_paragraph.tex.twig
@@ -24,6 +24,12 @@
             {% endif %}
   			{{ "file"|trans|latex|raw }}: & {% if statement.files|default([])|length > 0 %}{% for file in statement.files %}{{ file|getFile('name')|latex|raw }} {% endfor %}{% else %} {{ "notspecified"|trans|latex|raw }} {% endif %}\\
             {% if hasPermission('field_statement_public_allowed') %}{{ "publish.on.platform"|trans|latex|raw }}:& {% if statement.publicAllowed %}{{ "yes"|trans }}{% else %}{{ "no"|trans }}{% endif %} \\{% endif %}
+            {# custom fields #}
+            {% if hasPermission('feature_statements_custom_fields') and statement.resolvedCustomFields is defined %}
+                {% for field in statement.resolvedCustomFields %}
+                    {{ field.name|latex|raw }}: & {{ field.value|latex|raw }}\\
+                {% endfor %}
+            {% endif %}
   		\hline
 	\end{longtable}
 \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}17cm{{ '}' }}{{ '{' }}0cm{{ '}' }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
@@ -86,6 +86,12 @@
                 \\
             {% endif %}
             {% block categories %}{% endblock %}
+            {# custom fields #}
+            {% if hasPermission('feature_statements_custom_fields') and statement.resolvedCustomFields is defined %}
+                {% for field in statement.resolvedCustomFields %}
+                    {{ field.name|latex|raw }}: & {{ field.value|latex|raw }}\\
+                {% endfor %}
+            {% endif %}
         \hline
     \end{longtable}
 \begin{{ '{' }}Parallel{{ '}' }}{{ '{' }}17cm{{ '}' }}{{ '{' }}0cm{{ '}' }}

--- a/tests/backend/core/CustomField/CustomFieldDisplayResolverTest.php
+++ b/tests/backend/core/CustomField/CustomFieldDisplayResolverTest.php
@@ -23,7 +23,7 @@ use Tests\Base\FunctionalTestCase;
 class CustomFieldDisplayResolverTest extends FunctionalTestCase
 {
     private ?CustomFieldDisplayResolver $sut = null;
-    private $procedure = null;
+    private $procedure;
 
     protected function setUp(): void
     {

--- a/tests/backend/core/CustomField/CustomFieldDisplayResolverTest.php
+++ b/tests/backend/core/CustomField/CustomFieldDisplayResolverTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\CustomField;
+
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValue;
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValuesList;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\CustomFields\CustomFieldConfigurationFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
+use demosplan\DemosPlanCoreBundle\Utils\CustomField\CustomFieldDisplayResolver;
+use demosplan\DemosPlanCoreBundle\Utils\CustomField\Enum\CustomFieldSupportedEntity;
+use Tests\Base\FunctionalTestCase;
+
+class CustomFieldDisplayResolverTest extends FunctionalTestCase
+{
+    private ?CustomFieldDisplayResolver $sut = null;
+    private $procedure = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = $this->getContainer()->get(CustomFieldDisplayResolver::class);
+        $this->procedure = ProcedureFactory::createOne();
+    }
+
+    public function testResolveForDisplayReturnsEmptyArrayForEmptyValues(): void
+    {
+        $result = $this->sut->resolveForDisplay(
+            new CustomFieldValuesList(),
+            CustomFieldSupportedEntity::procedure,
+            $this->procedure->getId(),
+            CustomFieldSupportedEntity::statement
+        );
+
+        static::assertSame([], $result);
+    }
+
+    public function testResolveForDisplayReturnsSingleSelectFieldLabel(): void
+    {
+        // Arrange
+        $customField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($this->procedure->_real())
+            ->withRelatedTargetEntity(CustomFieldSupportedEntity::statement->value)
+            ->asRadioButton('Priority', options: ['High', 'Medium', 'Low'])
+            ->create();
+
+        $selectedOption = $customField->getConfiguration()->getOptions()[0];
+        $values = $this->buildValuesList($customField->getId(), $selectedOption->getId());
+
+        // Act
+        $result = $this->sut->resolveForDisplay(
+            $values,
+            CustomFieldSupportedEntity::procedure,
+            $this->procedure->getId(),
+            CustomFieldSupportedEntity::statement
+        );
+
+        // Assert
+        static::assertCount(1, $result);
+        static::assertSame($customField->getConfiguration()->getName(), $result[0]['name']);
+        static::assertSame($selectedOption->getLabel(), $result[0]['value']);
+    }
+
+    public function testResolveForDisplayReturnsMultiSelectLabelsJoined(): void
+    {
+        // Arrange
+        $customField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($this->procedure->_real())
+            ->withRelatedTargetEntity(CustomFieldSupportedEntity::statement->value)
+            ->asMultiSelect('Topics', options: ['Environment', 'Traffic', 'Housing'])
+            ->create();
+
+        $optionA = $customField->getConfiguration()->getOptions()[0]; // 'Environment'
+        $optionB = $customField->getConfiguration()->getOptions()[2]; // 'Housing'
+
+        $values = $this->buildValuesList($customField->getId(), [$optionA->getId(), $optionB->getId()]);
+
+        // Act
+        $result = $this->sut->resolveForDisplay(
+            $values,
+            CustomFieldSupportedEntity::procedure,
+            $this->procedure->getId(),
+            CustomFieldSupportedEntity::statement
+        );
+
+        // Assert
+        static::assertCount(1, $result);
+        static::assertSame($customField->getConfiguration()->getName(), $result[0]['name']);
+        static::assertSame($optionA->getLabel().', '.$optionB->getLabel(), $result[0]['value']);
+    }
+
+    public function testResolveForDisplaySkipsValueWithUnknownFieldId(): void
+    {
+        // Arrange — value references a config ID that does not exist in the DB
+        $values = $this->buildValuesList('non-existent-config-uuid', 'some-option-id');
+
+        // Act
+        $result = $this->sut->resolveForDisplay(
+            $values,
+            CustomFieldSupportedEntity::procedure,
+            $this->procedure->getId(),
+            CustomFieldSupportedEntity::statement
+        );
+
+        // Assert — unknown IDs are silently skipped, no exception thrown
+        static::assertSame([], $result);
+    }
+
+    public function testResolveForDisplayResolvesMultipleFieldsTogether(): void
+    {
+        // Arrange
+        $radioField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($this->procedure->_real())
+            ->withRelatedTargetEntity(CustomFieldSupportedEntity::statement->value)
+            ->asRadioButton('Status', options: ['Open', 'Closed'])
+            ->create();
+
+        $multiField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($this->procedure->_real())
+            ->withRelatedTargetEntity(CustomFieldSupportedEntity::statement->value)
+            ->asMultiSelect('Tags', options: ['Urgent', 'Review', 'Done'])
+            ->create();
+
+        $selectedRadioOption = $radioField->getConfiguration()->getOptions()[1];   // 'Closed'
+        $selectedMultiOptionA = $multiField->getConfiguration()->getOptions()[0];  // 'Urgent'
+        $selectedMultiOptionB = $multiField->getConfiguration()->getOptions()[2];  // 'Done'
+
+        $values = new CustomFieldValuesList();
+        $values->addCustomFieldValue($this->buildFieldValue($radioField->getId(), $selectedRadioOption->getId()));
+        $values->addCustomFieldValue($this->buildFieldValue($multiField->getId(), [$selectedMultiOptionA->getId(), $selectedMultiOptionB->getId()]));
+
+        // Act
+        $result = $this->sut->resolveForDisplay(
+            $values,
+            CustomFieldSupportedEntity::procedure,
+            $this->procedure->getId(),
+            CustomFieldSupportedEntity::statement
+        );
+
+        // Assert
+        static::assertCount(2, $result);
+
+        $resultByName = array_column($result, null, 'name');
+
+        static::assertArrayHasKey($radioField->getConfiguration()->getName(), $resultByName);
+        static::assertSame(
+            $selectedRadioOption->getLabel(),
+            $resultByName[$radioField->getConfiguration()->getName()]['value']
+        );
+
+        static::assertArrayHasKey($multiField->getConfiguration()->getName(), $resultByName);
+        static::assertSame(
+            $selectedMultiOptionA->getLabel().', '.$selectedMultiOptionB->getLabel(),
+            $resultByName[$multiField->getConfiguration()->getName()]['value']
+        );
+    }
+
+    private function buildValuesList(string $configId, mixed $value): CustomFieldValuesList
+    {
+        $values = new CustomFieldValuesList();
+        $values->addCustomFieldValue($this->buildFieldValue($configId, $value));
+
+        return $values;
+    }
+
+    private function buildFieldValue(string $configId, mixed $value): CustomFieldValue
+    {
+        $fieldValue = new CustomFieldValue();
+        $fieldValue->setId($configId);
+        $fieldValue->setValue($value);
+
+        return $fieldValue;
+    }
+}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-17244/ADO-50218-Konfigurierbare-Felder-in-Stellungnahmen-Part-4.1-Custom-Fields-fur-Abschnitte-und-Statements-zusammenfuhren-Bau-Rog

**Description**
- Custom fields filled in on a statement (e.g. radio buttons, checkboxes) now appear in the PDF export. 
-   A new CustomFieldDisplayResolver service was added to translate stored option IDs into human-readable labels  each field type is responsible for formatting its own value. The PDFtemplates were updated to render those labels, and a warning is logged if a field definition no longer exists in the database.

### How to review/test
- As a FP Admin create a new Verfahren and add custom fields for stn
- As a private citzen go to that Verfarehn and add stn (put it on draft)
- And then download the PDF, the chosen custom fields should be there