### PR TITLE
fix DS-539: strip XML-illegal chars before PhpWord parses statement HTML

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -942,6 +942,7 @@ class DocxExporter
         if ('' === $text) {
             return '';
         }
+        $text = $this->stripXmlIllegalChars($text);
         try {
             $text = self::replaceTags($text);
             Html::addHtml($cell, $text, false);
@@ -956,6 +957,23 @@ class DocxExporter
         }
 
         return '';
+    }
+
+    /**
+     * Drops codepoints that XML 1.0 forbids before PhpWord parses the HTML.
+     *
+     * Stripped: C0 controls except \t \n \r (e.g. \x02, the soft-hyphen marker
+     *   produced by PDF copy-paste), unpaired surrogates (U+D800-U+DFFF) and
+     *   the two non-characters U+FFFE / U+FFFF.
+     * Kept:     all printable text, C1 controls, the full BMP minus the holes
+     *   above, and the astral planes (so emoji and rare CJK survive).
+     *
+     * Without this, PhpWord's HTML parser either dumps raw tags via the catch-
+     * fallback or yields empty cells, depending on the libxml build.
+     */
+    public function stripXmlIllegalChars(string $text): string
+    {
+        return preg_replace('/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u', '', $text);
     }
 
     private static function replaceTags(string $text): string

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -962,17 +962,24 @@ class DocxExporter
     /**
      * Drops codepoints that XML 1.0 forbids before PhpWord parses the HTML.
      *
+     * Invalid UTF-8 sequences are first normalized via mb_scrub so the
+     * /u regex below cannot fail with PREG_BAD_UTF8_ERROR (which would
+     * otherwise return null and break the string return type).
+     *
      * Stripped: C0 controls except \t \n \r (e.g. \x02, the soft-hyphen marker
      *   produced by PDF copy-paste), unpaired surrogates (U+D800-U+DFFF) and
      *   the two non-characters U+FFFE / U+FFFF.
-     * Kept:     all printable text, C1 controls, the full BMP minus the holes
-     *   above, and the astral planes (so emoji and rare CJK survive).
+     * Kept:     all printable text, DEL (\x7F — legal in XML 1.0), C1 controls
+     *   (\x80-\x9F — also legal), the full BMP minus the holes above, and the
+     *   astral planes (so emoji and rare CJK survive).
      *
      * Without this, PhpWord's HTML parser either dumps raw tags via the catch-
      * fallback or yields empty cells, depending on the libxml build.
      */
     public function stripXmlIllegalChars(string $text): string
     {
+        $text = mb_scrub($text, 'UTF-8');
+
         return preg_replace('/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u', '', $text);
     }
 

--- a/tests/backend/core/Export/Unit/DocxExporterTest.php
+++ b/tests/backend/core/Export/Unit/DocxExporterTest.php
@@ -43,6 +43,30 @@ class DocxExporterTest extends UnitTestCase
         self::assertSame($kept, $this->sut->stripXmlIllegalChars($kept.$stripped));
     }
 
+    public function testStripXmlIllegalCharsRemovesVerticalTabAndFormFeed(): void
+    {
+        $input = "before\x0Bmid\x0Cafter";
+        $expected = 'beforemidafter';
+
+        self::assertSame($expected, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsKeepsDelByDesign(): void
+    {
+        // DEL (\x7F) is legal in XML 1.0 (#x20-#xD7FF) and is therefore kept.
+        $input = "before\x7Fafter";
+
+        self::assertSame($input, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsKeepsC1ControlsByDesign(): void
+    {
+        // C1 controls (U+0080-U+009F) are legal in XML 1.0 and must survive.
+        $input = "before\u{0080}mid\u{0085}end\u{009F}";
+
+        self::assertSame($input, $this->sut->stripXmlIllegalChars($input));
+    }
+
     public function testStripXmlIllegalCharsKeepsPrintableAsciiAndUmlauts(): void
     {
         $input = 'Grüße aus Köln – ÄÖÜß!';
@@ -63,6 +87,19 @@ class DocxExporterTest extends UnitTestCase
         $expected = 'beforemiddleafter';
 
         self::assertSame($expected, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsHandlesInvalidUtf8WithoutCrashing(): void
+    {
+        // "\xC3\x28" is a broken 2-byte UTF-8 sequence (continuation byte missing).
+        // Without mb_scrub, preg_replace would return null and trigger a TypeError.
+        $input = "valid\xC3\x28tail";
+
+        $result = $this->sut->stripXmlIllegalChars($input);
+
+        self::assertIsString($result);
+        self::assertStringContainsString('valid', $result);
+        self::assertStringContainsString('tail', $result);
     }
 
     public function testStripXmlIllegalCharsLeavesEmptyStringEmpty(): void

--- a/tests/backend/core/Export/Unit/DocxExporterTest.php
+++ b/tests/backend/core/Export/Unit/DocxExporterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Export\Unit;
+
+use demosplan\DemosPlanCoreBundle\Logic\Export\DocxExporter;
+use Tests\Base\UnitTestCase;
+
+class DocxExporterTest extends UnitTestCase
+{
+    /** @var DocxExporter */
+    protected $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = self::$container->get(DocxExporter::class);
+    }
+
+    public function testStripXmlIllegalCharsRemovesPdfSoftHyphenArtifact(): void
+    {
+        $input = "ge\x02planten Windenergiegebieten";
+        $expected = 'geplanten Windenergiegebieten';
+
+        self::assertSame($expected, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsRemovesAllC0ControlsExceptTabNewlineCr(): void
+    {
+        $kept = "\t\n\r";
+        $stripped = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x0E\x0F\x1F";
+
+        self::assertSame($kept, $this->sut->stripXmlIllegalChars($kept.$stripped));
+    }
+
+    public function testStripXmlIllegalCharsKeepsPrintableAsciiAndUmlauts(): void
+    {
+        $input = 'Grüße aus Köln – ÄÖÜß!';
+
+        self::assertSame($input, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsKeepsAstralPlaneEmoji(): void
+    {
+        $input = 'Hallo 😀 Welt';
+
+        self::assertSame($input, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsRemovesNonCharacters(): void
+    {
+        $input = "before\u{FFFE}middle\u{FFFF}after";
+        $expected = 'beforemiddleafter';
+
+        self::assertSame($expected, $this->sut->stripXmlIllegalChars($input));
+    }
+
+    public function testStripXmlIllegalCharsLeavesEmptyStringEmpty(): void
+    {
+        self::assertSame('', $this->sut->stripXmlIllegalChars(''));
+    }
+}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-539/Fehlender-Stellungnahmetext-beim-Export

Description: 

Statement texts pasted from PDFs can carry raw `\x02` bytes inside words (a soft-hyphen artifact produced by some PDF readers, e.g. `ge\x02planten` for "geplanten"). `\x02` and a few other codepoints are forbidden in XML 1.0, so when `DocxExporter::addHtml` hands the HTML to PhpWord, libxml rejects it. The catch-fallback then either prints the raw HTML tags (locally) or yields an empty cell (on prod — depending on the libxml build) instead of the actual statement text.

Reported symptom: on the procedure export (DOCX), 8 institution statements appeared with an empty text cell on prod even though the platform displayed them correctly. Each one contained a raw `\x02` byte; no other statement did.

  ### Solution
  Strip XML-1.0-illegal codepoints before PhpWord parses the HTML, in a dedicated `DocxExporter::stripXmlIllegalChars()` method.
  Stripped: C0 controls except `\t \n \r`, unpaired surrogates (`U+D800–U+DFFF`), and the two non-characters `U+FFFE` / `U+FFFF`.
  Kept: all printable text, C1 controls, the rest of the BMP, and the astral planes (so emoji and rare CJK survive).

  PDF export is unaffected — different rendering path and not impacted by this XML constraint.



- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

