### PR TITLE
fix(refs DPLAN-17866): add missing tagTopics to request

### DIFF
--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -527,7 +527,7 @@ export default {
           title: topic.attributes.title,
           id: topic.id,
           tags: this.tags
-            .filter(tag => tag.relationships.topic.data.id === topic.id)
+            .filter(tag => tag?.relationships?.topic?.data?.id === topic.id)
             .map(tag => {
               return {
                 title: tag.attributes.title,
@@ -811,7 +811,7 @@ export default {
         this.isLoading = false
       })
     if (this.segments.length === 1) {
-      this.getSegment({ id: this.segments[0], include: 'tags' })
+      this.getSegment({ id: this.segments[0], include: 'tags,tags.topic' })
         .then(() => {
           this.segmentDataLoaded = true
         })


### PR DESCRIPTION
### Ticket
DPLAN-17866

### The issue
> Klicke ich im Bulk-Edit der Abschnittsliste auf eine der beiden "Schlagworte"-Optionen, verschwindet dise und die andere kann anschließend ebenfalls nicht mehr genutzt werden.

### The cause and the fix
- in the case that only one segment was selected in the bulk edit flow, the tagTopics were not fetched, and the store data was overwritten and missing the tagTopics, which led to an error in the multiselects in the add/delete tag actions
- in addition, we're now filtering out multiselect options (= tags) that don't have a tagTopic in their relationships

### How to review/test

- Navigate to the segments list
- select **exactly one** segment
- open the bulk edit view ("Abschnitte bearbeiten")
- check the "Schlagworte hinzufügen" and the "Schlagworte entfernen" checkboxes - the multiselect should be displayed and you should be able to select tags

### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
