### PR TITLE
fix(refs DS-483): strip treelist selection data before saving

### DIFF
--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -174,7 +174,7 @@ export default {
           type,
           attributes: {
             ...attributes,
-            enabled: isEnabled,
+            enabled: isEnabled
           },
           ...(relationships && { relationships })
         }
@@ -217,7 +217,7 @@ export default {
         type,
         attributes: {
           ...attributes,
-          ...newSelection,
+          ...newSelection
         },
         ...(relationships && { relationships })
       }

--- a/client/js/components/faq/DpFaqItem.vue
+++ b/client/js/components/faq/DpFaqItem.vue
@@ -168,15 +168,18 @@ export default {
 
     handleToggle (isEnabled) {
       if (isEnabled !== this.isFaqEnabled) {
+        const { id, type, attributes, relationships } = this.faqItem
         const faqCopy = {
-          ...this.faqItem,
+          id,
+          type,
           attributes: {
-            ...this.faqItem.attributes,
-            enabled: isEnabled
-          }
+            ...attributes,
+            enabled: isEnabled,
+          },
+          ...(relationships && { relationships })
         }
 
-        this.updateFaq({ ...faqCopy, id: faqCopy.id })
+        this.updateFaq(faqCopy)
 
         const saveAction = () => {
           return this.saveFaq(this.faqItem.id)
@@ -208,8 +211,16 @@ export default {
 
       newSelection = { ...newSelection, ...selectedGroups }
 
-      const faqCpy = JSON.parse(JSON.stringify(this.faqItem))
-      faqCpy.attributes = { ...faqCpy.attributes, ...newSelection }
+      const { id, type, attributes, relationships } = this.faqItem
+      const faqCpy = {
+        id,
+        type,
+        attributes: {
+          ...attributes,
+          ...newSelection,
+        },
+        ...(relationships && { relationships })
+      }
 
       /**
        * Weirdly the input event seems to be fired on initial load of the vue multiselect.
@@ -221,7 +232,7 @@ export default {
         return this.faqItem.attributes[key] !== value
       }).length !== 0
       if (hasChangedAttributes === true) {
-        this.updateFaq({ ...faqCpy, id: faqCpy.id })
+        this.updateFaq(faqCpy)
         const saveAction = () => {
           return this.saveFaq(this.faqItem.id)
             .then(() => {


### PR DESCRIPTION
### Ticket
[ DS-483](https://demoseurope.youtrack.cloud/tickets/DS-483/Niedrig-BOB-SH-Bauleitplanung-STAGEPROD-Fehlermeldung-bei-Freigabe-einer-FAQ?backToIssues)

> Der Versuch, in der FAQ-Liste einen einzelnen FAQ-Eintrag von „Gesperrt“ auf „Freigegeben“ zu setzen, wird reproduzierbar durch folgende Fehlermeldungen abgebrochen:
> 
> - Während der Verarbeitung der Anfrage ist ein Fehler aufgetreten.
> - Beim Speichern der Änderung ist ein Fehler aufgetreten.

- the selectionManager used in DpTreeList (but not needed in the faq list!) adds `nodeId`, `nodeIsSelected` and `nodeType` to treelist items for selection tracking; these were erroneously sent to the BE at the root level of the json api resource object, making the request fail
- in the faq list, items are not even selectable, so these properties are not needed anywhere
- while this should clearly be fixed in DpTreeList/selectionManager, this fix in the faq item generally ensures we only send the allowed properties, which makes the code more robust, and it's a quick fix for the release branch

### How to test
If you want to test these changes, login as "Redakteur" and navigate to "Häufige Fragen", then toggle the status of an faq item -> there should be no error, but a green confirm message

### PR Checklist

- [x] Run `yarn lint`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
