### PR TITLE
F dplan 17767 register orga for customer command

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
@@ -53,48 +53,13 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('<info>Source customer:</info>');
-        $sourceCustomer = $this->helpers->askCustomer($input, $output);
-
-        $output->writeln('<info>Target customer:</info>');
-        $targetCustomer = $this->helpers->askCustomer($input, $output);
-
-        if ($sourceCustomer->getId() === $targetCustomer->getId()) {
-            $output->writeln('<error>Source and target customer must differ.</error>');
-
+        $context = $this->resolveRegistrationContext($input, $output);
+        if (null === $context) {
             return Command::FAILURE;
         }
 
-        $orga = $this->askOrgaById($input, $output);
-        if (!$orga instanceof Orga) {
-            $output->writeln('<error>No Orga found for the given ID.</error>');
-
-            return Command::FAILURE;
-        }
-
-        $sourceOrgaTypes = $this->collectOrgaTypesForCustomer($orga, $sourceCustomer);
-        if ([] === $sourceOrgaTypes) {
-            $output->writeln(sprintf(
-                '<error>Orga "%s" is not registered in source customer "%s".</error>',
-                $orga->getName(),
-                $sourceCustomer->getSubdomain()
-            ));
-
-            return Command::FAILURE;
-        }
-
-        if ([] !== $this->collectOrgaTypesForCustomer($orga, $targetCustomer)) {
-            $output->writeln(sprintf(
-                '<error>Orga "%s" is already registered in target customer "%s". Aborting.</error>',
-                $orga->getName(),
-                $targetCustomer->getSubdomain()
-            ));
-
-            return Command::FAILURE;
-        }
-
+        [$orga, $sourceCustomer, $targetCustomer, $sourceOrgaTypes] = $context;
         $users = $orga->getUsers();
-        $userCount = $users->count();
 
         $output->writeln('');
         $output->writeln(sprintf(
@@ -103,7 +68,7 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
             $orga->getId(),
             $sourceCustomer->getSubdomain(),
             $targetCustomer->getSubdomain(),
-            $userCount
+            $users->count()
         ));
 
         $confirm = new ConfirmationQuestion('Proceed? (y/N) ', false);
@@ -145,13 +110,66 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
                 $usersRegistered,
                 $usersSkipped
             );
-
-            return Command::SUCCESS;
         } catch (Exception $e) {
             $output->writeln('<error>Something went wrong: '.$e->getMessage().'</error>');
 
             return Command::FAILURE;
         }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Runs the four upfront validation guards and resolves the input into a
+     * registration context. Returns null and writes an error message to the
+     * output when any guard fails, so the caller can bail out with a single
+     * FAILURE return.
+     *
+     * @return array{0: Orga, 1: Customer, 2: Customer, 3: array<int, \demosplan\DemosPlanCoreBundle\Entity\User\OrgaType>}|null
+     */
+    private function resolveRegistrationContext(InputInterface $input, OutputInterface $output): ?array
+    {
+        $output->writeln('<info>Source customer:</info>');
+        $sourceCustomer = $this->helpers->askCustomer($input, $output);
+
+        $output->writeln('<info>Target customer:</info>');
+        $targetCustomer = $this->helpers->askCustomer($input, $output);
+
+        if ($sourceCustomer->getId() === $targetCustomer->getId()) {
+            $output->writeln('<error>Source and target customer must differ.</error>');
+
+            return null;
+        }
+
+        $orga = $this->askOrgaById($input, $output);
+        if (!$orga instanceof Orga) {
+            $output->writeln('<error>No Orga found for the given ID.</error>');
+
+            return null;
+        }
+
+        $sourceOrgaTypes = $this->collectOrgaTypesForCustomer($orga, $sourceCustomer);
+        if ([] === $sourceOrgaTypes) {
+            $output->writeln(sprintf(
+                '<error>Orga "%s" is not registered in source customer "%s".</error>',
+                $orga->getName(),
+                $sourceCustomer->getSubdomain()
+            ));
+
+            return null;
+        }
+
+        if ([] !== $this->collectOrgaTypesForCustomer($orga, $targetCustomer)) {
+            $output->writeln(sprintf(
+                '<error>Orga "%s" is already registered in target customer "%s". Aborting.</error>',
+                $orga->getName(),
+                $targetCustomer->getSubdomain()
+            ));
+
+            return null;
+        }
+
+        return [$orga, $sourceCustomer, $targetCustomer, $sourceOrgaTypes];
     }
 
     private function askOrgaById(InputInterface $input, OutputInterface $output): ?Orga

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command\Data;
+
+use demosplan\DemosPlanCoreBundle\Command\CoreCommand;
+use demosplan\DemosPlanCoreBundle\Command\Helpers\Helpers;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Repository\OrgaRepository;
+use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class RegisterOrgaForCustomerCommand extends CoreCommand
+{
+    protected static $defaultName = 'dplan:data:register-orga-for-customer';
+    protected static $defaultDescription = 'Registers an existing Orga (and all its users with their existing roles) from a source customer into a target customer in the same project.';
+
+    /**
+     * @var QuestionHelper
+     */
+    protected $helper;
+
+    public function __construct(
+        private readonly Helpers $helpers,
+        private readonly OrgaRepository $orgaRepository,
+        ParameterBagInterface $parameterBag,
+        private readonly UserRepository $userRepository,
+        ?string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+        $this->helper = new QuestionHelper();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('<info>Source customer:</info>');
+        $sourceCustomer = $this->helpers->askCustomer($input, $output);
+
+        $output->writeln('<info>Target customer:</info>');
+        $targetCustomer = $this->helpers->askCustomer($input, $output);
+
+        if ($sourceCustomer->getId() === $targetCustomer->getId()) {
+            $output->writeln('<error>Source and target customer must differ.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $orga = $this->askOrgaByEmail($input, $output);
+        if (!$orga instanceof Orga) {
+            $output->writeln('<error>No Orga found for the given email.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $sourceOrgaTypes = $this->collectOrgaTypesForCustomer($orga, $sourceCustomer);
+        if ([] === $sourceOrgaTypes) {
+            $output->writeln(sprintf(
+                '<error>Orga "%s" is not registered in source customer "%s".</error>',
+                $orga->getName(),
+                $sourceCustomer->getSubdomain()
+            ));
+
+            return Command::FAILURE;
+        }
+
+        if ([] !== $this->collectOrgaTypesForCustomer($orga, $targetCustomer)) {
+            $output->writeln(sprintf(
+                '<error>Orga "%s" is already registered in target customer "%s". Aborting.</error>',
+                $orga->getName(),
+                $targetCustomer->getSubdomain()
+            ));
+
+            return Command::FAILURE;
+        }
+
+        $users = $orga->getAllUsersOfDepartments();
+        $userCount = $users->count();
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            'About to register Orga "<info>%s</info>" (%s) from "<info>%s</info>" into "<info>%s</info>" with <info>%d</info> users.',
+            $orga->getName(),
+            $orga->getId(),
+            $sourceCustomer->getSubdomain(),
+            $targetCustomer->getSubdomain(),
+            $userCount
+        ));
+
+        $confirm = new ConfirmationQuestion('Proceed? (y/N) ', false);
+        if (!$this->helper->ask($input, $output, $confirm)) {
+            $output->writeln('Aborted by user.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            foreach ($sourceOrgaTypes as $orgaType) {
+                $orga->addCustomerAndOrgaType($targetCustomer, $orgaType, OrgaStatusInCustomer::STATUS_ACCEPTED);
+            }
+
+            $usersRegistered = 0;
+            $usersSkipped = [];
+
+            foreach ($users as $user) {
+                /** @var User $user */
+                $rolesInSource = $user->getDplanroles($sourceCustomer)->toArray();
+                if ([] === $rolesInSource) {
+                    $usersSkipped[] = $user->getLogin();
+                    continue;
+                }
+
+                $user->setDplanroles($rolesInSource, $targetCustomer);
+                $this->userRepository->updateObject($user);
+                ++$usersRegistered;
+            }
+
+            $this->orgaRepository->updateObject($orga);
+
+            $this->renderSummary(
+                $output,
+                $orga,
+                $sourceCustomer,
+                $targetCustomer,
+                $sourceOrgaTypes,
+                $usersRegistered,
+                $usersSkipped
+            );
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $output->writeln('<error>Something went wrong: '.$e->getMessage().'</error>');
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function askOrgaByEmail(InputInterface $input, OutputInterface $output): ?Orga
+    {
+        $question = new Question('Please enter the participation email of the Orga to register: ');
+        $question->setValidator(fn ($answer) => $this->orgaRepository->findOneBy(['email2' => $answer]));
+
+        return $this->helper->ask($input, $output, $question);
+    }
+
+    /**
+     * @return array<int, \demosplan\DemosPlanCoreBundle\Entity\User\OrgaType>
+     */
+    private function collectOrgaTypesForCustomer(Orga $orga, Customer $customer): array
+    {
+        $orgaTypes = [];
+        foreach ($orga->getStatusInCustomers() as $statusInCustomer) {
+            if ($statusInCustomer->getCustomer()->getId() === $customer->getId()) {
+                $orgaTypes[] = $statusInCustomer->getOrgaType();
+            }
+        }
+
+        return $orgaTypes;
+    }
+
+    /**
+     * @param array<int, \demosplan\DemosPlanCoreBundle\Entity\User\OrgaType> $orgaTypes
+     * @param array<int, string>                                              $usersSkipped
+     */
+    private function renderSummary(
+        OutputInterface $output,
+        Orga $orga,
+        Customer $sourceCustomer,
+        Customer $targetCustomer,
+        array $orgaTypes,
+        int $usersRegistered,
+        array $usersSkipped,
+    ): void {
+        $orgaTypeNames = array_map(static fn ($type) => $type->getName(), $orgaTypes);
+
+        $table = new Table($output);
+        $table->setHeaders(['Field', 'Value']);
+        $table->setRows([
+            ['Orga', sprintf('%s (%s)', $orga->getName(), $orga->getId())],
+            ['Source → Target', sprintf('%s → %s', $sourceCustomer->getSubdomain(), $targetCustomer->getSubdomain())],
+            ['OrgaTypes copied', implode(', ', $orgaTypeNames)],
+            ['Users registered', (string) $usersRegistered],
+            ['Users skipped (no roles in source)', (string) count($usersSkipped)],
+        ]);
+        $table->render();
+
+        if ([] !== $usersSkipped) {
+            $output->writeln('Skipped logins: '.implode(', ', $usersSkipped));
+        }
+
+        $output->writeln('<info>Orga successfully registered for target customer.</info>');
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/RegisterOrgaForCustomerCommand.php
@@ -65,9 +65,9 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
             return Command::FAILURE;
         }
 
-        $orga = $this->askOrgaByEmail($input, $output);
+        $orga = $this->askOrgaById($input, $output);
         if (!$orga instanceof Orga) {
-            $output->writeln('<error>No Orga found for the given email.</error>');
+            $output->writeln('<error>No Orga found for the given ID.</error>');
 
             return Command::FAILURE;
         }
@@ -93,7 +93,7 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
             return Command::FAILURE;
         }
 
-        $users = $orga->getAllUsersOfDepartments();
+        $users = $orga->getUsers();
         $userCount = $users->count();
 
         $output->writeln('');
@@ -154,10 +154,10 @@ class RegisterOrgaForCustomerCommand extends CoreCommand
         }
     }
 
-    private function askOrgaByEmail(InputInterface $input, OutputInterface $output): ?Orga
+    private function askOrgaById(InputInterface $input, OutputInterface $output): ?Orga
     {
-        $question = new Question('Please enter the participation email of the Orga to register: ');
-        $question->setValidator(fn ($answer) => $this->orgaRepository->findOneBy(['email2' => $answer]));
+        $question = new Question('Please enter the ID of the Orga to register: ');
+        $question->setValidator(fn ($answer) => $this->orgaRepository->find(trim((string) $answer)));
 
         return $this->helper->ask($input, $output, $question);
     }

--- a/tests/backend/core/Core/Functional/RegisterOrgaForCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/RegisterOrgaForCustomerCommandTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadCustomerData;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\Base\FunctionalTestCase;
+
+class RegisterOrgaForCustomerCommandTest extends FunctionalTestCase
+{
+    private const ORGA_EMAIL = 'fp-only-orga@example.test';
+
+    public function testSuccessfulExecute(): void
+    {
+        $this->prepareOrgaWithEmail();
+        /** @var Customer $source */
+        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+        /** @var Customer $target */
+        $target = $this->fixtures->getReference(LoadCustomerData::BB);
+
+        $tester = $this->getCommandTester();
+        $tester->setInputs([
+            $source->getSubdomain(),
+            $target->getSubdomain(),
+            self::ORGA_EMAIL,
+            'y',
+        ]);
+
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Orga successfully registered', $output);
+        self::assertStringContainsString($target->getSubdomain(), $output);
+    }
+
+    public function testInvalidEmailExecute(): void
+    {
+        /** @var Customer $source */
+        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+        /** @var Customer $target */
+        $target = $this->fixtures->getReference(LoadCustomerData::BB);
+
+        $tester = $this->getCommandTester();
+        $tester->setInputs([
+            $source->getSubdomain(),
+            $target->getSubdomain(),
+            'nonexistent@example.test',
+        ]);
+
+        $tester->execute([]);
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('No Orga found for the given email', $tester->getDisplay());
+    }
+
+    public function testSourceEqualsTargetExecute(): void
+    {
+        /** @var Customer $source */
+        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+
+        $tester = $this->getCommandTester();
+        $tester->setInputs([
+            $source->getSubdomain(),
+            $source->getSubdomain(),
+        ]);
+
+        $tester->execute([]);
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('Source and target customer must differ', $tester->getDisplay());
+    }
+
+    public function testOrgaNotInSourceExecute(): void
+    {
+        $this->prepareOrgaWithEmail();
+        /** @var Customer $source */
+        $source = $this->fixtures->getReference(LoadCustomerData::BB);
+        /** @var Customer $target */
+        $target = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+
+        $tester = $this->getCommandTester();
+        $tester->setInputs([
+            $source->getSubdomain(),
+            $target->getSubdomain(),
+            self::ORGA_EMAIL,
+        ]);
+
+        $tester->execute([]);
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('not registered in source customer', $tester->getDisplay());
+    }
+
+    public function testOrgaAlreadyInTargetExecute(): void
+    {
+        $orga = $this->prepareOrgaWithEmail();
+        /** @var Customer $source */
+        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+        /** @var Customer $target */
+        $target = $this->fixtures->getReference(LoadCustomerData::BB);
+
+        $sourceOrgaType = null;
+        foreach ($orga->getStatusInCustomers() as $status) {
+            if ($status->getCustomer()->getId() === $source->getId()) {
+                $sourceOrgaType = $status->getOrgaType();
+                break;
+            }
+        }
+        self::assertNotNull($sourceOrgaType, 'Fixture orga should have an OrgaType in the source customer.');
+
+        $orga->addCustomerAndOrgaType($target, $sourceOrgaType);
+        $this->getEntityManager()->flush();
+
+        $tester = $this->getCommandTester();
+        $tester->setInputs([
+            $source->getSubdomain(),
+            $target->getSubdomain(),
+            self::ORGA_EMAIL,
+        ]);
+
+        $tester->execute([]);
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('already registered in target customer', $tester->getDisplay());
+    }
+
+    private function prepareOrgaWithEmail(): Orga
+    {
+        /** @var Orga $orga */
+        $orga = $this->fixtures->getReference('testOrgaFPOnly');
+        $orga->setEmail2(self::ORGA_EMAIL);
+        $this->getEntityManager()->flush();
+
+        return $orga;
+    }
+
+    private function getCommandTester(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $command = $application->find('dplan:data:register-orga-for-customer');
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/backend/core/Core/Functional/RegisterOrgaForCustomerCommandTest.php
+++ b/tests/backend/core/Core/Functional/RegisterOrgaForCustomerCommandTest.php
@@ -12,136 +12,149 @@ declare(strict_types=1);
 
 namespace Tests\Core\Core\Functional;
 
-use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadCustomerData;
-use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
-use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaStatusInCustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\OrgaTypeFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Base\FunctionalTestCase;
 
 class RegisterOrgaForCustomerCommandTest extends FunctionalTestCase
 {
-    private const ORGA_EMAIL = 'fp-only-orga@example.test';
-
     public function testSuccessfulExecute(): void
     {
-        $this->prepareOrgaWithEmail();
-        /** @var Customer $source */
-        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
-        /** @var Customer $target */
-        $target = $this->fixtures->getReference(LoadCustomerData::BB);
+        // Arrange
+        $sourceCustomer = CustomerFactory::createOne(['subdomain' => 'source-'.uniqid()]);
+        $targetCustomer = CustomerFactory::createOne(['subdomain' => 'target-'.uniqid()]);
+        $orgaType = OrgaTypeFactory::createOne();
+        $orga = OrgaFactory::createOne();
+        // Persists the orga→source-customer registration row; not assigned because the command
+        // reads its state back from the DB after a fresh kernel boot.
+        OrgaStatusInCustomerFactory::createOne([
+            'orga'     => $orga,
+            'customer' => $sourceCustomer,
+            'orgaType' => $orgaType,
+        ]);
 
         $tester = $this->getCommandTester();
         $tester->setInputs([
-            $source->getSubdomain(),
-            $target->getSubdomain(),
-            self::ORGA_EMAIL,
+            $sourceCustomer->getSubdomain(),
+            $targetCustomer->getSubdomain(),
+            $orga->getId(),
             'y',
         ]);
 
+        // Act
         $tester->execute([]);
-        $tester->assertCommandIsSuccessful();
 
+        // Assert
+        $tester->assertCommandIsSuccessful();
         $output = $tester->getDisplay();
         self::assertStringContainsString('Orga successfully registered', $output);
-        self::assertStringContainsString($target->getSubdomain(), $output);
+        self::assertStringContainsString($targetCustomer->getSubdomain(), $output);
     }
 
-    public function testInvalidEmailExecute(): void
+    public function testInvalidOrgaIdExecute(): void
     {
-        /** @var Customer $source */
-        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
-        /** @var Customer $target */
-        $target = $this->fixtures->getReference(LoadCustomerData::BB);
+        // Arrange
+        $sourceCustomer = CustomerFactory::createOne(['subdomain' => 'source-'.uniqid()]);
+        $targetCustomer = CustomerFactory::createOne(['subdomain' => 'target-'.uniqid()]);
 
         $tester = $this->getCommandTester();
         $tester->setInputs([
-            $source->getSubdomain(),
-            $target->getSubdomain(),
-            'nonexistent@example.test',
+            $sourceCustomer->getSubdomain(),
+            $targetCustomer->getSubdomain(),
+            '00000000-0000-0000-0000-000000000000',
         ]);
 
+        // Act
         $tester->execute([]);
+
+        // Assert
         self::assertSame(1, $tester->getStatusCode());
-        self::assertStringContainsString('No Orga found for the given email', $tester->getDisplay());
+        self::assertStringContainsString('No Orga found for the given ID', $tester->getDisplay());
     }
 
     public function testSourceEqualsTargetExecute(): void
     {
-        /** @var Customer $source */
-        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+        // Arrange
+        $customer = CustomerFactory::createOne(['subdomain' => 'same-'.uniqid()]);
 
         $tester = $this->getCommandTester();
         $tester->setInputs([
-            $source->getSubdomain(),
-            $source->getSubdomain(),
+            $customer->getSubdomain(),
+            $customer->getSubdomain(),
         ]);
 
+        // Act
         $tester->execute([]);
+
+        // Assert
         self::assertSame(1, $tester->getStatusCode());
         self::assertStringContainsString('Source and target customer must differ', $tester->getDisplay());
     }
 
     public function testOrgaNotInSourceExecute(): void
     {
-        $this->prepareOrgaWithEmail();
-        /** @var Customer $source */
-        $source = $this->fixtures->getReference(LoadCustomerData::BB);
-        /** @var Customer $target */
-        $target = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
+        // Arrange — orga is registered in some unrelated customer, never in `sourceCustomer`
+        $unrelatedCustomer = CustomerFactory::createOne(['subdomain' => 'unrelated-'.uniqid()]);
+        $sourceCustomer = CustomerFactory::createOne(['subdomain' => 'source-'.uniqid()]);
+        $targetCustomer = CustomerFactory::createOne(['subdomain' => 'target-'.uniqid()]);
+        $orgaType = OrgaTypeFactory::createOne();
+        $orga = OrgaFactory::createOne();
+        OrgaStatusInCustomerFactory::createOne([
+            'orga'     => $orga,
+            'customer' => $unrelatedCustomer,
+            'orgaType' => $orgaType,
+        ]);
 
         $tester = $this->getCommandTester();
         $tester->setInputs([
-            $source->getSubdomain(),
-            $target->getSubdomain(),
-            self::ORGA_EMAIL,
+            $sourceCustomer->getSubdomain(),
+            $targetCustomer->getSubdomain(),
+            $orga->getId(),
         ]);
 
+        // Act
         $tester->execute([]);
+
+        // Assert
         self::assertSame(1, $tester->getStatusCode());
         self::assertStringContainsString('not registered in source customer', $tester->getDisplay());
     }
 
     public function testOrgaAlreadyInTargetExecute(): void
     {
-        $orga = $this->prepareOrgaWithEmail();
-        /** @var Customer $source */
-        $source = $this->fixtures->getReference(LoadCustomerData::HINDSIGHT);
-        /** @var Customer $target */
-        $target = $this->fixtures->getReference(LoadCustomerData::BB);
-
-        $sourceOrgaType = null;
-        foreach ($orga->getStatusInCustomers() as $status) {
-            if ($status->getCustomer()->getId() === $source->getId()) {
-                $sourceOrgaType = $status->getOrgaType();
-                break;
-            }
-        }
-        self::assertNotNull($sourceOrgaType, 'Fixture orga should have an OrgaType in the source customer.');
-
-        $orga->addCustomerAndOrgaType($target, $sourceOrgaType);
-        $this->getEntityManager()->flush();
+        // Arrange — orga is already registered in both source and target
+        $sourceCustomer = CustomerFactory::createOne(['subdomain' => 'source-'.uniqid()]);
+        $targetCustomer = CustomerFactory::createOne(['subdomain' => 'target-'.uniqid()]);
+        $orgaType = OrgaTypeFactory::createOne();
+        $orga = OrgaFactory::createOne();
+        OrgaStatusInCustomerFactory::createOne([
+            'orga'     => $orga,
+            'customer' => $sourceCustomer,
+            'orgaType' => $orgaType,
+        ]);
+        OrgaStatusInCustomerFactory::createOne([
+            'orga'     => $orga,
+            'customer' => $targetCustomer,
+            'orgaType' => $orgaType,
+        ]);
 
         $tester = $this->getCommandTester();
         $tester->setInputs([
-            $source->getSubdomain(),
-            $target->getSubdomain(),
-            self::ORGA_EMAIL,
+            $sourceCustomer->getSubdomain(),
+            $targetCustomer->getSubdomain(),
+            $orga->getId(),
         ]);
 
+        // Act
         $tester->execute([]);
+
+        // Assert
         self::assertSame(1, $tester->getStatusCode());
         self::assertStringContainsString('already registered in target customer', $tester->getDisplay());
-    }
-
-    private function prepareOrgaWithEmail(): Orga
-    {
-        /** @var Orga $orga */
-        $orga = $this->fixtures->getReference('testOrgaFPOnly');
-        $orga->setEmail2(self::ORGA_EMAIL);
-        $this->getEntityManager()->flush();
-
-        return $orga;
     }
 
     private function getCommandTester(): CommandTester


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17767/Deutschen-Wetterdienst-fur-mv-BLP-freischalten

Description: 
Registers an existing Orga (and all its users with their current roles) from a source customer into a target customer of the same
 project. Copies OrgaTypes from the source registration and replays each member's per-customer roles 1:1. Aborts when source equals target, when the Orga is not in the source customer, or when it is already in the target customer.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

