### PR TITLE
fix(refs: DPLAN-17707): add dropdown to choose layer in global layer creation

### DIFF
--- a/client/js/bundles/map/mapAdminGislayerGlobalEdit.js
+++ b/client/js/bundles/map/mapAdminGislayerGlobalEdit.js
@@ -14,9 +14,11 @@
 import { DpUploadFiles } from '@demos-europe/demosplan-ui'
 import GisLayerEdit from '@DpJs/lib/map/GisLayerEdit'
 import { initialize } from '@DpJs/InitVue'
+import LayerSettings from '@DpJs/components/map/admin/LayerSettings'
 
 const components = {
   DpUploadFiles,
+  LayerSettings,
 }
 
 initialize(components).then(() => {

--- a/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Map/DemosPlanMapController.php
@@ -629,6 +629,7 @@ class DemosPlanMapController extends BaseController
 
             // Template Variable aus Storage Ergebnis erstellen(Output)
             $templateVars['gislayer'] = $mapService->gislayerAdminGetGlobalLayer($gislayerID);
+            $templateVars['availableProjections'] = $this->globalConfig->getMapAvailableProjections();
 
             return $this->render(
                 '@DemosPlanCore/DemosPlanMap/map_admin_gislayer_global_edit.html.twig',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
@@ -50,14 +50,14 @@
 
         {% block baseSettings %}
             <layer-settings
+                :available-projections="JSON.parse('{{ templateVars.availableProjections|map(el => { label: el['label'], value: el['label'] })|json_encode|e('js', 'utf-8') }}')"
+                init-layers="{{ gislayer.layers|default }}"
+                init-matrix-set="{{ gislayer.tileMatrixSet|default }}"
                 init-name="{{ gislayer.name|default }}"
+                init-projection="{{ gislayer.projectionLabel|default }}"
                 init-service-type="{{ gislayer.serviceType|default }}"
                 init-url="{{ gislayer.url|default }}"
-                init-layers="{{ gislayer.layers|default }}"
                 init-version="{{ gislayer.layerVersion|default }}"
-                init-matrix-set="{{ gislayer.tileMatrixSet|default }}"
-                init-projection="{{ gislayer.projectionLabel|default }}"
-                :available-projections="JSON.parse('{{ templateVars.availableProjections|map(el => { label: el['label'], value: el['label'] })|json_encode|e('js', 'utf-8') }}')"
             ></layer-settings>
         {% endblock baseSettings %}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_admin_gislayer_global_edit.html.twig
@@ -49,18 +49,16 @@
         {% endblock layerType %}
 
         {% block baseSettings %}
-            <label class="u-mb-0_5">
-                {{ "name"|trans }}*
-                <input class="layout__item" type="text" name="r_name" value="{{ gislayer.name|default() }}">
-            </label>
-            <label class="u-mb-0_5">
-                {{ "url"|trans }}*
-                <input class="layout__item" type="text" name="r_url" value="{{ gislayer.url|default() }}">
-            </label>
-            <label class="u-mb-0_5">
-                {{ "layers"|trans }}*
-                <input class="layout__item" type="text" name="r_layers" value="{{ gislayer.layers|default() }}">
-            </label>
+            <layer-settings
+                init-name="{{ gislayer.name|default }}"
+                init-service-type="{{ gislayer.serviceType|default }}"
+                init-url="{{ gislayer.url|default }}"
+                init-layers="{{ gislayer.layers|default }}"
+                init-version="{{ gislayer.layerVersion|default }}"
+                init-matrix-set="{{ gislayer.tileMatrixSet|default }}"
+                init-projection="{{ gislayer.projectionLabel|default }}"
+                :available-projections="JSON.parse('{{ templateVars.availableProjections|map(el => { label: el['label'], value: el['label'] })|json_encode|e('js', 'utf-8') }}')"
+            ></layer-settings>
         {% endblock baseSettings %}
 
         {% if hasPermission('feature_map_layer_legend_file') %}
@@ -130,6 +128,6 @@
 
 {% block javascripts %}
     {{ parent() }}
-    {{ webpackBundle('map-mapAdminGislayerGlobalEdit.js') }}
+    {{ webpackBundles(['ol.js', 'map-mapAdminGislayerGlobalEdit.js']) }}
 {% endblock javascripts %}
 


### PR DESCRIPTION
### Ticket
DPLAN-17707

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

In the global layer creation dialog, there was only an normal input field send the layer, but there should be a dropdown, to choose the layer like in the layer creation dialog of the procedures. Since the LayerSettings component is used for this dialog, this pr also adds the same component to the global layer creation dialog.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as MA-Role and go to Plattformtools -> Globale Kartenebenen
2. Click on Neue globale Kartenebene anlegen
3. Check if you can create a new global map layer 


### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
