### PR TITLE
feat: add retention period for deleted procedure purging

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -43,6 +43,8 @@ parameters:
     procedure_public_list_default_sort_key: "publicParticipationEndDate"
     # Purge procedures if deleted
     purge_deleted_procedures: false
+    # Days to keep deleted procedures after deletion to be able to restore them in case of an emergency
+    purge_deleted_retention_period_days: 60
 
     # Defines whether access to procedure is granted by owning organisation (false)
     # or whether it is possible to define specific users withing the organisation

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -10,10 +10,10 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Procedure;
 
+use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Handler\ProcedureHandlerInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
-use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\NotificationReceiver;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureHandler.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Procedure;
 use DemosEurope\DemosplanAddon\Contracts\Handler\ProcedureHandlerInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use DateTime;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\NotificationReceiver;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
@@ -651,10 +652,11 @@ class ProcedureHandler extends CoreHandler implements ProcedureHandlerInterface
      *
      * @throws Exception
      */
-    public function purgeDeletedProcedures($limit = 1): int
+    public function purgeDeletedProcedures($limit = 1, int $retentionDays = 0): int
     {
+        $deletedBefore = $retentionDays > 0 ? new DateTime("-$retentionDays days") : null;
         $proceduresPurged = 0;
-        foreach ($this->procedureService->getDeletedProcedures($limit) as $deletedProcedure) {
+        foreach ($this->procedureService->getDeletedProcedures($limit, $deletedBefore) as $deletedProcedure) {
             $procedureId = $deletedProcedure->getId();
             try {
                 $this->procedureDeleter->beginTransactionAndDisableForeignKeyChecks();

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -562,14 +562,24 @@ class ProcedureService implements ProcedureServiceInterface
      *
      * @param int $limit
      *
-     * @return Procedure[]|null
+     * @return Procedure[]
      *
      * @throws Exception
      */
-    public function getDeletedProcedures($limit = 100_000_000)
+    public function getDeletedProcedures($limit = 100_000_000, ?\DateTimeInterface $deletedBefore = null): array
     {
         try {
-            return $this->procedureRepository->findBy(['deleted' => true], null, $limit);
+            if (null === $deletedBefore) {
+                return $this->procedureRepository->findBy(['deleted' => true], null, $limit);
+            }
+
+            return $this->procedureRepository->createQueryBuilder('p')
+                ->where('p.deleted = true')
+                ->andWhere('p.deletedDate <= :deletedBefore')
+                ->setParameter('deletedBefore', $deletedBefore)
+                ->setMaxResults($limit)
+                ->getQuery()
+                ->getResult();
         } catch (Exception $e) {
             $this->logger->warning('Fehler beim Abruf der getProcedureDeleted: ', [$e]);
             throw $e;

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -12,6 +12,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Procedure;
 
 use Carbon\Carbon;
 use DateTime;
+use DateTimeInterface;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
@@ -566,7 +567,7 @@ class ProcedureService implements ProcedureServiceInterface
      *
      * @throws Exception
      */
-    public function getDeletedProcedures($limit = 100_000_000, ?\DateTimeInterface $deletedBefore = null): array
+    public function getDeletedProcedures($limit = 100_000_000, ?DateTimeInterface $deletedBefore = null): array
     {
         try {
             if (null === $deletedBefore) {

--- a/demosplan/DemosPlanCoreBundle/MessageHandler/PurgeDeletedProceduresMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/PurgeDeletedProceduresMessageHandler.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Message\PurgeDeletedProceduresMessage;
 use demosplan\DemosPlanCoreBundle\Traits\InitializesAnonymousUserPermissionsTrait;
 use Exception;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -27,6 +28,7 @@ final class PurgeDeletedProceduresMessageHandler
     public function __construct(
         private readonly ProcedureHandler $procedureHandler,
         private readonly GlobalConfigInterface $globalConfig,
+        private readonly ParameterBagInterface $parameterBag,
         private readonly PermissionsInterface $permissions,
         private readonly LoggerInterface $logger,
     ) {
@@ -40,8 +42,9 @@ final class PurgeDeletedProceduresMessageHandler
         $purgedProcedures = 0;
         try {
             if (true === $this->globalConfig->getUsePurgeDeletedProcedures()) {
+                $retentionDays = (int) $this->parameterBag->get('purge_deleted_retention_period_days');
                 $this->logger->info('PurgeDeletedProcedures', [spl_object_id($message)]);
-                $purgedProcedures = $this->procedureHandler->purgeDeletedProcedures(5);
+                $purgedProcedures = $this->procedureHandler->purgeDeletedProcedures(5, $retentionDays);
             } else {
                 $this->logger->info('Purge deleted procedures is disabled.');
             }

--- a/tests/backend/core/MessageHandler/PurgeDeletedProceduresMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/PurgeDeletedProceduresMessageHandlerTest.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
 use demosplan\DemosPlanCoreBundle\Message\PurgeDeletedProceduresMessage;
 use demosplan\DemosPlanCoreBundle\MessageHandler\PurgeDeletedProceduresMessageHandler;
 use Exception;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Tests\Base\UnitTestCase;
 
 class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
@@ -25,8 +26,10 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
     use LoggerTestTrait;
 
     private const PURGE_DELETED_PROCEDURES = 'Purge deleted procedures... ';
+    private const RETENTION_DAYS = 60;
     private ?ProcedureHandler $procedureHandler = null;
     private ?GlobalConfigInterface $globalConfig = null;
+    private ?ParameterBagInterface $parameterBag = null;
     private ?PermissionsInterface $permissions = null;
     private ?PurgeDeletedProceduresMessageHandler $sut = null;
 
@@ -35,6 +38,10 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
         parent::setUp();
         $this->procedureHandler = $this->createMock(ProcedureHandler::class);
         $this->globalConfig = $this->createMock(GlobalConfigInterface::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
+        $this->parameterBag->method('get')
+            ->with('purge_deleted_retention_period_days')
+            ->willReturn(self::RETENTION_DAYS);
         $this->permissions = $this->createMock(PermissionsInterface::class);
     }
 
@@ -49,7 +56,7 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
             ->method('purgeDeletedProcedures');
 
         $logger = $this->createLoggerMockWithCapture(2);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->permissions, $logger);
+        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
 
         // Act
         ($this->sut)(new PurgeDeletedProceduresMessage());
@@ -67,11 +74,11 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
 
         $this->procedureHandler->expects($this->once())
             ->method('purgeDeletedProcedures')
-            ->with(5)
+            ->with(5, self::RETENTION_DAYS)
             ->willReturn(3);
 
         $logger = $this->createLoggerMockWithCapture(3);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->permissions, $logger);
+        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
 
         // Act
         ($this->sut)(new PurgeDeletedProceduresMessage());
@@ -89,11 +96,11 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
 
         $this->procedureHandler->expects($this->once())
             ->method('purgeDeletedProcedures')
-            ->with(5)
+            ->with(5, self::RETENTION_DAYS)
             ->willReturn(0);
 
         $logger = $this->createLoggerMockWithCapture(2);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->permissions, $logger);
+        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
 
         // Act
         ($this->sut)(new PurgeDeletedProceduresMessage());
@@ -116,7 +123,7 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
             ->willThrowException($exception);
 
         $logger = $this->createLoggerMockForError('Purge Procedures failed', $exception);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->permissions, $logger);
+        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
 
         // Act
         ($this->sut)(new PurgeDeletedProceduresMessage());

--- a/tests/backend/core/MessageHandler/PurgeDeletedProceduresMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/PurgeDeletedProceduresMessageHandlerTest.php
@@ -18,6 +18,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
 use demosplan\DemosPlanCoreBundle\Message\PurgeDeletedProceduresMessage;
 use demosplan\DemosPlanCoreBundle\MessageHandler\PurgeDeletedProceduresMessageHandler;
 use Exception;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Tests\Base\UnitTestCase;
 
@@ -67,45 +68,17 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
 
     public function testInvokePurgesProceduresWhenEnabled(): void
     {
-        // Arrange
-        $this->globalConfig->expects($this->once())
-            ->method('getUsePurgeDeletedProcedures')
-            ->willReturn(true);
-
-        $this->procedureHandler->expects($this->once())
-            ->method('purgeDeletedProcedures')
-            ->with(5, self::RETENTION_DAYS)
-            ->willReturn(3);
-
         $logger = $this->createLoggerMockWithCapture(3);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
+        $this->setupEnabledPurgeAndInvoke(3, $logger);
 
-        // Act
-        ($this->sut)(new PurgeDeletedProceduresMessage());
-
-        // Assert
         $this->assertSame([self::PURGE_DELETED_PROCEDURES, 'PurgeDeletedProcedures', 'Purged procedures: 3'], $this->getCapturedLoggerCalls());
     }
 
     public function testInvokeDoesNotLogWhenNoProceduresPurged(): void
     {
-        // Arrange
-        $this->globalConfig->expects($this->once())
-            ->method('getUsePurgeDeletedProcedures')
-            ->willReturn(true);
-
-        $this->procedureHandler->expects($this->once())
-            ->method('purgeDeletedProcedures')
-            ->with(5, self::RETENTION_DAYS)
-            ->willReturn(0);
-
         $logger = $this->createLoggerMockWithCapture(2);
-        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
+        $this->setupEnabledPurgeAndInvoke(0, $logger);
 
-        // Act
-        ($this->sut)(new PurgeDeletedProceduresMessage());
-
-        // Assert
         $this->assertSame([self::PURGE_DELETED_PROCEDURES, 'PurgeDeletedProcedures'], $this->getCapturedLoggerCalls());
     }
 
@@ -126,6 +99,21 @@ class PurgeDeletedProceduresMessageHandlerTest extends UnitTestCase
         $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
 
         // Act
+        ($this->sut)(new PurgeDeletedProceduresMessage());
+    }
+
+    private function setupEnabledPurgeAndInvoke(int $purgeReturnValue, LoggerInterface $logger): void
+    {
+        $this->globalConfig->expects($this->once())
+            ->method('getUsePurgeDeletedProcedures')
+            ->willReturn(true);
+
+        $this->procedureHandler->expects($this->once())
+            ->method('purgeDeletedProcedures')
+            ->with(5, self::RETENTION_DAYS)
+            ->willReturn($purgeReturnValue);
+
+        $this->sut = new PurgeDeletedProceduresMessageHandler($this->procedureHandler, $this->globalConfig, $this->parameterBag, $this->permissions, $logger);
         ($this->sut)(new PurgeDeletedProceduresMessage());
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `purge_deleted_retention_period_days` parameter (default: 60) so deleted procedures are kept for a configurable grace period before permanent purging
- Filter purge query by `deletedDate` to only purge procedures older than the retention period
- Thread retention days from message handler through handler to service via `ParameterBagInterface`

## Test plan
- [x] Existing `PurgeDeletedProceduresMessageHandlerTest` updated and passing (4/4)
- [ ] Verify on a environment with `purge_deleted_procedures: true` that only procedures deleted > 60 days ago are purged