### PR TITLE
feat(refs: DPLAN-17455): widen _procedure.extern_id to VARCHAR(255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Add text custom field definition editing
 - Add customer admin interface for managing procedure phases - displaying and creating new phases
 
+### Changed
+- Widen `_procedure.extern_id` from `VARCHAR(50)` to `VARCHAR(255)` so XBeteiligung planIDs longer than 50 characters can be stored (DPLAN-17455)
+
 ### Fixed
 - `AccessProcedureListener` now checks for array controller before accessing index, preventing crashes on API Platform routes
 - `dplan:procedure:delete` now also removes the two associated `procedure_phase` rows; previous runs left orphan rows behind, which are cleaned up by a one-shot migration

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260601060448.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260601060448.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260601060448.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260601060448.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260601060448 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-17455: widen _procedure.extern_id to VARCHAR(255) to fit XBeteiligung planIDs';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _procedure CHANGE extern_id extern_id VARCHAR(255) DEFAULT \'\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty. Narrowing extern_id back to VARCHAR(50) would
+        // either abort (strict mode) or silently truncate (non-strict mode) any
+        // planID longer than 50 characters that this migration was introduced to
+        // support. A lossy revert is worse than no revert, so the column stays wide.
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -57,6 +57,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ProcedureTemplateConstraint(groups={ProcedureInterface::VALIDATION_GROUP_MANDATORY_PROCEDURE_TEMPLATE})
@@ -484,7 +485,8 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var string
      */
-    #[ORM\Column(name: 'extern_id', type: 'string', length: 50, nullable: false, options: ['default' => ''])]
+    #[ORM\Column(name: 'extern_id', type: 'string', length: 255, nullable: false, options: ['default' => ''])]
+    #[Assert\Length(max: 255)]
     private $xtaPlanId = '';
 
     /**


### PR DESCRIPTION
### Ticket
[DPLAN-17455](https://demoseurope.youtrack.cloud/issue/DPLAN-17455
)
The XSD defines no length limit for the XBeteiligung `planID`. In the dev environment the planID was observed to be composed of a work-title prefix plus a UUID, which can grow long. The planID is persisted into `_procedure.extern_id`, which was capped at `VARCHAR(50)`. A planID longer than 50 characters would cause procedure creation (0401) to fail. The observed value currently sits just under the limit (49 chars), so this is a latent problem rather than an active one.

This widens the column to `VARCHAR(255)` and adds a matching `Assert\Length(max: 255)` constraint on `Procedure::$xtaPlanId`.

### Changes
- `Procedure.php`: `extern_id` column length `50 → 255` + `Assert\Length(max: 255)`
- New migration `Version20260601060448`: `ALTER TABLE _procedure CHANGE extern_id extern_id VARCHAR(255)`. `down()` is intentionally a no-op — narrowing back to 50 would abort (strict mode) or truncate (non-strict) any planID already stored beyond 50 chars.

### How to review/test
- Apply migration, confirm `_procedure.extern_id` is `varchar(255)`.
- Re-running `dplan:migrations:diff` produces no `extern_id` change.