### PR TITLE
feat(refs: DPLAN-15992): switch input order

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -26,19 +26,6 @@ All rights reserved
     </div>
 
     <div class="grid grid-cols-1 gap-x-4 md:grid-cols-2">
-      <dp-input
-        v-if="hasPermission('field_statement_meta_orga_department_name') && !localStatement.attributes.isSubmittedByCitizen"
-        id="statementDepartmentName"
-        :disabled="!editable || !isStatementManual"
-        :label="{
-          text: Translator.trans('department')
-        }"
-        :model-value="getDisplayValue(localStatement.attributes.initialOrganisationDepartmentName)"
-        class="mb-2"
-        data-cy="statementSubmitter:departmentName"
-        @update:model-value="value => localStatement.attributes.initialOrganisationDepartmentName = value"
-      />
-
       <!--  TO DO: add if not participationGuestOnly -->
       <dp-input
         v-if="!localStatement.attributes.isSubmittedByCitizen"
@@ -51,6 +38,18 @@ All rights reserved
         class="mb-2"
         data-cy="statementSubmitter:orgaName"
         @update:model-value="value => localStatement.attributes.initialOrganisationName = value"
+      />
+      <dp-input
+        v-if="hasPermission('field_statement_meta_orga_department_name') && !localStatement.attributes.isSubmittedByCitizen"
+        id="statementDepartmentName"
+        :disabled="!editable || !isStatementManual"
+        :label="{
+          text: Translator.trans('department')
+        }"
+        :model-value="getDisplayValue(localStatement.attributes.initialOrganisationDepartmentName)"
+        class="mb-2"
+        data-cy="statementSubmitter:departmentName"
+        @update:model-value="value => localStatement.attributes.initialOrganisationDepartmentName = value"
       />
 
       <dp-contextual-help


### PR DESCRIPTION
### Ticket
DPLAN-15992

Switched the order of two inputs because that makes more sense from a UX perspective.

### How to review/test
Login as admin, go to STN, click details, scroll to submitter, check that the institution input is to the left of the department input.