### PR TITLE
fix(refs DPLAN-17692): restore option to create tags

### DIFF
--- a/client/js/components/statement/splitStatement/DpCreateTag.vue
+++ b/client/js/components/statement/splitStatement/DpCreateTag.vue
@@ -24,7 +24,7 @@
     <dp-label
       :text="Translator.trans('topic')"
       for="newTagTopic"
-      class="u-mt-0_25"
+      class="mt-2 mb-0.5"
       required
     />
     <!-- topic select -->

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.17.0",
+    "@demos-europe/demosplan-ui": "0.17.1",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/tests/backend/core/Logic/Export/DocxExporterOdtTest.php
+++ b/tests/backend/core/Logic/Export/DocxExporterOdtTest.php
@@ -39,6 +39,7 @@ class DocxExporterOdtTest extends UnitTestCase
             $this->createMock(\demosplan\DemosPlanCoreBundle\Logic\FileService::class),
             $this->createMock(\League\Flysystem\FilesystemOperator::class),
             $this->createMock(\DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface::class),
+            $this->createMock(\demosplan\DemosPlanCoreBundle\Services\HTMLSanitizer::class),
             $this->createMock(\Psr\Log\LoggerInterface::class),
             $this->createMock(\demosplan\DemosPlanCoreBundle\Logic\Map\MapService::class),
             $odtHtmlProcessor,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.17.0":
-  version: 0.17.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.17.0"
+"@demos-europe/demosplan-ui@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@demos-europe/demosplan-ui@npm:0.17.1"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2868,7 +2868,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/6e9715a4ee4be2163873824d2f10fbc5f103ae14cf37334dead29717789d27f14b9e5e37ca720fb9604f15fbbd6bf8ec362f83a1549aef167cdf3262ba071b0f
+  checksum: 10c0/7bfb5e69dc56f4f6271104067a842263155d97f2c9891e82a23654ecc4e2e96f3bafdf7511e8ba99eec80dde6d54939aa03636d842cb7247b2d250df3e9782dd
   languageName: node
   linkType: hard
 
@@ -8289,7 +8289,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.17.0"
+    "@demos-europe/demosplan-ui": "npm:0.17.1"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
### Ticket
DPLAN-17692

The actual fix was done in demosplan-ui; here, we just need to bump demosplan-ui, and additionally I fixed the spacing of the label in the tag create form.

### How to review/test
- Go to the "Stellungnahme aufteilen" view
- Create a segment or edit an existing one
- when clicking into the search select ("Schlagwort suchen"), there should be the option "Schlagwort/Thema anlegen..."

### Linked PRs 
- [x] Hotfix in demosplan-ui: https://github.com/demos-europe/demosplan-ui/pull/1479

### Tasks
- [x] Wait for demosplan-ui hotfix release
- [x] Update demosplan-ui in demosplan (in this PR)

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
