### PR TITLE
fix(DPLAN-17499): dd LanguageTool proxy endpoint for spellcheck integration

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -532,6 +532,8 @@ parameters:
     ai_service_salt: ""
     ai_service_post_url: ""
 
+    languagetool_url: ''
+
     # #refactor: used only once, could be constant
     drafts_info_schema_path: "%kernel.project_dir%/config/json-schema/drafts-info-schema.json"
 

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -2514,6 +2514,11 @@ feature_statements_vote_may_vote:
     label: 'Stellungnahme anderer mitzeichnen (Aktion ausführen)'
     loginRequired: true
     parent: feature_statement
+feature_spellcheck:
+    description: 'Enables the spellcheck proxy to a self-hosted LanguageTool instance. Requires languagetool_url parameter to be configured.'
+    expose: true
+    label: 'Enables spellcheck via LanguageTool'
+    loginRequired: false
 feature_switchorga:
     label: 'Organisation Fachplanung und Institution wechseln'
     loginRequired: true

--- a/demosplan/DemosPlanCoreBundle/Controller/Platform/SpellcheckController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Platform/SpellcheckController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Controller\Platform;
+
+use DemosEurope\DemosplanAddon\Controller\APIController;
+use demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions;
+use demosplan\DemosPlanCoreBundle\Logic\Spellcheck\LanguageToolService;
+use Exception;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class SpellcheckController extends APIController
+{
+    #[DplanPermissions('feature_spellcheck')]
+    #[Route(path: '/api/1.0/spellcheck/check', methods: ['POST'], name: 'core_spellcheck_check', options: ['expose' => true])]
+    public function checkText(Request $request, LanguageToolService $languageToolService): Response
+    {
+        try {
+            return new JsonResponse($languageToolService->checkText($request->toArray()));
+        } catch (Exception $e) {
+            return $this->handleApiError($e);
+        }
+    }
+
+    #[DplanPermissions('feature_spellcheck')]
+    #[Route(path: '/api/1.0/spellcheck/languages', methods: ['GET'], name: 'core_spellcheck_languages', options: ['expose' => true])]
+    public function getLanguages(LanguageToolService $languageToolService): Response
+    {
+        try {
+            return new JsonResponse($languageToolService->getLanguages());
+        } catch (Exception $e) {
+            return $this->handleApiError($e);
+        }
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Exception/LanguageToolServiceException.php
+++ b/demosplan/DemosPlanCoreBundle/Exception/LanguageToolServiceException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Exception;
+
+use Exception;
+
+class LanguageToolServiceException extends Exception
+{
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
@@ -12,8 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Spellcheck;
 
-use Psr\Log\LoggerInterface;
-use RuntimeException;
+use demosplan\DemosPlanCoreBundle\Exception\LanguageToolServiceException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -23,7 +22,6 @@ class LanguageToolService
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly LoggerInterface $logger,
         ParameterBagInterface $parameterBag,
     ) {
         $this->languageToolUrl = $parameterBag->get('languagetool_url');
@@ -57,7 +55,7 @@ class LanguageToolService
     private function getUrl(string $path): string
     {
         if ('' === $this->languageToolUrl) {
-            throw new RuntimeException('LanguageTool service not configured');
+            throw new LanguageToolServiceException('LanguageTool service not configured: missing languagetool_url parameter');
         }
 
         return $this->languageToolUrl.$path;

--- a/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Spellcheck;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class LanguageToolService
+{
+    private readonly string $languageToolUrl;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        ParameterBagInterface $parameterBag,
+    ) {
+        $this->languageToolUrl = $parameterBag->get('languagetool_url');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function checkText(array $formData): array
+    {
+        $response = $this->httpClient->request('POST', $this->getUrl('/v2/check'), [
+            'body'    => $formData,
+            'timeout' => 10,
+        ]);
+
+        return $response->toArray();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getLanguages(): array
+    {
+        $response = $this->httpClient->request('GET', $this->getUrl('/v2/languages'), [
+            'timeout' => 10,
+        ]);
+
+        return $response->toArray();
+    }
+
+    private function getUrl(string $path): string
+    {
+        if ('' === $this->languageToolUrl) {
+            throw new RuntimeException('LanguageTool service not configured');
+        }
+
+        return $this->languageToolUrl.$path;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Spellcheck/LanguageToolService.php
@@ -15,7 +15,6 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Spellcheck;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class LanguageToolService


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-17499/FE-Rechtschreibprufung-im-Tiptap-Editor

Description:
add LanguageTool proxy endpoint for spellcheck integration                                                                                
  Adds a backend proxy that forwards spellcheck requests to a self-hosted                     
  LanguageTool server, allowing the frontend to use spellcheck without                        
  calling external services directly.                                                         
                                    
The FE needs:                                                                               

  1. LanguageTool container in docker-compose.override.yml:                                   
```  
services:
      languagetool:                                                                           
          image: erikvl87/languagetool:latest
          container_name: languagetool       
          ports:                                                                              
              - 8010:8010
```                                                                                          
  2. Network connection (since the containers are on different networks):
  docker network connect demosplan_demosplan_development_network languagetool                 
                                                                             
  3. Parameter in projects/{project}/app/config/parameters.yml:                               
  languagetool_url: 'http://languagetool:8010'                                                
                                                                                              
  4. Permission enabled in the project's Permissions.php (feature_spellcheck in               
  projectGlobalPermissions)                                                                   
  5. Cache clear after changes


- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog
