### PR TITLE
fix(refs DS-492): import cookie banner styles via scss vendor

### DIFF
--- a/client/fe/config/config.js
+++ b/client/fe/config/config.js
@@ -59,6 +59,7 @@ class Config {
           /multiselect.*/,
           /c-sliding-pagination.*/,
           /a1-.+/,
+          /^dp-consent-/,
           /data-enhance-url-field/,
           /ol-.+/,
           /plyr.+/,

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/index.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/index.scss
@@ -63,6 +63,7 @@
     'treelist',
     'tiptap',
     'vendor/a11y-datepicker',
+    'vendor/dp-consent',
     'vendor/flood-control-field',
     'vendor/multiselect',
     'vendor/openlayers',

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/vendor/_dp-consent.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/vendor/_dp-consent.scss
@@ -1,0 +1,14 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  (c) 2010-present DEMOS plan GmbH.
+//
+//  This file is part of the package demosplan,
+//  for more information see the license file.
+//
+//  All rights reserved
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Cookie consent banner styles. Loaded statically here so the banner is styled
+// even when dp-consent's runtime <style> injection from JS does not take effect
+// (DS-492). Tailwind 4 branches do this in client/css/tailwind.css instead —
+// see DPLAN-16591.
+@import '~@demos-europe/dp-consent/src/css/style.css';


### PR DESCRIPTION
### Ticket
[DS-492](https://demoseurope.youtrack.cloud/tickets/DS-492/BOB-SH-Bauleitplanung-Cookie-Banner-auf-der-Startseite-als-angemeldeter-Nutzer-ohne-Style-Mittel)

> Benutzername bzw. Rolle: Fachplaner-Admin
> Auf der Startseite als angemeldeter Nutzer erscheint der Cookie-Banner ohne Style

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This is the tailwind 3 version of the tailwind 4 (`main`) fix: https://github.com/demos-europe/demosplan-core/commit/f827a842cc176c0c84fa35df1b9392008690c72e

- dp-consent injects its CSS into `<head>` at runtime; that does not seem to work for logged-in users on the index page, leaving the banner unstyled
- by importing the library's styles via the scss vendor, the css ships statically as a `<link>` in `<head>`
- also, dp-consent is added to the purgecss safelist so the runtime-applied classes are kept

### How to review/test

- set `piwik_enable` to `true` in the project parameters file
- if the banner doesn't appear, you need to delete the dp-consent cookie in the dev tools (under Application > Cookies)
- login and navigate to the index page -> the banner should be styled

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
