### PR TITLE
fix: prevent control characters in procedure location fields breaking admin edit page

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -1277,7 +1277,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      */
     public function setLocationName($locationName)
     {
-        $this->locationName = $locationName;
+        $this->locationName = $this->stripControlCharacters($locationName);
 
         return $this;
     }
@@ -1301,7 +1301,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      */
     public function setLocationPostCode($locationPostCode)
     {
-        $this->locationPostCode = $locationPostCode;
+        $this->locationPostCode = $this->stripControlCharacters($locationPostCode);
 
         return $this;
     }
@@ -1359,7 +1359,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      */
     public function setMunicipalCode($municipalCode)
     {
-        $this->municipalCode = $municipalCode;
+        $this->municipalCode = $this->stripControlCharacters($municipalCode);
 
         return $this;
     }
@@ -1381,9 +1381,20 @@ class Procedure extends SluggedEntity implements ProcedureInterface
 
     public function setArs(string $ars): Procedure
     {
-        $this->ars = $ars;
+        $this->ars = $this->stripControlCharacters($ars);
 
         return $this;
+    }
+
+    /**
+     * Removes ASCII control characters (including tab, CR and LF) from single-line
+     * location values. These fields are embedded into a JSON.parse() string in the
+     * procedure administration template; a stray control character there produces a
+     * "bad control character in string literal" error and breaks the whole page.
+     */
+    private function stripControlCharacters(?string $value): string
+    {
+        return preg_replace('/[\x00-\x1F\x7F]/', '', (string) $value);
     }
 
     /**

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/administration_edit.html.twig
@@ -681,7 +681,7 @@
                                                 locationName: templateVars.procedure.locationName,
                                                 municipalCode: templateVars.procedure.municipalCode,
                                                 ars: templateVars.procedure.ars
-                                            }|e('js')|json_encode }}')"
+                                            }|json_encode|e('js', 'utf-8') }}')"
                                             :use-opengeodb="Boolean({{ useOpenGeoDb == true }})"
                                         >
                                             {# Noscript fallback #}

--- a/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
+++ b/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Procedure\Unit\Entity;
+
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use Tests\Base\UnitTestCase;
+
+class ProcedureTest extends UnitTestCase
+{
+    /**
+     * @var Procedure
+     */
+    protected $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = new Procedure();
+    }
+
+    public function testSetLocationNameStripsControlCharacters(): void
+    {
+        $this->sut->setLocationName("\tLausch\nammer\r");
+
+        self::assertSame('Lauschammer', $this->sut->getLocationName());
+    }
+
+    public function testSetLocationPostCodeStripsControlCharacters(): void
+    {
+        $this->sut->setLocationPostCode("0\t1979");
+
+        self::assertSame('01979', $this->sut->getLocationPostCode());
+    }
+
+    /**
+     * Reproduces the production data that broke the procedure administration page:
+     * a leading tab in the municipal code produced a raw control character inside
+     * the JSON.parse() string literal rendered by the template.
+     */
+    public function testSetMunicipalCodeStripsControlCharacters(): void
+    {
+        $this->sut->setMunicipalCode("\t12036616");
+
+        self::assertSame('12036616', $this->sut->getMunicipalCode());
+    }
+
+    public function testSetArsStripsControlCharacters(): void
+    {
+        $this->sut->setArs("\x0012036616176\x7f");
+
+        self::assertSame('12036616176', $this->sut->getArs());
+    }
+
+    public function testSettersKeepCleanValuesUnchanged(): void
+    {
+        $this->sut->setLocationName('Lauchhammer');
+        $this->sut->setLocationPostCode('01979');
+        $this->sut->setMunicipalCode('12036616');
+        $this->sut->setArs('12036616176');
+
+        self::assertSame('Lauchhammer', $this->sut->getLocationName());
+        self::assertSame('01979', $this->sut->getLocationPostCode());
+        self::assertSame('12036616', $this->sut->getMunicipalCode());
+        self::assertSame('12036616176', $this->sut->getArs());
+    }
+}

--- a/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
+++ b/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
@@ -15,6 +15,10 @@ use Tests\Base\UnitTestCase;
 
 class ProcedureTest extends UnitTestCase
 {
+    private const POSTCODE = '01979';
+    private const MUNICIPAL_CODE = '12036616';
+    private const ARS = '12036616176';
+
     /**
      * @var Procedure
      */
@@ -37,7 +41,7 @@ class ProcedureTest extends UnitTestCase
     {
         $this->sut->setLocationPostCode("0\t1979");
 
-        self::assertSame('01979', $this->sut->getLocationPostCode());
+        self::assertSame(self::POSTCODE, $this->sut->getLocationPostCode());
     }
 
     /**
@@ -47,28 +51,28 @@ class ProcedureTest extends UnitTestCase
      */
     public function testSetMunicipalCodeStripsControlCharacters(): void
     {
-        $this->sut->setMunicipalCode("\t12036616");
+        $this->sut->setMunicipalCode("\t".self::MUNICIPAL_CODE);
 
-        self::assertSame('12036616', $this->sut->getMunicipalCode());
+        self::assertSame(self::MUNICIPAL_CODE, $this->sut->getMunicipalCode());
     }
 
     public function testSetArsStripsControlCharacters(): void
     {
-        $this->sut->setArs("\x0012036616176\x7f");
+        $this->sut->setArs("\x00".self::ARS."\x7f");
 
-        self::assertSame('12036616176', $this->sut->getArs());
+        self::assertSame(self::ARS, $this->sut->getArs());
     }
 
     public function testSettersKeepCleanValuesUnchanged(): void
     {
         $this->sut->setLocationName('Lauchhammer');
-        $this->sut->setLocationPostCode('01979');
-        $this->sut->setMunicipalCode('12036616');
-        $this->sut->setArs('12036616176');
+        $this->sut->setLocationPostCode(self::POSTCODE);
+        $this->sut->setMunicipalCode(self::MUNICIPAL_CODE);
+        $this->sut->setArs(self::ARS);
 
         self::assertSame('Lauchhammer', $this->sut->getLocationName());
-        self::assertSame('01979', $this->sut->getLocationPostCode());
-        self::assertSame('12036616', $this->sut->getMunicipalCode());
-        self::assertSame('12036616176', $this->sut->getArs());
+        self::assertSame(self::POSTCODE, $this->sut->getLocationPostCode());
+        self::assertSame(self::MUNICIPAL_CODE, $this->sut->getMunicipalCode());
+        self::assertSame(self::ARS, $this->sut->getArs());
     }
 }


### PR DESCRIPTION
DPLAN-17910

## Problem

The procedure administration edit page (`administration_edit.html.twig`) crashed with a JavaScript `SyntaxError: JSON.parse: bad control character in string literal`, leaving the whole page unusable. The offending data was a stray control character — a leading tab in the procedure's municipal code — that was rendered unescaped into a `JSON.parse('...')` string literal.

## Root cause

The `:procedure-location` binding used the filter order `|e('js')|json_encode`, the reverse of every other binding on the page. With that order, `json_encode`'s control-char escapes (e.g. `\t`) get collapsed back into raw control characters by the JS string parser, which then break `JSON.parse`.

## Changes

- Correct the filter order to `|json_encode|e('js', 'utf-8')` in the procedure-location binding so escaped control characters survive into `JSON.parse`.
- Strip ASCII control characters in the `Procedure` location setters (`locationName`, `locationPostCode`, `municipalCode`, `ars`) so invalid values can no longer be persisted in the first place.
- Add unit tests covering all four setters (including the exact production data that triggered the bug).

## Notes

Existing rows that already contain a control character still need a one-off data cleanup; this PR prevents recurrence and makes the page resilient to such data.