### PR TITLE
fix(refs: DPLAN-17794) change fetch of custom fields in segments list and bulk edit

### DIFF
--- a/client/js/bundles/procedure/administrationSegmentsBulkEdit.js
+++ b/client/js/bundles/procedure/administrationSegmentsBulkEdit.js
@@ -23,8 +23,4 @@ if (hasPermission('area_admin_boilerplates')) {
   stores.boilerplates = BoilerplatesStore
 }
 
-if (hasPermission('field_segments_custom_fields')) {
-  apiStores = [...apiStores, 'AdminProcedure', 'CustomField']
-}
-
 initialize(components, stores, apiStores)

--- a/client/js/bundles/procedure/administrationSegmentsList.js
+++ b/client/js/bundles/procedure/administrationSegmentsList.js
@@ -26,8 +26,6 @@ const stores = {
 }
 const apiStores = [
   'AssignableUser',
-  'AdminProcedure',
-  'CustomField',
   'Place',
   'StatementSegment',
   'Tag',

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -355,6 +355,7 @@ import DpBoilerPlateModal from '@DpJs/components/statement/DpBoilerPlateModal'
 import lscache from 'lscache'
 import RecommendationModal from '../Shared/RecommendationModal'
 import SelectedTagsList from '@DpJs/components/procedure/SegmentsBulkEdit/SelectedTagsList'
+import { useCustomFields } from '@DpJs/composables/useCustomFields'
 
 export default {
   name: 'SegmentsBulkEdit',
@@ -433,6 +434,7 @@ export default {
       },
       assignableUsers: [],
       busy: false,
+      customFieldDefinitions: [],
       hasRecommendationTabs: false,
       isLoading: true,
       places: [],
@@ -444,10 +446,6 @@ export default {
   },
 
   computed: {
-    ...mapState('CustomField', {
-      customFieldItems: 'items',
-    }),
-
     ...mapState('Tag', {
       tagsItems: 'items',
     }),
@@ -571,10 +569,6 @@ export default {
   },
 
   methods: {
-    ...mapActions('AdminProcedure', {
-      getAdminProcedureWithFields: 'get',
-    }),
-
     ...mapActions('StatementSegment', {
       getSegment: 'get',
     }),
@@ -588,7 +582,7 @@ export default {
     }),
 
     addCustomFieldsToActions () {
-      Object.values(this.customFieldItems).forEach(customField => {
+      this.customFieldDefinitions.forEach(customField => {
         this.actions.customFields.push({
           checked: false,
           id: customField.id,
@@ -685,26 +679,15 @@ export default {
     },
 
     /**
-     * Fetch custom fields that are available either in the procedure or in the procedure template
+     * Fetch custom fields that are available either in the procedure or in the procedure template.
      */
-    fetchCustomFields () {
-      const payload = {
-        id: this.procedureId,
-        fields: {
-          AdminProcedure: [
-            'segmentCustomFields',
-          ].join(),
-          CustomField: [
-            'name',
-            'description',
-            'options',
-          ].join(),
-        },
-        include: ['segmentCustomFields'].join(),
-      }
-
-      return this.getAdminProcedureWithFields(payload)
-        .catch(err => console.error(err))
+    loadSegmentCustomFields () {
+      return useCustomFields().fetchCustomFields(this.procedureId, {
+        sourceEntity: 'PROCEDURE',
+        targetEntity: 'SEGMENT',
+      })
+        .then(definitions => { this.customFieldDefinitions = definitions })
+        .catch(() => { /* Notification already shown by useCustomFieldDefinitions */ })
     },
 
     fetchPlaces () {
@@ -798,7 +781,7 @@ export default {
     }
 
     if (hasPermission('field_segments_custom_fields')) {
-      promises.push(this.fetchCustomFields())
+      promises.push(this.loadSegmentCustomFields())
     }
 
     Promise.all(promises)

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -678,9 +678,6 @@ export default {
         })
     },
 
-    /**
-     * Fetch custom fields that are available either in the procedure or in the procedure template.
-     */
     loadSegmentCustomFields () {
       const { fetchCustomFields } = useCustomFields()
 

--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -682,7 +682,9 @@ export default {
      * Fetch custom fields that are available either in the procedure or in the procedure template.
      */
     loadSegmentCustomFields () {
-      return useCustomFields().fetchCustomFields(this.procedureId, {
+      const { fetchCustomFields } = useCustomFields()
+
+      return fetchCustomFields(this.procedureId, {
         sourceEntity: 'PROCEDURE',
         targetEntity: 'SEGMENT',
       })

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -848,7 +848,7 @@ export default {
       return definition?.attributes.options.find(option => option.id === customFieldOptionId)?.label || ''
     },
 
-    getCustomFields () {
+    loadSegmentCustomFields () {
       const { fetchCustomFields } = useCustomFields()
       fetchCustomFields(this.procedureId, { sourceEntity: 'PROCEDURE', targetEntity: 'SEGMENT' })
         .then(definitions => {
@@ -1175,7 +1175,7 @@ export default {
     }
     this.initPagination()
     if (hasPermission('field_segments_custom_fields')) {
-      this.getCustomFields()
+      this.loadSegmentCustomFields()
     }
     this.applyQuery(this.pagination.currentPage)
 

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -850,10 +850,12 @@ export default {
 
     loadSegmentCustomFields () {
       const { fetchCustomFields } = useCustomFields()
-      fetchCustomFields(this.procedureId, { sourceEntity: 'PROCEDURE', targetEntity: 'SEGMENT' })
+
+      return fetchCustomFields(this.procedureId, { sourceEntity: 'PROCEDURE', targetEntity: 'SEGMENT' })
         .then(definitions => {
           this.customFieldDefinitions = definitions
         })
+        .catch(() => { /* Notification already shown by useCustomFieldDefinitions */ })
     },
 
     getTagsBySegment (id) {

--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -414,6 +414,7 @@ import StatementMetaTooltip from '@DpJs/components/statement/StatementMetaToolti
 import StatusBadge from '../Shared/StatusBadge'
 import tableScrollbarMixin from '@DpJs/components/shared/mixins/tableScrollbarMixin'
 import TextContentRenderer from '@DpJs/components/shared/TextContentRenderer'
+import { useCustomFields } from '@DpJs/composables/useCustomFields'
 
 export default {
   name: 'SegmentsList',
@@ -501,6 +502,7 @@ export default {
       columnSelectorKey: 0,
       defaultColumnSelection: [],
       currentSelection: [],
+      customFieldDefinitions: [],
       defaultPagination: {
         currentPage: 1,
         limits: [10, 25, 50, 100],
@@ -540,10 +542,6 @@ export default {
 
     ...mapState('AssignableUser', {
       assignableUsersObject: 'items',
-    }),
-
-    ...mapState('CustomField', {
-      customFields: 'items',
     }),
 
     ...mapState('Orga', {
@@ -588,12 +586,11 @@ export default {
         ]
       }
 
-      const customFields = Object.values(this.customFields)
-      const selectedCustomFields = customFields
-        .filter(customField => this.currentSelection.includes(`customField_${customField.id}`))
-        .map(customField => ({
-          field: `customField_${customField.id}`,
-          label: customField.attributes.name,
+      const selectedCustomFields = this.customFieldDefinitions
+        .filter(definition => this.currentSelection.includes(`customField_${definition.id}`))
+        .map(definition => ({
+          field: `customField_${definition.id}`,
+          label: definition.attributes.name,
           colWidth: '180px',
           initialMinWidth: 180,
         }))
@@ -658,7 +655,7 @@ export default {
         return staticColumns
       }
 
-      const customFields = Object.values(this.customFields).map(customField => ([`customField_${customField.id}`, customField.attributes.name]))
+      const customFields = this.customFieldDefinitions.map(definition => ([`customField_${definition.id}`, definition.attributes.name]))
 
       return [
         ...staticColumns,
@@ -671,14 +668,12 @@ export default {
         return []
       }
 
-      return Object.values(this.customFields)
-        .filter(customField => this.currentSelection.includes(`customField_${customField.id}`))
-        .map(customField => {
-          return {
-            field: `customField_${customField.id}`,
-            fieldId: customField.id,
-          }
-        })
+      return this.customFieldDefinitions
+        .filter(definition => this.currentSelection.includes(`customField_${definition.id}`))
+        .map(definition => ({
+          field: `customField_${definition.id}`,
+          fieldId: definition.id,
+        }))
     },
 
     storageKeyPagination () {
@@ -689,10 +684,6 @@ export default {
   methods: {
     ...mapActions('AssignableUser', {
       fetchAssignableUsers: 'list',
-    }),
-
-    ...mapActions('AdminProcedure', {
-      getCustomFieldsForProcedure: 'get',
     }),
 
     ...mapActions('FilterFlyout', [
@@ -852,28 +843,17 @@ export default {
         return ''
       }
 
-      return this.customFields[fieldId].attributes.options.find(option => option.id === customFieldOptionId)?.label || ''
+      const definition = this.customFieldDefinitions.find(customField => customField.id === fieldId)
+
+      return definition?.attributes.options.find(option => option.id === customFieldOptionId)?.label || ''
     },
 
     getCustomFields () {
-      const payload = {
-        id: this.procedureId,
-        fields: {
-          AdminProcedure: [
-            'segmentCustomFields',
-          ].join(),
-          CustomField: [
-            'name',
-            'description',
-            'options',
-          ].join(),
-        },
-        include: [
-          'segmentCustomFields',
-        ].join(),
-      }
-
-      this.getCustomFieldsForProcedure(payload)
+      const { fetchCustomFields } = useCustomFields()
+      fetchCustomFields(this.procedureId, { sourceEntity: 'PROCEDURE', targetEntity: 'SEGMENT' })
+        .then(definitions => {
+          this.customFieldDefinitions = definitions
+        })
     },
 
     getTagsBySegment (id) {


### PR DESCRIPTION
### Ticket
DPLAN-17794

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR changes the fetch behavior for the custom fields in segments list and bulk edit. It was necessary because the old fetch mechanism didn't get the values of the fields anymore.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and go to a procedure with custom fields
2. In the procedure, go to segments list
3. Try to add the custom field columns to the list
4. Mark one or more segments and change to bulk edit
5. Custom fields can be rendered and used in both places 

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
