### PR TITLE
Fix DPLAN-17645 Elasticsearch keyword parsing error when removing use…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/User.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/User.php
@@ -1651,7 +1651,7 @@ class User implements AddonUserInterface, TotpTwoFactorInterface, EmailTwoFactor
     public function getCustomers(): array
     {
         return $this->roleInCustomers
-            ->map(static fn (UserRoleInCustomerInterface $roleInCustomer) => $roleInCustomer->getCustomer())->toArray();
+            ->map(static fn (UserRoleInCustomerInterface $roleInCustomer) => $roleInCustomer->getCustomer())->getValues();
     }
 
     public function isConnectedToCustomerId(string $customerId): bool


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17645/Kein-Autobahnnutzer-darf-die-Rolle-Fachplanung-Masteruser-haben

Description: 

- getCustomers() used toArray() which preserves Collection array keys. When removeElement() removes a middle element, it leaves a gap in keys (e.g. 0,1,2,3,5). PHP json_encode treats non-sequential keys as a JSON object instead of array, causing Elasticsearch to reject the document with "failed to parse field [customers] of type [keyword]".
- Replaced toArray() with getValues() which re-indexes keys sequentially.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

