### PR TITLE
fix(refs: DPLAN-17835): delete procedure_phase rows on procedure deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Added
 - Add text custom field definition editing
 
+### Fixed
+- `dplan:procedure:delete` now also removes the two associated `procedure_phase` rows; previous runs left orphan rows behind, which are cleaned up by a one-shot migration
+
 ## v4.42.0 (2026-05-21)
 ## v4.40.1 (2026-05-21)
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/05/Version20260522073104.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/05/Version20260522073104.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260522073104 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Delete orphan procedure_phase rows left behind by previous runs of dplan:procedure:delete.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql(
+            'DELETE pp FROM procedure_phase pp '
+            .'LEFT JOIN _procedure p1 ON p1.phase_id = pp.id '
+            .'LEFT JOIN _procedure p2 ON p2.public_participation_phase_id = pp.id '
+            .'WHERE p1._p_id IS NULL AND p2._p_id IS NULL'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+        // Irreversible data cleanup.
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -173,8 +173,14 @@ class ProcedureDeleter
         // delete procedure report entries
         $this->deleteReportEntriesByIdentifierAndType($procedureIds, $isDryRun);
 
+        // collect referenced procedure_phase ids before deleting the procedures
+        $phaseIds = $this->collectProcedurePhaseIds($procedureIds);
+
         // delete procedures
         $this->deleteProcedure($procedureIds, $isDryRun);
+
+        // delete the now-orphaned procedure_phase rows
+        $this->deleteProcedurePhases($phaseIds, $isDryRun);
     }
 
     /**
@@ -476,6 +482,48 @@ class ProcedureDeleter
     private function deleteProcedure(array $procedureIds, bool $isDryRun): void
     {
         $this->queriesService->deleteFromTableByIdentifierArray('_procedure', '_p_id', $procedureIds, $isDryRun);
+    }
+
+    /**
+     * Returns the ids of every procedure_phase row referenced by the given procedures
+     * through `_procedure.phase_id` or `_procedure.public_participation_phase_id`.
+     *
+     * @return list<string>
+     *
+     * @throws Exception
+     */
+    private function collectProcedurePhaseIds(array $procedureIds): array
+    {
+        $rows = $this->queriesService->fetchFromTableByParameter(
+            ['phase_id', 'public_participation_phase_id'],
+            '_procedure',
+            '_p_id',
+            $procedureIds
+        );
+
+        $phaseIds = [];
+        foreach ($rows as $row) {
+            if (null !== $row['phase_id'] && '' !== $row['phase_id']) {
+                $phaseIds[] = $row['phase_id'];
+            }
+            if (null !== $row['public_participation_phase_id'] && '' !== $row['public_participation_phase_id']) {
+                $phaseIds[] = $row['public_participation_phase_id'];
+            }
+        }
+
+        return array_values(array_unique($phaseIds));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteProcedurePhases(array $phaseIds, bool $isDryRun): void
+    {
+        if ([] === $phaseIds) {
+            return;
+        }
+
+        $this->queriesService->deleteFromTableByIdentifierArray('procedure_phase', 'id', $phaseIds, $isDryRun);
     }
 
     /**

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -16,6 +16,7 @@ use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFacto
 use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhase;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use League\Flysystem\FilesystemOperator;
@@ -115,6 +116,42 @@ class ProcedureDeleterTest extends FunctionalTestCase
         }
 
         return $customFieldsCount;
+    }
+
+    public function testDeleteProcedureRemovesProcedurePhases(): void
+    {
+        // Arrange
+        $procedureIds = $this->extractTestProcedureIds($this->testProcedures);
+        $phasesBefore = $this->countEntries(ProcedurePhase::class);
+
+        // Act
+        $this->sut->deleteProcedures($procedureIds, false);
+
+        // Assert
+        // Each procedure owns two procedure_phase rows (phase + publicParticipationPhase).
+        $expectedPhasesAfter = $phasesBefore - (2 * count($procedureIds));
+        static::assertSame(
+            $expectedPhasesAfter,
+            $this->countEntries(ProcedurePhase::class),
+            'Both procedure_phase rows per deleted procedure should be removed'
+        );
+    }
+
+    public function testDeleteProcedureDryRunKeepsProcedurePhases(): void
+    {
+        // Arrange
+        $procedureIds = $this->extractTestProcedureIds($this->testProcedures);
+        $phasesBefore = $this->countEntries(ProcedurePhase::class);
+
+        // Act
+        $this->sut->deleteProcedures($procedureIds, true);
+
+        // Assert
+        static::assertSame(
+            $phasesBefore,
+            $this->countEntries(ProcedurePhase::class),
+            'Dry run must not delete procedure_phase rows'
+        );
     }
 
     public function testDeleteProcedureRemovesFilesFromStorage(): void


### PR DESCRIPTION
### Ticket
DPLAN-17835

### Description
`ProcedureDeleter` uses raw SQL with foreign-key checks disabled, so the Doctrine cascade declared on `Procedure->ProcedurePhase` is never invoked. Each procedure deleted via `dplan:procedure:delete` therefore leaves two orphan rows in `procedure_phase` (one for `phase_id`, one for `public_participation_phase_id`).

This PR:
- collects the two phase ids per procedure before deleting `_procedure`, then deletes those rows from `procedure_phase`
- adds a core migration that removes rows already orphaned by previous runs of the command
- adds two functional test cases (real deletion + dry-run)

### How to review/test
- Inspect `ProcedureDeleter::deleteProcedures()` — new `collectProcedurePhaseIds()` / `deleteProcedurePhases()` helpers.
- Run `./vendor/bin/phpunit tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php` — all 7 tests green.
- The cleanup migration was verified end-to-end against a real DB with injected orphan rows; only orphans were removed, referenced phases were untouched.

### PR Checklist
- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Update changelog