### PR TITLE
fix(refs DPLAN-16987, DS-487): reduce margin-bottom for label

### DIFF
--- a/client/js/components/news/ChangeStateAtDate.vue
+++ b/client/js/components/news/ChangeStateAtDate.vue
@@ -62,6 +62,7 @@ All rights reserved
           class="layout__item u-2-of-12 u-6-of-12-lap-down"
           :class="{ 'color--grey': active === false }">
           <dp-label
+            class="mb-0.5"
             required
             :text="Translator.trans('on')"
             :for="dateId" />


### PR DESCRIPTION
### Ticket
DPLAN-16987

The label had too much margin-bottom and the layout looked broken.

### How to review/test
- To test it in the browser, go to "Aktuelles" -> "Neue Mitteilung anlegen", then check "Status automatisch umstellen"
- the space below the label for the datepicker input should be the same as for the status select

### PR Checklist

- [x] Link all relevant tickets

