### PR TITLE
fix: align ProcedureTest with required Procedure phase definition constructor args

### DIFF
--- a/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
+++ b/tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php
@@ -11,6 +11,7 @@
 namespace Tests\Core\Procedure\Unit\Entity;
 
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhaseDefinition;
 use Tests\Base\UnitTestCase;
 
 class ProcedureTest extends UnitTestCase
@@ -27,7 +28,8 @@ class ProcedureTest extends UnitTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->sut = new Procedure();
+        $def = new ProcedurePhaseDefinition();
+        $this->sut = new Procedure($def, $def);
     }
 
     public function testSetLocationNameStripsControlCharacters(): void


### PR DESCRIPTION
### Ticket
[DPLAN-17910](https://demoseurope.youtrack.cloud/issue/DPLAN-17910
)
### Description
On `release`, all of `ProcedureTest` failed at `setUp()` with `ArgumentCountError: Too few arguments to function Procedure::__construct(), 0 passed`.

The control-character stripping logic from DPLAN-17910 is correct. The test broke because the `Procedure` constructor now requires two `ProcedurePhaseDefinition` arguments (introduced separately), while the test still instantiated `new Procedure()`. The control-char test was branched off a base predating that constructor change, so the two only collided once both landed on `release`.

This aligns the test with the current constructor signature, matching how every other test already constructs a `Procedure` (`new Procedure($def, $def)`).

### How to review/test
`./vendor/bin/phpunit tests/backend/core/Procedure/Unit/Entity/ProcedureTest.php` — 5 tests, 8 assertions, green.
