### PR TITLE
fix(refs: DPLAN-17672): change initial state handling for statements

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -2141,9 +2141,11 @@ export default {
               this.counties.find(el => el.selected)?.value :
               '',
           }
+
           if (this.isNameUsageRequired) {
             initialStatementDefaults.r_useName = '1'
           }
+
           this.applyInitialDefaults(initialStatementDefaults)
         }
       } else {

--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -1202,6 +1202,10 @@ export default {
       return this.unsavedDrafts.includes(this.draftStatementId)
     },
 
+    isNameUsageRequired () {
+      return !this.allowAnonymousStatements && this.formData.r_useName !== '1'
+    },
+
     personalDataFormDefinitions () {
       return this.personalDataFormFields.map(el => {
         this.availableFormComponents[el.name].width = this.availableFormComponents[el.name].width || 'u-1-of-2'
@@ -1257,6 +1261,7 @@ export default {
 
     ...mapMutations('PublicStatement', [
       'addUnsavedDraft',
+      'applyInitialDefaults',
       'clearDraftState',
       'removeStatementProp',
       'removeUnsavedDraft',
@@ -2123,25 +2128,28 @@ export default {
           sessionStorageBegunStatementParsed.r_ident === ''
         ) {
           this.setStatementData(sessionStorageBegunStatementParsed)
+          if (this.isNameUsageRequired) {
+            this.setStatementData({ r_useName: '1' })
+          }
 
           this.$nextTick(() => {
             this.restoreCustomFieldSelections()
           })
         } else {
-          this.setStatementData({
+          const initialStatementDefaults = {
             r_county: this.counties.some(el => el.selected) ?
               this.counties.find(el => el.selected)?.value :
               '',
-          })
+          }
+          if (this.isNameUsageRequired) {
+            initialStatementDefaults.r_useName = '1'
+          }
+          this.applyInitialDefaults(initialStatementDefaults)
         }
       } else {
         this.getDraftStatement(this.draftStatementId)
       }
     })
-
-    if (!this.allowAnonymousStatements && this.formData.r_useName !== '1') {
-      this.setPrivacyPreference({ r_useName: '1' })
-    }
 
     this.$root.$on('updateStatementFormMapData', (data = {}, toggle = true) => {
       this.setStatementData(data)

--- a/client/js/store/statement/PublicStatement.js
+++ b/client/js/store/statement/PublicStatement.js
@@ -184,6 +184,11 @@ const PublicStatementStore = {
       }
     },
 
+    applyInitialDefaults (state, data) {
+      state.statement = { ...state.statement, ...data }
+      state.initForm = JSON.stringify(state.statement)
+    },
+
     removeStatementProp (state, propKey) {
       delete state.statement[propKey]
     },


### PR DESCRIPTION
### Ticket
DPLAN-DPLAN-17672


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

Pre-selected default values (e.g. the pre-selected county) were applied to the statement form via setStatementData, which does not update the initForm baseline. This caused the form to be considered unsaved immediately on open, before the user made any changes, resulting in the wrong processing status being set for new statements.             

A new applyInitialDefaults Vuex mutation is introduced that updates both statement and initForm at the same time, so  the form baseline correctly reflects the applied defaults. Additionally, the r_useName enforcement for non-anonymous procedures was moved inside the fetchCustomFields().then() callback to ensure it runs after async initialization.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
1. Open a procedure as a public user where anonymous statements are not allowed
2. Open the Statement modal without making any changes                                                                           
3. Check if the button that opens the modal does not immediately change its text after opening the modal
4. Fill in a field and check, if the button changes its text now to "Stellungnahme fortsetzen..."

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
