### PR TITLE
fix(refs DPLAN-17830): add table-cell borders to ODT export of assess…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocumentWriterSelector.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocumentWriterSelector.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Export;
 
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Logic\Export\Odt\OdtBorderedWriter;
+use PhpOffice\PhpWord\IOFactory;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Writer\WriterInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class DocumentWriterSelector
@@ -28,6 +32,19 @@ class DocumentWriterSelector
         return $this->shouldUseOdt()
             ? 'ODText'
             : 'Word2007';
+    }
+
+    /**
+     * PhpWord's stock ODText writer drops table-cell borders, so wrap it with
+     * {@see OdtBorderedWriter} which post-processes content.xml to add them.
+     */
+    public function createWriter(PhpWord $phpWord): WriterInterface
+    {
+        if ($this->shouldUseOdt()) {
+            return new OdtBorderedWriter($phpWord);
+        }
+
+        return IOFactory::createWriter($phpWord, $this->getWriterType());
     }
 
     public function getFileExtension(): string

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -44,7 +44,6 @@ use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\Cell;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\Table;
-use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\Html;
 use PhpOffice\PhpWord\Writer\WriterInterface;
@@ -1939,7 +1938,7 @@ class DocxExporter
             );
         }
 
-        return IOFactory::createWriter($phpWord, $this->writerSelector->getWriterType());
+        return $this->writerSelector->createWriter($phpWord);
     }
 
     /**
@@ -2007,7 +2006,7 @@ class DocxExporter
         $footer = $tableSection->addFooter();
         $this->addPageNumbers($footer);
 
-        return IOFactory::createWriter($phpWord, $this->writerSelector->getWriterType());
+        return $this->writerSelector->createWriter($phpWord);
     }
 
     /**
@@ -2057,7 +2056,7 @@ class DocxExporter
         $footer = $section->addFooter();
         $this->addPageNumbers($footer);
 
-        return IOFactory::createWriter($phpWord, $this->writerSelector->getWriterType());
+        return $this->writerSelector->createWriter($phpWord);
     }
 
     /**
@@ -2097,7 +2096,7 @@ class DocxExporter
         $footer = $section->addFooter();
         $this->addPageNumbers($footer);
 
-        return IOFactory::createWriter($phpWord, $this->writerSelector->getWriterType());
+        return $this->writerSelector->createWriter($phpWord);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Export\Odt;
+
+use demosplan\DemosPlanCoreBundle\Exception\OdtProcessingException;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Writer\ODText;
+use PhpOffice\PhpWord\Writer\WriterInterface;
+use ZipArchive;
+
+/**
+ * PhpWord's ODText writer drops table borders: `Writer/ODText/Style/Table`
+ * only emits alignment, and `Writer/ODText/Element/Table` attaches no cell
+ * style. The dispatch sits behind `private` Part\Content helpers, so we
+ * cannot override it via inheritance. Wraps a stock ODText writer and patches
+ * `content.xml` after the .odt is written: one bordered table-cell automatic
+ * style, referenced from every `<table:table-cell>`.
+ */
+class OdtBorderedWriter implements WriterInterface
+{
+    private const CELL_STYLE_NAME = 'DPlanBorderedCell';
+    private const CELL_STYLE_XML = '<style:style style:name="'.self::CELL_STYLE_NAME.'" style:family="table-cell">'
+        .'<style:table-cell-properties fo:border="0.5pt solid #000000" fo:padding="0.05cm"/>'
+        .'</style:style>';
+
+    private readonly ODText $inner;
+
+    public function __construct(?PhpWord $phpWord = null)
+    {
+        $this->inner = new ODText($phpWord);
+    }
+
+    public function save(string $filename): void
+    {
+        $targetIsOutputStream = 'php://output' === $filename || 'php://stdout' === $filename;
+        $workFile = $targetIsOutputStream ? \tempnam(\sys_get_temp_dir(), 'odtb_') : $filename;
+
+        if (false === $workFile) {
+            throw OdtProcessingException::processingFailed('Could not allocate temp file for ODT writer.');
+        }
+
+        $this->inner->save($workFile);
+        $this->injectBorders($workFile);
+
+        if ($targetIsOutputStream) {
+            // Open the patched .odt for reading. 'rb' = read, binary mode —
+            // important so ZIP bytes are passed through verbatim on every platform.
+            $stream = \fopen($workFile, 'rb');
+            if (false !== $stream) {
+                // Stream from current position to EOF straight into php://output in
+                // ~8 KiB chunks. Same destination as echo, i.e. the HTTP response body
+                // under FPM. readfile() does the same in one call but is on FPM's
+                // disable_functions list; this fopen + fpassthru + fclose trio is not.
+                \fpassthru($stream);
+
+                // fpassthru advances the handle's position to EOF but does not close it.
+                \fclose($stream);
+            }
+
+            // Remove the temp file; bytes are already on the wire.
+            @\unlink($workFile);
+        }
+    }
+
+    private function injectBorders(string $odtPath): void
+    {
+        $zip = new ZipArchive();
+        if (true !== $zip->open($odtPath)) {
+            throw OdtProcessingException::unableToOpenFile($odtPath);
+        }
+
+        $content = $zip->getFromName('content.xml');
+        if (false === $content) {
+            $zip->close();
+            throw OdtProcessingException::processingFailed('ODT archive is missing content.xml.');
+        }
+
+        $patched = $this->patchContentXml($content);
+
+        if ($patched !== $content) {
+            $zip->deleteName('content.xml');
+            $zip->addFromString('content.xml', $patched);
+        }
+
+        $zip->close();
+    }
+
+    private function patchContentXml(string $xml): string
+    {
+        if (false === \strpos($xml, '<table:table-cell')) {
+            return $xml;
+        }
+
+        $withStyle = \preg_replace(
+            '#(</office:automatic-styles>)#',
+            self::CELL_STYLE_XML.'$1',
+            $xml,
+            1
+        );
+
+        if (null === $withStyle || $withStyle === $xml) {
+            return $xml;
+        }
+
+        return \preg_replace(
+            '#<table:table-cell(?![^>]*table:style-name=)#',
+            '<table:table-cell table:style-name="'.self::CELL_STYLE_NAME.'"',
+            $withStyle
+        ) ?? $withStyle;
+    }
+}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17898/ROBOB-LibreOffice-Ausdruck-aus-Abwagungstabelle-hat-keine-sichtbaren-Linien

Description: picked from https://github.com/demos-europe/demosplan-core/pull/6321
## Problem

Assessment-table export (`verfahren/abwaegung/export/<procedureId>` with format `odt`) produced ODT files with no visible cell borders. The DOCX path rendered borders correctly. Two defects in PhpWord's stock ODText writer cause this:

- `Writer/ODText/Style/Table` emits only alignment and column widths — never a style:family="table-cell"` style with border properties.
- `Writer/ODText/Element/Table::writeRow` writes `<table:table-cell>` nodes with no `table:style-name` attribute, so even a registered cell style wouldn't be referenced.

The dispatch (`Part/Content::writeAutoStyles`, `getAutoStyles`, the `$autoStyles` array, and `Element/Table::writeRow`) is all `private`, so subclassing cannot reach it.

## Solution

Wrap PhpWord's ODText writer rather than subclass it: `OdtBorderedWriter` produces the `.odt` via the stock writer, then opens the ZIP and patches `content.xml`.

- Injects one automatic style `DPlanBorderedCell` (`fo:border="0.5pt solid #000000"`, `fo:padding="0.05cm"`) into `<office:automatic-styles>`.
- Stamps `table:style-name="DPlanBorderedCell"` on every `<table:table-cell>` that does not already carry a style. Negative-lookahead regex keeps the patch idempotent and preserves any pre-existing cell styling.

Wired via `DocumentWriterSelector::createWriter()` so the wrapper activates only on ODT exports. The four call sites in `DocxExporter` (`createDocxGrouped`, `createDocxCondensed`, `createDocxUngrouped`, `createDocxGroupedBobHH`) now
obtain their writer from the selector. DOCX path is unchanged.

### Streaming to the browser

When the caller passes `php://output`, the patched bytes are streamed out via `fopen` + `fpassthru` + `fclose`. `readfile` was the obvious choice but is on PHP-FPM's `disable_functions` list; `fpassthru` is not and gives identical chunked streaming straight to the response body without buffering the whole
file in RAM.

## Files changed

- `demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php` (new)
- `demosplan/DemosPlanCoreBundle/Logic/Export/DocumentWriterSelector.php`
  (added `createWriter()`)
- `demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php` (four call
  sites routed through the selector; unused `IOFactory` import removed)

## Test plan

- [x] Export an assessment table via `verfahren/abwaegung/export/<procedureId>`
      with format `odt` — open the file in LibreOffice and confirm every table
      cell has visible borders.
- [x] Repeat with `format=docx` — confirm the DOCX output is unchanged.


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

