### PR TITLE
fix: disable BuildKit provenance to fix docker push on CI

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -74,6 +74,7 @@ function docker_build() {
 
     DOCKER_BUILDKIT=1 docker build \
         $VERBOSE \
+        --provenance=false \
         --platform $PLATFORM \
         --build-arg PROJECT_NAME=$PROJECT_NAME \
         --build-arg BUILD_MODE=$BUILD_MODE \


### PR DESCRIPTION
## Summary
- Adds `--provenance=false` to the `docker build` command in `docker/build.sh`
- Recent BuildKit versions generate provenance attestation manifests alongside the image, creating an OCI index. `docker push` then tries to push all referenced manifests, failing when attestation blobs are not available in the target registry.

## Test plan
- [ ] Verify CI pipeline builds and pushes images successfully without the manifest list error