### PR TITLE
fix(refs: DPLAN-17907)fix tag sort in splitstatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 - Widen `_procedure.extern_id` from `VARCHAR(50)` to `VARCHAR(255)` so XBeteiligung planIDs longer than 50 characters can be stored (DPLAN-17455)
+- Tag selection when splitting a statement now lists keywords in the manual sort order from tag administration instead of alphabetically
 
 ### Fixed
 - `AccessProcedureListener` now checks for array controller before accessing index, preventing crashes on API Platform routes

--- a/client/js/store/statement/SplitStatementStore.js
+++ b/client/js/store/statement/SplitStatementStore.js
@@ -362,7 +362,6 @@ const SplitStatementStore = {
 
     fetchTags ({ commit }) {
       const url = Routing.generate('api_resource_list', { resourceType: 'Tag' })
-      // Sort by sortIndex so categorized tags keep the manual order from the tag management view (DPLAN-17907)
       return dpApi.get(url, { include: 'topic', sort: 'sortIndex' })
         .then(response => {
           const tags = response.data
@@ -384,9 +383,8 @@ const SplitStatementStore = {
             return acc
           }, { uncategorizedTags: [], categorizedTags: [] })
 
-          // Uncategorized tags have no meaningful sortIndex, so keep them alphabetical (natural number ordering)
+          // Categorized tags keep the backend sortIndex order; only uncategorized tags fall back to alphabetical
           uncategorizedTags.sort(sortByTitle)
-          // Categorized tags are already ordered by sortIndex from the backend, preserving the manual order per topic
 
           commit('setProperty', { prop: 'uncategorizedTags', val: uncategorizedTags })
           commit('setProperty', { prop: 'categorizedTags', val: categorizedTags })

--- a/client/js/store/statement/SplitStatementStore.js
+++ b/client/js/store/statement/SplitStatementStore.js
@@ -362,7 +362,8 @@ const SplitStatementStore = {
 
     fetchTags ({ commit }) {
       const url = Routing.generate('api_resource_list', { resourceType: 'Tag' })
-      return dpApi.get(url, { include: 'topic' })
+      // Sort by sortIndex so categorized tags keep the manual order from the tag management view (DPLAN-17907)
+      return dpApi.get(url, { include: 'topic', sort: 'sortIndex' })
         .then(response => {
           const tags = response.data
           commit('setProperty', { prop: 'availableTags', val: tags.data })
@@ -383,8 +384,9 @@ const SplitStatementStore = {
             return acc
           }, { uncategorizedTags: [], categorizedTags: [] })
 
+          // Uncategorized tags have no meaningful sortIndex, so keep them alphabetical (natural number ordering)
           uncategorizedTags.sort(sortByTitle)
-          categorizedTags.sort(sortByTitle)
+          // Categorized tags are already ordered by sortIndex from the backend, preserving the manual order per topic
 
           commit('setProperty', { prop: 'uncategorizedTags', val: uncategorizedTags })
           commit('setProperty', { prop: 'categorizedTags', val: categorizedTags })


### PR DESCRIPTION
### Ticket
[DPLAN-17907](https://demoseurope.youtrack.cloud/issue/DPLAN-17907/ADO-Fehler-55523-Integration-Raumordnung-2026.10-Schlagwortsortierung-in-der-Aufteilung-falsch-im-Auswahldropdown)

In the split statement view, the tag selection listed the keywords within a topic alphabetically. This overrode the manual sort order defined in the tag management view, so the order was inconsistent between the two places.

Tags are now loaded sorted by `sortIndex`, and categorized tags keep that order instead of being re-sorted alphabetically. Uncategorized tags (which have no meaningful sort index) stay alphabetical.

### How to review/test
1. In tag management, sort the keywords within a topic into a custom order.
2. Open a statement and split it.
3. In the sidebar tag selection, expand the topic — the keywords now appear
   in the same order as in tag management (no longer alphabetical).

### Linked PRs (optional)
https://github.com/demos-europe/demosplan-core/pull/6250

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [x] Update changelog 

