### PR TITLE
fix(refs: DPLAN-17502): add dissolving of visibility groups with only…

### DIFF
--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -792,6 +792,28 @@ export default {
           route: 'layer',
           relationshipType: 'gisLayers',
         }
+
+        const groupId = this.layer.attributes.visibilityGroupId
+        if (groupId) {
+          const groupMembers = this.$store.getters['Layers/elementsListByAttribute']({
+            type: 'visibilityGroupId',
+            value: groupId,
+          })
+          if (groupMembers.length <= 2) {
+            const dissolvePromises = groupMembers
+              .filter(member => member.id !== this.layer.id)
+              .map(member => this.$store.dispatch('Layers/save', {
+                ...member,
+                attributes: { ...member.attributes, visibilityGroupId: null },
+              }))
+
+            Promise.all(dissolvePromises).then(() => {
+              this.$store.dispatch('Layers/deleteElement', deleteData)
+            })
+
+            return
+          }
+        }
       }
       this.$store.dispatch('Layers/deleteElement', deleteData)
     },

--- a/client/js/components/map/admin/AdminLayerListItem.vue
+++ b/client/js/components/map/admin/AdminLayerListItem.vue
@@ -793,7 +793,7 @@ export default {
           relationshipType: 'gisLayers',
         }
 
-        const groupId = this.layer.attributes.visibilityGroupId
+        const groupId = this.layer.attributes?.visibilityGroupId
         if (groupId) {
           const groupMembers = this.$store.getters['Layers/elementsListByAttribute']({
             type: 'visibilityGroupId',
@@ -807,9 +807,13 @@ export default {
                 attributes: { ...member.attributes, visibilityGroupId: null },
               }))
 
-            Promise.all(dissolvePromises).then(() => {
-              this.$store.dispatch('Layers/deleteElement', deleteData)
-            })
+            Promise.all(dissolvePromises)
+              .then(() => {
+                this.$store.dispatch('Layers/deleteElement', deleteData)
+              })
+              .catch(() => {
+                dplan.notify.notify('error', Translator.trans('error.gislayer.visibility.group.dissolve'))
+              })
 
             return
           }

--- a/client/js/store/map/Layers.js
+++ b/client/js/store/map/Layers.js
@@ -540,6 +540,7 @@ const LayersStore = {
         })
         .catch(err => {
           console.error('Error: save layer', err)
+          throw err
         })
         .finally(() => {
           commit('setActiveLayerId', '')

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -1261,6 +1261,7 @@ error.gdpr.revoke.of.statement.not.permitted: "Sie sind nicht berechtigt die Ein
 error.gislayer.delete: "Die Kartenebene konnte nicht gelöscht werden."
 error.gislayer.noprotocol: "Bitte geben Sie das Protokoll http:// oder https:// für die URL an."
 error.gislayer.update: "Fehler beim Speichern der Kartenebene."
+error.gislayer.visibility.group.dissolve: 'Die Kartenebene konnte nicht gelöscht werden. Gegebenenfalls liegt es an der Sichtbarkeitsgruppe, diese können Sie auch manuell auflösen.'
 error.gislayers.updated: "Die Kartenebenen konnten nicht gespeichert werden."
 error.gislayerCategory.treedepth: "Kartenebenen-Kategorien können nicht mehr als {max_depth} Ebenen tief gruppiert werden."
 error.gislayerCategory.delete: "Die Kartenebenen-Kategorie konnte nicht gelöscht werden."


### PR DESCRIPTION
### Ticket
DPLAN-17502

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds the behavior, that dissolves visibility groups, when one of the last two members is deleted completely. 

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as FP-Admin and choose a procedure
2. Open "Planungsdokumente und Planzeichnungen"
3. Go to the dialog, where you can define map layers
4. Define at least two map layers and group them
5. Delete one of the map layers and check if the group was dissolved too

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
