### PR TITLE
fix(refs DS-490): reject authoredDate > submitDate in statement edit

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -692,9 +692,16 @@ class DemosPlanAssessmentTableController extends BaseController
             );
         }
 
-        // redirect to same form to avoid sending form multiple times on reload
-        // also mitigate effect that changes are not visible immediately
-        if ($request->request->has('r_action') && null === $redirectReturn) {
+        /*
+         * Redirect to same form to avoid sending form multiple times on reload
+         * Mitigate effect that changes are not visible immediately
+         * Skip the redirect when cross-field validation fired (authoredDate can't be > submitDate,
+         * submitDate can't be < authoredDate) so the template can render the inline error state on the date inputs.
+         */
+        if ($request->request->has('r_action')
+            && null === $redirectReturn
+            && !$assessmentTableServiceOutput->hasDateOrderError()
+        ) {
             $redirectRoute = 'dm_plan_assessment_single_view';
             if ($isCluster) {
                 $redirectRoute = 'DemosPlan_cluster_view';

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
@@ -470,6 +470,17 @@ class AssessmentTableServiceOutput
     }
 
     /**
+     * Whether the last {@see self::singleStatementHandler()} call was aborted
+     * because the proposed authoredDate would be later than the submitDate.
+     *
+     * @return bool true if the cross-field validation rejected the last update
+     */
+    public function hasDateOrderError(): bool
+    {
+        return $this->assessmentTableServiceStorage->hasDateOrderError();
+    }
+
+    /**
      * Is user authorized.
      *
      * @param string $procedureId

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceStorage.php
@@ -51,6 +51,8 @@ class AssessmentTableServiceStorage
 {
     use RefreshElasticsearchIndexTrait;
 
+    private bool $dateOrderError = false;
+
     /** @var Container Container */
     protected $container;
 
@@ -158,6 +160,7 @@ class AssessmentTableServiceStorage
      */
     private function updateStatement($rParams): void
     {
+        $this->dateOrderError = false;
         $statementArray = [];
         $statementService = $this->getStatementService();
 
@@ -297,6 +300,14 @@ class AssessmentTableServiceStorage
             $statementArray['submittedDate'] = $incomingDate->rawFormat('d.m.Y H:i:s');
         }
 
+        // authoredDate must not be later than submittedDate
+        if ($this->isAuthoredDateAfterSubmittedDate($statementArray, $currentStatement)) {
+            $this->dateOrderError = true;
+            $this->getMessageBag()->add('error', 'error.date.authored.after.submitted');
+
+            return;
+        }
+
         // We always get this value except it's empty string
         if (array_key_exists('voters_anonym', $rParams['request'])) {
             if (!is_numeric($rParams['request']['voters_anonym'])) {
@@ -376,6 +387,36 @@ class AssessmentTableServiceStorage
         }
 
         return false;
+    }
+
+    private function isAuthoredDateAfterSubmittedDate(array $statementArray, Statement $currentStatement): bool
+    {
+        $currentAuthored = $currentStatement->getMeta()?->getAuthoredDateObject();
+        $currentSubmitted = $currentStatement->getSubmitObject();
+
+        $proposedAuthored = isset($statementArray['authoredDate']) && '' !== $statementArray['authoredDate']
+            ? DateTime::createFromFormat('d.m.Y', $statementArray['authoredDate'])
+            : $currentAuthored;
+        $proposedSubmitted = isset($statementArray['submittedDate']) && '' !== $statementArray['submittedDate']
+            ? DateTime::createFromFormat('d.m.Y H:i:s', $statementArray['submittedDate'])
+            : $currentSubmitted;
+
+        if (!$proposedAuthored instanceof DateTime || !$proposedSubmitted instanceof DateTime) {
+            return false;
+        }
+
+        // The form always submits both dates. Only reject if the user actually
+        // changes at least one of them, so editing other fields on a Bestandsstatement
+        // with pre-existing invalid dates is still possible.
+        $authoredUnchanged = $currentAuthored instanceof DateTime
+            && $proposedAuthored->format('Ymd') === $currentAuthored->format('Ymd');
+        $submittedUnchanged = $currentSubmitted instanceof DateTime
+            && $proposedSubmitted->format('Ymd') === $currentSubmitted->format('Ymd');
+        if ($authoredUnchanged && $submittedUnchanged) {
+            return false;
+        }
+
+        return $proposedAuthored->format('Ymd') > $proposedSubmitted->format('Ymd');
     }
 
     /**
@@ -773,5 +814,19 @@ class AssessmentTableServiceStorage
     protected function getStatementService(): StatementService
     {
         return $this->statementService;
+    }
+
+    /**
+     * Whether the last {@see self::updateStatement()} call was aborted because
+     * the proposed authoredDate would be later than the submitDate.
+     *
+     * Used by the controller to skip the post-submit redirect so the user keeps
+     * the values they typed in the form.
+     *
+     * @return bool true if the cross-field validation rejected the last update
+     */
+    public function hasDateOrderError(): bool
+    {
+        return $this->dateOrderError;
     }
 }

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanAssessmentTable/DemosPlan/shared/v1/assessment_statement_detail_statement_data.html.twig
@@ -715,6 +715,11 @@
                         {% set authoredDateValue = '' %}
                     {% endif %}
 
+                    {# cap authoredDate at submitDate (or today, whichever is earlier) #}
+                    {% set authoredMaxDate = 'now'|date('d.m.Y') %}
+                    {% if statement.submit > 0 and statement.submit < 'now'|date('U') %}
+                        {% set authoredMaxDate = statement.submit|dplanDate() %}
+                    {% endif %}
                     {% set authorDateRowElements = authorDateRowElements|merge([{
                         label: { text: 'statement.date.authored'|trans },
                         control: {
@@ -723,7 +728,7 @@
                             calendarsBefore: 2,
                             class: 'u-5-of-6 o-form__control-wrapper',
                             dataCy: 'statementDetail:authoredDate',
-                            maxDate: 'now'|date('d.m.Y')
+                            maxDate: authoredMaxDate
                         },
                         type: submitDateDisabled|default(false) ? 'text' : 'datepicker',
                         id: 'r_authored_date',
@@ -733,6 +738,11 @@
                     }]) %}
                 {% endif %}
 
+                {# pin submitDate to at least the authoredDate #}
+                {% set submittedMinDate = '' %}
+                {% if statement.meta.authoredDate is defined and statement.meta.authoredDate|dplanDate() != '' %}
+                    {% set submittedMinDate = statement.meta.authoredDate|dplanDate() %}
+                {% endif %}
                 {% set authorDateRowElements = authorDateRowElements|merge([{
                     label: { text: 'statement.date.submitted'|trans },
                     control: {
@@ -741,6 +751,7 @@
                         statement.submit|default()|dplanDate(),
                         calendarsBefore: 2,
                         maxDate: 'now'|date('d.m.Y'),
+                        minDate: submittedMinDate,
                         class: 'u-5-of-6 o-form__control-wrapper',
                         dataCy: 'statementDetail:submittedDate'
                     },

--- a/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
+++ b/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
@@ -22,6 +22,9 @@ use Tests\Base\FunctionalTestCase;
 
 class AssessmentTableServiceStorageTest extends FunctionalTestCase
 {
+    private const BASE_DATE = '01.01.2020';
+    private const SUBMITTED_DATE = self::BASE_DATE.' 00:00:00';
+
     /**
      * @var AssessmentTableServiceStorage
      */
@@ -104,28 +107,28 @@ class AssessmentTableServiceStorageTest extends FunctionalTestCase
     {
         return [
             'authored after submitted, dates changed -> rejected' => [
-                ['authoredDate' => '10.01.2020', 'submittedDate' => '01.01.2020 00:00:00'],
-                '01.01.2020', '01.01.2020', true,
+                ['authoredDate' => '10.01.2020', 'submittedDate' => self::SUBMITTED_DATE],
+                self::BASE_DATE, self::BASE_DATE, true,
             ],
             'authored equals submitted -> allowed' => [
                 ['authoredDate' => '05.01.2020', 'submittedDate' => '05.01.2020 12:00:00'],
-                '01.01.2020', '01.01.2020', false,
+                self::BASE_DATE, self::BASE_DATE, false,
             ],
             'authored before submitted -> allowed' => [
-                ['authoredDate' => '01.01.2020', 'submittedDate' => '05.01.2020 00:00:00'],
-                '01.01.2020', '01.01.2020', false,
+                ['authoredDate' => self::BASE_DATE, 'submittedDate' => '05.01.2020 00:00:00'],
+                self::BASE_DATE, self::BASE_DATE, false,
             ],
             'both dates unchanged on pre-existing invalid record -> allowed' => [
-                ['authoredDate' => '10.01.2020', 'submittedDate' => '01.01.2020 00:00:00'],
-                '10.01.2020', '01.01.2020', false,
+                ['authoredDate' => '10.01.2020', 'submittedDate' => self::SUBMITTED_DATE],
+                '10.01.2020', self::BASE_DATE, false,
             ],
             'invalid authored date string -> ignored' => [
-                ['authoredDate' => 'not-a-date', 'submittedDate' => '01.01.2020 00:00:00'],
-                '01.01.2020', '01.01.2020', false,
+                ['authoredDate' => 'not-a-date', 'submittedDate' => self::SUBMITTED_DATE],
+                self::BASE_DATE, self::BASE_DATE, false,
             ],
             'no authored date available -> ignored' => [
-                ['submittedDate' => '01.01.2020 00:00:00'],
-                null, '01.01.2020', false,
+                ['submittedDate' => self::SUBMITTED_DATE],
+                null, self::BASE_DATE, false,
             ],
         ];
     }

--- a/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
+++ b/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
@@ -23,6 +23,7 @@ use Tests\Base\FunctionalTestCase;
 class AssessmentTableServiceStorageTest extends FunctionalTestCase
 {
     private const BASE_DATE = '01.01.2020';
+    private const LATER_DATE = '10.01.2020';
     private const SUBMITTED_DATE = self::BASE_DATE.' 00:00:00';
 
     /**
@@ -107,7 +108,7 @@ class AssessmentTableServiceStorageTest extends FunctionalTestCase
     {
         return [
             'authored after submitted, dates changed -> rejected' => [
-                ['authoredDate' => '10.01.2020', 'submittedDate' => self::SUBMITTED_DATE],
+                ['authoredDate' => self::LATER_DATE, 'submittedDate' => self::SUBMITTED_DATE],
                 self::BASE_DATE, self::BASE_DATE, true,
             ],
             'authored equals submitted -> allowed' => [
@@ -119,8 +120,8 @@ class AssessmentTableServiceStorageTest extends FunctionalTestCase
                 self::BASE_DATE, self::BASE_DATE, false,
             ],
             'both dates unchanged on pre-existing invalid record -> allowed' => [
-                ['authoredDate' => '10.01.2020', 'submittedDate' => self::SUBMITTED_DATE],
-                '10.01.2020', self::BASE_DATE, false,
+                ['authoredDate' => self::LATER_DATE, 'submittedDate' => self::SUBMITTED_DATE],
+                self::LATER_DATE, self::BASE_DATE, false,
             ],
             'invalid authored date string -> ignored' => [
                 ['authoredDate' => 'not-a-date', 'submittedDate' => self::SUBMITTED_DATE],

--- a/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
+++ b/tests/backend/core/AssessmentTable/Functional/AssessmentTableServiceStorageTest.php
@@ -10,7 +10,10 @@
 
 namespace Tests\Core\AssessmentTable\Functional;
 
+use DateTime;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadProcedureData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementMetaFactory;
 use demosplan\DemosPlanCoreBundle\Exception\MessageBagException;
 use demosplan\DemosPlanCoreBundle\Exception\StatementNameTooLongException;
 use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceStorage;
@@ -48,6 +51,83 @@ class AssessmentTableServiceStorageTest extends FunctionalTestCase
         ];
         $this->sut->executeAdditionalSingleViewAction($rParams);
         self::fail('expected specific exception');
+    }
+
+    /**
+     * The authoredDate (Verfassungsdatum) must not be later than the submittedDate
+     * (Einreichungsdatum). Editing other fields on a pre-existing statement whose
+     * dates are already invalid must still be possible, so the check only fires
+     * when the user actually changes at least one of the two dates.
+     *
+     * @dataProvider authoredAfterSubmittedProvider
+     */
+    public function testIsAuthoredDateAfterSubmittedDate(
+        array $statementArray,
+        ?string $currentAuthored,
+        ?string $currentSubmitted,
+        bool $expected,
+    ): void {
+        // Arrange: build the currently stored statement via factories, without persisting
+        // (the method under test is pure in-memory logic and never touches the database).
+        $statement = StatementFactory::new()
+            ->create([
+                'submit' => null === $currentSubmitted
+                    ? null
+                    : DateTime::createFromFormat('d.m.Y', $currentSubmitted),
+            ])
+            ->_real();
+        $meta = StatementMetaFactory::new()
+            ->create([
+                'statement'    => $statement,
+                'authoredDate' => null === $currentAuthored
+                    ? null
+                    : DateTime::createFromFormat('d.m.Y', $currentAuthored),
+            ])
+            ->_real();
+        $statement->setMeta($meta);
+
+        // Act: run the cross-field date validation against the proposed values.
+        $result = $this->invokeProtectedMethod(
+            [AssessmentTableServiceStorage::class, 'isAuthoredDateAfterSubmittedDate'],
+            $statementArray,
+            $statement
+        );
+
+        // Assert: only an authoredDate later than the submittedDate is rejected.
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{0: array<string, string>, 1: ?string, 2: ?string, 3: bool}>
+     */
+    public static function authoredAfterSubmittedProvider(): array
+    {
+        return [
+            'authored after submitted, dates changed -> rejected' => [
+                ['authoredDate' => '10.01.2020', 'submittedDate' => '01.01.2020 00:00:00'],
+                '01.01.2020', '01.01.2020', true,
+            ],
+            'authored equals submitted -> allowed' => [
+                ['authoredDate' => '05.01.2020', 'submittedDate' => '05.01.2020 12:00:00'],
+                '01.01.2020', '01.01.2020', false,
+            ],
+            'authored before submitted -> allowed' => [
+                ['authoredDate' => '01.01.2020', 'submittedDate' => '05.01.2020 00:00:00'],
+                '01.01.2020', '01.01.2020', false,
+            ],
+            'both dates unchanged on pre-existing invalid record -> allowed' => [
+                ['authoredDate' => '10.01.2020', 'submittedDate' => '01.01.2020 00:00:00'],
+                '10.01.2020', '01.01.2020', false,
+            ],
+            'invalid authored date string -> ignored' => [
+                ['authoredDate' => 'not-a-date', 'submittedDate' => '01.01.2020 00:00:00'],
+                '01.01.2020', '01.01.2020', false,
+            ],
+            'no authored date available -> ignored' => [
+                ['submittedDate' => '01.01.2020 00:00:00'],
+                null, '01.01.2020', false,
+            ],
+        ];
     }
 
     protected function setUp(): void

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1166,6 +1166,7 @@ error.custom_field.name.duplicate: "Der Name des Feldes ist bereits in Verwendun
 error.custom_field.option_name.duplicate: "Bitte vergeben Sie unterschiedliche Bezeichnungen für die einzelnen Optionen."
 error.custom_field.minimum.option.count: "Das konfigurierte Feld kann nicht weniger als zwei Optionen haben. Um diese Option zu löschen, fügen Sie bitte zunächst eine weitere Option hinzu."
 error.date.authored: "Bitte geben Sie ein Verfassungsdatum ein."
+error.date.authored.after.submitted: "Das Verfassungsdatum darf nicht nach dem Einreichungsdatum liegen."
 error.in.fields: "Bitte korrigieren Sie Ihre Eingabe in folgenden Feldern: "
 error.phone_or_email.required: "Bitte geben Sie entweder eine gültige E-Mail-Adresse oder Telefonnummer ein."
 error.phone.pattern: "Bitte geben Sie gültige Telefonnummer ein."


### PR DESCRIPTION
Ticket: [DS-490](https://demoseurope.youtrack.cloud/tickets/DS-490/BOB-SH-ROBOB-Stage-Beim-nachtraglichen-Andern-einer-STN-kann-Verfassungsdatum-grosser-Einreichungsdatum-eingetragen-werden)

> Beim manuellen Ändern einer STN kann das Verfassungsdatum neuer als das Einreichungsdatum sein. Hier findet keine Prüfung statt.
Funktionsbereich: Abwägungstabelle

## The fix

- backend now rejects updates where Verfassungsdatum is later than Einreichungsdatum. Only fires when a date is actually being changed, so existing statements with pre-existing invalid data stay editable on their other fields.
- the assessment-table Detailansicht doesn't reload when the backend throws an error, so the user keeps what they had typed
- **Datepicker constraints**: \`max-date\` on Verfassungsdatum and \`min-date\` on Einreichungsdatum are wired to the partner field on the Detailansicht, so the picker UI prevents creating bad pairs in the calendar grid.
- New translation key `error.date.authored.after.submitted`.

## How to review/test
- Open a statement's Detailansicht in the Abwägungstabelle, assign it to yourself.
- Verfassungsdatum picker: confirm dates after Einreichungsdatum are disabled in the calendar.
- Einreichungsdatum picker: confirm dates before Verfassungsdatum are disabled in the calendar.
- Type Verfassungsdatum > Einreichungsdatum manually, click Speichern → expect error \`Das Verfassungsdatum darf nicht nach dem Einreichungsdatum liegen.\` Form retains the typed values; no DB write.
- Edit any non-date field on an existing statement that already has invalid dates → still saves cleanly.
- Edit a statement with valid dates → still saves cleanly.