### PR TITLE
fix login-list cache invalidation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -43,8 +43,8 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
-use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function in_array;
@@ -308,7 +308,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
         ParameterBagInterface $parameterBag,
         Request $request,
     ) {
-        if (!($currentUser->getUser() instanceof AnonymousUser)) {
+        if (!$currentUser->getUser() instanceof AnonymousUser) {
             return $this->redirectToRoute('core_home_loggedin');
         }
 

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -43,7 +43,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
-use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Throwable;
 
@@ -300,7 +300,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     #[DplanPermissions('area_demosplan')]
     #[Route(name: 'DemosPlan_user_login_alternative', path: '/dplan/login', options: ['expose' => true])]
     public function alternativeLogin(
-        CacheInterface $cache,
+        TagAwareCacheInterface $cache,
         CurrentUserInterface $currentUser,
         CustomerService $customerService,
         CustomerOAuthConfigRepository $customerOAuthConfigRepository,
@@ -330,6 +330,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
             $users = $cache->get('login_testuser_list'.$customerKey,
                 function (ItemInterface $item) use ($parameterBag) {
                     $item->expiresAfter(UserRepository::LOGIN_LIST_CACHE_DURATION);
+                    $item->tag([UserRepository::LOGIN_LIST_CACHE_TAG]);
 
                     $testPassword = $parameterBag->get('alternative_login_testuser_defaultpass');
 
@@ -345,6 +346,7 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
         if (true === $parameterBag->get('alternative_login_use_testuser_osi')) {
             $usersOsi = $cache->get('login_testuser_list_osi'.$customerKey, function (ItemInterface $item) {
                 $item->expiresAfter(UserRepository::LOGIN_LIST_CACHE_DURATION);
+                $item->tag([UserRepository::LOGIN_LIST_CACHE_TAG]);
 
                 return $this->userService->getTestUsersOsi($this->globalConfig->getProjectFolder());
             });

--- a/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
@@ -42,7 +42,7 @@ use RuntimeException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
  * @template-extends CoreRepository<User>
@@ -54,8 +54,10 @@ class UserRepository extends CoreRepository implements ArrayInterface, ObjectInt
      */
     final public const LOGIN_LIST_CACHE_DURATION = 43200;
 
+    public const LOGIN_LIST_CACHE_TAG = 'login_list';
+
     public function __construct(
-        private readonly CacheInterface $cache,
+        private readonly TagAwareCacheInterface $cache,
         DqlConditionFactory $dqlConditionFactory,
         ManagerRegistry $registry,
         SortMethodFactory $sortMethodFactory,
@@ -738,7 +740,7 @@ class UserRepository extends CoreRepository implements ArrayInterface, ObjectInt
      */
     private function invalidateCachedLoginList(): void
     {
-        $this->cache->delete(self::LOGIN_LIST_CACHE_DURATION);
+        $this->cache->invalidateTags([self::LOGIN_LIST_CACHE_TAG]);
     }
 
     private function applyCriteriaFilters(array $criteria, QueryBuilder $qb): QueryBuilder


### PR DESCRIPTION
## Summary
- `UserRepository::invalidateCachedLoginList()` was calling `cache->delete(self::LOGIN_LIST_CACHE_DURATION)`, passing the integer `43200` (the TTL) as the cache key. The actual entries are stored under `login_testuser_list{customer}` and `login_testuser_list_osi{customer}`, so the delete was a silent no-op and changes to users took up to 12h to surface on the alternative login page.
- Switch `UserRepository` and `DemosPlanUserAuthenticationController` to `TagAwareCacheInterface`. Tag both write sites with a new `LOGIN_LIST_CACHE_TAG` constant. Replace the broken `delete()` with `invalidateTags()`.

## Test plan
- [ ] After creating a user, the new user appears in the alternative login list on next page load (no 12h wait).
- [ ] After deleting a user, the user is removed from the alternative login list on next page load.
- [ ] `tests/backend/core/User/Functional/UserServiceTest.php` and `tests/backend/core/Security/ApiAuthenticatorTest.php` still pass.