### PR TITLE
refac: adjust props for the DpButtonRow component

### DIFF
--- a/client/js/components/shared/UnsavedChangesDialog.vue
+++ b/client/js/components/shared/UnsavedChangesDialog.vue
@@ -17,7 +17,6 @@
     :header="Translator.trans('unsaved.changes')"
     :message="Translator.trans('warning.unsaved.changes')"
     :tertiary-button-text="Translator.trans('change.discard')"
-    secondary-btn-variant="outline"
     @confirmed="handleConfirm"
     @tertiary-action="handleTertiaryAction"
   />

--- a/client/js/components/statement/splitStatement/DpCreateTag.vue
+++ b/client/js/components/statement/splitStatement/DpCreateTag.vue
@@ -72,7 +72,7 @@
       alignment="left"
       primary
       secondary
-      variant="outline"
+      primary-btn-variant="outline"
       @primary-action="dpValidateAction('createTag', save, false)"
       @secondary-action="closeForm"
     />

--- a/client/js/components/statement/splitStatement/SideBar.vue
+++ b/client/js/components/statement/splitStatement/SideBar.vue
@@ -180,7 +180,7 @@
       alignment="left"
       secondary
       primary
-      variant="outline"
+      primary-btn-variant="outline"
       @primary-action="save"
       @secondary-action="$emit('abort')"
     />


### PR DESCRIPTION
**Ticket:** https://demosdeutschland.slack.com/archives/C5BA8ABB2/p1777449660735409?thread_ts=1777041601.817489&cid=C5BA8ABB2 and https://www.figma.com/design/A1KcVmxRk6kap5Yo1pR7AV/Component-Library-2.0?node-id=0-1&p=f

**Description:** This PR updates the styling of the DpButtonRow component according to the new design of the component library:

- new button order: the primary button is on the right, and the secondary button is on the left
- set the secondary button to the outline variant, as this is now the new default