### PR TITLE
f DS-537 Force xlsx exports to write all cells as strings to prevent errors while exporting

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/SimpleSpreadsheetService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/SimpleSpreadsheetService.php
@@ -10,6 +10,8 @@
 
 namespace demosplan\DemosPlanCoreBundle\Logic;
 
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
@@ -116,6 +118,13 @@ class SimpleSpreadsheetService
                 $formattedData[$key]['recommendation'] = htmlspecialchars_decode((string) $dataSet['recommendation']);
             }
         }
+
+        // Force every cell to TYPE_STRING so PhpSpreadsheet's default value binder does not
+        // interpret citizen-written content as a formula (leading '=') or rewrite numeric/date
+        // looking strings. Prevents export crashes like "Formula Error: Unexpected operator '%'"
+        // on segment text such as '=15%' or '=>...' and preserves leading-zero phone numbers,
+        // German date strings etc. as written.
+        Cell::setValueBinder(new StringValueBinder());
 
         $worksheet->fromArray($formattedData, null, 'A2');
         $phpExcel->setActiveSheetIndex($worksheetIndex);


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-537/Herunterladen-Stellungnahmen-in-Excel?backToIssues
Description: 
 Segments xlsx export crashed and returned ~300 KB of HTML (the dev exception page) whenever a segment's text rendered to a string starting with `=`, e.g. `=Gleichwertigkeit der Varianten` or `=>Zum LWL-Kabel`. Excel/Libre rejected the file as corrupt.                                                                                                                                                   
                                                                                                                                                                                              
  ## Root cause                                                                                                                                                                               
                  
  `StatementFormatter` converts segment text from HTML to Markdown, so  `<p>=...</p>` becomes the bare line `=...`. PhpSpreadsheet's default value binder then tags any cell whose value starts with `=` as a formula, and the Xlsx writer pre-calculates formulas before saving. Citizen content like `=15%` makes the calculation engine throw  `Unexpected operator '%'`. Because the response is streamed, the body can't be reset — the dev error page lands on top of partial xlsx bytes.                                                                                                                     
                                                                                                                                                                                              
  ## Fix                                                                                                                                                                                      
                                                                                                                                                                                              
  Switch the cell value binder to PhpSpreadsheet's shipped `StringValueBinder` right before `fromArray()` in
  `SimpleSpreadsheetService::addWorksheet()`. All cells are then stored as `TYPE_STRING`, no formula path fires.
                                                                                                                                                                                              
  ```diff         
  +use PhpOffice\PhpSpreadsheet\Cell\Cell;                                                                                                                                                    
  +use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
  +                                                                                                                                                                                           
  +Cell::setValueBinder(new StringValueBinder());
   $worksheet->fromArray($formattedData, null, 'A2');                                                                                                                                         
                                                                                                                                                                                              
  Side effects (all desirable for an export of user content):                                                                                                                                 
  - Leading-= text appears literally instead of crashing.                                                                                                                                     
  - Leading-zero strings keep their zeros.                                                                                                                                                    
  - Date-looking strings render as written.
                                                                                                                                                                                              
  Pre-stringified date/numeric columns (submitDateString, meta.authoredDate, votesNum, numberOfAnonymVotes) are unaffected.                                                                                                                           
                                                                                                                                                                                              
  Files changed                                                                                                                                                                               
                                                                                                                                                                                              
  - demosplan/DemosPlanCoreBundle/Logic/SimpleSpreadsheetService.php                                                                                                                          
  
  Test plan                                                                                                                                                                                   
                  
  - Re-run the previously-crashing export — file opens cleanly in Excel/LibreOffice with no "needs repair" warning.
  - Spot-check the offending cell renders the literal user content (with = and % visible).                                                                                                                                                                     
  - Spot-check a previously-working export — no visual regression.

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly

