### PR TITLE
fix(refs HDDP-18): add command to repair cross-procedure file references

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
@@ -12,11 +12,14 @@ namespace demosplan\DemosPlanCoreBundle\Command;
 
 use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
 use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
+use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,13 +28,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Throwable;
 
+#[AsCommand(
+    name: 'dplan:files:fix-procedure-mismatches',
+    description: 'Find and (with --apply) fix _elements/_single_doc references pointing at files owned by a different procedure. Dry-run by default.',
+)]
 class FixProcedureFileMismatchesCommand extends CoreCommand
 {
-    protected static $defaultName = 'dplan:files:fix-procedure-mismatches';
-
-    protected static $defaultDescription = 'Find and (with --apply) fix _elements/_single_doc references pointing at files owned by a different procedure (HDDP-18). Dry-run by default.';
-
     private const BATCH_SIZE = 50;
+
+    private const OUTCOME_FIXED = 'fixed';
+    private const OUTCOME_SKIPPED = 'skipped';
 
     public function __construct(
         ParameterBagInterface $parameterBag,
@@ -82,10 +88,26 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
         $includeDeleted = (bool) $input->getOption('include-deleted-owners');
         $limit = null !== $input->getOption('limit') ? (int) $input->getOption('limit') : null;
 
-        $io->title('HDDP-18 — procedure/file mismatch '.($apply ? 'fix' : 'audit (dry-run)'));
+        $io->title('Procedure/file mismatch '.($apply ? 'fix' : 'audit (dry-run)'));
 
-        $elementIds = $this->findMismatchedElementIds($procedureId, $includeDeleted, $limit);
-        $singleDocIds = $this->findMismatchedSingleDocIds($procedureId, $includeDeleted, $limit);
+        $elementIds = $this->findMismatchedReferenceIds(
+            '_elements',
+            '_e_id',
+            '_e_file',
+            '_e_deleted',
+            $procedureId,
+            $includeDeleted,
+            $limit
+        );
+        $singleDocIds = $this->findMismatchedReferenceIds(
+            '_single_doc',
+            '_sd_id',
+            '_sd_document',
+            '_sd_deleted',
+            $procedureId,
+            $includeDeleted,
+            $limit
+        );
 
         $io->section('Discovery');
         $io->table(
@@ -124,8 +146,8 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
         }
 
         $io->section('Applying fixes');
-        $elementsResult = $this->fixElements($io, $elementIds);
-        $singleDocsResult = $this->fixSingleDocs($io, $singleDocIds);
+        $elementsResult = $this->applyFixes($io, $elementIds, fn (string $id): string => $this->fixElement($id));
+        $singleDocsResult = $this->applyFixes($io, $singleDocIds, fn (string $id): string => $this->fixSingleDoc($id));
 
         $io->section('Summary');
         $io->table(
@@ -148,56 +170,50 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
     }
 
     /**
+     * Finds references in $table whose embedded file ident resolves to a _files
+     * row owned by a different procedure than the reference's own procedure.
+     *
+     * The reference is stored as a colon-delimited file string (see
+     * {@see File::getFileString()}: "filename:ident:size:mimetype"). The nested
+     * SUBSTRING_INDEX calls peel the ident (2nd field) off the right-hand end, so
+     * a filename containing ":" does not shift the result. Keep the extraction in
+     * sync with that format.
+     *
      * @return list<string>
      */
-    private function findMismatchedElementIds(?string $procedureId, bool $includeDeleted, ?int $limit): array
-    {
-        $sql = 'SELECT e._e_id
-                FROM _elements e
-                JOIN _files f
-                  ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(e._e_file, ":", -3), ":", 1)
-                JOIN _procedure p
-                  ON p._p_id = e._p_id
-                WHERE e._e_deleted = 0
-                  AND f._f_deleted = 0
-                  AND e._p_id <> f.procedure_id';
+    private function findMismatchedReferenceIds(
+        string $table,
+        string $idColumn,
+        string $fileColumn,
+        string $deletedColumn,
+        ?string $procedureId,
+        bool $includeDeleted,
+        ?int $limit,
+    ): array {
+        // Identifiers are internal constants (never user input); $limit is cast to
+        // int by the caller, so interpolating them is safe.
+        $sql = sprintf(
+            'SELECT ref.%1$s
+             FROM %2$s ref
+             JOIN _files f
+               ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(ref.%3$s, ":", -3), ":", 1)
+             JOIN _procedure p
+               ON p._p_id = ref._p_id
+             WHERE ref.%4$s = 0
+               AND f._f_deleted = 0
+               AND ref._p_id <> f.procedure_id',
+            $idColumn,
+            $table,
+            $fileColumn,
+            $deletedColumn
+        );
         $params = [];
 
         if (!$includeDeleted) {
             $sql .= ' AND p._p_deleted = 0';
         }
         if (null !== $procedureId) {
-            $sql .= ' AND e._p_id = :pid';
-            $params['pid'] = $procedureId;
-        }
-        if (null !== $limit) {
-            $sql .= ' LIMIT '.$limit;
-        }
-
-        return $this->connection->fetchFirstColumn($sql, $params);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function findMismatchedSingleDocIds(?string $procedureId, bool $includeDeleted, ?int $limit): array
-    {
-        $sql = 'SELECT sd._sd_id
-                FROM _single_doc sd
-                JOIN _files f
-                  ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(sd._sd_document, ":", -3), ":", 1)
-                JOIN _procedure p
-                  ON p._p_id = sd._p_id
-                WHERE sd._sd_deleted = 0
-                  AND f._f_deleted = 0
-                  AND sd._p_id <> f.procedure_id';
-        $params = [];
-
-        if (!$includeDeleted) {
-            $sql .= ' AND p._p_deleted = 0';
-        }
-        if (null !== $procedureId) {
-            $sql .= ' AND sd._p_id = :pid';
+            $sql .= ' AND ref._p_id = :pid';
             $params['pid'] = $procedureId;
         }
         if (null !== $limit) {
@@ -261,44 +277,32 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
     }
 
     /**
-     * @param list<string> $ids
+     * Runs $fixOne for each id, owning the shared bookkeeping: progress bar,
+     * batched flush/clear, per-reference error isolation and outcome counters.
+     * $fixOne returns self::OUTCOME_FIXED or self::OUTCOME_SKIPPED and may throw
+     * to mark a reference as failed.
      *
-     * @return array{fixed:int,skipped:int,errors:int}
+     * @param list<string>             $ids
+     * @param callable(string): string $fixOne
+     *
+     * @return array{fixed: int, skipped: int, errors: int}
      */
-    private function fixElements(SymfonyStyle $io, array $ids): array
+    private function applyFixes(SymfonyStyle $io, array $ids, callable $fixOne): array
     {
         $fixed = $skipped = $errors = 0;
         $io->progressStart(count($ids));
 
         foreach ($ids as $i => $id) {
             try {
-                /** @var Elements|null $element */
-                $element = $this->entityManager->find(Elements::class, $id);
-                if (null === $element) {
-                    ++$errors;
-                    $this->logger->error('Element not found during HDDP-18 fix', ['_e_id' => $id]);
-                    continue;
-                }
-
-                $newFile = $this->fileService->createCopyOfFile(
-                    $element->getFile(),
-                    $element->getProcedure()->getId()
-                );
-                if (null === $newFile) {
+                if (self::OUTCOME_SKIPPED === $fixOne($id)) {
                     ++$skipped;
-                    $this->logger->warning('Skipped element — source file missing', [
-                        '_e_id'   => $id,
-                        'oldFile' => $element->getFile(),
-                    ]);
-                    continue;
+                } else {
+                    ++$fixed;
                 }
-
-                $element->setFile($newFile->getFileString());
-                ++$fixed;
             } catch (Throwable $e) {
                 ++$errors;
-                $this->logger->error('Failed to fix element', [
-                    '_e_id'     => $id,
+                $this->logger->error('Failed to fix file reference', [
+                    'id'        => $id,
                     'exception' => $e,
                 ]);
             }
@@ -317,60 +321,47 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
         return ['fixed' => $fixed, 'skipped' => $skipped, 'errors' => $errors];
     }
 
-    /**
-     * @param list<string> $ids
-     *
-     * @return array{fixed:int,skipped:int,errors:int}
-     */
-    private function fixSingleDocs(SymfonyStyle $io, array $ids): array
+    private function fixElement(string $id): string
     {
-        $fixed = $skipped = $errors = 0;
-        $io->progressStart(count($ids));
-
-        foreach ($ids as $i => $id) {
-            try {
-                /** @var SingleDocument|null $sd */
-                $sd = $this->entityManager->find(SingleDocument::class, $id);
-                if (null === $sd) {
-                    ++$errors;
-                    $this->logger->error('SingleDocument not found during HDDP-18 fix', ['_sd_id' => $id]);
-                    continue;
-                }
-
-                $newFile = $this->fileService->createCopyOfFile(
-                    $sd->getDocument(),
-                    $sd->getProcedure()->getId()
-                );
-                if (null === $newFile) {
-                    ++$skipped;
-                    $this->logger->warning('Skipped single_doc — source file missing', [
-                        '_sd_id'  => $id,
-                        'oldFile' => $sd->getDocument(),
-                    ]);
-                    continue;
-                }
-
-                $sd->setDocument($newFile->getFileString());
-                ++$fixed;
-            } catch (Throwable $e) {
-                ++$errors;
-                $this->logger->error('Failed to fix single_doc', [
-                    '_sd_id'    => $id,
-                    'exception' => $e,
-                ]);
-            }
-
-            if (0 === ($i + 1) % self::BATCH_SIZE) {
-                $this->entityManager->flush();
-                $this->entityManager->clear();
-            }
-            $io->progressAdvance();
+        $element = $this->entityManager->find(Elements::class, $id);
+        if (!$element instanceof Elements) {
+            throw new RuntimeException(sprintf('Element %s not found', $id));
         }
 
-        $this->entityManager->flush();
-        $this->entityManager->clear();
-        $io->progressFinish();
+        $newFile = $this->fileService->createCopyOfFile($element->getFile(), $element->getProcedure()->getId());
+        if (null === $newFile) {
+            $this->logger->warning('Skipped element — source file missing', [
+                '_e_id'   => $id,
+                'oldFile' => $element->getFile(),
+            ]);
 
-        return ['fixed' => $fixed, 'skipped' => $skipped, 'errors' => $errors];
+            return self::OUTCOME_SKIPPED;
+        }
+
+        $element->setFile($newFile->getFileString());
+
+        return self::OUTCOME_FIXED;
+    }
+
+    private function fixSingleDoc(string $id): string
+    {
+        $singleDoc = $this->entityManager->find(SingleDocument::class, $id);
+        if (!$singleDoc instanceof SingleDocument) {
+            throw new RuntimeException(sprintf('SingleDocument %s not found', $id));
+        }
+
+        $newFile = $this->fileService->createCopyOfFile($singleDoc->getDocument(), $singleDoc->getProcedure()->getId());
+        if (null === $newFile) {
+            $this->logger->warning('Skipped single_doc — source file missing', [
+                '_sd_id'  => $id,
+                'oldFile' => $singleDoc->getDocument(),
+            ]);
+
+            return self::OUTCOME_SKIPPED;
+        }
+
+        $singleDoc->setDocument($newFile->getFileString());
+
+        return self::OUTCOME_FIXED;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
@@ -1,0 +1,376 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command;
+
+use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
+use demosplan\DemosPlanCoreBundle\Logic\FileService;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Throwable;
+
+class FixProcedureFileMismatchesCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:files:fix-procedure-mismatches';
+
+    protected static $defaultDescription = 'Find and (with --apply) fix _elements/_single_doc references pointing at files owned by a different procedure (HDDP-18). Dry-run by default.';
+
+    private const BATCH_SIZE = 50;
+
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly Connection $connection,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FileService $fileService,
+        private readonly LoggerInterface $logger,
+        string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'apply',
+                null,
+                InputOption::VALUE_NONE,
+                'Actually perform the fix. Without this flag the command only reports what would change.'
+            )
+            ->addOption(
+                'procedure',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Restrict to a single owning procedure ID.'
+            )
+            ->addOption(
+                'include-deleted-owners',
+                null,
+                InputOption::VALUE_NONE,
+                'Also process references whose owning procedure is soft-deleted (skipped by default).'
+            )
+            ->addOption(
+                'limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Process at most N references per table (useful for staged rollout).'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $apply          = (bool) $input->getOption('apply');
+        $procedureId    = $input->getOption('procedure');
+        $includeDeleted = (bool) $input->getOption('include-deleted-owners');
+        $limit          = null !== $input->getOption('limit') ? (int) $input->getOption('limit') : null;
+
+        $io->title('HDDP-18 — procedure/file mismatch '.($apply ? 'fix' : 'audit (dry-run)'));
+
+        $elementIds   = $this->findMismatchedElementIds($procedureId, $includeDeleted, $limit);
+        $singleDocIds = $this->findMismatchedSingleDocIds($procedureId, $includeDeleted, $limit);
+
+        $io->section('Discovery');
+        $io->table(
+            ['Reference table', 'Broken references'],
+            [
+                ['_elements', count($elementIds)],
+                ['_single_doc', count($singleDocIds)],
+            ]
+        );
+
+        if ([] === $elementIds && [] === $singleDocIds) {
+            $io->success('Nothing to fix.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->reportByOwningProcedure($io, $elementIds, $singleDocIds);
+
+        if (!$apply) {
+            $io->note('Dry-run only. No changes made. Re-run with --apply to fix.');
+
+            return Command::SUCCESS;
+        }
+
+        if ($input->isInteractive() && !$io->confirm(
+            sprintf(
+                'About to fix %d _elements and %d _single_doc references. Continue?',
+                count($elementIds),
+                count($singleDocIds)
+            ),
+            false
+        )) {
+            $io->warning('Aborted.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->section('Applying fixes');
+        $elementsResult   = $this->fixElements($io, $elementIds);
+        $singleDocsResult = $this->fixSingleDocs($io, $singleDocIds);
+
+        $io->section('Summary');
+        $io->table(
+            ['Reference table', 'Fixed', 'Skipped (file missing)', 'Errors'],
+            [
+                ['_elements',   $elementsResult['fixed'],   $elementsResult['skipped'],   $elementsResult['errors']],
+                ['_single_doc', $singleDocsResult['fixed'], $singleDocsResult['skipped'], $singleDocsResult['errors']],
+            ]
+        );
+
+        if ($elementsResult['errors'] > 0 || $singleDocsResult['errors'] > 0) {
+            $io->warning('Completed with errors. Inspect the log for details.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Done.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findMismatchedElementIds(?string $procedureId, bool $includeDeleted, ?int $limit): array
+    {
+        $sql = 'SELECT e._e_id
+                FROM _elements e
+                JOIN _files f
+                  ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(e._e_file, ":", -3), ":", 1)
+                JOIN _procedure p
+                  ON p._p_id = e._p_id
+                WHERE e._e_deleted = 0
+                  AND f._f_deleted = 0
+                  AND e._p_id <> f.procedure_id';
+        $params = [];
+
+        if (!$includeDeleted) {
+            $sql .= ' AND p._p_deleted = 0';
+        }
+        if (null !== $procedureId) {
+            $sql .= ' AND e._p_id = :pid';
+            $params['pid'] = $procedureId;
+        }
+        if (null !== $limit) {
+            $sql .= ' LIMIT '.$limit;
+        }
+
+        return $this->connection->fetchFirstColumn($sql, $params);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findMismatchedSingleDocIds(?string $procedureId, bool $includeDeleted, ?int $limit): array
+    {
+        $sql = 'SELECT sd._sd_id
+                FROM _single_doc sd
+                JOIN _files f
+                  ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(sd._sd_document, ":", -3), ":", 1)
+                JOIN _procedure p
+                  ON p._p_id = sd._p_id
+                WHERE sd._sd_deleted = 0
+                  AND f._f_deleted = 0
+                  AND sd._p_id <> f.procedure_id';
+        $params = [];
+
+        if (!$includeDeleted) {
+            $sql .= ' AND p._p_deleted = 0';
+        }
+        if (null !== $procedureId) {
+            $sql .= ' AND sd._p_id = :pid';
+            $params['pid'] = $procedureId;
+        }
+        if (null !== $limit) {
+            $sql .= ' LIMIT '.$limit;
+        }
+
+        return $this->connection->fetchFirstColumn($sql, $params);
+    }
+
+    /**
+     * @param list<string> $elementIds
+     * @param list<string> $singleDocIds
+     */
+    private function reportByOwningProcedure(SymfonyStyle $io, array $elementIds, array $singleDocIds): void
+    {
+        $unionParts = [];
+        $params     = [];
+        $types      = [];
+
+        if ([] !== $elementIds) {
+            $unionParts[]   = 'SELECT _p_id, COUNT(*) AS cnt FROM _elements WHERE _e_id IN (:eids) GROUP BY _p_id';
+            $params['eids'] = $elementIds;
+            $types['eids']  = ArrayParameterType::STRING;
+        }
+        if ([] !== $singleDocIds) {
+            $unionParts[]    = 'SELECT _p_id, COUNT(*) AS cnt FROM _single_doc WHERE _sd_id IN (:sdids) GROUP BY _p_id';
+            $params['sdids'] = $singleDocIds;
+            $types['sdids']  = ArrayParameterType::STRING;
+        }
+        if ([] === $unionParts) {
+            return;
+        }
+
+        $sql = 'SELECT p._p_id      AS proc_id,
+                       p._p_name    AS proc_name,
+                       p._p_master  AS is_blueprint,
+                       p._p_deleted AS deleted,
+                       SUM(refs.cnt) AS broken
+                FROM ('.implode(' UNION ALL ', $unionParts).') refs
+                JOIN _procedure p ON p._p_id = refs._p_id
+                GROUP BY p._p_id, p._p_name, p._p_master, p._p_deleted
+                ORDER BY broken DESC
+                LIMIT 30';
+
+        $rows = $this->connection->fetchAllAssociative($sql, $params, $types);
+
+        $io->section('Top owning procedures with broken refs');
+        $io->table(
+            ['Procedure ID', 'Name', 'Blaupause', 'Deleted', 'Broken refs'],
+            array_map(
+                static fn (array $r): array => [
+                    $r['proc_id'],
+                    mb_substr((string) $r['proc_name'], 0, 50),
+                    $r['is_blueprint'] ? 'yes' : '',
+                    $r['deleted'] ? 'yes' : '',
+                    (int) $r['broken'],
+                ],
+                $rows
+            )
+        );
+    }
+
+    /**
+     * @param list<string> $ids
+     *
+     * @return array{fixed:int,skipped:int,errors:int}
+     */
+    private function fixElements(SymfonyStyle $io, array $ids): array
+    {
+        $fixed = $skipped = $errors = 0;
+        $io->progressStart(count($ids));
+
+        foreach ($ids as $i => $id) {
+            try {
+                /** @var Elements|null $element */
+                $element = $this->entityManager->find(Elements::class, $id);
+                if (null === $element) {
+                    ++$errors;
+                    $this->logger->error('Element not found during HDDP-18 fix', ['_e_id' => $id]);
+                    continue;
+                }
+
+                $newFile = $this->fileService->createCopyOfFile(
+                    $element->getFile(),
+                    $element->getProcedure()->getId()
+                );
+                if (null === $newFile) {
+                    ++$skipped;
+                    $this->logger->warning('Skipped element — source file missing', [
+                        '_e_id'   => $id,
+                        'oldFile' => $element->getFile(),
+                    ]);
+                    continue;
+                }
+
+                $element->setFile($newFile->getFileString());
+                ++$fixed;
+            } catch (Throwable $e) {
+                ++$errors;
+                $this->logger->error('Failed to fix element', [
+                    '_e_id'     => $id,
+                    'exception' => $e,
+                ]);
+            }
+
+            if (0 === ($i + 1) % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+            }
+            $io->progressAdvance();
+        }
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+        $io->progressFinish();
+
+        return ['fixed' => $fixed, 'skipped' => $skipped, 'errors' => $errors];
+    }
+
+    /**
+     * @param list<string> $ids
+     *
+     * @return array{fixed:int,skipped:int,errors:int}
+     */
+    private function fixSingleDocs(SymfonyStyle $io, array $ids): array
+    {
+        $fixed = $skipped = $errors = 0;
+        $io->progressStart(count($ids));
+
+        foreach ($ids as $i => $id) {
+            try {
+                /** @var SingleDocument|null $sd */
+                $sd = $this->entityManager->find(SingleDocument::class, $id);
+                if (null === $sd) {
+                    ++$errors;
+                    $this->logger->error('SingleDocument not found during HDDP-18 fix', ['_sd_id' => $id]);
+                    continue;
+                }
+
+                $newFile = $this->fileService->createCopyOfFile(
+                    $sd->getDocument(),
+                    $sd->getProcedure()->getId()
+                );
+                if (null === $newFile) {
+                    ++$skipped;
+                    $this->logger->warning('Skipped single_doc — source file missing', [
+                        '_sd_id'  => $id,
+                        'oldFile' => $sd->getDocument(),
+                    ]);
+                    continue;
+                }
+
+                $sd->setDocument($newFile->getFileString());
+                ++$fixed;
+            } catch (Throwable $e) {
+                ++$errors;
+                $this->logger->error('Failed to fix single_doc', [
+                    '_sd_id'    => $id,
+                    'exception' => $e,
+                ]);
+            }
+
+            if (0 === ($i + 1) % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+            }
+            $io->progressAdvance();
+        }
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+        $io->progressFinish();
+
+        return ['fixed' => $fixed, 'skipped' => $skipped, 'errors' => $errors];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FixProcedureFileMismatchesCommand.php
@@ -39,7 +39,7 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
         private readonly EntityManagerInterface $entityManager,
         private readonly FileService $fileService,
         private readonly LoggerInterface $logger,
-        string $name = null,
+        ?string $name = null,
     ) {
         parent::__construct($parameterBag, $name);
     }
@@ -77,14 +77,14 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
     {
         $io = new SymfonyStyle($input, $output);
 
-        $apply          = (bool) $input->getOption('apply');
-        $procedureId    = $input->getOption('procedure');
+        $apply = (bool) $input->getOption('apply');
+        $procedureId = $input->getOption('procedure');
         $includeDeleted = (bool) $input->getOption('include-deleted-owners');
-        $limit          = null !== $input->getOption('limit') ? (int) $input->getOption('limit') : null;
+        $limit = null !== $input->getOption('limit') ? (int) $input->getOption('limit') : null;
 
         $io->title('HDDP-18 — procedure/file mismatch '.($apply ? 'fix' : 'audit (dry-run)'));
 
-        $elementIds   = $this->findMismatchedElementIds($procedureId, $includeDeleted, $limit);
+        $elementIds = $this->findMismatchedElementIds($procedureId, $includeDeleted, $limit);
         $singleDocIds = $this->findMismatchedSingleDocIds($procedureId, $includeDeleted, $limit);
 
         $io->section('Discovery');
@@ -124,7 +124,7 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
         }
 
         $io->section('Applying fixes');
-        $elementsResult   = $this->fixElements($io, $elementIds);
+        $elementsResult = $this->fixElements($io, $elementIds);
         $singleDocsResult = $this->fixSingleDocs($io, $singleDocIds);
 
         $io->section('Summary');
@@ -214,18 +214,18 @@ class FixProcedureFileMismatchesCommand extends CoreCommand
     private function reportByOwningProcedure(SymfonyStyle $io, array $elementIds, array $singleDocIds): void
     {
         $unionParts = [];
-        $params     = [];
-        $types      = [];
+        $params = [];
+        $types = [];
 
         if ([] !== $elementIds) {
-            $unionParts[]   = 'SELECT _p_id, COUNT(*) AS cnt FROM _elements WHERE _e_id IN (:eids) GROUP BY _p_id';
+            $unionParts[] = 'SELECT _p_id, COUNT(*) AS cnt FROM _elements WHERE _e_id IN (:eids) GROUP BY _p_id';
             $params['eids'] = $elementIds;
-            $types['eids']  = ArrayParameterType::STRING;
+            $types['eids'] = ArrayParameterType::STRING;
         }
         if ([] !== $singleDocIds) {
-            $unionParts[]    = 'SELECT _p_id, COUNT(*) AS cnt FROM _single_doc WHERE _sd_id IN (:sdids) GROUP BY _p_id';
+            $unionParts[] = 'SELECT _p_id, COUNT(*) AS cnt FROM _single_doc WHERE _sd_id IN (:sdids) GROUP BY _p_id';
             $params['sdids'] = $singleDocIds;
-            $types['sdids']  = ArrayParameterType::STRING;
+            $types['sdids'] = ArrayParameterType::STRING;
         }
         if ([] === $unionParts) {
             return;

--- a/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
+++ b/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
@@ -32,8 +32,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class FixProcedureFileMismatchesCommandTest extends TestCase
 {
-    private const ELEMENT_DISCOVERY_SQL_FRAGMENT = 'FROM _elements e';
-    private const SINGLE_DOC_DISCOVERY_SQL_FRAGMENT = 'FROM _single_doc sd';
+    private const ELEMENT_DISCOVERY_SQL_FRAGMENT = 'FROM _elements ref';
+    private const SINGLE_DOC_DISCOVERY_SQL_FRAGMENT = 'FROM _single_doc ref';
 
     private Connection&MockObject $connection;
     private EntityManagerInterface&MockObject $entityManager;
@@ -210,8 +210,8 @@ class FixProcedureFileMismatchesCommandTest extends TestCase
             ->expects(self::once())
             ->method('error')
             ->with(
-                self::stringContains('Failed to fix single_doc'),
-                self::callback(static fn (array $ctx) => 'sd1' === ($ctx['_sd_id'] ?? null)
+                self::stringContains('Failed to fix file reference'),
+                self::callback(static fn (array $ctx) => 'sd1' === ($ctx['id'] ?? null)
                     && $ctx['exception'] instanceof RuntimeException)
             );
 
@@ -228,11 +228,8 @@ class FixProcedureFileMismatchesCommandTest extends TestCase
             ->expects(self::exactly(2))
             ->method('fetchFirstColumn')
             ->willReturnCallback(function (string $sql, array $params): array {
-                // First call is the _elements query (alias e), second the _single_doc query (alias sd).
-                self::assertTrue(
-                    str_contains($sql, 'e._p_id = :pid') || str_contains($sql, 'sd._p_id = :pid'),
-                    'Expected procedure filter on either e._p_id or sd._p_id'
-                );
+                // Both discovery queries share the generic alias "ref".
+                self::assertStringContainsString('ref._p_id = :pid', $sql);
                 self::assertSame('only-this-procedure', $params['pid']);
 
                 return [];

--- a/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
+++ b/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class FixProcedureFileMismatchesCommandTest extends TestCase
 {
-    private const ELEMENT_DISCOVERY_SQL_FRAGMENT   = 'FROM _elements e';
+    private const ELEMENT_DISCOVERY_SQL_FRAGMENT = 'FROM _elements e';
     private const SINGLE_DOC_DISCOVERY_SQL_FRAGMENT = 'FROM _single_doc sd';
 
     private Connection&MockObject $connection;
@@ -45,11 +45,11 @@ class FixProcedureFileMismatchesCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->connection    = $this->createMock(Connection::class);
+        $this->connection = $this->createMock(Connection::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->fileService   = $this->createMock(FileService::class);
-        $this->logger        = $this->createMock(LoggerInterface::class);
-        $this->parameterBag  = $this->createMock(ParameterBagInterface::class);
+        $this->fileService = $this->createMock(FileService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
     }
 
     public function testDryRunReportsNothingToFixWhenDiscoveryEmpty(): void

--- a/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
+++ b/tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Unit\Command;
+
+use demosplan\DemosPlanCoreBundle\Application\ConsoleApplication;
+use demosplan\DemosPlanCoreBundle\Command\FixProcedureFileMismatchesCommand;
+use demosplan\DemosPlanCoreBundle\Entity\Document\Elements;
+use demosplan\DemosPlanCoreBundle\Entity\Document\SingleDocument;
+use demosplan\DemosPlanCoreBundle\Entity\File;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Logic\FileService;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class FixProcedureFileMismatchesCommandTest extends TestCase
+{
+    private const ELEMENT_DISCOVERY_SQL_FRAGMENT   = 'FROM _elements e';
+    private const SINGLE_DOC_DISCOVERY_SQL_FRAGMENT = 'FROM _single_doc sd';
+
+    private Connection&MockObject $connection;
+    private EntityManagerInterface&MockObject $entityManager;
+    private FileService&MockObject $fileService;
+    private LoggerInterface&MockObject $logger;
+    private ParameterBagInterface&MockObject $parameterBag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection    = $this->createMock(Connection::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->fileService   = $this->createMock(FileService::class);
+        $this->logger        = $this->createMock(LoggerInterface::class);
+        $this->parameterBag  = $this->createMock(ParameterBagInterface::class);
+    }
+
+    public function testDryRunReportsNothingToFixWhenDiscoveryEmpty(): void
+    {
+        $this->stubDiscovery(elementIds: [], singleDocIds: []);
+
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('Nothing to fix', $tester->getDisplay());
+        self::assertStringNotContainsString('Applying fixes', $tester->getDisplay());
+    }
+
+    public function testDryRunReportsCountsAndDoesNotMutate(): void
+    {
+        $this->stubDiscovery(elementIds: ['e1'], singleDocIds: ['sd1', 'sd2']);
+        $this->stubReportByOwningProcedure();
+
+        // No find / flush / FileService calls expected during dry-run.
+        $this->entityManager->expects(self::never())->method('find');
+        $this->entityManager->expects(self::never())->method('flush');
+        $this->fileService->expects(self::never())->method('createCopyOfFile');
+
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dry-run only', $display);
+        self::assertStringContainsString('_elements', $display);
+        self::assertStringContainsString('_single_doc', $display);
+    }
+
+    public function testApplyFixesSingleDocMismatch(): void
+    {
+        $this->stubDiscovery(elementIds: [], singleDocIds: ['sd1']);
+        $this->stubReportByOwningProcedure();
+
+        $procedure = $this->makeProcedure('proc-derived');
+        $singleDoc = $this->createMock(SingleDocument::class);
+        $singleDoc->method('getDocument')->willReturn('old.pdf:old-ident:123:application/pdf');
+        $singleDoc->method('getProcedure')->willReturn($procedure);
+        $singleDoc->expects(self::once())
+            ->method('setDocument')
+            ->with('new.pdf:new-ident:123:application/pdf');
+
+        $newFile = $this->createMock(File::class);
+        $newFile->method('getFileString')->willReturn('new.pdf:new-ident:123:application/pdf');
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('find')
+            ->with(SingleDocument::class, 'sd1')
+            ->willReturn($singleDoc);
+
+        $this->fileService
+            ->expects(self::once())
+            ->method('createCopyOfFile')
+            ->with('old.pdf:old-ident:123:application/pdf', 'proc-derived')
+            ->willReturn($newFile);
+
+        // Flush is called once at the end of the loop (count < BATCH_SIZE).
+        $this->entityManager->expects(self::atLeastOnce())->method('flush');
+
+        $tester = $this->makeTester();
+        $tester->execute(['--apply' => true], ['interactive' => false]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Done', $display);
+        self::assertStringNotContainsString('Aborted', $display);
+    }
+
+    public function testApplyFixesElementMismatch(): void
+    {
+        $this->stubDiscovery(elementIds: ['e1'], singleDocIds: []);
+        $this->stubReportByOwningProcedure();
+
+        $procedure = $this->makeProcedure('proc-derived');
+        $element = $this->createMock(Elements::class);
+        $element->method('getFile')->willReturn('plan.pdf:old-ident:456:application/pdf');
+        $element->method('getProcedure')->willReturn($procedure);
+        $element->expects(self::once())
+            ->method('setFile')
+            ->with('plan.pdf:new-ident:456:application/pdf');
+
+        $newFile = $this->createMock(File::class);
+        $newFile->method('getFileString')->willReturn('plan.pdf:new-ident:456:application/pdf');
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('find')
+            ->with(Elements::class, 'e1')
+            ->willReturn($element);
+
+        $this->fileService
+            ->expects(self::once())
+            ->method('createCopyOfFile')
+            ->with('plan.pdf:old-ident:456:application/pdf', 'proc-derived')
+            ->willReturn($newFile);
+
+        $tester = $this->makeTester();
+        $tester->execute(['--apply' => true], ['interactive' => false]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testApplySkipsAndLogsWhenFileServiceReturnsNull(): void
+    {
+        $this->stubDiscovery(elementIds: [], singleDocIds: ['sd1']);
+        $this->stubReportByOwningProcedure();
+
+        $procedure = $this->makeProcedure('proc-derived');
+        $singleDoc = $this->createMock(SingleDocument::class);
+        $singleDoc->method('getDocument')->willReturn('old.pdf:old-ident:123:application/pdf');
+        $singleDoc->method('getProcedure')->willReturn($procedure);
+        $singleDoc->expects(self::never())->method('setDocument');
+
+        $this->entityManager->method('find')->willReturn($singleDoc);
+        $this->fileService->method('createCopyOfFile')->willReturn(null);
+
+        $this->logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('source file missing'),
+                self::callback(static fn (array $ctx) => 'sd1' === ($ctx['_sd_id'] ?? null))
+            );
+
+        $tester = $this->makeTester();
+        $tester->execute(['--apply' => true], ['interactive' => false]);
+
+        // Skipped path returns SUCCESS (skip != error). Behaviour is asserted via
+        // the logger expectation above and the absence of a setDocument call on
+        // the SingleDocument mock.
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringNotContainsString('Completed with errors', $tester->getDisplay());
+    }
+
+    public function testApplyReportsErrorWhenFileServiceThrows(): void
+    {
+        $this->stubDiscovery(elementIds: [], singleDocIds: ['sd1']);
+        $this->stubReportByOwningProcedure();
+
+        $procedure = $this->makeProcedure('proc-derived');
+        $singleDoc = $this->createMock(SingleDocument::class);
+        $singleDoc->method('getDocument')->willReturn('old.pdf:old-ident:123:application/pdf');
+        $singleDoc->method('getProcedure')->willReturn($procedure);
+        $singleDoc->expects(self::never())->method('setDocument');
+
+        $this->entityManager->method('find')->willReturn($singleDoc);
+        $this->fileService
+            ->method('createCopyOfFile')
+            ->willThrowException(new RuntimeException('blob storage unreachable'));
+
+        $this->logger
+            ->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('Failed to fix single_doc'),
+                self::callback(static fn (array $ctx) => 'sd1' === ($ctx['_sd_id'] ?? null)
+                    && $ctx['exception'] instanceof RuntimeException)
+            );
+
+        $tester = $this->makeTester();
+        $tester->execute(['--apply' => true], ['interactive' => false]);
+
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('Completed with errors', $tester->getDisplay());
+    }
+
+    public function testProcedureOptionRestrictsBothQueries(): void
+    {
+        $this->connection
+            ->expects(self::exactly(2))
+            ->method('fetchFirstColumn')
+            ->willReturnCallback(function (string $sql, array $params): array {
+                // First call is the _elements query (alias e), second the _single_doc query (alias sd).
+                self::assertTrue(
+                    str_contains($sql, 'e._p_id = :pid') || str_contains($sql, 'sd._p_id = :pid'),
+                    'Expected procedure filter on either e._p_id or sd._p_id'
+                );
+                self::assertSame('only-this-procedure', $params['pid']);
+
+                return [];
+            });
+
+        $this->stubReportByOwningProcedure();
+
+        $tester = $this->makeTester();
+        $tester->execute(['--procedure' => 'only-this-procedure']);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testIncludeDeletedOwnersDropsDeletedFilter(): void
+    {
+        $this->connection
+            ->expects(self::exactly(2))
+            ->method('fetchFirstColumn')
+            ->willReturnCallback(function (string $sql): array {
+                self::assertStringNotContainsString('p._p_deleted = 0', $sql);
+
+                return [];
+            });
+
+        $this->stubReportByOwningProcedure();
+
+        $tester = $this->makeTester();
+        $tester->execute(['--include-deleted-owners' => true]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    private function makeTester(): CommandTester
+    {
+        $command = new FixProcedureFileMismatchesCommand(
+            $this->parameterBag,
+            $this->connection,
+            $this->entityManager,
+            $this->fileService,
+            $this->logger,
+        );
+
+        // CoreCommand::getApplication() insists on a ConsoleApplication being
+        // attached, and CommandTester::execute() reaches for getApplication()
+        // before running. Provide a stub so the check passes; the stub's empty
+        // definition makes hasArgument('command') return false, skipping the
+        // implicit "command" argument injection in CommandTester.
+        $application = $this->createMock(ConsoleApplication::class);
+        $application->method('getDefinition')->willReturn(new InputDefinition());
+        $application->method('getHelperSet')->willReturn(new HelperSet());
+        $command->setApplication($application);
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * @param list<string> $elementIds
+     * @param list<string> $singleDocIds
+     */
+    private function stubDiscovery(array $elementIds, array $singleDocIds): void
+    {
+        $this->connection
+            ->method('fetchFirstColumn')
+            ->willReturnCallback(static function (string $sql) use ($elementIds, $singleDocIds): array {
+                if (str_contains($sql, self::ELEMENT_DISCOVERY_SQL_FRAGMENT)) {
+                    return $elementIds;
+                }
+                if (str_contains($sql, self::SINGLE_DOC_DISCOVERY_SQL_FRAGMENT)) {
+                    return $singleDocIds;
+                }
+
+                return [];
+            });
+    }
+
+    /**
+     * The "Top owning procedures" report runs a separate aggregate query.
+     * Stubbing it to return [] keeps the test focused on the fix loop.
+     */
+    private function stubReportByOwningProcedure(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+    }
+
+    private function makeProcedure(string $id): Procedure&MockObject
+    {
+        $procedure = $this->createMock(Procedure::class);
+        $procedure->method('getId')->willReturn($id);
+
+        return $procedure;
+    }
+}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/HDDP-18/BOBSH-FM-beim-Download-von-Dokumenten-bei-Verfahren-aus-Blaupause

Description:

Adds `dplan:files:fix-procedure-mismatches` to repair historical cross-procedure file references (HDDP-18). The old blueprint-clone code copied the references in `_elements._e_file` and
  `_single_doc._sd_document` but did **not** duplicate the underlying `_files` row, so the referenced file's `procedure_id` still points at the source procedure.
  `FileController::fileProcedureAction` enforces a per-procedure check and 404s those downloads when the file is requested through a derived procedure's slug.
  
  Newer clone code (`ProcedureService::copyProcedureRelatedFilesFromBlueprint`, `ElementsService::copyDocumentRelatedFiles`, `ElementsService::copyElementRelatedFiles`) already does this
  right — this is a historical data issue, not a live code regression.

  ## What the command does

  - **Dry-run by default**: prints per-table mismatch counts and a top-30 breakdown of owning procedures with broken refs. No DB writes, no file work.
  - **With `--apply`**: repairs each broken reference by calling `FileService::createCopyOfFile($oldFileString, $owningProcedureId)` — the same method the current blueprint-clone path uses.
  Result per reference: a fresh `_files` row with new `_f_ident`/`_f_hash`, a physical blob copy via the configured Flysystem storage, and the entity's reference string rewritten through  `Elements::setFile` / `SingleDocument::setDocument`.

  ### Options

  | Option | Effect |
  |---|---|
  | `--apply` | Actually perform the fix (default: dry-run). |
  | `--procedure=<id>` | Restrict scope to one owning procedure. |
  | `--include-deleted-owners` | Also process refs whose owning procedure is soft-deleted. |
  | `--limit=<n>` | Process at most N references per table (staged rollout). |

  ### Safety

  - Default is dry-run; `--apply` is an explicit opt-in.
  - Interactive runs prompt for confirmation before writing.
  - Each reference is wrapped in its own try/catch — one failure logs and the run continues.
  - `createCopyOfFile()` returning `null` (source blob missing on disk) is recorded as **skipped**, not an error.
  - Flush every 50 entities to keep memory bounded.

  ## Out of scope

  - **`file_container`** references are not touched. Its owner is polymorphic (`entity_id` + `entity_class`); current blueprint-clone code doesn't process it either. Separate follow-up if audit surfaces mismatches there.
  - **Search-engine-cached URLs** that embed the old `_f_ident` with a derived procedure's slug will continue to 404 — the old `_f_ident` row is still owned by the source procedure. After  the fix, URLs newly generated by the application use the new ident and work.

  ## Test plan

  - [ ] Run the audit against a recent prod-style DB dump and cross-check the discovery counts against the bug report.
  Sql:
`SELECT
    f.procedure_id             AS source_procedure_id,
    src._p_name        AS source_procedure_name,
    src._p_deleted     AS source_deleted,
    src._p_master      AS source_is_blueprint,
    COUNT(*)           AS affected_single_docs
  FROM _single_doc sd
  JOIN _files f
    ON f._f_ident = SUBSTRING_INDEX(SUBSTRING_INDEX(sd._sd_document, ':', -3), ':', 1)
  JOIN _procedure p
    ON p._p_id = sd._p_id          -- owning (derived) procedure
  LEFT JOIN _procedure src
    ON src._p_id = f.procedure_id          -- source procedure that the file row belongs to
  WHERE sd._sd_deleted = 0
    AND f._f_deleted = 0
    AND p._p_deleted  = 0          -- same filter as the fix
    AND sd._p_id <> f.procedure_id 
  GROUP BY f.procedure_id , src._p_name, src._p_deleted, src._p_master
  ORDER BY affected_single_docs DESC;`
  - [ ] `bin/console dplan:files:fix-procedure-mismatches --procedure=<id>` against a single known-affected procedure and verify the per-procedure breakdown contains only that procedure.
  - [ ] `bin/console dplan:files:fix-procedure-mismatches --apply --limit=1` on local; re-run the audit; expect the count to drop by one.
  - [ ] After full `--apply`, confirm a previously-failing download URL under a derived procedure's slug returns 200.
  - [ ] Unit tests green: `vendor/bin/phpunit tests/backend/core/Core/Unit/Command/FixProcedureFileMismatchesCommandTest.php`

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
