### PR TITLE
fix(refs DPLAN-16987, DS-487): restore search field width

### DIFF
--- a/client/js/components/procedure/admin/AdministrationProceduresList.vue
+++ b/client/js/components/procedure/admin/AdministrationProceduresList.vue
@@ -30,6 +30,7 @@
 
     <div class="flex w-full">
       <dp-search-field
+        class="w-full"
         input-width="u-1-of-2"
         @search="searchTerm => searchAdministrationProceduresList(searchTerm)"
         @reset="resetAdministrationProceduresList" />


### PR DESCRIPTION
### Ticket
DPLAN-16987

This PR restores the correct width of the search field in the procedure list.

### How to review/test
Ideally, symlink https://github.com/demos-europe/demosplan-ui/pull/1472 for demosplan-ui, so the spacing between buttons in the search field is also fixed.

### Linked PRs
- [ ] https://github.com/demos-europe/demosplan-ui/pull/1472


### PR Checklist

- [x] Link all relevant tickets
