### PR TITLE
fix(refs DPLAN-17692): restore option to create tags

### DIFF
--- a/client/js/components/statement/splitStatement/DpCreateTag.vue
+++ b/client/js/components/statement/splitStatement/DpCreateTag.vue
@@ -24,7 +24,7 @@
     <dp-label
       :text="Translator.trans('topic')"
       for="newTagTopic"
-      class="u-mt-0_25"
+      class="mt-2 mb-0.5"
       required
     />
     <!-- topic select -->

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.15.0",
+    "@demos-europe/demosplan-ui": "0.15.1",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.15.0"
+"@demos-europe/demosplan-ui@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@demos-europe/demosplan-ui@npm:0.15.1"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2868,7 +2868,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/2466a7eeeba7333299085f0e87752df7df6225e34b58838dc5bbb5b3cf77a23574ce9d7b95c3cd07fbd410daeabc3af8361fa1f8d1a4cf24409fa33969ca1c73
+  checksum: 10c0/c44adc83f04f506dcec14f620af693e8a12742b0e997be5c17d13cf8f059b42b03b4e855dfd6b67ea3c440a49acbdeca7d2fa548e1435461800d24e2ab135371
   languageName: node
   linkType: hard
 
@@ -8298,7 +8298,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.15.0"
+    "@demos-europe/demosplan-ui": "npm:0.15.1"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
### Ticket
DPLAN-17692

The actual fix was done in demosplan-ui; here, we just need to bump demosplan-ui, and additionally I fixed the spacing of the label in the tag create form.

### How to review/test
- Go to the "Stellungnahme aufteilen" view
- Create a segment or edit an existing one
- when clicking into the search select ("Schlagwort suchen"), there should be the option "Schlagwort/Thema anlegen..."

### Linked PRs
- [x] Hotfix in demosplan-ui: https://github.com/demos-europe/demosplan-ui/pull/1478

### Tasks
- [x] Wait for demosplan-ui hotfix release
- [x] Update demosplan-ui in demosplan (in this PR)

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
