### PR TITLE
fix: real CSRF validation in CsrfSubscriber + IP-keyed anon limiter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -2538,8 +2538,7 @@ class DemosPlanStatementController extends BaseController
         path: '/verfahren/{procedureId}/stellungnahmen/beteilugengsimport',
         name: 'DemosPlan_statement_participation_import',
         options: ['expose' => true],
-        methods: [Request::METHOD_POST])
-    ]
+        methods: [Request::METHOD_POST])]
     public function importParticipationStatements(
         FileService $fileService,
         ProcedureService $procedureService,

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -882,7 +882,11 @@ class DemosPlanStatementController extends BaseController
                 throw new Exception('In der aktuellen Phase darf keine Stellungnahme abgegeben werden');
             }
 
-            $limiter = $anonymousStatementLimiter->create($request->getSession()->getId());
+            // Key the limiter on the client IP, matching the pattern used by the
+            // other anonymous-flow limiters (userRegisterLimiter, password recovery).
+            // Trusted proxies must be configured (PROXY_IP) for this to be per-visitor
+            // behind a load balancer.
+            $limiter = $anonymousStatementLimiter->create($request->getClientIp() ?? '');
             $isLoggedIn = $this->currentUser->getUser()->isLoggedIn();
 
             // avoid brute force attacks

--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/CsrfSubscriber.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class CsrfSubscriber implements EventSubscriberInterface
 {
+    public const TOKEN_ID = 'csrf';
+
     public function __construct(
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly MessageBagInterface $messageBag,
@@ -37,28 +39,28 @@ class CsrfSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $tokenId = $request->request->get('_token');
+        // The form field / header carries the token *value*, not its id. The id
+        // is the well-known 'csrf' constant matching the value emitted by
+        // `csrf_token('csrf')` in twig templates.
+        $tokenValue = $request->request->get('_token');
         if ($request->headers->has('x-csrf-token')) {
-            $tokenId = $this->headerSanitizer->sanitizeCsrfToken(
+            $tokenValue = $this->headerSanitizer->sanitizeCsrfToken(
                 $request->headers->get('x-csrf-token')
             );
         }
 
-        if (null === $tokenId) {
+        if (null === $tokenValue || '' === $tokenValue) {
             $this->messageBag->add('dev', 'error.csrf.missing', ['uri' => $request->getRequestUri()]);
             $this->logger->info('CSRF token missing', ['uri' => $request->getRequestUri()]);
 
             return;
         }
 
-        $token = $this->csrfTokenManager->getToken($tokenId);
-
-        if ($token instanceof CsrfToken && $this->csrfTokenManager->isTokenValid($token)) {
-            // all clear, token is set and valid
+        if ($this->csrfTokenManager->isTokenValid(new CsrfToken(self::TOKEN_ID, $tokenValue))) {
             return;
         }
 
-        $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri(), 'token' => $tokenId]);
+        $this->logger->info('CSRF token invalid', ['uri' => $request->getRequestUri()]);
     }
 
     public static function getSubscribedEvents(): array

--- a/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
+++ b/tests/backend/core/Core/Functional/CsrfSubscriberTest.php
@@ -46,33 +46,25 @@ class CsrfSubscriberTest extends FunctionalTestCase
      */
     public function testOnKernelRequestWithValidToken($method): void
     {
-        // Set up a valid token
-        $validToken = new CsrfToken('token_id', 'valid_token');
-        $this->csrfTokenManager->expects($this->once())
-            ->method('getToken')
-            ->with('valid_token')
-            ->willReturn($validToken);
-
+        // The subscriber must NOT lazily look up tokens by client-supplied id —
+        // that was the original bug. It must validate isTokenValid directly
+        // against the well-known CsrfSubscriber::TOKEN_ID with the client value.
+        $this->csrfTokenManager->expects($this->never())->method('getToken');
         $this->csrfTokenManager->expects($this->once())
             ->method('isTokenValid')
-            ->with($validToken)
+            ->with($this->callback(fn (CsrfToken $t) => CsrfSubscriber::TOKEN_ID === $t->getId()
+                && 'valid_token' === $t->getValue()))
             ->willReturn(true);
 
-        // Create a subscriber with the mocked dependencies
         $subscriber = new CsrfSubscriber($this->csrfTokenManager, $this->messageBag, $this->logger, $this->headerSanitizer);
 
-        // Create a request event with a request and a valid token
         $request = new Request([], ['_token' => 'valid_token'], [], [], [], ['REQUEST_URI' => '/some-uri', 'REQUEST_METHOD' => $method]);
         $event = new RequestEvent($this->createMock(KernelInterface::class), $request, 1);
 
-        // Call the onKernelRequest method
-        $subscriber->onKernelRequest($event);
-
-        // Assert that no messages were added to the message bag
         $this->messageBag->expects($this->never())->method('add');
-
-        // Assert that the logger was not called for a valid token
         $this->logger->expects($this->never())->method('info');
+
+        $subscriber->onKernelRequest($event);
     }
 
     /**

--- a/tests/backend/core/Core/Unit/EventSubscriber/CsrfSubscriberTest.php
+++ b/tests/backend/core/Core/Unit/EventSubscriber/CsrfSubscriberTest.php
@@ -27,10 +27,9 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 class CsrfSubscriberTest extends TestCase
 {
     private const TEST_URL = '/test';
-    private const VALID_TOKEN_ID = 'valid-token-1234';
+    private const VALID_TOKEN_VALUE = 'valid-token-1234';
     private const MALICIOUS_TOKEN = "valid-token-1234\r\nX-Malicious: exploit";
     private const SCRIPT_TOKEN = 'valid-token-<script>alert(1)</script>';
-    private const TOKEN_VALUE = 'token-value';
 
     private CsrfSubscriber $subscriber;
     private MockObject $csrfTokenManager;
@@ -63,8 +62,8 @@ class CsrfSubscriberTest extends TestCase
         $requestEvent = $this->createMock(RequestEvent::class);
         $requestEvent->method('getRequest')->willReturn($request);
 
-        // Expect no interactions with token manager
         $this->csrfTokenManager->expects($this->never())->method('getToken');
+        $this->csrfTokenManager->expects($this->never())->method('isTokenValid');
 
         $this->subscriber->onKernelRequest($requestEvent);
     }
@@ -75,31 +74,31 @@ class CsrfSubscriberTest extends TestCase
     public function testStandardCsrfToken(): void
     {
         $request = Request::create(self::TEST_URL, 'POST');
-        $request->headers->set('x-csrf-token', self::VALID_TOKEN_ID);
+        $request->headers->set('x-csrf-token', self::VALID_TOKEN_VALUE);
 
         $requestEvent = $this->createMock(RequestEvent::class);
         $requestEvent->method('getRequest')->willReturn($request);
 
-        // Mock a valid CSRF token
-        $token = new CsrfToken(self::VALID_TOKEN_ID, self::TOKEN_VALUE);
-        $this->csrfTokenManager->method('getToken')->with(self::VALID_TOKEN_ID)->willReturn($token);
-        $this->csrfTokenManager->method('isTokenValid')->with($token)->willReturn(true);
+        $this->csrfTokenManager
+            ->method('isTokenValid')
+            ->with($this->callback(fn (CsrfToken $t) => CsrfSubscriber::TOKEN_ID === $t->getId()
+                && self::VALID_TOKEN_VALUE === $t->getValue()))
+            ->willReturn(true);
 
-        // No messages should be added to message bag
         $this->messageBag->expects($this->never())->method('add');
 
         $this->subscriber->onKernelRequest($requestEvent);
     }
 
     /**
-     * Test that malicious CSRF token is properly sanitized.
+     * Test that a malicious CSRF token is properly sanitized before validation.
      */
     public function testMaliciousCsrfToken(): void
     {
         $sanitizedToken = $this->headerSanitizer->sanitizeCsrfToken(self::MALICIOUS_TOKEN);
 
-        // Make sure sanitization actually removed the malicious part
-        $this->assertEquals(self::VALID_TOKEN_ID, $sanitizedToken);
+        // Sanity-check that sanitization actually removed the malicious part.
+        $this->assertEquals(self::VALID_TOKEN_VALUE, $sanitizedToken);
 
         $request = Request::create(self::TEST_URL, 'POST');
         $request->headers->set('x-csrf-token', self::MALICIOUS_TOKEN);
@@ -107,12 +106,12 @@ class CsrfSubscriberTest extends TestCase
         $requestEvent = $this->createMock(RequestEvent::class);
         $requestEvent->method('getRequest')->willReturn($request);
 
-        // Mock a valid CSRF token
-        $token = new CsrfToken($sanitizedToken, self::TOKEN_VALUE);
-        $this->csrfTokenManager->method('getToken')->with($sanitizedToken)->willReturn($token);
-        $this->csrfTokenManager->method('isTokenValid')->with($token)->willReturn(true);
+        $this->csrfTokenManager
+            ->method('isTokenValid')
+            ->with($this->callback(fn (CsrfToken $t) => CsrfSubscriber::TOKEN_ID === $t->getId()
+                && $sanitizedToken === $t->getValue()))
+            ->willReturn(true);
 
-        // No messages should be added to message bag
         $this->messageBag->expects($this->never())->method('add');
 
         $this->subscriber->onKernelRequest($requestEvent);
@@ -131,13 +130,42 @@ class CsrfSubscriberTest extends TestCase
         $requestEvent = $this->createMock(RequestEvent::class);
         $requestEvent->method('getRequest')->willReturn($request);
 
-        // Mock a valid CSRF token
-        $token = new CsrfToken($sanitizedToken, self::TOKEN_VALUE);
-        $this->csrfTokenManager->method('getToken')->with($sanitizedToken)->willReturn($token);
-        $this->csrfTokenManager->method('isTokenValid')->with($token)->willReturn(true);
+        $this->csrfTokenManager
+            ->method('isTokenValid')
+            ->with($this->callback(fn (CsrfToken $t) => CsrfSubscriber::TOKEN_ID === $t->getId()
+                && $sanitizedToken === $t->getValue()))
+            ->willReturn(true);
 
-        // No messages should be added to message bag
         $this->messageBag->expects($this->never())->method('add');
+
+        $this->subscriber->onKernelRequest($requestEvent);
+    }
+
+    /**
+     * Regression test for the bug where any non-empty client-supplied string
+     * was accepted: the subscriber used to call getToken($clientValue), which
+     * lazily creates a token under that id and then validates it against
+     * itself. The fix wires isTokenValid directly with the well-known id.
+     */
+    public function testInvalidTokenIsRejectedAndGetTokenIsNeverCalled(): void
+    {
+        $request = Request::create(self::TEST_URL, 'POST', ['_token' => 'attacker-supplied-value']);
+
+        $requestEvent = $this->createMock(RequestEvent::class);
+        $requestEvent->method('getRequest')->willReturn($request);
+
+        $this->csrfTokenManager->expects($this->never())->method('getToken');
+        $this->csrfTokenManager
+            ->expects($this->once())
+            ->method('isTokenValid')
+            ->with($this->callback(fn (CsrfToken $t) => CsrfSubscriber::TOKEN_ID === $t->getId()
+                && 'attacker-supplied-value' === $t->getValue()))
+            ->willReturn(false);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('info')
+            ->with('CSRF token invalid', ['uri' => self::TEST_URL]);
 
         $this->subscriber->onKernelRequest($requestEvent);
     }


### PR DESCRIPTION
## Summary
- `CsrfSubscriber` was treating the submitted token *value* as its *id* and calling `getToken($value)` followed by `isTokenValid()` on the just-fetched token, which always returned true. The central CSRF guard performed no real validation. Now compares the submitted value against the well-known `'csrf'` token id (matching the value emitted by `csrf_token('csrf')` in twig templates), so invalid tokens correctly log "invalid".
- Anonymous statement submission's rate limiter was keyed on `$request->getSession()->getId()`. Switched to `$request->getClientIp()`, matching `userRegisterLimiter` and the password-recovery limiter. Requires `PROXY_IP` to be correctly configured behind the load balancer for per-visitor behaviour — already a deploy-time invariant relied on by the other limiters.

## Notes for reviewers
- Real CSRF blocking still happens at the controller level (`isCsrfTokenValid` in `registerCitizen`, `createOrgaRegister`) and at the firewall (`CsrfTokenBadge` in `LoginFormAuthenticator`). The subscriber is defense-in-depth logging only — that part is unchanged.
- After this change, `dev.log` will start surfacing "CSRF token invalid" entries on admin form posts whose `_token` field carries a Symfony form-component CSRF (different token id, e.g. `boilerplate`, `procedure`). The form component re-validates correctly with the right id and accepts the request — the log entry is noise, not a functional break. Worth knowing if you grep dev logs.

## Test plan
- [ ] POST a form (e.g. login, public statement submit) with a valid `csrf_token('csrf')` — request passes through.
- [ ] POST the same form with a tampered or missing `_token` / `x-csrf-token` — `dev.log` records "CSRF token invalid" or "CSRF token missing".
- [ ] Verify the controller-level CSRF checks still block on bad tokens (citizen registration, orga registration, login).
- [ ] Hit `/verfahren/{procedure}/stellungnahmen/public/neu/ajax` more than `RATELIMIT_ANONYMOUS_STATEMENT_LIMIT` times from the same IP — first N pass, then HTTP 429.
- [ ] On stage, confirm `PROXY_IP` is set to the LB CIDR (smoke: register two accounts from two different external IPs within a minute; both should succeed).