### PR TITLE
feat(DPLAN-17695): PiiAwareLogger keeps personal data out of file logs

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -2,6 +2,7 @@ monolog:
     use_microseconds: false
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - pii # Redacted reference lines from PiiAwareLogger; full records live in the pii_log table
 
 when@dev:
     monolog:

--- a/config/services_repositories.yml
+++ b/config/services_repositories.yml
@@ -24,6 +24,9 @@ services:
     demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository:
         $entityClass: 'demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl'
 
+    demosplan\DemosPlanCoreBundle\Repository\PersonalDataLogEntryRepository:
+        $entityClass: 'demosplan\DemosPlanCoreBundle\Entity\PersonalDataLogEntry'
+
     DemosEurope\DemosplanAddon\Contracts\Repositories\ProcedurePhaseRepositoryInterface: '@demosplan\DemosPlanCoreBundle\Repository\ProcedurePhaseRepository'
 
     DemosEurope\DemosplanAddon\Contracts\Repositories\GisLayerCategoryRepositoryInterface: '@demosplan\DemosPlanCoreBundle\Repository\GisLayerCategoryRepository'

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/04/Version20260428120000.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/04/Version20260428120000.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260428120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pii_log table backing PiiAwareLogger: full PII-bearing log records '
+            .'are persisted here while only a UUID + content hash + non-PII context are emitted '
+            .'to the filesystem log.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('
+            CREATE TABLE pii_log (
+                id CHAR(36) NOT NULL PRIMARY KEY,
+                created DATETIME NOT NULL,
+                level SMALLINT NOT NULL,
+                level_name VARCHAR(16) NOT NULL,
+                channel VARCHAR(64) NOT NULL,
+                message LONGTEXT NOT NULL,
+                pii_context LONGTEXT NULL,
+                non_pii_context LONGTEXT NULL,
+                content_hash CHAR(64) NOT NULL,
+                request_id VARCHAR(32) NULL,
+                procedure_id CHAR(36) NULL,
+                orga_id CHAR(36) NULL,
+                source_context VARCHAR(8) NOT NULL,
+
+                INDEX idx_pii_created (created),
+                INDEX idx_pii_hash (content_hash),
+                INDEX idx_pii_procedure (procedure_id),
+                INDEX idx_pii_orga (orga_id),
+                INDEX idx_pii_request (request_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('DROP TABLE pii_log');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/PersonalDataLogEntry.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/PersonalDataLogEntry.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Entity;
+
+use DateTime;
+use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * Captures log statements that contain personal data: the full record (incl. PII)
+ * is stored here; only a UUID + content hash + non-PII context is emitted to the
+ * filesystem log via {@see \demosplan\DemosPlanCoreBundle\Logger\PiiAwareLogger}.
+ *
+ * Sister mechanism to {@see PersonalDataAuditLog}, which captures *changes to*
+ * personal-data entities; this captures *log lines about* personal data.
+ *
+ * @ORM\Table(
+ *     name="pii_log",
+ *     indexes={
+ *
+ *         @ORM\Index(name="idx_pii_created", columns={"created"}),
+ *         @ORM\Index(name="idx_pii_hash", columns={"content_hash"}),
+ *         @ORM\Index(name="idx_pii_procedure", columns={"procedure_id"}),
+ *         @ORM\Index(name="idx_pii_orga", columns={"orga_id"}),
+ *         @ORM\Index(name="idx_pii_request", columns={"request_id"})
+ *     }
+ * )
+ *
+ * @ORM\Entity(repositoryClass="demosplan\DemosPlanCoreBundle\Repository\PersonalDataLogEntryRepository")
+ */
+class PersonalDataLogEntry extends CoreEntity implements UuidEntityInterface
+{
+    final public const CONTEXT_WEB = 'web';
+    final public const CONTEXT_CLI = 'cli';
+
+    /**
+     * @ORM\Column(type="string", length=36, options={"fixed":true})
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     *
+     * @ORM\CustomIdGenerator(class="\demosplan\DemosPlanCoreBundle\Doctrine\Generator\UuidV4Generator")
+     */
+    protected ?string $id = null;
+
+    /**
+     * @Gedmo\Timestampable(on="create")
+     *
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    protected DateTime $created;
+
+    /**
+     * PSR-3 / Monolog level integer.
+     *
+     * @ORM\Column(type="smallint", nullable=false)
+     */
+    protected int $level;
+
+    /**
+     * Lower-case PSR-3 level name (e.g. 'info', 'warning'); duplicated for query convenience.
+     *
+     * @ORM\Column(type="string", length=16, nullable=false)
+     */
+    protected string $levelName;
+
+    /**
+     * @ORM\Column(type="string", length=64, nullable=false)
+     */
+    protected string $channel;
+
+    /**
+     * Log message with PSR-3 placeholders interpolated.
+     *
+     * @ORM\Column(type="text", nullable=false)
+     */
+    protected string $message;
+
+    /**
+     * Confidential payload (anything the caller passed under context['pii']),
+     * JSON-encoded. NEVER written to the file log.
+     *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    protected ?string $piiContext = null;
+
+    /**
+     * Non-PII context (everything else from the call's $context array, minus
+     * the keys consumed by the logger), JSON-encoded. Mirrors what the file log
+     * line carries — useful when reconstructing what the user/operator saw.
+     *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    protected ?string $nonPiiContext = null;
+
+    /**
+     * SHA-256 hex over canonical JSON of (channel + level + message + piiContext).
+     * Indexed but not unique — identical messages legitimately recur.
+     *
+     * @ORM\Column(type="string", length=64, nullable=false, options={"fixed":true})
+     */
+    protected string $contentHash;
+
+    /**
+     * Correlation id from {@see \demosplan\DemosPlanCoreBundle\Monolog\Processor\RequestIdProcessor}.
+     *
+     * @ORM\Column(type="string", length=32, nullable=true)
+     */
+    protected ?string $requestId = null;
+
+    /**
+     * @ORM\Column(type="string", length=36, options={"fixed":true}, nullable=true)
+     */
+    protected ?string $procedureId = null;
+
+    /**
+     * @ORM\Column(type="string", length=36, options={"fixed":true}, nullable=true)
+     */
+    protected ?string $orgaId = null;
+
+    /**
+     * Source context: web, cli.
+     *
+     * @ORM\Column(type="string", length=8, nullable=false)
+     */
+    protected string $sourceContext;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCreated(): DateTime
+    {
+        return $this->created;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function setLevel(int $level): self
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
+    public function getLevelName(): string
+    {
+        return $this->levelName;
+    }
+
+    public function setLevelName(string $levelName): self
+    {
+        $this->levelName = $levelName;
+
+        return $this;
+    }
+
+    public function getChannel(): string
+    {
+        return $this->channel;
+    }
+
+    public function setChannel(string $channel): self
+    {
+        $this->channel = $channel;
+
+        return $this;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): self
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    public function getPiiContext(): ?string
+    {
+        return $this->piiContext;
+    }
+
+    public function setPiiContext(?string $piiContext): self
+    {
+        $this->piiContext = $piiContext;
+
+        return $this;
+    }
+
+    public function getNonPiiContext(): ?string
+    {
+        return $this->nonPiiContext;
+    }
+
+    public function setNonPiiContext(?string $nonPiiContext): self
+    {
+        $this->nonPiiContext = $nonPiiContext;
+
+        return $this;
+    }
+
+    public function getContentHash(): string
+    {
+        return $this->contentHash;
+    }
+
+    public function setContentHash(string $contentHash): self
+    {
+        $this->contentHash = $contentHash;
+
+        return $this;
+    }
+
+    public function getRequestId(): ?string
+    {
+        return $this->requestId;
+    }
+
+    public function setRequestId(?string $requestId): self
+    {
+        $this->requestId = $requestId;
+
+        return $this;
+    }
+
+    public function getProcedureId(): ?string
+    {
+        return $this->procedureId;
+    }
+
+    public function setProcedureId(?string $procedureId): self
+    {
+        $this->procedureId = $procedureId;
+
+        return $this;
+    }
+
+    public function getOrgaId(): ?string
+    {
+        return $this->orgaId;
+    }
+
+    public function setOrgaId(?string $orgaId): self
+    {
+        $this->orgaId = $orgaId;
+
+        return $this;
+    }
+
+    public function getSourceContext(): string
+    {
+        return $this->sourceContext;
+    }
+
+    public function setSourceContext(string $sourceContext): self
+    {
+        $this->sourceContext = $sourceContext;
+
+        return $this;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logger/PiiAwareLogger.php
+++ b/demosplan/DemosPlanCoreBundle/Logger/PiiAwareLogger.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logger;
+
+use DateTimeImmutable;
+use DemosEurope\DemosplanAddon\Contracts\CurrentContextProviderInterface;
+use demosplan\DemosPlanCoreBundle\Entity\PersonalDataLogEntry;
+use Doctrine\DBAL\Exception as DBALException;
+use JsonException;
+use Monolog\Level;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Stringable;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Throwable;
+
+/**
+ * PSR-3 logger that persists the full record (incl. PII) to the {@see PersonalDataLogEntry}
+ * table and forwards only a redacted reference line (UUID + content hash + non-PII
+ * context) to the decorated channel logger.
+ *
+ * Inject **explicitly** at the call site that needs PII handling — this is not a
+ * drop-in replacement for the autowired application logger.
+ *
+ * Recognised $context keys:
+ *  - 'pii'         array<string,mixed>  confidential payload — written to DB only
+ *  - 'procedureId' ?string              overrides auto-resolution from request
+ *  - 'orgaId'      ?string              overrides auto-resolution from token
+ *  - any other key                      treated as non-PII; forwarded to file log
+ *
+ * Example:
+ *  $piiLogger->info('User logged in', [
+ *      'pii'    => ['email' => $email, 'ip' => $ip],
+ *      'action' => 'login',
+ *      'outcome'=> 'success',
+ *  ]);
+ *
+ * Failure mode: on DBAL exception the call is swallowed (logging must not break
+ * business flows) and a redacted WARNING is forwarded to the decorated logger
+ * so operators can see something happened without exposing PII.
+ */
+class PiiAwareLogger extends AbstractLogger
+{
+    private const CONTEXT_KEY_PII = 'pii';
+    private const CONTEXT_KEY_PROCEDURE = 'procedureId';
+    private const CONTEXT_KEY_ORGA = 'orgaId';
+
+    private const DEFAULT_CHANNEL = 'pii';
+
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.pii')]
+        private readonly LoggerInterface $decoratedLogger,
+        private readonly PiiLogWriter $writer,
+        private readonly CurrentContextProviderInterface $contextProvider,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @param mixed                $level   PSR-3 string or Monolog int/Level
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $monologLevel = $this->toMonologLevel($level);
+        $messageString = (string) $message;
+
+        $piiContext = $this->extractPii($context);
+        $procedureOverride = $this->extractScalar($context, self::CONTEXT_KEY_PROCEDURE);
+        $orgaOverride = $this->extractScalar($context, self::CONTEXT_KEY_ORGA);
+        $nonPiiContext = $context; // residue after extracts
+
+        $piiContextJson = $this->encodeJson($piiContext);
+        $nonPiiContextJson = $this->encodeJson($nonPiiContext);
+
+        $contentHash = $this->computeHash($monologLevel->value, $messageString, $piiContextJson);
+
+        $record = new PiiLogRecord(
+            createdAt: new DateTimeImmutable(),
+            level: $monologLevel->value,
+            levelName: strtolower($monologLevel->getName()),
+            channel: self::DEFAULT_CHANNEL,
+            message: $messageString,
+            piiContextJson: $piiContextJson,
+            nonPiiContextJson: $nonPiiContextJson,
+            contentHash: $contentHash,
+            requestId: $this->resolveRequestId($this->requestStack->getCurrentRequest()),
+            procedureId: $procedureOverride ?? $this->resolveProcedureId(),
+            orgaId: $orgaOverride ?? $this->resolveOrgaId(),
+            sourceContext: $this->resolveSourceContext(),
+        );
+
+        try {
+            $rowId = $this->writer->write($record);
+        } catch (DBALException) {
+            $this->decoratedLogger->warning(
+                '[pii WRITE_FAILED] hash={hash}',
+                ['hash' => substr($contentHash, 0, 16)] + $nonPiiContext,
+            );
+
+            return;
+        }
+
+        $this->decoratedLogger->log(
+            $monologLevel->toPsrLogLevel(),
+            '[pii ref={ref} hash={hash}]',
+            ['ref' => $rowId, 'hash' => substr($contentHash, 0, 16)] + $nonPiiContext,
+        );
+    }
+
+    private function toMonologLevel(mixed $level): Level
+    {
+        if ($level instanceof Level) {
+            return $level;
+        }
+        if (is_int($level)) {
+            return Level::tryFrom($level) ?? Level::Info;
+        }
+        if (is_string($level)) {
+            return match (strtolower($level)) {
+                LogLevel::EMERGENCY => Level::Emergency,
+                LogLevel::ALERT     => Level::Alert,
+                LogLevel::CRITICAL  => Level::Critical,
+                LogLevel::ERROR     => Level::Error,
+                LogLevel::WARNING   => Level::Warning,
+                LogLevel::NOTICE    => Level::Notice,
+                LogLevel::DEBUG     => Level::Debug,
+                default             => Level::Info,
+            };
+        }
+
+        return Level::Info;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>|null
+     */
+    private function extractPii(array &$context): ?array
+    {
+        if (!array_key_exists(self::CONTEXT_KEY_PII, $context)) {
+            return null;
+        }
+        $value = $context[self::CONTEXT_KEY_PII];
+        unset($context[self::CONTEXT_KEY_PII]);
+
+        return is_array($value) ? $value : null;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function extractScalar(array &$context, string $key): ?string
+    {
+        if (!array_key_exists($key, $context)) {
+            return null;
+        }
+        $value = $context[$key];
+        unset($context[$key]);
+
+        return is_scalar($value) ? (string) $value : null;
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     */
+    private function encodeJson(?array $payload): ?string
+    {
+        if (null === $payload || [] === $payload) {
+            return null;
+        }
+        try {
+            return json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+        } catch (JsonException) {
+            return json_encode(['__pii_encode_error' => true], JSON_PARTIAL_OUTPUT_ON_ERROR) ?: null;
+        }
+    }
+
+    private function computeHash(int $level, string $message, ?string $piiJson): string
+    {
+        return hash('sha256', self::DEFAULT_CHANNEL."\0".$level."\0".$message."\0".($piiJson ?? ''));
+    }
+
+    private function resolveRequestId(?Request $request): ?string
+    {
+        if (!$request instanceof Request) {
+            return null;
+        }
+        $rid = $request->attributes->get('request_id');
+
+        return is_string($rid) ? $rid : null;
+    }
+
+    private function resolveProcedureId(): ?string
+    {
+        try {
+            return $this->contextProvider->getCurrentProcedure()?->getId();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function resolveOrgaId(): ?string
+    {
+        try {
+            $user = $this->contextProvider->getCurrentUser();
+        } catch (Throwable) {
+            return null;
+        }
+        if (method_exists($user, 'getOrganisationId')) {
+            $id = $user->getOrganisationId();
+
+            return is_string($id) ? $id : null;
+        }
+
+        return null;
+    }
+
+    private function resolveSourceContext(): string
+    {
+        return 'cli' === PHP_SAPI ? PersonalDataLogEntry::CONTEXT_CLI : PersonalDataLogEntry::CONTEXT_WEB;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logger/PiiAwareLogger.php
+++ b/demosplan/DemosPlanCoreBundle/Logger/PiiAwareLogger.php
@@ -71,7 +71,6 @@ class PiiAwareLogger extends AbstractLogger
 
     /**
      * @param mixed                $level   PSR-3 string or Monolog int/Level
-     * @param string|Stringable    $message
      * @param array<string, mixed> $context
      */
     public function log($level, string|Stringable $message, array $context = []): void

--- a/demosplan/DemosPlanCoreBundle/Logger/PiiLogRecord.php
+++ b/demosplan/DemosPlanCoreBundle/Logger/PiiLogRecord.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logger;
+
+use DateTimeImmutable;
+
+/**
+ * Frozen DTO carrying everything {@see PiiLogWriter} needs to insert one row.
+ *
+ * Built by {@see PiiAwareLogger} from the PSR-3 call arguments + auto-resolved
+ * context (current user, current procedure, request id, source context).
+ */
+final readonly class PiiLogRecord
+{
+    public function __construct(
+        public DateTimeImmutable $createdAt,
+        public int $level,
+        public string $levelName,
+        public string $channel,
+        public string $message,
+        public ?string $piiContextJson,
+        public ?string $nonPiiContextJson,
+        public string $contentHash,
+        public ?string $requestId,
+        public ?string $procedureId,
+        public ?string $orgaId,
+        public string $sourceContext,
+    ) {
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logger/PiiLogWriter.php
+++ b/demosplan/DemosPlanCoreBundle/Logger/PiiLogWriter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Writes a {@see PiiLogRecord} to the `pii_log` table via DBAL.
+ *
+ * Separated from {@see PiiAwareLogger} so the logger can mock the writer in unit
+ * tests and so the writer can be reused (e.g. by a future async/messenger path)
+ * without dragging in a logger dependency.
+ *
+ * @noinspection PhpClassCanBeReadonlyInspection — PHPUnit cannot mock readonly classes
+ */
+class PiiLogWriter
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return string The generated row UUID
+     *
+     * @throws DBALException on insert failure (caller is responsible for fallback)
+     */
+    public function write(PiiLogRecord $record): string
+    {
+        $id = Uuid::uuid4()->toString();
+
+        $this->connection->beginTransaction();
+        try {
+            $this->connection->insert('pii_log', [
+                'id'              => $id,
+                'created'         => $record->createdAt->format('Y-m-d H:i:s'),
+                'level'           => $record->level,
+                'level_name'      => $record->levelName,
+                'channel'         => $record->channel,
+                'message'         => $record->message,
+                'pii_context'     => $record->piiContextJson,
+                'non_pii_context' => $record->nonPiiContextJson,
+                'content_hash'    => $record->contentHash,
+                'request_id'      => $record->requestId,
+                'procedure_id'    => $record->procedureId,
+                'orga_id'         => $record->orgaId,
+                'source_context'  => $record->sourceContext,
+            ]);
+            $this->connection->commit();
+        } catch (DBALException $e) {
+            $this->connection->rollBack();
+
+            throw $e;
+        }
+
+        return $id;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Repository/PersonalDataLogEntryRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/PersonalDataLogEntryRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Repository;
+
+use DateTime;
+use demosplan\DemosPlanCoreBundle\Entity\PersonalDataLogEntry;
+
+/**
+ * @template-extends CoreRepository<PersonalDataLogEntry>
+ */
+class PersonalDataLogEntryRepository extends CoreRepository
+{
+    private const DEFAULT_LIMIT = 1000;
+
+    /**
+     * @return array<int, PersonalDataLogEntry>
+     */
+    public function findByContentHash(string $hash, int $limit = self::DEFAULT_LIMIT): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.contentHash = :hash')
+            ->setParameter('hash', $hash)
+            ->orderBy('p.created', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array<int, PersonalDataLogEntry>
+     */
+    public function findByProcedureId(string $procedureId, int $limit = self::DEFAULT_LIMIT): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.procedureId = :procedureId')
+            ->setParameter('procedureId', $procedureId)
+            ->orderBy('p.created', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array<int, PersonalDataLogEntry>
+     */
+    public function findByOrgaId(string $orgaId, int $limit = self::DEFAULT_LIMIT): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.orgaId = :orgaId')
+            ->setParameter('orgaId', $orgaId)
+            ->orderBy('p.created', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array<int, PersonalDataLogEntry>
+     */
+    public function findByRequestId(string $requestId): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.requestId = :requestId')
+            ->setParameter('requestId', $requestId)
+            ->orderBy('p.created', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array<int, PersonalDataLogEntry>
+     */
+    public function findInRange(DateTime $from, DateTime $to, int $limit = self::DEFAULT_LIMIT): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.created BETWEEN :from AND :to')
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->orderBy('p.created', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
+++ b/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -277,7 +278,7 @@ class PiiAwareLoggerTest extends TestCase
     /** @return callable(): PiiLogRecord */
     private function captureWrittenRecord(): callable
     {
-        $holder = new \stdClass();
+        $holder = new stdClass();
         $holder->record = null;
 
         $this->writer

--- a/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
+++ b/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
@@ -225,6 +225,7 @@ class PiiAwareLoggerTest extends TestCase
 
             public function eraseCredentials(): void
             {
+                // No transient credentials held by this stub; required by Symfony's UserInterface.
             }
 
             public function getUserIdentifier(): string
@@ -276,20 +277,22 @@ class PiiAwareLoggerTest extends TestCase
     /** @return callable(): PiiLogRecord */
     private function captureWrittenRecord(): callable
     {
-        $captured = null;
+        $holder = new \stdClass();
+        $holder->record = null;
+
         $this->writer
             ->expects(self::once())
             ->method('write')
-            ->willReturnCallback(static function (PiiLogRecord $record) use (&$captured): string {
-                $captured = $record;
+            ->willReturnCallback(static function (PiiLogRecord $record) use ($holder): string {
+                $holder->record = $record;
 
                 return 'row-id';
             });
 
-        return static function () use (&$captured): PiiLogRecord {
-            self::assertInstanceOf(PiiLogRecord::class, $captured);
+        return static function () use ($holder): PiiLogRecord {
+            self::assertInstanceOf(PiiLogRecord::class, $holder->record);
 
-            return $captured;
+            return $holder->record;
         };
     }
 }

--- a/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
+++ b/tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Unit\Logger;
+
+use DemosEurope\DemosplanAddon\Contracts\CurrentContextProviderInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use demosplan\DemosPlanCoreBundle\Logger\PiiAwareLogger;
+use demosplan\DemosPlanCoreBundle\Logger\PiiLogRecord;
+use demosplan\DemosPlanCoreBundle\Logger\PiiLogWriter;
+use Doctrine\DBAL\Exception as DBALException;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @group UnitTest
+ */
+class PiiAwareLoggerTest extends TestCase
+{
+    private LoggerInterface&MockObject $decoratedLogger;
+    private PiiLogWriter&MockObject $writer;
+    private CurrentContextProviderInterface&MockObject $contextProvider;
+    private RequestStack $requestStack;
+    private PiiAwareLogger $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->decoratedLogger = $this->createMock(LoggerInterface::class);
+        $this->writer = $this->createMock(PiiLogWriter::class);
+        $this->contextProvider = $this->createMock(CurrentContextProviderInterface::class);
+        $this->contextProvider->method('getCurrentProcedure')->willReturn(null);
+        $this->contextProvider->method('getCurrentUser')->willThrowException(new Exception('no user'));
+        $this->requestStack = new RequestStack();
+
+        $this->sut = new PiiAwareLogger(
+            $this->decoratedLogger,
+            $this->writer,
+            $this->contextProvider,
+            $this->requestStack,
+        );
+    }
+
+    public function testWritesFullPayloadToWriterAndForwardsRedactedLine(): void
+    {
+        $captured = $this->captureWrittenRecord();
+
+        $this->decoratedLogger
+            ->expects(self::once())
+            ->method('log')
+            ->with(
+                LogLevel::INFO,
+                self::stringContains('[pii ref={ref} hash={hash}]'),
+                self::callback(static function (array $context): bool {
+                    self::assertArrayHasKey('ref', $context);
+                    self::assertArrayHasKey('hash', $context);
+                    self::assertArrayHasKey('action', $context);
+                    self::assertSame('login', $context['action']);
+                    self::assertArrayNotHasKey('pii', $context);
+                    self::assertArrayNotHasKey('email', $context);
+
+                    foreach ($context as $value) {
+                        if (is_string($value)) {
+                            self::assertStringNotContainsString('user@example.com', $value);
+                        }
+                    }
+
+                    return true;
+                }),
+            );
+
+        $this->sut->info('User logged in', [
+            'pii'    => ['email' => 'user@example.com', 'ip' => '203.0.113.5'],
+            'action' => 'login',
+        ]);
+
+        $record = $captured();
+        self::assertNotNull($record->piiContextJson);
+        self::assertStringContainsString('user@example.com', $record->piiContextJson);
+        self::assertNotNull($record->nonPiiContextJson);
+        self::assertStringContainsString('"action":"login"', $record->nonPiiContextJson);
+        self::assertStringNotContainsString('user@example.com', $record->nonPiiContextJson);
+        self::assertSame('User logged in', $record->message);
+        self::assertSame('pii', $record->channel);
+    }
+
+    public function testHashStableForIdenticalInputs(): void
+    {
+        $hashes = [];
+        $this->writer->method('write')->willReturnCallback(static function (PiiLogRecord $r) use (&$hashes): string {
+            $hashes[] = $r->contentHash;
+
+            return 'row-id';
+        });
+        $this->decoratedLogger->method('log');
+
+        $this->sut->warning('msg', ['pii' => ['email' => 'a@b.c'], 'action' => 'x']);
+        $this->sut->warning('msg', ['pii' => ['email' => 'a@b.c'], 'action' => 'x']);
+
+        self::assertCount(2, $hashes);
+        self::assertSame($hashes[0], $hashes[1]);
+        self::assertSame(64, strlen($hashes[0]));
+    }
+
+    public function testHashDiffersOnDifferentPii(): void
+    {
+        $hashes = [];
+        $this->writer->method('write')->willReturnCallback(static function (PiiLogRecord $r) use (&$hashes): string {
+            $hashes[] = $r->contentHash;
+
+            return 'row-id';
+        });
+        $this->decoratedLogger->method('log');
+
+        $this->sut->info('msg', ['pii' => ['email' => 'a@b.c']]);
+        $this->sut->info('msg', ['pii' => ['email' => 'c@d.e']]);
+
+        self::assertNotSame($hashes[0], $hashes[1]);
+    }
+
+    public function testDbalFailureDoesNotLeakPiiAndDoesNotPropagate(): void
+    {
+        $this->writer
+            ->expects(self::once())
+            ->method('write')
+            ->willThrowException(new DBALException('boom'));
+
+        $this->decoratedLogger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('[pii WRITE_FAILED]'),
+                self::callback(static function (array $context): bool {
+                    self::assertArrayHasKey('hash', $context);
+                    self::assertArrayNotHasKey('pii', $context);
+                    self::assertArrayNotHasKey('email', $context);
+
+                    foreach ($context as $value) {
+                        if (is_string($value)) {
+                            self::assertStringNotContainsString('user@example.com', $value);
+                        }
+                    }
+
+                    return true;
+                }),
+            );
+
+        $this->decoratedLogger->expects(self::never())->method('log');
+
+        $this->sut->error('something broke', [
+            'pii'    => ['email' => 'user@example.com'],
+            'action' => 'mail-send',
+        ]);
+    }
+
+    public function testCallerCanOverrideProcedureAndOrgaIds(): void
+    {
+        $captured = $this->captureWrittenRecord();
+        $this->decoratedLogger->method('log');
+
+        $this->sut->info('m', [
+            'procedureId' => 'proc-1234',
+            'orgaId'      => 'orga-5678',
+            'pii'         => ['email' => 'a@b.c'],
+        ]);
+
+        $record = $captured();
+        self::assertSame('proc-1234', $record->procedureId);
+        self::assertSame('orga-5678', $record->orgaId);
+    }
+
+    public function testProcedureAndRequestIdAutoResolved(): void
+    {
+        $request = Request::create('/');
+        $request->attributes->set('request_id', 'rid-abc');
+        $this->requestStack->push($request);
+
+        $procedure = $this->createMock(ProcedureInterface::class);
+        $procedure->method('getId')->willReturn('auto-proc');
+
+        $contextProvider = $this->createMock(CurrentContextProviderInterface::class);
+        $contextProvider->method('getCurrentProcedure')->willReturn($procedure);
+        $contextProvider->method('getCurrentUser')->willThrowException(new Exception('no user'));
+
+        $sut = new PiiAwareLogger($this->decoratedLogger, $this->writer, $contextProvider, $this->requestStack);
+
+        $captured = $this->captureWrittenRecord();
+        $this->decoratedLogger->method('log');
+
+        $sut->info('m', ['pii' => ['x' => 1]]);
+
+        $record = $captured();
+        self::assertSame('auto-proc', $record->procedureId);
+        self::assertSame('rid-abc', $record->requestId);
+    }
+
+    public function testOrgaResolvedFromCurrentUser(): void
+    {
+        $user = new class implements UserInterface {
+            public function getOrganisationId(): string
+            {
+                return 'orga-99';
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function eraseCredentials(): void
+            {
+            }
+
+            public function getUserIdentifier(): string
+            {
+                return 'user-42';
+            }
+        };
+
+        $contextProvider = $this->createMock(CurrentContextProviderInterface::class);
+        $contextProvider->method('getCurrentProcedure')->willReturn(null);
+        $contextProvider->method('getCurrentUser')->willReturn($user);
+
+        $sut = new PiiAwareLogger($this->decoratedLogger, $this->writer, $contextProvider, $this->requestStack);
+
+        $captured = $this->captureWrittenRecord();
+        $this->decoratedLogger->method('log');
+
+        $sut->info('m', ['pii' => ['x' => 1]]);
+
+        $record = $captured();
+        self::assertSame('orga-99', $record->orgaId);
+    }
+
+    public function testMessageAndLevelStored(): void
+    {
+        $captured = $this->captureWrittenRecord();
+        $this->decoratedLogger->method('log');
+
+        $this->sut->error('boom {x}', ['pii' => ['x' => 'sensitive'], 'note' => 'hi']);
+
+        $record = $captured();
+        self::assertSame('boom {x}', $record->message);
+        self::assertSame('error', $record->levelName);
+        self::assertSame(400, $record->level);
+    }
+
+    public function testEmptyContextDoesNotProduceJsonNullStrings(): void
+    {
+        $captured = $this->captureWrittenRecord();
+        $this->decoratedLogger->method('log');
+
+        $this->sut->info('plain message');
+
+        $record = $captured();
+        self::assertNull($record->piiContextJson);
+        self::assertNull($record->nonPiiContextJson);
+    }
+
+    /** @return callable(): PiiLogRecord */
+    private function captureWrittenRecord(): callable
+    {
+        $captured = null;
+        $this->writer
+            ->expects(self::once())
+            ->method('write')
+            ->willReturnCallback(static function (PiiLogRecord $record) use (&$captured): string {
+                $captured = $record;
+
+                return 'row-id';
+            });
+
+        return static function () use (&$captured): PiiLogRecord {
+            self::assertInstanceOf(PiiLogRecord::class, $captured);
+
+            return $captured;
+        };
+    }
+}


### PR DESCRIPTION
[DPLAN-17695](https://demoseurope.youtrack.cloud/issue/DPLAN-17695)

## Summary

- New `PiiAwareLogger` (PSR-3) persists the full record incl. PII to a new `pii_log` table; the file log only sees `[pii ref=<uuid> hash=<sha256[..16]>] <non-PII context>`.
- Procedure and orga auto-resolved via `CurrentContextProviderInterface`; caller can override (`procedureId`, `orgaId` in context).
- On DBAL failure the call is swallowed and a redacted `WARNING` is forwarded — logging never breaks business flows.
- Sister to the GDPR audit log (changes-to-PII): the actor lives only there, not duplicated here.

## Scope

Logger infrastructure only — entity, migration, DBAL writer, logger, repository, Monolog `pii` channel, unit tests. Call-site migration (Mail recipients, Keycloak/Azure user mappers, DraftStatement PDF debug logs, UserService uniqueness logs) follows in separate area-scoped PRs.

## Usage

```php
$piiLogger->info('User logged in', [
    'pii'    => ['email' => $email, 'ip' => $ip],
    'action' => 'login',
]);
```

File log: `[pii ref=… hash=…] action=login` — no email.
DB row: full payload in `pii_context`, queryable by `procedure_id` / `orga_id` / `request_id` / `content_hash`.

## Test plan

- [ ] `bin/diplanbau d:m:migrate` then `dplan:migrations:diff` — no `pii_log` drift
- [ ] `vendor/bin/phpunit tests/backend/core/Core/Unit/Logger/PiiAwareLoggerTest.php` — 9 tests pass
- [ ] `bin/diplanbau d:php -l5 --ci demosplan/DemosPlanCoreBundle/Logger` — clean
- [ ] `bin/diplanbau lint:container` — services resolve
- [ ] Smoke: call logger with sample PII; verify file log contains only ref + hash, DB row contains the full payload