### PR TITLE
fix(refs DS-538): pass tag-name array to per-statement DOCX export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -271,6 +271,7 @@ class SegmentsExportController extends BaseController
         // Apply tag filtering after JsonAPI filtering
         $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
         $statements = $this->statementExportTagFilter->filterStatementsByTags($statements, $tagsFilter);
+        $filteredTagNames = $this->statementExportTagFilter->getTagNames();
 
         $statements = $exporter->mapStatementsToPathInZip(
             $statements,
@@ -289,7 +290,8 @@ class SegmentsExportController extends BaseController
                 $tableHeaders,
                 $censorCitizenData,
                 $censorInstitutionData,
-                $obscureParameter
+                $obscureParameter,
+                $filteredTagNames
             ): void {
                 array_map(
                     function (Statement $statement, string $filePathInZip) use (
@@ -300,7 +302,8 @@ class SegmentsExportController extends BaseController
                         $tableHeaders,
                         $censorCitizenData,
                         $censorInstitutionData,
-                        $obscureParameter
+                        $obscureParameter,
+                        $filteredTagNames
                     ): void {
                         $docx = $exporter->exportStatementSegmentsInSeparateDocx(
                             $statement,
@@ -309,7 +312,7 @@ class SegmentsExportController extends BaseController
                             $censorCitizenData,
                             $censorInstitutionData,
                             $obscureParameter,
-                            $this->statementExportTagFilter->hasAnySupportedFilterSet()
+                            $filteredTagNames
                         );
                         $writer = IOFactory::createWriter($docx);
                         $zipExportService->addWriterToZipStream(


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-538

Description: 

 `SegmentsByStatementsExporter::exportStatementSegmentsInSeparateDocx()`'s `$exportFilteredByTags` parameter was widened from `bool` to `array` in DPLAN-17226 (commit `78865a6f0`, 2026-02-12). The synopsis caller was migrated correctly (captures `$statementExportTagFilter->getTagNames()` and passes the array), but the per-statement "Einzelne DOCX-Dateien" caller in `SegmentsExportController` was missed — it kept passing `$statementExportTagFilter->hasAnySupportedFilterSet()` (a `bool`). Every "Einzelne DOCX-Dateien" export has thrown `TypeError` since then.

  ## What the fix does

  Mirrors the synopsis-caller pattern in the same controller:

  1. Capture `$filteredTagNames = $this->statementExportTagFilter->getTagNames();` right after `filterStatementsByTags()`.
  2. Add `$filteredTagNames` to both `use` clauses of the streaming-response closures.
  3. Replace the boolean argument at the `exportStatementSegmentsInSeparateDocx()` call site with `$filteredTagNames`.

  Net result: the DOCX header on each generated file now correctly carries the filtered tag names, the same way the synopsis export already does.

  ## Why it slipped past review

  DPLAN-17226's focus was the visible synopsis path (DOCX title / XLSX worksheet behaviour when filters are active). The per-statement caller lives inside a nested closure inside
  `array_map(...)` inside `buildZipStreamResponse(...)` — PHP doesn't type-check closure bodies until they execute, and no automated test triggers this specific export path, so neither
  static checks nor CI caught it. The regression only surfaces when a user actually clicks "Einzelne DOCX-Dateien".

  ## Test plan

  - [ ] In a procedure with statements + segments, open the statements list export.
  - [ ] Without any tag filter set, choose **"Einzelne DOCX-Dateien"** → expect a ZIP with one DOCX per statement, no error.
  - [ ] With a tag filter set (e.g. one tag), repeat → expect the ZIP, and the DOCX header on each file should reflect the active filter (same string the synopsis export shows).
  - [ ] Repeat the synopsis export (regression-check the other code path that DPLAN-17226 already handled) → unchanged behaviour.



- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

