### PR TITLE
fix(refs: DPLAN-17646): hide submitter name, address and priority in portraitWithPrioritization export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentExportController.php
@@ -20,6 +20,7 @@ use demosplan\DemosPlanCoreBundle\Exception\InvalidPostParameterTypeException;
 use demosplan\DemosPlanCoreBundle\Exception\MissingPostParameterException;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceOutput;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableViewMode;
+use demosplan\DemosPlanCoreBundle\Logic\Export\DocxExporter;
 use demosplan\DemosPlanCoreBundle\Logic\FileResponseGenerator\FileResponseGeneratorStrategy;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentExportOptions;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
@@ -72,11 +73,11 @@ class DemosPlanAssessmentExportController extends BaseController
     ): ?Response {
         $exportFormat = $request->request->get('r_export_format');
         $docxTemplates = $this->assessmentExportOptions->get('assessment_table')['docx']['templates'] ?? [];
-        $hasPortraitWithPrioritization = is_array($docxTemplates) && array_key_exists('portraitWithPrioritization', $docxTemplates);
+        $hasPortraitWithPrioritization = is_array($docxTemplates) && array_key_exists(DocxExporter::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION, $docxTemplates);
         $exportParameters = $this->getExportParameters($request, $procedureId, $original);
         // switch to elements view for the dedicated portraitWithPrioritization template if permission allows:
         if ('docx' === $exportFormat && $permissions->hasPermission('feature_export_docx_elements_view_mode_only')) {
-            $shouldOverride = $hasPortraitWithPrioritization ? 'portraitWithPrioritization' === $exportParameters['template'] : 'portrait' !== $exportParameters['template'];
+            $shouldOverride = $hasPortraitWithPrioritization ? DocxExporter::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION === $exportParameters['template'] : 'portrait' !== $exportParameters['template'];
             if ($shouldOverride) {
                 $exportParameters['viewMode'] = AssessmentTableViewMode::ELEMENTS_VIEW;
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -63,6 +63,7 @@ class DocxExporter
     final public const EXPORT_SORT_BY_PARAGRAPH_FRAGMENTS_ONLY = 'byParagraphFragmentsOnly';
     final public const EXPORT_SORT_BY_PARAGRAPH = 'byParagraph';
     final public const EXPORT_SORT_DEFAULT = 'default';
+    final public const TEMPLATE_PORTRAIT_WITH_PRIORITIZATION = 'portraitWithPrioritization';
     /**
      * @var array Style, wie Tabelle im gesamten aussehen soll
      */
@@ -1359,7 +1360,7 @@ class DocxExporter
                 }
 
                 // Address
-                if ('portraitWithPrioritization' !== $templateName && $this->isAddressExportable($organisationData, $exportConfig, $statement, $anonym)) {
+                if (self::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION !== $templateName && $this->isAddressExportable($organisationData, $exportConfig, $statement, $anonym)) {
                     $cell2->addText(
                         htmlspecialchars($organisationData['postalAddressPartsOfAuthor']),
                         null,
@@ -1367,7 +1368,7 @@ class DocxExporter
                     );
                 }
 
-                if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_SUBMITTER_NAME,
+                if (self::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_SUBMITTER_NAME,
                     $exportConfig,
                     $statement,
                     $organisationData,
@@ -1418,7 +1419,7 @@ class DocxExporter
                     );
                 }
 
-                if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(
+                if (self::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION !== $templateName && $this->exportFieldDecider->isExportable(
                     FieldDecider::FIELD_SUBMITTER_NAME,
                     $exportConfig,
                     $statement,
@@ -1433,7 +1434,7 @@ class DocxExporter
                     );
                 }
 
-                if ('portraitWithPrioritization' !== $templateName && $this->isAddressExportable($citizenDetails, $exportConfig, $statement, $anonym)) {
+                if (self::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION !== $templateName && $this->isAddressExportable($citizenDetails, $exportConfig, $statement, $anonym)) {
                     // Adresse
                     $cell2->addText(
                         htmlspecialchars((string) $citizenDetails['postalAddressPartsOfAuthor']),
@@ -1540,8 +1541,8 @@ class DocxExporter
                     });
             }
 
-            // Priorität (redundant in portraitWithPrioritization as it is already shown in the group heading)
-            if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_PRIORITY, $exportConfig, $statement)) {
+            // Priorität (redundant in TEMPLATE_PORTRAIT_WITH_PRIORITIZATION as it is already shown in the group heading)
+            if (self::TEMPLATE_PORTRAIT_WITH_PRIORITIZATION !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_PRIORITY, $exportConfig, $statement)) {
                 $textRun2 = $cell2->addTextRun($cellHCentered);
                 $textRun2AddText = $this->containerAddTextFunctionConstructor($textRun2, null, null);
                 $textRun2AddText('priority', '');

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -1359,7 +1359,7 @@ class DocxExporter
                 }
 
                 // Address
-                if ($this->isAddressExportable($organisationData, $exportConfig, $statement, $anonym)) {
+                if ('portraitWithPrioritization' !== $templateName && $this->isAddressExportable($organisationData, $exportConfig, $statement, $anonym)) {
                     $cell2->addText(
                         htmlspecialchars($organisationData['postalAddressPartsOfAuthor']),
                         null,
@@ -1367,7 +1367,7 @@ class DocxExporter
                     );
                 }
 
-                if ($this->exportFieldDecider->isExportable(FieldDecider::FIELD_SUBMITTER_NAME,
+                if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_SUBMITTER_NAME,
                     $exportConfig,
                     $statement,
                     $organisationData,
@@ -1418,7 +1418,7 @@ class DocxExporter
                     );
                 }
 
-                if ($this->exportFieldDecider->isExportable(
+                if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(
                     FieldDecider::FIELD_SUBMITTER_NAME,
                     $exportConfig,
                     $statement,
@@ -1433,7 +1433,7 @@ class DocxExporter
                     );
                 }
 
-                if ($this->isAddressExportable($citizenDetails, $exportConfig, $statement, $anonym)) {
+                if ('portraitWithPrioritization' !== $templateName && $this->isAddressExportable($citizenDetails, $exportConfig, $statement, $anonym)) {
                     // Adresse
                     $cell2->addText(
                         htmlspecialchars((string) $citizenDetails['postalAddressPartsOfAuthor']),
@@ -1540,8 +1540,8 @@ class DocxExporter
                     });
             }
 
-            // Priorität
-            if ($this->exportFieldDecider->isExportable(FieldDecider::FIELD_PRIORITY, $exportConfig, $statement)) {
+            // Priorität (redundant in portraitWithPrioritization as it is already shown in the group heading)
+            if ('portraitWithPrioritization' !== $templateName && $this->exportFieldDecider->isExportable(FieldDecider::FIELD_PRIORITY, $exportConfig, $statement)) {
                 $textRun2 = $cell2->addTextRun($cellHCentered);
                 $textRun2AddText = $this->containerAddTextFunctionConstructor($textRun2, null, null);
                 $textRun2AddText('priority', '');


### PR DESCRIPTION
### Ticket
[DPLAN-17646](https://demoseurope.youtrack.cloud/issue/DPLAN-17646)

In the 'Hochformat (mit Priorisierung und Gliederung)' docx export format, the submitter name, postal address and priority value were being shown. Per the ticket:
- Name and address of the submitter should not be shown (both for institutions and citizens)
- Priority is redundant since it is already displayed in the section group heading

### How to review/test
Export the Abwägungstabelle using "Hochformat (mit Priorisierung und Gliederung)" and verify that:
- Submitter name is not shown for institution statements
- Institution address is not shown for institution statements
- Submitter name is not shown for citizen statements
- Citizen address is not shown for citizen statements
- Priority value is not shown per statement (already visible in the group heading)

Other export formats should be unaffected.

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog