### PR TITLE
fix(ADO-54112): drop stale UNIQUE index on _procedure.customer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/04/Version20260423104500.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/04/Version20260423104500.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260423104500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Drop stale UNIQUE index on _procedure.customer that survived Version20240105113406 '
+            .'on some environments and still enforces a 1:1 procedure-customer relation, '
+            .'causing duplicate-key errors on procedure creation.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $procedureTable = $schema->getTable('_procedure');
+
+        if (!$procedureTable->hasIndex('UNIQ_D1A01D0281398E09')) {
+            return;
+        }
+
+        // FK_D1A01D0281398E09 currently relies on UNIQ_… as its backing index;
+        // MySQL would refuse to drop it without another usable index on `customer`.
+        if (!$procedureTable->hasIndex('IDX_D1A01D0281398E09')) {
+            $this->addSql('CREATE INDEX IDX_D1A01D0281398E09 ON _procedure (customer)');
+        }
+
+        $this->addSql('ALTER TABLE _procedure DROP INDEX UNIQ_D1A01D0281398E09');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->write('Down migration not supported — restoring the unique constraint would fail on customers with multiple procedures.');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}


### PR DESCRIPTION
Refs: ADO 54112

## Problem

Creating a procedure fails on some environments with:

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
'<customer-uuid>' for key 'UNIQ_D1A01D0281398E09'
```

`UNIQ_D1A01D0281398E09` is the leftover unique index on `_procedure.customer` from when the relationship was 1:1. The Procedure entity is now `@ManyToOne`, so multiple procedures per customer should be valid.

## Root cause

`Version20240105113406` (Jan 2024) dropped that index inside a `try { ... } catch (Exception) {}` block. On environments where the drop threw (e.g. the FK still held the index at that moment), the error was swallowed and the unique constraint remained. The later `Version20250409185422` only renamed `fk_...` → `IDX_...` and did not touch a surviving `UNIQ_...`.

## Fix

New migration that, only if `UNIQ_D1A01D0281398E09` still exists:
1. Creates a non-unique `IDX_D1A01D0281398E09` on `customer` so the foreign key has a backing index.
2. Drops `UNIQ_D1A01D0281398E09`.

No FK churn, no moment without FK enforcement. No-op on environments where the Jan-2024 migration already succeeded.

## Test plan

- [ ] `dplan:migrations:diff` shows no drift on `_procedure` after the migration runs
- [ ] On an affected DB: creating a second procedure for the same customer succeeds
- [ ] On a clean DB: migration logs "did not result in any SQL statements" and produces no changes