### PR TITLE
Block password login for IdP users on configured subdomains

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -378,6 +378,10 @@ parameters:
     azure_sso_enabled: false
     # and if, which customers?
     azure_sso_customers: []
+    # Subdomains of customers that have completed the IdP migration. For those subdomains the
+    # password/form login rejects users flagged providedByIdentityProvider, so they can only
+    # log in via IdP. Leave empty during the transition to keep form login working.
+    idp_only_subdomains: []
     # knpu_oauth2_client settings
     # oath client referenced by knpu_oauth2_client when oauth is used
     oauth_client: ''

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/LoginFormAuthenticator.php
@@ -12,12 +12,21 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator;
 
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Event\RequestValidationWeakEvent;
+use demosplan\DemosPlanCoreBundle\EventDispatcher\TraceableEventDispatcher;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use Exception;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
@@ -31,6 +40,23 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
 final class LoginFormAuthenticator extends DplanAuthenticator implements AuthenticationEntryPointInterface
 {
     public const LOGIN_ROUTE = 'DemosPlan_user_login';
+
+    /**
+     * @param list<string> $idpOnlySubdomains
+     */
+    public function __construct(
+        UserMapperInterface $authenticator,
+        LoggerInterface $logger,
+        MessageBagInterface $messageBag,
+        TraceableEventDispatcher $eventDispatcher,
+        UrlGeneratorInterface $urlGenerator,
+        UserService $userService,
+        private readonly CustomerService $customerService,
+        #[Autowire('%idp_only_subdomains%')]
+        private readonly array $idpOnlySubdomains,
+    ) {
+        parent::__construct($authenticator, $logger, $messageBag, $eventDispatcher, $urlGenerator, $userService);
+    }
 
     public function supports(Request $request): bool
     {
@@ -65,6 +91,15 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
     {
         $user = $this->userMapper->getValidUser($credentials);
 
+        if ($user instanceof User
+            && $user->isProvidedByIdentityProvider()
+            && $this->isIdpOnlySubdomain()
+        ) {
+            $this->logger->info('Password login rejected for identity-provider user on IdP-only subdomain', ['login' => $user->getLogin()]);
+
+            throw new AuthenticationException('Password login is disabled for identity-provider users on this customer.');
+        }
+
         return new Passport(
             new UserBadge($user ? $user->getLogin() : ''),
             new PasswordCredentials($credentials->getPassword()),
@@ -94,5 +129,22 @@ final class LoginFormAuthenticator extends DplanAuthenticator implements Authent
     public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new RedirectResponse($this->urlGenerator->generate('DemosPlan_user_login_alternative'));
+    }
+
+    private function isIdpOnlySubdomain(): bool
+    {
+        if ([] === $this->idpOnlySubdomains) {
+            return false;
+        }
+
+        try {
+            $subdomain = $this->customerService->getCurrentCustomer()->getSubdomain();
+        } catch (Exception $e) {
+            $this->logger->warning('Could not resolve current customer for IdP-only subdomain check', [$e]);
+
+            return false;
+        }
+
+        return in_array($subdomain, $this->idpOnlySubdomains, true);
     }
 }

--- a/tests/backend/core/Security/LoginFormAuthenticatorTest.php
+++ b/tests/backend/core/Security/LoginFormAuthenticatorTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Security;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
+use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\EventDispatcher\TraceableEventDispatcher;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserMapperInterface;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
+use demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\LoginFormAuthenticator;
+use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use ReflectionException;
+use ReflectionMethod;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Tests\Base\UnitTestCase;
+
+class LoginFormAuthenticatorTest extends UnitTestCase
+{
+    private const MATCHING_SUBDOMAIN = 'idp-only';
+    private const OTHER_SUBDOMAIN = 'mixed';
+
+    private ?MockObject $userMapper = null;
+    private ?MockObject $customerService = null;
+    private ?MockObject $logger = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userMapper = $this->createMock(UserMapperInterface::class);
+        $this->customerService = $this->createMock(CustomerService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testRejectsIdpUserWhenSubdomainIsIdpOnly(): void
+    {
+        $sut = $this->buildSut([self::MATCHING_SUBDOMAIN]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isProvidedByIdentityProvider')->willReturn(true);
+        $user->method('getLogin')->willReturn('idp-user@example.test');
+
+        $this->userMapper->method('getValidUser')->willReturn($user);
+        $this->customerService->method('getCurrentCustomer')
+            ->willReturn($this->customerWithSubdomain(self::MATCHING_SUBDOMAIN));
+
+        $this->expectException(AuthenticationException::class);
+        $this->invokeGetPassport($sut, $this->credentials());
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testAllowsIdpUserWhenSubdomainIsNotInList(): void
+    {
+        $sut = $this->buildSut([self::MATCHING_SUBDOMAIN]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isProvidedByIdentityProvider')->willReturn(true);
+        $user->method('getLogin')->willReturn('idp-user@example.test');
+
+        $this->userMapper->method('getValidUser')->willReturn($user);
+        $this->customerService->method('getCurrentCustomer')
+            ->willReturn($this->customerWithSubdomain(self::OTHER_SUBDOMAIN));
+
+        $passport = $this->invokeGetPassport($sut, $this->credentials());
+
+        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testAllowsLocalUserWhenSubdomainIsIdpOnly(): void
+    {
+        $sut = $this->buildSut([self::MATCHING_SUBDOMAIN]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isProvidedByIdentityProvider')->willReturn(false);
+        $user->method('getLogin')->willReturn('local-user@example.test');
+
+        $this->userMapper->method('getValidUser')->willReturn($user);
+        // Customer lookup is irrelevant for non-IdP users but may still be invoked; allow either.
+        $this->customerService->method('getCurrentCustomer')
+            ->willReturn($this->customerWithSubdomain(self::MATCHING_SUBDOMAIN));
+
+        $passport = $this->invokeGetPassport($sut, $this->credentials());
+
+        self::assertPassportBuiltForLogin($passport, 'local-user@example.test');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testEmptyConfigSkipsCustomerLookup(): void
+    {
+        $sut = $this->buildSut([]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isProvidedByIdentityProvider')->willReturn(true);
+        $user->method('getLogin')->willReturn('idp-user@example.test');
+
+        $this->userMapper->method('getValidUser')->willReturn($user);
+        $this->customerService->expects(self::never())->method('getCurrentCustomer');
+
+        $passport = $this->invokeGetPassport($sut, $this->credentials());
+
+        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testCustomerLookupFailureDoesNotBlockLogin(): void
+    {
+        $sut = $this->buildSut([self::MATCHING_SUBDOMAIN]);
+
+        $user = $this->createMock(User::class);
+        $user->method('isProvidedByIdentityProvider')->willReturn(true);
+        $user->method('getLogin')->willReturn('idp-user@example.test');
+
+        $this->userMapper->method('getValidUser')->willReturn($user);
+        $this->customerService->method('getCurrentCustomer')
+            ->willThrowException(new CustomerNotFoundException('no customer'));
+
+        $passport = $this->invokeGetPassport($sut, $this->credentials());
+
+        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+    }
+
+    /**
+     * @param list<string> $idpOnlySubdomains
+     */
+    private function buildSut(array $idpOnlySubdomains): LoginFormAuthenticator
+    {
+        return new LoginFormAuthenticator(
+            $this->userMapper,
+            $this->logger,
+            $this->createMock(MessageBagInterface::class),
+            $this->createMock(TraceableEventDispatcher::class),
+            $this->createMock(UrlGeneratorInterface::class),
+            $this->createMock(UserService::class),
+            $this->customerService,
+            $idpOnlySubdomains,
+        );
+    }
+
+    private function credentials(): Credentials
+    {
+        $credentials = new Credentials();
+        $credentials->setLogin('whatever@example.test');
+        $credentials->setPassword('secret');
+        $credentials->setToken('csrf');
+        $credentials->lock();
+
+        return $credentials;
+    }
+
+    private function customerWithSubdomain(string $subdomain): CustomerInterface
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getSubdomain')->willReturn($subdomain);
+
+        return $customer;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function invokeGetPassport(LoginFormAuthenticator $sut, Credentials $credentials): Passport
+    {
+        return (new ReflectionMethod($sut, 'getPassport'))->invoke($sut, $credentials);
+    }
+
+    private static function assertPassportBuiltForLogin(Passport $passport, string $expectedLogin): void
+    {
+        /** @var UserBadge $userBadge */
+        $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertNotNull($userBadge, 'Passport must carry a UserBadge');
+        self::assertSame($expectedLogin, $userBadge->getUserIdentifier());
+    }
+}

--- a/tests/backend/core/Security/LoginFormAuthenticatorTest.php
+++ b/tests/backend/core/Security/LoginFormAuthenticatorTest.php
@@ -24,9 +24,9 @@ use demosplan\DemosPlanCoreBundle\Security\Authentication\Authenticator\LoginFor
 use demosplan\DemosPlanCoreBundle\ValueObject\Credentials;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use ReflectionException;
 use ReflectionMethod;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;

--- a/tests/backend/core/Security/LoginFormAuthenticatorTest.php
+++ b/tests/backend/core/Security/LoginFormAuthenticatorTest.php
@@ -36,6 +36,9 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 {
     private const MATCHING_SUBDOMAIN = 'idp-only';
     private const OTHER_SUBDOMAIN = 'mixed';
+    private const IDP_USER_LOGIN = 'idp-user@example.test';
+    private const LOCAL_USER_LOGIN = 'local-user@example.test';
+    private const CREDENTIAL_LOGIN = 'whatever@example.test';
 
     private ?MockObject $userMapper = null;
     private ?MockObject $customerService = null;
@@ -59,7 +62,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $user = $this->createMock(User::class);
         $user->method('isProvidedByIdentityProvider')->willReturn(true);
-        $user->method('getLogin')->willReturn('idp-user@example.test');
+        $user->method('getLogin')->willReturn(self::IDP_USER_LOGIN);
 
         $this->userMapper->method('getValidUser')->willReturn($user);
         $this->customerService->method('getCurrentCustomer')
@@ -78,7 +81,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $user = $this->createMock(User::class);
         $user->method('isProvidedByIdentityProvider')->willReturn(true);
-        $user->method('getLogin')->willReturn('idp-user@example.test');
+        $user->method('getLogin')->willReturn(self::IDP_USER_LOGIN);
 
         $this->userMapper->method('getValidUser')->willReturn($user);
         $this->customerService->method('getCurrentCustomer')
@@ -86,7 +89,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $passport = $this->invokeGetPassport($sut, $this->credentials());
 
-        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+        self::assertPassportBuiltForLogin($passport, self::IDP_USER_LOGIN);
     }
 
     /**
@@ -98,7 +101,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $user = $this->createMock(User::class);
         $user->method('isProvidedByIdentityProvider')->willReturn(false);
-        $user->method('getLogin')->willReturn('local-user@example.test');
+        $user->method('getLogin')->willReturn(self::LOCAL_USER_LOGIN);
 
         $this->userMapper->method('getValidUser')->willReturn($user);
         // Customer lookup is irrelevant for non-IdP users but may still be invoked; allow either.
@@ -107,7 +110,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $passport = $this->invokeGetPassport($sut, $this->credentials());
 
-        self::assertPassportBuiltForLogin($passport, 'local-user@example.test');
+        self::assertPassportBuiltForLogin($passport, self::LOCAL_USER_LOGIN);
     }
 
     /**
@@ -119,14 +122,14 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $user = $this->createMock(User::class);
         $user->method('isProvidedByIdentityProvider')->willReturn(true);
-        $user->method('getLogin')->willReturn('idp-user@example.test');
+        $user->method('getLogin')->willReturn(self::IDP_USER_LOGIN);
 
         $this->userMapper->method('getValidUser')->willReturn($user);
         $this->customerService->expects(self::never())->method('getCurrentCustomer');
 
         $passport = $this->invokeGetPassport($sut, $this->credentials());
 
-        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+        self::assertPassportBuiltForLogin($passport, self::IDP_USER_LOGIN);
     }
 
     /**
@@ -138,7 +141,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $user = $this->createMock(User::class);
         $user->method('isProvidedByIdentityProvider')->willReturn(true);
-        $user->method('getLogin')->willReturn('idp-user@example.test');
+        $user->method('getLogin')->willReturn(self::IDP_USER_LOGIN);
 
         $this->userMapper->method('getValidUser')->willReturn($user);
         $this->customerService->method('getCurrentCustomer')
@@ -146,7 +149,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
 
         $passport = $this->invokeGetPassport($sut, $this->credentials());
 
-        self::assertPassportBuiltForLogin($passport, 'idp-user@example.test');
+        self::assertPassportBuiltForLogin($passport, self::IDP_USER_LOGIN);
     }
 
     /**
@@ -169,7 +172,7 @@ class LoginFormAuthenticatorTest extends UnitTestCase
     private function credentials(): Credentials
     {
         $credentials = new Credentials();
-        $credentials->setLogin('whatever@example.test');
+        $credentials->setLogin(self::CREDENTIAL_LOGIN);
         $credentials->setPassword('secret');
         $credentials->setToken('csrf');
         $credentials->lock();


### PR DESCRIPTION
DPLAN-17900

## Summary
- New `idp_only_subdomains` parameter (array of customer subdomains, empty by default).
- `LoginFormAuthenticator` now rejects users with `providedByIdentityProvider = true` when the current customer's subdomain is listed, throwing a generic `AuthenticationException`.
- The guard is scoped to the password authenticator: `UserService::getValidUser()` and other authenticator paths are untouched, so user listings and SSO flows behave as before.
- Customer lookup is short-circuited when the list is empty and falls back safely if `CustomerNotFoundException` is thrown.

## Why
Without this gate any IdP-provisioned user whose `_u_password` column contains a hash (admin reset, migration, legacy local account flipped to IdP, etc.) can log in via the form and bypass the configured identity provider.

## Test plan
- [x] `tests/backend/core/Security/LoginFormAuthenticatorTest` — 5 cases (reject on match, allow on non-match, allow non-IdP user, empty config short-circuits customer lookup, customer lookup failure does not block).
- [ ] Manual: with `idp_only_subdomains: ['<subdomain>']`, attempt form login as an IdP-flagged user on that subdomain and confirm rejection; verify a non-flagged user on the same subdomain and an IdP user on a different subdomain still log in normally.