### PR TITLE
feat(ref. DPLAN-17737) Change session to localStorage DpDataTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## UNRELEASED
 
+### Changed
+- Column widths in the segment list now persist across browser sessions
+- "column reset" in the segment list now also resets column widths to defaults
+
 ## v4.39.0 (2026-05-06)
 
 ## v4.38.0 (2026-05-06)

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -156,27 +156,28 @@
         >
           <dp-data-table
             ref="dataTable"
-            class="min-h-12"
+            :key="columnSelectorKey"
             :class="{ 'px-2': isFullscreen, 'scrollbar-none': !isFullscreen }"
+            :header-fields="availableHeaderFields"
+            :items="items"
+            :multi-page-all-selected="allSelectedVisually"
+            :multi-page-selection-items-toggled="toggledItems.length"
+            :multi-page-selection-items-total="allItemsCount"
+            :should-be-selected-items="currentlySelectedItems"
+            class="min-h-12"
             column-storage-key="segmentsList"
             column-width-storage-key="segmentsListColumnWidths"
             data-cy="segmentsList"
             density="spacious"
-            has-flyout
+            track-by="id"
             has-borders
+            has-flyout
             has-sticky-header
-            :header-fields="availableHeaderFields"
             is-columns-draggable
             is-resizable
             is-selectable
-            :items="items"
-            :multi-page-all-selected="allSelectedVisually"
-            :multi-page-selection-items-total="allItemsCount"
-            :multi-page-selection-items-toggled="toggledItems.length"
-            :should-be-selected-items="currentlySelectedItems"
-            track-by="id"
-            @select-all="handleSelectAll"
             @items-toggled="handleToggleItem"
+            @select-all="handleSelectAll"
           >
             <template v-slot:header-tags>
               <span class="inline-flex items-center">
@@ -929,6 +930,12 @@ export default {
     resetColumnSelection () {
       localStorage.removeItem('segmentList')
       this.setCurrentSelection([...this.defaultColumnSelection])
+
+      // Clear persisted column widths
+      Object.keys(localStorage)
+        .filter(key => key.startsWith('dpDataTable:colWidth:segmentsListColumnWidths:'))
+        .forEach(key => localStorage.removeItem(key))
+
       this.columnSelectorKey++
     },
 

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -158,13 +158,14 @@
             ref="dataTable"
             class="min-h-12"
             :class="{ 'px-2': isFullscreen, 'scrollbar-none': !isFullscreen }"
+            column-storage-key="segmentsList"
+            column-width-storage-key="segmentsListColumnWidths"
             data-cy="segmentsList"
             density="spacious"
             has-flyout
             has-borders
             has-sticky-header
             :header-fields="availableHeaderFields"
-            column-storage-key="segmentsList"
             is-columns-draggable
             is-resizable
             is-selectable


### PR DESCRIPTION
 ### Tickets                                                                                       
  [DPLAN-17737](https://demoseurope.youtrack.cloud/issue/DPLAN-17737)
                                                                                                    
  Migrate the SegmentsList column-width persistence from sessionStorage to localStorage so user-set
  column widths survive tab close, browser restart, logout, and incidental `sessionStorage.clear()`
  calls (e.g. after submitting a statement).                                                        
                                                                                         
  - Set the new `column-width-storage-key` prop on `DpDataTable` to `segmentsListColumnWidths`      
  - Bind `columnSelectorKey` to `:key` on `DpDataTable` so the reset button forces a fresh mount    
  that re-reads the (cleared) storage                                                               
  - Extend `resetColumnSelection` to remove persisted column-width entries from localStorage        
  - Sort the attribute order on `DpDataTable` to follow the Vue style guide grouping                
                                                     
  Requires the corresponding library PR in demosplan-ui to be merged first.                         
                                                                                         
  ### How to review/test                                                                            
  - Open the SegmentsList view, resize columns, close the browser tab, reopen → widths are restored
  - Click "Spaltenauswahl zurücksetzen" → columns are reset to default selection AND widths fall    
  back to initial values                 
  - Log out, log back in → column widths still match                                                                                                                                 
                                                     
  ### Linked PRs                           
[  - Library PR: demos-europe/demosplan-ui#<PR-Nummer>       ](https://github.com/demos-europe/demosplan-ui/pull/1485)                                        
                                                   
  ### PR Checklist                                                                                  
  - [x] Run `yarn lint`   
  - [x] Run `yarn test`                                                                          
  - [x] Link all relevant tickets                                                        
  - [x] Move the tickets on the board accordingly                                                   
                                         
