### PR TITLE
fix(DPLAN-17759): unsaved changes modal triggers after save

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementEntry.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementEntry.vue
@@ -245,13 +245,29 @@ export default {
         return false
       }
 
-      const initialAttributes = this.deepCloneSerializable(this.statement.attributes)
-      initialAttributes.authoredDate = this.getFormattedDate(initialAttributes.authoredDate)
-      initialAttributes.submitDate = this.getFormattedDate(initialAttributes.submitDate)
-
+      const initialAttributes = this.statement.attributes
       const currentAttributes = this.localStatement.attributes
 
-      return JSON.stringify(currentAttributes) !== JSON.stringify(initialAttributes)
+      if (this.getFormattedDate(currentAttributes.authoredDate) !== this.getFormattedDate(initialAttributes.authoredDate)) {
+        return true
+      }
+      if (this.getFormattedDate(currentAttributes.submitDate) !== this.getFormattedDate(initialAttributes.submitDate)) {
+        return true
+      }
+      if ((currentAttributes.submitType ?? '') !== (initialAttributes.submitType ?? '')) {
+        return true
+      }
+      if ((currentAttributes.internId ?? '') !== (initialAttributes.internId ?? '')) {
+        return true
+      }
+      if (hasPermission('field_statement_phase') && (currentAttributes.procedurePhase?.key ?? '') !== (initialAttributes.procedurePhase?.key ?? '')) {
+        return true
+      }
+      if (hasPermission('field_statement_memo') && (currentAttributes.memo ?? '') !== (initialAttributes.memo ?? '')) {
+        return true
+      }
+
+      return false
     },
 
     isStatementManual () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementEntry.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementEntry.vue
@@ -247,27 +247,19 @@ export default {
 
       const initialAttributes = this.statement.attributes
       const currentAttributes = this.localStatement.attributes
+      const isDifferent = (a, b) => (a ?? '') !== (b ?? '')
+      const isDifferentDate = (a, b) => this.getFormattedDate(a) !== this.getFormattedDate(b)
 
-      if (this.getFormattedDate(currentAttributes.authoredDate) !== this.getFormattedDate(initialAttributes.authoredDate)) {
-        return true
-      }
-      if (this.getFormattedDate(currentAttributes.submitDate) !== this.getFormattedDate(initialAttributes.submitDate)) {
-        return true
-      }
-      if ((currentAttributes.submitType ?? '') !== (initialAttributes.submitType ?? '')) {
-        return true
-      }
-      if ((currentAttributes.internId ?? '') !== (initialAttributes.internId ?? '')) {
-        return true
-      }
-      if (hasPermission('field_statement_phase') && (currentAttributes.procedurePhase?.key ?? '') !== (initialAttributes.procedurePhase?.key ?? '')) {
-        return true
-      }
-      if (hasPermission('field_statement_memo') && (currentAttributes.memo ?? '') !== (initialAttributes.memo ?? '')) {
-        return true
-      }
-
-      return false
+      return [
+        isDifferentDate(currentAttributes.authoredDate, initialAttributes.authoredDate),
+        isDifferentDate(currentAttributes.submitDate, initialAttributes.submitDate),
+        isDifferent(currentAttributes.submitType, initialAttributes.submitType),
+        isDifferent(currentAttributes.internId, initialAttributes.internId),
+        hasPermission('field_statement_phase') &&
+          isDifferent(currentAttributes.procedurePhase?.key, initialAttributes.procedurePhase?.key),
+        hasPermission('field_statement_memo') &&
+          isDifferent(currentAttributes.memo, initialAttributes.memo),
+      ].some(Boolean)
     },
 
     isStatementManual () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementMetaAttachments.vue
@@ -248,14 +248,10 @@ export default {
 
   computed: {
     hasUnsavedChanges () {
-      if (!this.localAttachments || !this.initialAttachments) {
-        return false
-      }
-
-      const initialAttributes = this.initialAttachments
-      const currentAttributes = this.localAttachments
-
-      return JSON.stringify(currentAttributes) !== JSON.stringify(initialAttributes)
+      return this.fileIds.length > 0 ||
+        this.genericAttachmentsMarkedForDeletion.length > 0 ||
+        this.isSourceAttachmentMarkedForDeletion ||
+        this.fileIdSourceAttachment !== ''
     },
   },
 

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -244,7 +244,23 @@ export default {
       const initialAttributes = this.statement.attributes
       const currentAttributes = this.localStatement.attributes
 
-      return JSON.stringify(currentAttributes) !== JSON.stringify(initialAttributes)
+      const stringFields = [
+        'initialOrganisationDepartmentName',
+        'initialOrganisationName',
+        'authorName',
+        'submitName',
+        'submitterEmailAddress',
+        'initialOrganisationStreet',
+        'initialOrganisationHouseNumber',
+        'initialOrganisationPostalCode',
+        'initialOrganisationCity',
+      ]
+
+      if (stringFields.some(field => (currentAttributes[field] ?? '') !== (initialAttributes[field] ?? ''))) {
+        return true
+      }
+
+      return Boolean(currentAttributes.representationChecked) !== Boolean(initialAttributes.representationChecked)
     },
 
     isStatementManual () {

--- a/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementMeta/StatementSubmitter.vue
@@ -243,6 +243,7 @@ export default {
 
       const initialAttributes = this.statement.attributes
       const currentAttributes = this.localStatement.attributes
+      const isDifferent = (a, b) => (a ?? '') !== (b ?? '')
 
       const stringFields = [
         'initialOrganisationDepartmentName',
@@ -256,11 +257,10 @@ export default {
         'initialOrganisationCity',
       ]
 
-      if (stringFields.some(field => (currentAttributes[field] ?? '') !== (initialAttributes[field] ?? ''))) {
-        return true
-      }
-
-      return Boolean(currentAttributes.representationChecked) !== Boolean(initialAttributes.representationChecked)
+      return [
+        ...stringFields.map(field => isDifferent(currentAttributes[field], initialAttributes[field])),
+        Boolean(currentAttributes.representationChecked) !== Boolean(initialAttributes.representationChecked),
+      ].some(Boolean)
     },
 
     isStatementManual () {


### PR DESCRIPTION
### Ticket
DPLAN-17759

### Description
`hasUnsavedChanges` in `StatementEntry`, `StatementSubmitter` and `StatementMetaAttachments` compared the full attribute object via `JSON.stringify`. After a save, the store re-builds the statement resource (different key order, server-canonicalized values, added fields like `modifyDate`) while the local clone stays untouched, so the comparison flagged a diff even though every edited field matched. Editing the text editor below `StatementMeta` mutated unrelated attributes on the same record and produced the same false positive. Switched each component to compare only the fields it actually edits.

### How to review/test
1. Log in as admin
2. Open a procedure → Stellungnahmen → open a statement → Details
3. Edit a submitter field (e.g. email), click the form save button
4. Click a menu link to navigate away — modal must NOT appear
5. Edit the field again, do NOT save, click a link — modal MUST appear
6. Repeat for the Eintrag section (intern ID, memo, dates, submit type)
7. Repeat for attachments: add file → save → navigate (no modal); mark for delete → save → navigate (no modal)
8. Edit text in the editor below `StatementMeta`, save it, navigate — modal must NOT appear

### PR Checklist
- [x] Run `yarn lint`
- [x] Run `yarn test`