### PR TITLE
perf(HDDP-15): stabilize placeholder collections in StatementMover

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -1067,6 +1067,25 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
         $this->statementsCreatedFromOriginal = new ArrayCollection();
     }
 
+    /**
+     * Reset collections to fresh empty ones without triggering inverse-side
+     * collection initialization. Used after `clone` for placeholder creation,
+     * where the cloned entity is not yet present in any inverse collection
+     * and the per-element setter -> remove* -> inverse-contains() chain would
+     * needlessly hydrate large mappedBy collections (counties, municipalities,
+     * priorityAreas) on each related join entity.
+     */
+    public function resetCollectionsForPlaceholder(): void
+    {
+        $this->fragments = new ArrayCollection();
+        $this->votes = new ArrayCollection();
+        $this->tags = new ArrayCollection();
+        $this->counties = new ArrayCollection();
+        $this->municipalities = new ArrayCollection();
+        $this->priorityAreas = new ArrayCollection();
+        $this->files = [];
+    }
+
     public function getId(): ?string
     {
         return $this->id;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementMover.php
@@ -327,14 +327,12 @@ class StatementMover
     {
         $placeholderStatement = clone $statementToMove;
 
-        // remove related Entitycollections
-        $placeholderStatement->setFragments([]);
-        $placeholderStatement->setVotes([]);
-        $placeholderStatement->setTags([]);
-        $placeholderStatement->setCounties([]);
-        $placeholderStatement->setMunicipalities([]);
-        $placeholderStatement->setPriorityAreas([]);
-        $placeholderStatement->setFiles([]);
+        // Reset collections via direct assignment instead of per-element setters.
+        // Placeholder is a fresh clone not present in any inverse collection,
+        // so the previous setCounties/setMunicipalities/setPriorityAreas calls
+        // hydrated huge mappedBy collections (e.g. County::$statements) for no
+        // data-side effect.
+        $placeholderStatement->resetCollectionsForPlaceholder();
         $placeholderStatement->setInternId(null);
         $placeholderStatement->setMovedStatement($statementToMove);
         $placeholderStatement->setExternId($statementToMove->getExternId()); // maybe Moved %externId%

--- a/tests/backend/core/Statement/Functional/StatementMoverTest.php
+++ b/tests/backend/core/Statement/Functional/StatementMoverTest.php
@@ -29,8 +29,8 @@ class StatementMoverTest extends FunctionalTestCase
     /** @var StatementMover */
     protected $sut;
 
-    private StatementService|null $statementService;
-    private StatementDeleter|null $statementDeleter;
+    private ?StatementService $statementService;
+    private ?StatementDeleter $statementDeleter;
 
     protected function setUp(): void
     {

--- a/tests/backend/core/Statement/Functional/StatementMoverTest.php
+++ b/tests/backend/core/Statement/Functional/StatementMoverTest.php
@@ -322,6 +322,98 @@ class StatementMoverTest extends FunctionalTestCase
         static::assertEquals(0, $movedStatement->getVotesNum());
     }
 
+    /**
+     * Regression guard for the placeholder-creation determinism fix.
+     *
+     * `clone $statement` is a shallow copy: every collection field on the
+     * clone points to the same `PersistentCollection` instance as the source.
+     * If that ref is not severed before persist/flush, Doctrine's join-table
+     * inserts and inverse-side mutations become order-dependent and trigger
+     * full hydration of large mappedBy collections. The fix in
+     * `Statement::resetCollectionsForPlaceholder()` reassigns fresh empty
+     * collections directly. This test pins that contract: independent
+     * collection instances + mutating one must not bleed into the other.
+     */
+    public function testPlaceholderCollectionsAreIndependentFromMovedStatement(): void
+    {
+        self::markSkippedForCIElasticsearchUnavailable();
+
+        /** @var Statement $statementToMove */
+        $statementToMove = $this->fixtures->getReference('testStatement20');
+        /** @var Procedure $targetProcedure */
+        $targetProcedure = $this->fixtures->getReference('testProcedure2');
+
+        $movedMunicipalitiesBefore = $statementToMove->getMunicipalities()->count();
+        $movedCountiesBefore = $statementToMove->getCounties()->count();
+        $movedPriorityAreasBefore = $statementToMove->getPriorityAreas()->count();
+
+        $movedStatement = $this->sut->moveStatementToProcedure($statementToMove, $targetProcedure);
+        static::assertInstanceOf(Statement::class, $movedStatement);
+
+        $placeholder = $movedStatement->getPlaceholderStatement();
+        static::assertInstanceOf(Statement::class, $placeholder);
+
+        // each collection on the placeholder must be a different object than on
+        // the moved statement -- otherwise shared PersistentCollection bombs
+        static::assertNotSame(
+            $movedStatement->getMunicipalities(),
+            $placeholder->getMunicipalities(),
+            'placeholder.municipalities shares ref with moved statement'
+        );
+        static::assertNotSame(
+            $movedStatement->getCounties(),
+            $placeholder->getCounties(),
+            'placeholder.counties shares ref with moved statement'
+        );
+        static::assertNotSame(
+            $movedStatement->getPriorityAreas(),
+            $placeholder->getPriorityAreas(),
+            'placeholder.priorityAreas shares ref with moved statement'
+        );
+        static::assertNotSame(
+            $movedStatement->getTags(),
+            $placeholder->getTags()
+        );
+        static::assertNotSame(
+            $movedStatement->getVotes(),
+            $placeholder->getVotes()
+        );
+        static::assertNotSame(
+            $movedStatement->getFragments(),
+            $placeholder->getFragments()
+        );
+
+        // placeholder collections empty by policy
+        static::assertCount(0, $placeholder->getMunicipalities());
+        static::assertCount(0, $placeholder->getCounties());
+        static::assertCount(0, $placeholder->getPriorityAreas());
+        static::assertCount(0, $placeholder->getTags());
+        static::assertCount(0, $placeholder->getVotes());
+        static::assertCount(0, $placeholder->getFragments());
+        static::assertEmpty($placeholder->getFiles());
+
+        // mutating placeholder collections must not affect moved statement
+        $placeholder->getMunicipalities()->clear();
+        $placeholder->getCounties()->clear();
+        $placeholder->getPriorityAreas()->clear();
+
+        static::assertCount(
+            $movedMunicipalitiesBefore,
+            $movedStatement->getMunicipalities(),
+            'moved statement lost municipalities -- placeholder mutation bled through'
+        );
+        static::assertCount(
+            $movedCountiesBefore,
+            $movedStatement->getCounties(),
+            'moved statement lost counties -- placeholder mutation bled through'
+        );
+        static::assertCount(
+            $movedPriorityAreasBefore,
+            $movedStatement->getPriorityAreas(),
+            'moved statement lost priorityAreas -- placeholder mutation bled through'
+        );
+    }
+
     public function testHandleInternIdOnCopyStatement(): void
     {
         self::markSkippedForCIElasticsearchUnavailable();


### PR DESCRIPTION
## Ticket
HDDP-15

## Summary
- `clone $statement` is shallow: original and clone shared every `PersistentCollection` instance, making placeholder creation timing-dependent and causing full hydration of large `mappedBy` collections (counties, municipalities, priorityAreas) via inverse-side `contains()`.
- Add `Statement::resetCollectionsForPlaceholder()` that reassigns fresh empty `ArrayCollection` instances directly. Severs the shared ref before persist/flush so join-table writes are deterministic and cheap.
- Replace per-element `setCounties([])` / `setMunicipalities([])` / `setPriorityAreas([])` / `setTags([])` / `setVotes([])` / `setFragments([])` / `setFiles([])` chain in `StatementMover::createPlaceholderStatement` with the new helper.

## Why
Previous setter chain iterated the shared collection while calling `$relation->removeStatement($this)` on each element. The remove path hit `$this->statements->contains($statement)` on inverse-side `mappedBy` collections, triggering full hydration of every Statement linked to each related entity. Side effect: order-dependent join-table inserts on flush -- placeholder could end up with leaked refs from the moved statement depending on UoW commit order.

## Test plan
- [ ] CI runs new `testPlaceholderCollectionsAreIndependentFromMovedStatement` -- pins three invariants: distinct collection instances, placeholder collections empty by policy, mutating placeholder does not bleed into moved statement
- [ ] Existing `testMoveStatementCopyToProcedure` still green (already asserts placeholder counts == 0 and moved statement counts preserved)
- [ ] Manual: move a statement with municipalities/counties/priorityAreas; verify placeholder row has zero rows in `_statement_municipality` / `_statement_county` / `_statement_priority_area`; moved statement keeps its full set