### PR TITLE
fix(DPLAN-17831): enable image button in segment edit editor

### DIFF
--- a/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
+++ b/client/js/components/procedure/DpSimplifiedNewStatementForm.vue
@@ -355,6 +355,7 @@
         v-model="values.text"
         :aria-label="Translator.trans('statement.text.short')"
         :procedure-id="procedureId"
+        :routes="{ getFileByHash: (hash) => Routing.generate('core_file_procedure', { procedureId, hash }) }"
         :toolbar-items="{ linkButton: true, imageButton: true }"
         :tus-endpoint="dplan.paths.tusEndpoint"
         required

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegmentsEdit.vue
@@ -72,7 +72,9 @@
             <template v-slot:edit>
               <dp-editor
                 class="mr-4 pt-1"
-                :toolbar-items="{ linkButton: true, obscure: hasPermission('feature_obscure_text') }"
+                :routes="{ getFileByHash: (hash) => Routing.generate('core_file_procedure', { procedureId, hash }) }"
+                :toolbar-items="{ imageButton: true, linkButton: true, obscure: hasPermission('feature_obscure_text') }"
+                :tus-endpoint="dplan.paths.tusEndpoint"
                 :value="getSegmentInitialText(segment.id)"
                 @transform-obscure-tag="(val) => transformObscureTag(segment.id, val)"
                 @input="(val) => updateSegmentText(segment.id, val)"
@@ -181,6 +183,8 @@ export default {
   },
 
   mixins: [dpValidateMixin, paginationMixin],
+
+  inject: ['procedureId'],
 
   props: {
     currentUser: {


### PR DESCRIPTION
### Ticket
DPLAN-17831

### Description
The segment edit `DpEditor` had no image support: `imageButton`, `tus-endpoint` and `routes.getFileByHash` were missing, so existing images were neither shown in the editor nor could new ones be inserted.

Also fixes a pre-existing bug in `DpSimplifiedNewStatementForm`: `imageButton` was enabled (DPLAN-17565) but the required `routes.getFileByHash` was never added, so a successful upload threw `TypeError: this.getFileByHash is not a function` and broke statement creation with an image.

### How to review/test
1. Log in as admin
2. Open a procedure → Stellungnahmen → open a statement with segments (or split a statement with an image PDF)
3. Scroll to the segments list and edit a segment
4. Verify the image toolbar icon appears and existing images render inside the editor
5. Insert a new image via the toolbar, save, reopen — image should persist
6. Additionally: create a new statement (Erwiderung verfassen / neue Stellungnahme) with an image in the text — upload should complete without a console error

### PR Checklist
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly