### PR TITLE
perf(refs DS-428): speed up procedure phase resolution

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementProcedurePhaseResolver.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementProcedurePhaseResolver.php
@@ -19,6 +19,16 @@ use demosplan\DemosPlanCoreBundle\ValueObject\Procedure\ProcedurePhaseVO;
 
 class StatementProcedurePhaseResolver
 {
+    /**
+     * @var array<int, list<ProcedurePhaseVO>>
+     */
+    private array $cachedPhases = [];
+
+    /**
+     * @var array<int, array<string, ProcedurePhaseVO>>
+     */
+    private array $cachedPhaseMap = [];
+
     public function __construct(private readonly GlobalConfigInterface $globalConfig)
     {
     }
@@ -40,33 +50,61 @@ class StatementProcedurePhaseResolver
      */
     public function getProcedurePhaseVO(string $phaseKey, bool $isSubmittedByCitizen): ProcedurePhaseVO
     {
-        $availablePhases = $this->getAvailableProcedurePhases($isSubmittedByCitizen);
-
-        foreach ($availablePhases as $phase) {
-            if ($phase->getKey() === $phaseKey) {
-                // Phase key matches the name of the phase
-                return $phase;
-            }
+        $phaseMap = $this->getPhaseMap($isSubmittedByCitizen);
+        if (isset($phaseMap[$phaseKey])) {
+            return $phaseMap[$phaseKey];
         }
+
         throw new UndefinedPhaseException($phaseKey);
     }
 
+    /**
+     * @return list<ProcedurePhaseVO>
+     */
     public function getAvailableProcedurePhases(bool $isSubmittedByCitizen): array
     {
-        $phases = [];
-
-        if ($isSubmittedByCitizen) {
-            foreach ($this->globalConfig->getExternalPhasesAssoc() as $internalPhase) {
-                $phases[] = $this->createProcedurePhaseVO($internalPhase, Permissions::PROCEDURE_PERMISSION_SCOPE_EXTERNAL);
-            }
-
-            return $phases;
+        $bucket = (int) $isSubmittedByCitizen;
+        if (!isset($this->cachedPhases[$bucket])) {
+            $this->cachedPhases[$bucket] = $this->buildAvailableProcedurePhases($isSubmittedByCitizen);
         }
 
-        foreach ($this->globalConfig->getInternalPhasesAssoc() as $internalPhase) {
-            $phases[] = $this->createProcedurePhaseVO($internalPhase, Permissions::PROCEDURE_PERMISSION_SCOPE_INTERNAL);
+        return $this->cachedPhases[$bucket];
+    }
+
+    /**
+     * @return list<ProcedurePhaseVO>
+     */
+    private function buildAvailableProcedurePhases(bool $isSubmittedByCitizen): array
+    {
+        $source = $isSubmittedByCitizen
+            ? $this->globalConfig->getExternalPhasesAssoc()
+            : $this->globalConfig->getInternalPhasesAssoc();
+        $scope = $isSubmittedByCitizen
+            ? Permissions::PROCEDURE_PERMISSION_SCOPE_EXTERNAL
+            : Permissions::PROCEDURE_PERMISSION_SCOPE_INTERNAL;
+
+        $phases = [];
+        foreach ($source as $phaseConfig) {
+            $phases[] = $this->createProcedurePhaseVO($phaseConfig, $scope);
         }
 
         return $phases;
+    }
+
+    /**
+     * @return array<string, ProcedurePhaseVO>
+     */
+    private function getPhaseMap(bool $isSubmittedByCitizen): array
+    {
+        $bucket = (int) $isSubmittedByCitizen;
+        if (!isset($this->cachedPhaseMap[$bucket])) {
+            $map = [];
+            foreach ($this->getAvailableProcedurePhases($isSubmittedByCitizen) as $phase) {
+                $map[$phase->getKey()] = $phase;
+            }
+            $this->cachedPhaseMap[$bucket] = $map;
+        }
+
+        return $this->cachedPhaseMap[$bucket];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -130,11 +130,11 @@ use Doctrine\Persistence\ManagerRegistry;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use EDT\Querying\Contracts\PathException;
 use Elastica\Aggregation\GlobalAggregation;
-use FOS\ElasticaBundle\Index\IndexManager;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\BoolQuery;
 use Exception;
+use FOS\ElasticaBundle\Index\IndexManager;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
@@ -1153,7 +1153,6 @@ class StatementService implements StatementServiceInterface
                 $this->logger->warning('Trying to update a locked by assignment statement.');
             }
 
-
             // is a original statement?
             $lockedByOriginal = false;
             $isOriginal = $currentStatementObject->isOriginal();
@@ -1271,7 +1270,6 @@ class StatementService implements StatementServiceInterface
 
         return $fileHashToFileContainerMapping;
     }
-
 
     /**
      * Determines if the given statement is "locked" because of assigned to another user.

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2695,10 +2695,27 @@ class StatementService implements StatementServiceInterface
      */
     public function getProcedurePhaseNameFromArray(array $statement): string
     {
-        $statementObject = $this->getStatement($statement['id']);
+        // Fast path: large exports feed thousands of statement arrays through here,
+        // so avoid the per-statement getStatement() round-trip when publicStatement
+        // is already present on the array (ES- and JSON-sourced statements have it).
+        if (isset($statement['publicStatement'])) {
+            return $this->getProcedurePhaseName(
+                $statement['phase'] ?? '',
+                StatementInterface::EXTERNAL === $statement['publicStatement']
+            );
+        }
+
+        $statementId = $statement['id'] ?? null;
+        $statementObject = null !== $statementId ? $this->getStatement($statementId) : null;
+
+        if (!$statementObject instanceof Statement) {
+            $this->logger->warning('Statement with id '.($statementId ?? '').' not found.');
+
+            return '';
+        }
 
         return $this->getProcedurePhaseName(
-            $statement['phase'],
+            $statement['phase'] ?? '',
             $statementObject->isSubmittedByCitizen()
         );
     }
@@ -2714,7 +2731,10 @@ class StatementService implements StatementServiceInterface
                 throw new UndefinedPhaseException($phaseKey);
             }
         } catch (UndefinedPhaseException $e) {
-            $this->logger->error($e->getMessage());
+            // warning, not error: legacy statements can carry phase keys no longer
+            // defined in the phase config, which floods the error channel on large
+            // exports/listings without representing an actionable runtime fault.
+            $this->logger->warning($e->getMessage());
         }
 
         return $phaseName;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -16,6 +16,7 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\ManualOriginalStatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementCreatedEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\StatementUpdatedEventInterface;
@@ -2694,12 +2695,16 @@ class StatementService implements StatementServiceInterface
     public function getProcedurePhaseNameFromArray(array $statement): string
     {
         // Fast path: large exports feed thousands of statement arrays through here,
-        // so avoid the per-statement getStatement() round-trip when publicStatement
-        // is already present on the array (ES- and JSON-sourced statements have it).
-        if (isset($statement['publicStatement'])) {
+        // so avoid the per-statement getStatement() round-trip when the submitting
+        // organisation id is already present on the array (ES- and JSON-sourced
+        // statements carry it). A statement is citizen-submitted when it belongs to
+        // the default citizen organisation, mirroring Statement::isSubmittedByCitizen().
+        // Note: publicStatement === EXTERNAL is not equivalent, as organisation
+        // statements submitted via the public view are also flagged EXTERNAL.
+        if (isset($statement['oId'])) {
             return $this->getProcedurePhaseName(
                 $statement['phase'] ?? '',
-                StatementInterface::EXTERNAL === $statement['publicStatement']
+                UserInterface::ANONYMOUS_USER_ORGA_ID === $statement['oId']
             );
         }
 


### PR DESCRIPTION
## Summary

Backport of the phase-resolver performance fix from main (#6185).

Reduces per-statement overhead in `StatementProcedurePhaseResolver` and `StatementService::getProcedurePhaseNameFromArray`, which dominated assessment-table list and export paths when a procedure contained statements with phase keys no longer defined in the phase config.

- Memoize the available phase list and a precomputed `key → ProcedurePhaseVO` map in `StatementProcedurePhaseResolver`; `getProcedurePhaseVO` becomes O(1).
- Skip the per-statement `getStatement($id)` Doctrine round-trip in `getProcedurePhaseNameFromArray` when `publicStatement` is already on the array. Entity-fallback path retained for callers that pass a minimal array.
- Downgrade `logger->error` → `logger->warning` for the "Undefined phase for key" path: legacy phase values caused this to flood the error channel during large exports without representing an actionable runtime fault.

## Ticket

DS-428

## Test plan

- [ ] `tests/backend/core/Statement/Functional/StatementServiceTest.php` passes
- [ ] `tests/backend/core/AssessmentTable/` passes
- [ ] Manually export an assessment table on a procedure carrying legacy phase values; confirm no "Undefined phase" entries appear on the error channel (warning channel is expected)
- [ ] Confirm equivalence with the main PR (#6185)