### PR TITLE
chore: update demosplan-ui to v0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.19.0",
+    "@demos-europe/demosplan-ui": "0.20.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.19.0":
-  version: 0.19.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.19.0"
+"@demos-europe/demosplan-ui@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.20.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2867,7 +2867,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/3860e1ea497f8e85acf702eb9fa46eae5410f44a32f6e67883ef3b8079b4f7cb0f5f21536fa82eb48222a4dfe54599c1d3d5e975e2cafa9c245bb11cedcf08b0
+  checksum: 10c0/8747a5797f26cdd842e9e37097904a45ba23e6e5793b9ad15811d81b44ae95509bef46b6ca16c1d9d24a8840fb75c3d527435b4e0b20cc7a85d123577f8545f4
   languageName: node
   linkType: hard
 
@@ -8090,7 +8090,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.19.0"
+    "@demos-europe/demosplan-ui": "npm:0.20.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
Use newest version of demosplan-ui in core.

what's new?

- DpButtonRow: button order is reversed (secondary button left, primary button right); secondary button now always uses outline variant. BREAKING: secondaryBtnVariant prop is removed