### PR TITLE
DPLAN-17659: Fix filter flyout stacking behind sticky table header   

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -152,7 +152,7 @@
         <div
           id="segmentsListScrollContainer"
           ref="scrollContainer"
-          class="overflow-x-auto scrollbar-none"
+          class="overflow-x-auto scrollbar-none isolate"
         >
           <dp-data-table
             ref="dataTable"

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_data-table.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_data-table.scss
@@ -170,8 +170,8 @@
         position: sticky;
         top: 0;
 
-        /* Ensure sticky header renders above regular cells but below flyout/expand columns */
-        z-index: $dp-z-above-zero + 1;
+        /* Stacking within table: header (12) > sticky side cells (11) > resize handle (10) */
+        z-index: $dp-z-above-zero + 2;
         background-color: $dp-color-white;
     }
 
@@ -190,7 +190,7 @@
     th.c-data-table__col--flyout {
         position: sticky;
         right: 0;
-        z-index: $dp-z-above-zero;
+        z-index: $dp-z-above-zero + 1;
         background-color: $dp-color-white;
         text-align: center;
 
@@ -216,7 +216,7 @@
     th.c-data-table__col--expand {
         position: sticky;
         right: 0;
-        z-index: $dp-z-above-zero;
+        z-index: $dp-z-above-zero + 1;
         background-color: $dp-color-white;
         text-align: center;
 


### PR DESCRIPTION
### Ticket
[DPLAN-17659](https://demoseurope.youtrack.cloud/issue/DPLAN-17659/Abschnittsliste-Filterflyout-liegt-unter-Tabellenheader)

The segments list filter dropdown ("Suche einschränken auf") rendered behind the sticky table header because table sticky cells and external flyouts shared the same global stacking context.

Changes:        
- Isolate the scroll container into its own stacking context so external dropdowns always paint above the table.                                                                 
- Rebalance z-index within the table so sticky side cells (flyout/expand) cover the resize handle that bleeds in from the preceding column: sticky header (12) > flyout/expand cells (11) > resize handle (10).                              

### How to review/test
1. Open Abschnittsliste in any procedure.
2. Click the gear icon next to the search field — "Suche einschränken auf"                                
 dropdown must fully cover the table header.
3. Click one of the filter dropdowns (Schlagworte / Bearbeiter*in / Schritt) —                            
 same expected result.                                                                                  
4. Hover the second-to-last resizable column — the resize handle stays                                    
 hidden behind the flyout/expand sticky column.  

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
