### PR TITLE
chore: pin d3-color to ^3.1.0 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,8 @@
     "prosemirror-model": "1.25.2",
     "prosemirror-view": "1.40.1",
     "prosemirror-state": "1.4.3",
-    "prosemirror-transform": "1.10.4"
+    "prosemirror-transform": "1.10.4",
+    "d3-color": "^3.1.0"
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7699,14 +7699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-color@npm:1":
-  version: 1.4.1
-  resolution: "d3-color@npm:1.4.1"
-  checksum: 10c0/668721dedc1d7e84aa9b3c51ccbaa1facd92ae9303d86ea0d5d0cf589dab892bc4cc7e155696537ed43e8f053d3ad0dde86363e1a789bad800a786f2ede527d7
-  languageName: node
-  linkType: hard
-
-"d3-color@npm:1 - 3":
+"d3-color@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
   checksum: 10c0/a4e20e1115fa696fce041fbe13fbc80dc4c19150fa72027a7c128ade980bc0eeeba4bcf28c9e21f0bce0e0dbfe7ca5869ef67746541dcfda053e4802ad19783c


### PR DESCRIPTION
Resolves transitive [ReDoS vulnerability](https://github.com/demos-europe/demosplan-core/security/dependabot/4) in d3-color < 3.1.0, pulled in through d3-sankey-diagram → d3-interpolate@1 / d3-transition@1. The 3.x API surface used by these v1 consumers (rgb, interpolateRgb) is backward-compatible.

d3-sankey-diagram has not been maintained for a very long time, and we should either replace it with the official d3-sankey package or implement a new design for displaying the moved statements in the dashboard (I'd prefer the latter, but am not sure how much the feature is used and if it's worth the effort). While this is still being discussed, we can pin the resolution as a quick fix.

### How to review/test
- Open a project that has the `permission feature_statement_move_to_procedure` enabled
- Navigate to the dashboard of a procedure where statements have been moved into or from (i.e., the sankey diagram is displayed)
- Everything should work as before