### PR TITLE
feat(DPLAN-17509): add draggable column reordering with localStorage  #AB52560

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -164,7 +164,7 @@
             has-borders
             has-sticky-header
             :header-fields="availableHeaderFields"
-            :is-columns-draggable="true"
+            :is-columns-draggable
             is-resizable
             is-selectable
             :items="items"

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -164,6 +164,7 @@
             has-borders
             has-sticky-header
             :header-fields="availableHeaderFields"
+            column-storage-key="segmentsList"
             is-columns-draggable
             is-resizable
             is-selectable

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -164,7 +164,7 @@
             has-borders
             has-sticky-header
             :header-fields="availableHeaderFields"
-            :is-columns-draggable
+            is-columns-draggable
             is-resizable
             is-selectable
             :items="items"

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -508,7 +508,7 @@ export default {
       demosplanUi,
       hasStyledTopicalTags: false,
       headerFieldsAvailable: [
-        { field: 'externId', label: Translator.trans('id'), colWidth: '120px', initialMinWidth: 120 },
+        { field: 'externId', label: Translator.trans('id'), colWidth: '120px', initialMinWidth: 120, fixed: true },
         { field: 'statementStatus', label: Translator.trans('statement.status'), colWidth: '180px', initialMinWidth: 180 },
         { field: 'internId', label: Translator.trans('internId.shortened'), colWidth: '120px', initialMinWidth: 120 },
         { field: 'submitter', label: Translator.trans('submitter'), colWidth: '180px', initialMinWidth: 180 },

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -164,6 +164,7 @@
             has-borders
             has-sticky-header
             :header-fields="availableHeaderFields"
+            :is-columns-draggable="true"
             is-resizable
             is-selectable
             :items="items"


### PR DESCRIPTION
### Ticket
[DPLAN-17509](https://demoseurope.youtrack.cloud/issue/DPLAN-17509/ADO-issue-52560-Optimierung-Abschnittsliste-dragdrop-der-Spalten)

Passes the new `isColumnsDraggable` and `columnStorageKey` props from  `SegmentsList` to `DpDataTable`, enabling drag-and-drop column reordering. The `id` and checkbox columns are marked as `fixed` and excluded from reordering. Column order is persisted in localStorage

### How to review/tes
  - Go to SegmentsList                                                          
  - Drag a column header via the grip icon → order changes
  - Reload the page → order is restored from localStorage                       
  - The `id` and checkbox columns cannot be dragged and stay in position   

### Linked PRs 
- Demosplan-ui #{[1469](https://github.com/demos-europe/demosplan-ui/pull/1469)}

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
