### PR TITLE
fix(refs DS-489): fix background-color of textarea

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_form.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/objects/_form.scss
@@ -421,6 +421,7 @@ input.disabled {
 
         &-textarea {
             min-height: $element-height; // [1]
+            background:  $dp-color-white;
             border-radius: $form-radius !important;
 
             &[disabled],


### PR DESCRIPTION
### Ticket
[DS-489](https://demoseurope.youtrack.cloud/tickets/DS-489/BOB-SH-ROBOB-Stage-Detailansicht-STN-Notizfeld-ausgegraut-Mittel)

Tailwind sets the `background-color` of textareas to `transparent`, so in a container with gray background, the textarea appears disabled. 

### How to review/test
- Go to a statement detail view and claim the statement
- Scroll down to "Notiz anlegen" and open it
- The textarea should have a white background

### PR Checklist

- [x] Link all relevant tickets

