### PR TITLE
fix(DPLAN-17001): preserve LAYERS in GetFeatureInfo when client sends params

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
@@ -78,7 +78,7 @@ class GetFeatureInfo
         private readonly DatasheetService $datasheetService,
         GlobalConfigInterface $config,
         HttpCall $httpCall,
-        private readonly StatementGeoService $statementGeoService
+        private readonly StatementGeoService $statementGeoService,
     ) {
         $this->globalConfig = $config;
 

--- a/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Map/GetFeatureInfo.php
@@ -227,16 +227,19 @@ class GetFeatureInfo
         // Baue den Hostnamen auf
         $path = parse_url($featureInfoUrl, PHP_URL_SCHEME).'://'.
             parse_url($featureInfoUrl, PHP_URL_HOST).parse_url($featureInfoUrl, PHP_URL_PATH);
-        // Hole die Paramter aus der eingegebenen URL und merge sie mit den
-        // übergebenen Koordinationsdaten
+        // Hole die Parameter aus der eingegebenen URL und merge sie mit den
+        // übergebenen Koordinationsdaten. parse_str() leert das Ziel-Array vor
+        // dem Schreiben, daher müssen URL- und Client-Parameter getrennt
+        // geparst werden, sonst überschreiben Client-Parameter (BBOX, X, Y …)
+        // die in der konfigurierten URL hinterlegten LAYERS/QUERY_LAYERS.
         $queryString = parse_url($featureInfoUrl, PHP_URL_QUERY);
-        parse_str($queryString, $query);
-        // if a get parameter params is given, add its contents
+        parse_str($queryString ?? '', $urlParams);
+        $clientParams = [];
         if (array_key_exists('params', $queryData)) {
-            parse_str((string) $queryData['params'], $query);
+            parse_str((string) $queryData['params'], $clientParams);
             unset($queryData['params']);
         }
-        $data = array_merge($queryData, $query);
+        $data = array_merge($queryData, $urlParams, $clientParams);
         $this->getLogger()->info('Sending Request', ['path' => $path, 'data' => $data]);
         $response = $this->sendGetFeatureInfoRequest($path, $data);
         $this->getLogger()->info('Got Response', [$response]);

--- a/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
+++ b/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
@@ -34,7 +34,7 @@ class GetFeatureInfoTest extends TestCase
     private HttpCall $httpCall;
 
     /**
-     * @var array<string, string>|null Captured `$data` argument from the last HttpCall::request() call.
+     * @var array<string, string>|null captured `$data` argument from the last HttpCall::request() call
      */
     private ?array $capturedRequestData = null;
 

--- a/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
+++ b/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Map\Unit;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\Logic\ContentService;
+use demosplan\DemosPlanCoreBundle\Logic\HttpCall;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementGeoService;
+use demosplan\DemosPlanCoreBundle\Services\DatasheetService;
+use demosplan\DemosPlanCoreBundle\Services\Map\GetFeatureInfo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class GetFeatureInfoTest extends TestCase
+{
+    private const CONFIGURED_URL =
+        'https://wms.example/path?LAYERS=xplan&QUERY_LAYERS=xplan&SRS=EPSG:25832&STYLES=';
+
+    private GetFeatureInfo $sut;
+
+    /** @var HttpCall&MockObject */
+    private HttpCall $httpCall;
+
+    /**
+     * @var array<string, string>|null Captured `$data` argument from the last HttpCall::request() call.
+     */
+    private ?array $capturedRequestData = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = $this->createMock(GlobalConfigInterface::class);
+        $config->method('getMapGetFeatureInfoUrl')->willReturn(self::CONFIGURED_URL);
+        $config->method('useMapGetFeatureInfoUrlUseDb')->willReturn(false);
+        $config->method('isMapGetFeatureInfoUrlGlobal')->willReturn(false);
+
+        $this->httpCall = $this->createMock(HttpCall::class);
+        $this->httpCall->method('request')->willReturnCallback(
+            function (string $method, string $path, array $data): array {
+                $this->capturedRequestData = $data;
+
+                return ['body' => ''];
+            }
+        );
+
+        $this->sut = new GetFeatureInfo(
+            $this->createMock(ContentService::class),
+            $this->createMock(CurrentProcedureService::class),
+            $this->createMock(DatasheetService::class),
+            $config,
+            $this->httpCall,
+            $this->createMock(StatementGeoService::class),
+        );
+        $this->sut->setLogger(new NullLogger());
+    }
+
+    /**
+     * Regression guard for DPLAN-17001. When the client supplies a `params`
+     * payload that does not include LAYERS/QUERY_LAYERS, the params parsed
+     * from the procedure's configured informationUrl must still reach the
+     * outbound WMS request — otherwise XPlan feature queries return nothing.
+     */
+    public function testUrlLayersSurviveWhenClientParamsArePresent(): void
+    {
+        $this->sut->getFeatureInfo([
+            'REQUEST' => 'GetFeatureInfo',
+            'params'  => 'BBOX=100,200,300,400&X=1&Y=2',
+        ]);
+
+        self::assertNotNull($this->capturedRequestData);
+        self::assertSame('xplan', $this->capturedRequestData['LAYERS'] ?? null);
+        self::assertSame('xplan', $this->capturedRequestData['QUERY_LAYERS'] ?? null);
+        self::assertSame('100,200,300,400', $this->capturedRequestData['BBOX'] ?? null);
+        self::assertSame('1', $this->capturedRequestData['X'] ?? null);
+        self::assertSame('2', $this->capturedRequestData['Y'] ?? null);
+    }
+
+    /**
+     * Client params win over URL params when both define the same key
+     * (e.g. SRS), so the click-time coordinate system is honoured.
+     */
+    public function testClientParamsOverrideUrlParamsOnConflict(): void
+    {
+        $this->sut->getFeatureInfo([
+            'REQUEST' => 'GetFeatureInfo',
+            'params'  => 'SRS=EPSG:3857',
+        ]);
+
+        self::assertNotNull($this->capturedRequestData);
+        self::assertSame('EPSG:3857', $this->capturedRequestData['SRS'] ?? null);
+        self::assertSame('xplan', $this->capturedRequestData['LAYERS'] ?? null);
+    }
+
+    /**
+     * When the client does not send a `params` payload at all, the URL
+     * params still drive the outbound request.
+     */
+    public function testUrlLayersSurviveWhenClientParamsAreAbsent(): void
+    {
+        $this->sut->getFeatureInfo(['REQUEST' => 'GetFeatureInfo']);
+
+        self::assertNotNull($this->capturedRequestData);
+        self::assertSame('xplan', $this->capturedRequestData['LAYERS'] ?? null);
+        self::assertSame('xplan', $this->capturedRequestData['QUERY_LAYERS'] ?? null);
+    }
+}

--- a/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
+++ b/tests/backend/core/Map/Unit/GetFeatureInfoTest.php
@@ -33,6 +33,8 @@ class GetFeatureInfoTest extends TestCase
     /** @var HttpCall&MockObject */
     private HttpCall $httpCall;
 
+    private ?string $capturedRequestMethod = null;
+    private ?string $capturedRequestPath = null;
     /**
      * @var array<string, string>|null captured `$data` argument from the last HttpCall::request() call
      */
@@ -50,6 +52,8 @@ class GetFeatureInfoTest extends TestCase
         $this->httpCall = $this->createMock(HttpCall::class);
         $this->httpCall->method('request')->willReturnCallback(
             function (string $method, string $path, array $data): array {
+                $this->capturedRequestMethod = $method;
+                $this->capturedRequestPath = $path;
                 $this->capturedRequestData = $data;
 
                 return ['body' => ''];
@@ -80,6 +84,8 @@ class GetFeatureInfoTest extends TestCase
             'params'  => 'BBOX=100,200,300,400&X=1&Y=2',
         ]);
 
+        self::assertSame('GET', $this->capturedRequestMethod);
+        self::assertSame('https://wms.example/path', $this->capturedRequestPath);
         self::assertNotNull($this->capturedRequestData);
         self::assertSame('xplan', $this->capturedRequestData['LAYERS'] ?? null);
         self::assertSame('xplan', $this->capturedRequestData['QUERY_LAYERS'] ?? null);


### PR DESCRIPTION
### Ticket
DPLAN-17001

The GetFeatureInfo proxy for XPlan layers stripped `LAYERS`/`QUERY_LAYERS` from the proxied request whenever the frontend supplied additional click parameters. Cause: a PHP `parse_str` quirk — passing the same array to two consecutive `parse_str` calls resets it on the second call (PHP 7+), wiping the URL-derived params. Now URL and client params are parsed into separate arrays and merged with explicit precedence so URL-supplied `LAYERS`/`QUERY_LAYERS` survive while client coordinate params still win.

### How to review/test
Run the new unit tests:

```
docker compose exec development su -l $USER -s /usr/bin/zsh -c \
  'cd /srv/www && SYMFONY_DEPRECATIONS_HELPER=disabled php -d xdebug.mode=off ./vendor/bin/phpunit --filter GetFeatureInfoTest tests/backend/core/Map/Unit/GetFeatureInfoTest.php'
```

For a manual check, verify against a procedure with XPlan layers: click on the plan layer on the public detail page and confirm the popup shows the WMS feature attributes.

### PR Checklist
- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
