### PR TITLE
fix(refs: DPLAN-17360) overview map being displayed initially

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -878,7 +878,7 @@ export default {
         overviewMapControlView = new View({
           center: [this.mapx, this.mapy],
           projection: this.mapprojection,
-          resolutions: this.resolutions,
+          resolution: this.resolutions[0],
         })
       }
 

--- a/client/js/components/statement/statement/DpAutofillSubmitterData.vue
+++ b/client/js/components/statement/statement/DpAutofillSubmitterData.vue
@@ -132,7 +132,8 @@
     <input
       type="hidden"
       name="r_oId"
-      :value="selectedOrgaId">
+      :value="selectedOrgaId"
+    >
 
     <!-- User fields that are specific to institutions: orga, department. These fields shall not be changeable in Bob-HH, but visible and present to submit their values when filled by autoFill function -->
     <template


### PR DESCRIPTION
### Ticket
[DPLAN-17360](https://demoseurope.youtrack.cloud/issue/DPLAN-17360/Ubersichtskarte-unsichtbar-und-blendet-Karte-aus)

The overview map view was initialized with `resolutions: this.resolutions` but no explicit `resolution`.                                                    
Without an initial resolution, `view.isDef()` returns false — OL skips creating a frameState for the                                                  mini-map, so `isRendered()` stays false, `validateExtent_()` always bails early and `resetExtent_()`                                                  is never called. The view is permanently stuck without a resolution.                                                                                        
                                                                                                                                                            
This was triggered by DPLAN-17145, which wrapped `view.fit()` in `$nextTick`. Before that, the fit                                                          
ran synchronously so the view was already defined when `addControl` was called.       


### How to review/test
Open a procedure with a configured base layer → overview map should show the layer and clicking it                                                         should pan the main map correctly without it going blank.     

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
