### PR TITLE
fix(refs ADO-54897): replace all {currentYear} placeholders in map copyright

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -1810,7 +1810,7 @@ export default {
       let label = ''
 
       if (hasOwnProp(this.procedureSettings, 'copyright') && this.procedureSettings.copyright !== '') {
-        label = this.procedureSettings.copyright.replace('{currentYear}', currentYear)
+        label = this.procedureSettings.copyright.replaceAll('{currentYear}', currentYear)
       } else {
         label = Translator.trans('map.attribution.default', {
           linkImprint: Routing.generate('DemosPlan_misccontent_static_imprint'),


### PR DESCRIPTION
## Summary
Public procedure map attribution only substituted the first `{currentYear}` occurrence in the configured copyright string, so a second use of the placeholder (e.g. when citing multiple map sources) stayed unreplaced. Switched to `replaceAll` to match the sibling `DpOlMapLayer` behavior.

Ref: ADO 54897

## Test plan
- [ ] Configure a procedure copyright/source text containing two `{currentYear}` occurrences
- [ ] Open the public procedure detail map and confirm both occurrences render the current year