### PR TITLE
fix: delete physical files from storage when purging procedures

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -1121,7 +1121,7 @@ class ProcedureDeleter
                 $this->defaultStorage->delete($flysystemPath);
             } catch (FilesystemException $e) {
                 $this->logger->warning('Could not delete file from storage during procedure deletion', [
-                    'path' => $flysystemPath,
+                    'path'  => $flysystemPath,
                     'error' => $e->getMessage(),
                 ]);
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -14,11 +14,16 @@ use demosplan\DemosPlanCoreBundle\Logic\Orga\OrgaDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use Doctrine\DBAL\ArrayParameterType;
 use Exception;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
 
 class ProcedureDeleter
 {
     public function __construct(
         private readonly SqlQueriesService $queriesService,
+        private readonly FilesystemOperator $defaultStorage,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -153,7 +158,16 @@ class ProcedureDeleter
         // procedure_user
         $this->deleteProcedureUser($procedureIds, $isDryRun);
 
-        // delete remaining procedure files
+        // delete remaining procedure files (physical + DB)
+        $remainingFiles = $this->queriesService->fetchFromTableByParameter(
+            ['_f_path', '_f_hash'],
+            '_files',
+            'procedure_id',
+            $procedureIds
+        );
+        if (!$isDryRun) {
+            $this->deleteFilesFromStorage($remainingFiles);
+        }
         $this->queriesService->deleteFromTableByIdentifierArray('_files', 'procedure_id', $procedureIds, $isDryRun);
 
         // delete procedure report entries
@@ -253,12 +267,7 @@ class ProcedureDeleter
             ),
             'file_id'
         );
-        $this->queriesService->deleteFromTableByIdentifierArray(
-            '_files',
-            '_f_ident',
-            $fileIds,
-            $isDryRun
-        );
+        $this->deleteFiles($fileIds, $isDryRun);
         $this->queriesService->deleteFromTableByIdentifierArray(
             'file_container',
             'entity_id',
@@ -344,7 +353,7 @@ class ProcedureDeleter
     {
         $attachmentData = $this->queriesService->fetchFromTableByParameter(['file_id'], 'statement_import_email_attachments', 'statement_import_email_id', $importEmailIds);
 
-        $this->deleteFiles($attachmentData, $isDryRun);
+        $this->deleteFiles(array_column($attachmentData, 'file_id'), $isDryRun);
         $this->deleteStatementImportEmailAttachments($importEmailIds, $isDryRun);
     }
 
@@ -1077,7 +1086,46 @@ class ProcedureDeleter
      */
     private function deleteFiles(array $fileIds, bool $isDryRun): void
     {
+        if ([] === $fileIds) {
+            return;
+        }
+
+        $fileData = $this->queriesService->fetchFromTableByParameter(
+            ['_f_path', '_f_hash'],
+            '_files',
+            '_f_ident',
+            $fileIds
+        );
+
+        if (!$isDryRun) {
+            $this->deleteFilesFromStorage($fileData);
+        }
+
         $this->queriesService->deleteFromTableByIdentifierArray('_files', '_f_ident', $fileIds, $isDryRun);
+    }
+
+    private function deleteFilesFromStorage(array $fileData): void
+    {
+        foreach ($fileData as $file) {
+            $hash = $file['_f_hash'] ?? null;
+            if (null === $hash || '' === $hash) {
+                continue;
+            }
+
+            $path = $file['_f_path'] ?? '';
+            $flysystemPath = '' !== $path
+                ? rtrim($path, '/').'/'.$hash
+                : $hash;
+
+            try {
+                $this->defaultStorage->delete($flysystemPath);
+            } catch (FilesystemException $e) {
+                $this->logger->warning('Could not delete file from storage during procedure deletion', [
+                    'path' => $flysystemPath,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
     }
 
     /**

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -11,11 +11,14 @@
 namespace backend\core\Procedure\Functional;
 
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\CustomFields\CustomFieldConfigurationFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\FileFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
 use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
+use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
+use League\Flysystem\FilesystemOperator;
 use Tests\Base\FunctionalTestCase;
 use Zenstruck\Foundry\Persistence\Proxy;
 
@@ -112,6 +115,66 @@ class ProcedureDeleterTest extends FunctionalTestCase
         }
 
         return $customFieldsCount;
+    }
+
+    public function testDeleteProcedureRemovesFilesFromStorage(): void
+    {
+        // Arrange
+        $defaultStorage = $this->getContainer()->get('default.storage');
+        \assert($defaultStorage instanceof FilesystemOperator);
+
+        $procedure = $this->testProcedure->_real();
+        $filePath = 'files/test';
+        $fileHash = md5(uniqid('', true));
+        $flysystemPath = $filePath.'/'.$fileHash;
+
+        $defaultStorage->write($flysystemPath, 'test content');
+        static::assertTrue($defaultStorage->fileExists($flysystemPath));
+
+        FileFactory::createOne([
+            'hash'      => $fileHash,
+            'path'      => $filePath,
+            'filename'  => 'test.txt',
+            'mimetype'  => 'text/plain',
+            'size'      => 12,
+            'procedure' => $procedure,
+        ]);
+
+        // Act
+        $this->sut->deleteProcedures([$procedure->getId()], false);
+
+        // Assert
+        static::assertFalse($defaultStorage->fileExists($flysystemPath), 'File should be deleted from storage');
+        static::assertSame(0, $this->countEntries(File::class, ['procedure' => $procedure]));
+    }
+
+    public function testDeleteProcedureDryRunKeepsFilesInStorage(): void
+    {
+        // Arrange
+        $defaultStorage = $this->getContainer()->get('default.storage');
+        \assert($defaultStorage instanceof FilesystemOperator);
+
+        $procedure = $this->testProcedure->_real();
+        $filePath = 'files/test';
+        $fileHash = md5(uniqid('', true));
+        $flysystemPath = $filePath.'/'.$fileHash;
+
+        $defaultStorage->write($flysystemPath, 'test content');
+
+        FileFactory::createOne([
+            'hash'      => $fileHash,
+            'path'      => $filePath,
+            'filename'  => 'test.txt',
+            'mimetype'  => 'text/plain',
+            'size'      => 12,
+            'procedure' => $procedure,
+        ]);
+
+        // Act
+        $this->sut->deleteProcedures([$procedure->getId()], true);
+
+        // Assert
+        static::assertTrue($defaultStorage->fileExists($flysystemPath), 'File should still exist in storage after dry run');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Delete files from Flysystem storage before removing DB records during procedure purge
- Add `deleteFilesFromStorage()` to handle physical file deletion with error handling
- Cover both per-entity file cleanup and the catch-all remaining-files sweep
- Fix bug in `processImportEmailAttachments` passing wrong array shape to `deleteFiles`

## Test plan
- [x] Added `testDeleteProcedureRemovesFilesFromStorage` — verifies files are deleted from disk
- [x] Added `testDeleteProcedureDryRunKeepsFilesInStorage` — verifies dry-run leaves files intact