### PR TITLE
feat(refs DPLAN-17565): render pdf_importer_image anchors inline in statement text

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -355,7 +355,7 @@
         v-model="values.text"
         :aria-label="Translator.trans('statement.text.short')"
         :procedure-id="procedureId"
-        :toolbar-items="{ linkButton: true }"
+        :toolbar-items="{ linkButton: true, imageButton: true }"
         required
         hidden-input="r_text"
       />

--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -356,6 +356,7 @@
         :aria-label="Translator.trans('statement.text.short')"
         :procedure-id="procedureId"
         :toolbar-items="{ linkButton: true, imageButton: true }"
+        :tus-endpoint="dplan.paths.tusEndpoint"
         required
         hidden-input="r_text"
       />

--- a/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
+++ b/client/js/components/procedure/imageAnnotator/DpConvertAnnotatedPdf.vue
@@ -87,6 +87,7 @@
 import { dpApi, DpButton, DpLoading } from '@demos-europe/demosplan-ui'
 import DpSendBeacon from './DpSendBeacon'
 import DpSimplifiedNewStatementForm from '@DpJs/components/procedure/DpSimplifiedNewStatementForm'
+import { inlineImageAnchors } from '@DpJs/lib/shared/inlineImageAnchors'
 
 export default {
   name: 'DpConvertAnnotatedPdf',
@@ -225,7 +226,7 @@ export default {
       this.formValues = {
         ...this.formValues,
         quickSave: this.document.attributes.quickSave,
-        text: this.document.attributes.quickSave ?? this.document.attributes.text,
+        text: inlineImageAnchors(this.document.attributes.quickSave ?? this.document.attributes.text),
       }
       this.pages = documentResponse.data.included.filter(el => el.type === 'AnnotatedStatementPdfPage')
       this.isLoading = false

--- a/client/js/components/shared/TextContentRenderer.vue
+++ b/client/js/components/shared/TextContentRenderer.vue
@@ -2,6 +2,7 @@
 import { h, resolveComponent } from 'vue'
 import DomPurify from 'dompurify'
 import { DpLoading } from '@demos-europe/demosplan-ui'
+import { inlineImageAnchors } from '@DpJs/lib/shared/inlineImageAnchors'
 
 export default {
   name: 'TextContentRenderer',
@@ -45,7 +46,7 @@ export default {
    * @return {*}
    */
   render () {
-    const sanitizedText = DomPurify.sanitize(this.text, { ADD_TAGS: ['dp-obscure'] })
+    const sanitizedText = DomPurify.sanitize(inlineImageAnchors(this.text), { ADD_TAGS: ['dp-obscure'] })
 
     const immediateComponent = {
       template: `<div class='text-wrapper w-fit' data-cy='textWrapper'>${sanitizedText}</div>`,

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -339,6 +339,7 @@ import {
 import { mapActions, mapMutations, mapState } from 'vuex'
 import CustomSearchStatements from './CustomSearchStatements'
 import DpClaim from '@DpJs/components/statement/DpClaim'
+import { inlineImageAnchors } from '@DpJs/lib/shared/inlineImageAnchors'
 import lscache from 'lscache'
 import paginationMixin from '@DpJs/components/shared/mixins/paginationMixin'
 import StatementExportModal from '@DpJs/components/statement/StatementExportModal'
@@ -563,9 +564,7 @@ export default {
         return ''
       }
 
-      return attributes.isFulltextDisplayed ?
-        attributes.fullText :
-        attributes.text
+      return inlineImageAnchors(attributes.isFulltextDisplayed ? attributes.fullText : attributes.text)
     },
 
     getAssignee (statement) {

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -131,6 +131,30 @@ export default {
           doc: parsedContent,
           plugins: rangePlugin.plugins,
         }),
+        markViews: {
+          link: (mark) => {
+            const className = mark.attrs.class || ''
+            const anchor = document.createElement('a')
+            anchor.setAttribute('href', mark.attrs.href)
+            if (className) {
+              anchor.setAttribute('class', className)
+            }
+
+            if (!className.split(/\s+/).includes('pdf_importer_image')) {
+              return { dom: anchor, contentDOM: anchor }
+            }
+
+            const img = document.createElement('img')
+            img.setAttribute('src', mark.attrs.href)
+            img.setAttribute('alt', '')
+            img.setAttribute('loading', 'lazy')
+            const label = document.createElement('span')
+            label.hidden = true
+            anchor.appendChild(img)
+            anchor.appendChild(label)
+            return { dom: anchor, contentDOM: label }
+          },
+        },
       })
 
       const transformedSegments = this.transformSegments(this.segments.filter(segment => segment.charEnd <= this.maxRange))

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -134,25 +134,26 @@ export default {
         markViews: {
           link: (mark) => {
             const className = mark.attrs.class || ''
-            const anchor = document.createElement('a')
-            anchor.setAttribute('href', mark.attrs.href)
-            if (className) {
-              anchor.setAttribute('class', className)
-            }
 
             if (!className.split(/\s+/).includes('pdf_importer_image')) {
+              const anchor = document.createElement('a')
+              anchor.setAttribute('href', mark.attrs.href)
+              if (className) {
+                anchor.setAttribute('class', className)
+              }
               return { dom: anchor, contentDOM: anchor }
             }
 
+            const wrapper = document.createElement('span')
             const img = document.createElement('img')
             img.setAttribute('src', mark.attrs.href)
             img.setAttribute('alt', '')
             img.setAttribute('loading', 'lazy')
             const label = document.createElement('span')
             label.className = 'sr-only'
-            anchor.appendChild(img)
-            anchor.appendChild(label)
-            return { dom: anchor, contentDOM: label }
+            wrapper.appendChild(img)
+            wrapper.appendChild(label)
+            return { dom: wrapper, contentDOM: label }
           },
         },
       })

--- a/client/js/components/statement/splitStatement/SegmentationEditor.vue
+++ b/client/js/components/statement/splitStatement/SegmentationEditor.vue
@@ -149,7 +149,7 @@ export default {
             img.setAttribute('alt', '')
             img.setAttribute('loading', 'lazy')
             const label = document.createElement('span')
-            label.hidden = true
+            label.className = 'sr-only'
             anchor.appendChild(img)
             anchor.appendChild(label)
             return { dom: anchor, contentDOM: label }

--- a/client/js/lib/shared/inlineImageAnchors.js
+++ b/client/js/lib/shared/inlineImageAnchors.js
@@ -1,0 +1,28 @@
+const DEFAULT_CLASS = 'pdf_importer_image'
+
+/**
+ * Replace `<a class="<className>" href="…">label</a>` anchors with `<img>` tags
+ * so image links render inline. Display-time only — stored HTML is untouched.
+ */
+export function inlineImageAnchors (html, className = DEFAULT_CLASS) {
+  if (typeof html !== 'string' || !html.includes(className)) {
+    return html
+  }
+
+  const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html')
+  const root = doc.body.firstElementChild
+
+  if (!root) {
+    return html
+  }
+
+  root.querySelectorAll(`a.${className}[href]`).forEach((anchor) => {
+    const img = doc.createElement('img')
+    img.setAttribute('src', anchor.getAttribute('href'))
+    img.setAttribute('alt', anchor.textContent.trim())
+    img.setAttribute('loading', 'lazy')
+    anchor.replaceWith(img)
+  })
+
+  return root.innerHTML
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -37,9 +37,10 @@ class HtmlHelper
     }
 
     /**
-     * Extracts URLs from the given HTML text that are contained within <a> tags with the specified class, and
-     * creates ImageReference objects from those URLs. The link text of the <a> tags is used as the image reference.
-     * The image reference is prefixed with the specified prefix.
+     * Extracts image references from the given HTML text. The $class parameter identifies legacy anchor-form
+     * image references `<a class="…" href="…">label</a>` (the form is required to disambiguate from real
+     * hyperlinks). All `<img src="…" alt="label">` tags are extracted regardless of class — for an `<img>`
+     * there's no ambiguity, every `<img>` in statement text is an image reference.
      *
      * @return array<int, ImageReference> an array containing the extracted ImageReference objects
      */
@@ -47,19 +48,24 @@ class HtmlHelper
     {
         $imageReferences = [];
 
-        // The regex pattern to match <a> tags with the specified class and extract their href attributes and link text
-        // irrespective of the order of class and href attributes
-        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'.preg_quote($class, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
-
-        // Perform the regex match
-        if (preg_match_all($pattern, $htmlText, $matches)) {
+        $anchorPattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'.preg_quote($class, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
+        if (preg_match_all($anchorPattern, $htmlText, $matches)) {
             foreach ($matches[1] as $index => $url) {
                 $linkText = $matches[2][$index];
-                // Create an ImageReference object with linkText as imageReference and url as imagePath
                 $srcParts = explode('/', $url);
                 $hash = $srcParts[array_key_last($srcParts)];
-                $imageReference = new ImageReference($prefix.$linkText, $url, $hash);
-                $imageReferences[] = $imageReference;
+                $imageReferences[] = new ImageReference($prefix.$linkText, $url, $hash);
+            }
+        }
+
+        $imgPattern = '/<img\b(?=[^>]*\bsrc="([^"]*)")[^>]*\/?>/i';
+        if (preg_match_all($imgPattern, $htmlText, $matches)) {
+            foreach ($matches[0] as $index => $fullTag) {
+                $src = $matches[1][$index];
+                $alt = $this->extractAttribute($fullTag, 'alt');
+                $srcParts = explode('/', $src);
+                $hash = $srcParts[array_key_last($srcParts)];
+                $imageReferences[] = new ImageReference($prefix.$alt, $src, $hash);
             }
         }
 
@@ -67,19 +73,33 @@ class HtmlHelper
     }
 
     /**
-     * Updates the link text of all links with the specified class by appending a prefix, changing the href value based
-     * on the link text, changing the text color to blue and underlining the text.
+     * Rewrites image references to styled cross-reference anchors suitable for DOCX export. Matches the
+     * legacy anchor form `<a class="…" href="…">label</a>` (identified by $className) and any
+     * `<img src="…" alt="label">` tag (matched regardless of class).
      */
     public function updateLinkTextWithClass(string $htmlText, string $className, string $prefix): string
     {
-        $pattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'
+        $anchorPattern = '/<a\b(?=[^>]*\bclass="[^"]*\b'
             .preg_quote($className, '/').'\b[^"]*")(?=[^>]*\bhref="([^"]*)")[^>]*>(.*?)<\/a>/i';
-        if (preg_match_all($pattern, $htmlText, $matches)) {
+        if (preg_match_all($anchorPattern, $htmlText, $matches)) {
             foreach ($matches[2] as $index => $linkText) {
-                $replacement = '<a class="'.$className
-                    .'" href="#'.$prefix.$linkText.'" style="color: blue; text-decoration: underline;">'
-                    .$prefix.$linkText.'</a>';
-                $htmlText = str_replace($matches[0][$index], $replacement, $htmlText);
+                $htmlText = str_replace(
+                    $matches[0][$index],
+                    $this->buildCrossReferenceAnchor($className, $prefix.$linkText),
+                    $htmlText
+                );
+            }
+        }
+
+        $imgPattern = '/<img\b[^>]*\/?>/i';
+        if (preg_match_all($imgPattern, $htmlText, $matches)) {
+            foreach ($matches[0] as $fullTag) {
+                $label = $this->extractAttribute($fullTag, 'alt');
+                $htmlText = str_replace(
+                    $fullTag,
+                    $this->buildCrossReferenceAnchor($className, $prefix.$label),
+                    $htmlText
+                );
             }
         }
 
@@ -87,16 +107,36 @@ class HtmlHelper
     }
 
     /**
-     * Removes all <a> tags with the specified class from the given HTML text.
-     * The inner text of the removed tags is replaced with the specified prefix.
+     * Strips anchor-form image references (identified by $className) and all `<img>` tags. The label
+     * (anchor inner text or img alt) is kept inline, prefixed with $prefix.
      */
     public function removeLinkTagsByClass(string $htmlText, string $className, string $prefix): string
     {
-        // Regex pattern to match <a> tags with the specified class and capture their inner text
-        $pattern = '/<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>(.*?)<\/a>/i';
-        // Replacement string to keep only the inner text
-        $replacement = $prefix.'$1';
+        $anchorPattern = '/<a\b[^>]*class="[^"]*\b'.preg_quote($className, '/').'\b[^"]*"[^>]*>(.*?)<\/a>/i';
+        $htmlText = preg_replace($anchorPattern, $prefix.'$1', $htmlText);
 
-        return preg_replace($pattern, $replacement, $htmlText);
+        $imgPattern = '/<img\b[^>]*\/?>/i';
+        if (preg_match_all($imgPattern, $htmlText, $matches)) {
+            foreach ($matches[0] as $fullTag) {
+                $alt = $this->extractAttribute($fullTag, 'alt');
+                $htmlText = str_replace($fullTag, $prefix.$alt, $htmlText);
+            }
+        }
+
+        return $htmlText;
+    }
+
+    private function buildCrossReferenceAnchor(string $className, string $label): string
+    {
+        return '<a class="'.$className.'" href="#'.$label.'" style="color: blue; text-decoration: underline;">'.$label.'</a>';
+    }
+
+    private function extractAttribute(string $tagHtml, string $attribute): string
+    {
+        if (preg_match('/\b'.preg_quote($attribute, '/').'="([^"]*)"/i', $tagHtml, $match)) {
+            return $match[1];
+        }
+
+        return '';
     }
 }

--- a/tests/backend/core/SegmentExport/HtmlHelperTest.php
+++ b/tests/backend/core/SegmentExport/HtmlHelperTest.php
@@ -145,4 +145,104 @@ class HtmlHelperTest extends FunctionalTestCase
         $result = $this->sut->removeLinkTagsByClass($htmlMixed, $class, $prefix);
         static::assertSame($expectedMixed, $result);
     }
+
+    public function testExtractImageDataFromImgTags(): void
+    {
+        $prefix = 'New_';
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+
+        // Test 1: <img> tag with class and alt
+        $htmlImg = '<img class="'.$class.'" src="https://www.example1.com/hash1.jpg" alt="Image 1">';
+        $resultA = $this->sut->extractImageDataByClass($htmlImg, $class, $prefix);
+        static::assertCount(1, $resultA);
+        static::assertSame($prefix.'Image 1', $resultA[0]->getImageReference());
+        static::assertSame('https://www.example1.com/hash1.jpg', $resultA[0]->getImagePath());
+        static::assertSame('hash1.jpg', $resultA[0]->getFileHash());
+
+        // Test 2: <img> without the target class is also extracted — every <img> is an image reference
+        $htmlImgOtherClass = '<img class="other-class" src="https://www.example2.com/hash2.jpg" alt="Image 2">';
+        $resultB = $this->sut->extractImageDataByClass($htmlImgOtherClass, $class, $prefix);
+        static::assertCount(1, $resultB);
+        static::assertSame($prefix.'Image 2', $resultB[0]->getImageReference());
+
+        // Test 3: <img> without any class is extracted too
+        $htmlImgNoClass = '<img src="https://www.example3.com/hash3.jpg" alt="Image 3">';
+        $resultC = $this->sut->extractImageDataByClass($htmlImgNoClass, $class, $prefix);
+        static::assertCount(1, $resultC);
+        static::assertSame($prefix.'Image 3', $resultC[0]->getImageReference());
+
+        // Test 4: <img> without alt -> empty label
+        $htmlImgNoAlt = '<img class="'.$class.'" src="https://www.example4.com/hash4.jpg">';
+        $resultD = $this->sut->extractImageDataByClass($htmlImgNoAlt, $class, $prefix);
+        static::assertCount(1, $resultD);
+        static::assertSame($prefix, $resultD[0]->getImageReference());
+        static::assertSame('hash4.jpg', $resultD[0]->getFileHash());
+
+        // Test 5: self-closing form `<img … />`
+        $htmlSelfClosing = '<img src="https://www.example5.com/hash5.jpg" alt="Image 5" />';
+        $resultE = $this->sut->extractImageDataByClass($htmlSelfClosing, $class, $prefix);
+        static::assertCount(1, $resultE);
+        static::assertSame($prefix.'Image 5', $resultE[0]->getImageReference());
+    }
+
+    public function testExtractImageDataFromMixedForms(): void
+    {
+        $prefix = 'New_';
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+
+        $htmlMixed = '<a class="'.$class.'" href="https://www.example.com/hashA.jpg">Anchor Label</a>'.
+            ' some text '.
+            '<img class="'.$class.'" src="https://www.example.com/hashB.jpg" alt="Img Label">';
+
+        $result = $this->sut->extractImageDataByClass($htmlMixed, $class, $prefix);
+
+        static::assertCount(2, $result);
+        $references = array_map(fn ($r) => $r->getImageReference(), $result);
+        static::assertContains($prefix.'Anchor Label', $references);
+        static::assertContains($prefix.'Img Label', $references);
+    }
+
+    public function testUpdateLinkTextWithClassFromImgTags(): void
+    {
+        $prefix = 'New_';
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+
+        // Test 1: <img> is rewritten to cross-reference anchor regardless of class
+        $htmlImg = '<img src="https://www.example1.com/img.jpg" alt="Old Text">';
+        $expected = '<a class="'.$class.'" href="#'.$prefix.'Old Text"'
+            .' style="color: blue; text-decoration: underline;">'.$prefix.'Old Text</a>';
+        static::assertSame($expected, $this->sut->updateLinkTextWithClass($htmlImg, $class, $prefix));
+
+        // Test 2: Mixed <a> and <img> forms both get rewritten
+        $htmlMixed = '<a class="'.$class.'" href="https://www.example.com/imgA.jpg">Label A</a>'.
+            ' between '.
+            '<img src="https://www.example.com/imgB.jpg" alt="Label B">';
+        $result = $this->sut->updateLinkTextWithClass($htmlMixed, $class, $prefix);
+        static::assertStringContainsString('href="#'.$prefix.'Label A"', $result);
+        static::assertStringContainsString('href="#'.$prefix.'Label B"', $result);
+        static::assertStringNotContainsString('<img', $result);
+
+        // Test 3: <a> without the target class is left alone (real hyperlinks, not image references)
+        $htmlOtherAnchor = '<a class="other-class" href="https://example.com">a real link</a>';
+        static::assertSame($htmlOtherAnchor, $this->sut->updateLinkTextWithClass($htmlOtherAnchor, $class, $prefix));
+    }
+
+    public function testRemoveLinkTagsByClassFromImgTags(): void
+    {
+        $prefix = 'New_';
+        $class = HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL;
+
+        // Test 1: <img> is replaced with prefix + alt regardless of class
+        $htmlImg = '<img src="https://www.example1.com/img.jpg" alt="Image 1">';
+        static::assertSame($prefix.'Image 1', $this->sut->removeLinkTagsByClass($htmlImg, $class, $prefix));
+
+        // Test 2: Mixed <a> (with class) and <img> forms both stripped; unrelated <a> kept
+        $htmlMixed = '<a class="'.$class.'" href="https://www.example.com/imgA.jpg">Label A</a>'.
+            '<a class="other-class" href="https://example.com">keep me</a>'.
+            '<img src="https://www.example.com/imgB.jpg" alt="Label B">';
+        $expected = $prefix.'Label A'.
+            '<a class="other-class" href="https://example.com">keep me</a>'.
+            $prefix.'Label B';
+        static::assertSame($expected, $this->sut->removeLinkTagsByClass($htmlMixed, $class, $prefix));
+    }
 }

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -25,6 +25,8 @@ use Tests\Base\FunctionalTestCase;
 
 class ImageLinkConverterTest extends FunctionalTestCase
 {
+    private const AND_SEPARATOR = ' and ';
+
     /**
      * @var ImageLinkConverter
      */
@@ -73,7 +75,7 @@ class ImageLinkConverterTest extends FunctionalTestCase
         $expectedSegmentText = '<p>Some text '.$linkStartSegmentText.'001'.$linkEnd.
             $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001'.$linkClose.
             ' more text <a href="path/to/image2.jpg">image2</a>'.
-            ' and '.$linkStartSegmentText.'002'.$linkEnd.
+            self::AND_SEPARATOR.$linkStartSegmentText.'002'.$linkEnd.
             $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002'.$linkClose.'</p>';
 
         $expectedRecommendation = '<p>Some text '.$linkStartRecommendation.'001'.$linkEnd.
@@ -165,7 +167,7 @@ class ImageLinkConverterTest extends FunctionalTestCase
             '" src="path/to/image1.jpg" alt="Darstellung_Stell_001">';
         $img2 = '<img class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '" src="path/to/image3.jpg" alt="Darstellung_Stell_002">';
-        $segment->setText('<p>Some text '.$img1.' and '.$img2.'</p>');
+        $segment->setText('<p>Some text '.$img1.self::AND_SEPARATOR.$img2.'</p>');
         $segment->setRecommendation('<p>nothing</p>');
 
         $statementExternId = 'statement123';
@@ -175,7 +177,7 @@ class ImageLinkConverterTest extends FunctionalTestCase
         $linkEnd = '" '.$linkStyle.'>';
         $expectedSegmentText = '<p>Some text '.$linkStartSegmentText.'001'.$linkEnd.
             $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001</a>'.
-            ' and '.$linkStartSegmentText.'002'.$linkEnd.
+            self::AND_SEPARATOR.$linkStartSegmentText.'002'.$linkEnd.
             $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002</a></p>';
 
         $result = $this->sut->convert($segment, $statementExternId);
@@ -205,7 +207,7 @@ class ImageLinkConverterTest extends FunctionalTestCase
         $link2 = '<a href="path/to/image2.jpg">image2</a>';
         $link3 = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
             '" href="path/to/image3.jpg">Darstellung_Stell_002</a>';
-        $text = '<p>Some text '.$link1.' more text '.$link2.' and '.$link3.'</p>';
+        $text = '<p>Some text '.$link1.' more text '.$link2.self::AND_SEPARATOR.$link3.'</p>';
         $recommendation = '<p>Some text <img src="path/to/image4.jpg" /> more text <img src="path/to/image5.jpg" /></p>';
         $segment->setRecommendation($recommendation);
         $segment->setText($text);

--- a/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
+++ b/tests/backend/core/Statement/Functional/ImageLinkConverterTest.php
@@ -157,6 +157,45 @@ class ImageLinkConverterTest extends FunctionalTestCase
         static::assertEmpty($this->sut->getImages());
     }
 
+    public function testConvertWithImgFormInSegmentText(): void
+    {
+        /** @var Segment $segment */
+        $segment = SegmentFactory::createOne()->_real();
+        $img1 = '<img class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" src="path/to/image1.jpg" alt="Darstellung_Stell_001">';
+        $img2 = '<img class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" src="path/to/image3.jpg" alt="Darstellung_Stell_002">';
+        $segment->setText('<p>Some text '.$img1.' and '.$img2.'</p>');
+        $segment->setRecommendation('<p>nothing</p>');
+
+        $statementExternId = 'statement123';
+        $linkStyle = 'style="color: blue; text-decoration: underline;"';
+        $linkStartSegmentText = '<a class="'.HtmlHelper::LINK_CLASS_FOR_DARSTELLUNG_STELL.
+            '" href="#'.$statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX;
+        $linkEnd = '" '.$linkStyle.'>';
+        $expectedSegmentText = '<p>Some text '.$linkStartSegmentText.'001'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001</a>'.
+            ' and '.$linkStartSegmentText.'002'.$linkEnd.
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002</a></p>';
+
+        $result = $this->sut->convert($segment, $statementExternId);
+
+        static::assertSame($expectedSegmentText, $result->getText());
+
+        $images = $this->sut->getImages();
+        [$ref1, $ref2] = $images[0][ImageLinkConverter::IMAGES_KEY_SEGMENTS];
+        static::assertSame(
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'001',
+            $ref1->getImageReference()
+        );
+        static::assertSame('/absolute/path/to/image1.jpg', $ref1->getImagePath());
+        static::assertSame(
+            $statementExternId.ImageLinkConverter::IMAGE_REFERENCE_SEGMENT_TEXT_SUFFIX.'002',
+            $ref2->getImageReference()
+        );
+        static::assertSame('/absolute/path/to/image3.jpg', $ref2->getImagePath());
+    }
+
     private function createTestSegment(): Segment
     {
         /** @var Segment $segment */

--- a/tests/frontend/unit/inlineImageAnchors.test.js
+++ b/tests/frontend/unit/inlineImageAnchors.test.js
@@ -1,0 +1,77 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+import { inlineImageAnchors } from '@DpJs/lib/shared/inlineImageAnchors'
+
+describe('inlineImageAnchors', () => {
+  it('replaces a pdf_importer_image anchor with an img tag', () => {
+    const html = '<p><a class="pdf_importer_image" href="http://example.com/hash.jpg">Label</a></p>'
+    const result = inlineImageAnchors(html)
+
+    expect(result).toContain('<img')
+    expect(result).toContain('src="http://example.com/hash.jpg"')
+    expect(result).toContain('alt="Label"')
+    expect(result).toContain('loading="lazy"')
+    expect(result).not.toContain('<a')
+  })
+
+  it('preserves anchors without the target class', () => {
+    const html = '<a class="other-class" href="http://example.com">keep me</a>'
+    expect(inlineImageAnchors(html)).toBe(html)
+  })
+
+  it('handles anchors with multiple attributes (rel, target)', () => {
+    const html = '<a class="pdf_importer_image" href="http://example.com/img.jpg" rel="noopener noreferrer nofollow" target="_blank">L</a>'
+    const result = inlineImageAnchors(html)
+
+    expect(result).toContain('<img')
+    expect(result).toContain('src="http://example.com/img.jpg"')
+    expect(result).toContain('alt="L"')
+  })
+
+  it('trims the alt value from anchor text content', () => {
+    const html = '<a class="pdf_importer_image" href="x">  spaced label  </a>'
+    expect(inlineImageAnchors(html)).toContain('alt="spaced label"')
+  })
+
+  it('replaces multiple anchors in one pass', () => {
+    const html = '<a class="pdf_importer_image" href="a">A</a><a class="pdf_importer_image" href="b">B</a>'
+    const result = inlineImageAnchors(html)
+
+    const matches = result.match(/<img/g)
+    expect(matches).toHaveLength(2)
+    expect(result).not.toContain('<a')
+  })
+
+  it('mixes pdf_importer_image anchors and unrelated anchors correctly', () => {
+    const html = '<a class="pdf_importer_image" href="x">img</a><a href="y">link</a>'
+    const result = inlineImageAnchors(html)
+
+    expect(result).toContain('<img')
+    expect(result).toContain('<a href="y">link</a>')
+  })
+
+  it('returns the input unchanged when the class is absent', () => {
+    const html = '<p>no images here</p>'
+    expect(inlineImageAnchors(html)).toBe(html)
+  })
+
+  it('returns non-string input unchanged', () => {
+    expect(inlineImageAnchors(null)).toBeNull()
+    expect(inlineImageAnchors(undefined)).toBeUndefined()
+  })
+
+  it('respects a custom className', () => {
+    const html = '<a class="my-class" href="x">L</a>'
+    const result = inlineImageAnchors(html, 'my-class')
+
+    expect(result).toContain('<img')
+    expect(result).toContain('src="x"')
+  })
+})


### PR DESCRIPTION
## Summary
DPLAN-17565

- PI emits image references in segment text as `<a class="pdf_importer_image" href="…">label</a>` so DOCX export can extract them via the anchor class selector. Until now the frontend showed them as plain link text and the umwandeln editor stripped them entirely.
- Frontend swaps anchor → `<img>` at display time (`inlineImageAnchors` helper) and routes the umwandeln DpEditor through it; DpEditor's `imageButton` is enabled so `CustomImage` actually parses the resulting `<img>` instead of dropping it as unknown.
- SegmentationEditor (drafts-list) gets a ProseMirror `markView` for the `link` mark that renders the anchor as inline `<img>` while keeping the text label in a hidden `contentDOM` span — PM doc size and segment char offsets unchanged.
- Backend: `HtmlHelper` now accepts both the legacy anchor form (still produced by PI) and any `<img>` in segment text. Class is only required to disambiguate `<a>` from real hyperlinks; for `<img>` it's redundant.

## Test plan
- [x] Backend: `HtmlHelperTest` (8/8) and `ImageLinkConverterTest` (6/6) including new img-form cases
- [x] Frontend: jest `inlineImageAnchors.test.js` (9/9)
- [x] PHPStan level 5 clean on changed PHP
- [x] Manual: image renders inline in einwendungen list, abschnitte (segment views), drafts-list, and umwandeln editor; round-trip save preserves image