### PR TITLE
chore: prefix Keycloak/OAuth login logs with oauthAuthenticator

### DIFF
--- a/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
+++ b/demosplan/DemosPlanCoreBundle/EventSubscriber/LogoutSubscriber.php
@@ -74,7 +74,7 @@ class LogoutSubscriber implements EventSubscriberInterface
             try {
                 $this->oauthTokenStorageService->deleteTokensUnlessPendingData($user->getId());
             } catch (Exception $e) {
-                $this->logger->warning('Failed to delete OAuth tokens on logout', ['error' => $e->getMessage()]);
+                $this->logger->warning('oauthAuthenticator: Failed to delete OAuth tokens on logout', ['error' => $e->getMessage()]);
             }
 
             // Keycloak logout
@@ -83,14 +83,14 @@ class LogoutSubscriber implements EventSubscriberInterface
                 $keycloakToken = $event->getRequest()->getSession()->get(OzgKeycloakSessionManager::KEYCLOAK_TOKEN);
                 $event->getRequest()->getSession()->invalidate();
 
-                $this->logger->info('Redirecting to Keycloak for logout initial', [$logoutRoute]);
+                $this->logger->info('oauthAuthenticator: Redirecting to Keycloak for logout initial', [$logoutRoute]);
 
                 // add additional parameters to keycloak logout url for redirect
                 try {
                     $logoutRoute = $this->ozgKeycloakSessionManager->getLogoutUrl($logoutRoute, $keycloakToken);
-                    $this->logger->info('Redirecting to Keycloak for logout adjusted', [$logoutRoute]);
+                    $this->logger->info('oauthAuthenticator: Redirecting to Keycloak for logout adjusted', [$logoutRoute]);
                 } catch (Exception $e) {
-                    $this->logger->error('Could not get current customer', [$e->getMessage()]);
+                    $this->logger->error('oauthAuthenticator: Could not get current customer', [$e->getMessage()]);
                 }
                 $response = $this->redirect($logoutRoute);
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/KeycloakUserDataMapper.php
@@ -57,14 +57,14 @@ class KeycloakUserDataMapper
         $user = $this->userService->findDistinctUserByEmailOrLogin($keycloakUserData->getEmailAddress());
 
         if ($user instanceof User) {
-            $this->logger->info('Found user in Keycloak request', ['data' => $keycloakUserData]);
+            $this->logger->info('oauthAuthenticator: Found user in Keycloak request', ['data' => $keycloakUserData]);
 
             $this->updateOrgaWithKnownValues($user->getOrga(), $keycloakUserData);
 
             return $this->updateUserWithKnownValues($user, $keycloakUserData);
         }
 
-        $this->logger->info('Eventually create new User from Keycloak', ['data' => $keycloakUserData]);
+        $this->logger->info('oauthAuthenticator: Eventually create new User from Keycloak', ['data' => $keycloakUserData]);
 
         // At this state the login attempt may be from different Identity Providers (IdP).
         // In some cases the IdP only passes an orga without any acting user (like Orgakonto Bund)
@@ -73,13 +73,13 @@ class KeycloakUserDataMapper
 
         // Does the payload carry an organisation?
         if ('' !== $keycloakUserData->getOrganisationName()) {
-            $this->logger->info('User is Orgauser');
+            $this->logger->info('oauthAuthenticator: User is Orgauser');
 
             return $this->getUserForOrga($keycloakUserData);
         }
 
         // otherwise we assume that it is a citizen
-        $this->logger->info('User is citizen');
+        $this->logger->info('oauthAuthenticator: User is citizen');
 
         return $this->getUserForNewCitizen($keycloakUserData);
     }
@@ -88,7 +88,7 @@ class KeycloakUserDataMapper
     {
         $login = $keycloakUserData->getUserName();
 
-        $this->logger->info('Create new User from Keycloak data');
+        $this->logger->info('oauthAuthenticator: Create new User from Keycloak data');
 
         // user does not yet exist
         $user = $this->getNewUserWithDefaultValues();
@@ -109,21 +109,21 @@ class KeycloakUserDataMapper
         // in this context the given Id is the GatewayName of the organisation
         $orgas = $this->orgaService->getOrgaByFields(['gwId' => $keycloakUserData->getOrganisationId()]);
         if (null === $orgas || ([] === $orgas)) {
-            $this->logger->info('Create new User and Orga from Keycloak');
+            $this->logger->info('oauthAuthenticator: Create new User and Orga from Keycloak');
 
             return $this->createNewUserAndOrgaFromOrga($keycloakUserData);
         }
 
         // orga is already registered in customer, return default user
 
-        $this->logger->info('Orga is already registered in customer');
+        $this->logger->info('oauthAuthenticator: Orga is already registered in customer');
         $orga = $orgas[0] ?? null;
         if (!$orga instanceof Orga) {
-            $this->logger->error('Could not find valid orga in Keycloak request', [$orgas]);
+            $this->logger->error('oauthAuthenticator: Could not find valid orga in Keycloak request', [$orgas]);
             throw new InvalidArgumentException('Could not find valid orga in Keycloak request');
         }
 
-        $this->logger->info('Update existing Orga with Keycloak data');
+        $this->logger->info('oauthAuthenticator: Update existing Orga with Keycloak data');
         $orga = $this->updateOrgaWithKnownValues($orga, $keycloakUserData);
 
         $users = $orga->getUsers();
@@ -131,13 +131,13 @@ class KeycloakUserDataMapper
         // return the orga default user
         $user = $users->filter(fn (User $user) => UserInterface::DEFAULT_ORGA_USER_NAME === $user->getLastname());
 
-        $this->logger->info('Fetched users', ['users' => $user]);
+        $this->logger->info('oauthAuthenticator: Fetched users', ['users' => $user]);
 
         if (1 === $user->count()) {
             return $user->first();
         }
 
-        $this->logger->error('No valid users found');
+        $this->logger->error('oauthAuthenticator: No valid users found');
 
         throw new InvalidArgumentException('Invalid Keycloak user attributes given');
     }
@@ -199,7 +199,7 @@ class KeycloakUserDataMapper
             );
             $this->eventDispatcherPost->post($newOrgaRegisteredEvent);
         } catch (Exception $e) {
-            $this->logger->warning('Could not successfully perform orga registered from OAuth login event', [$e]);
+            $this->logger->warning('oauthAuthenticator: Could not successfully perform orga registered from OAuth login event', [$e]);
         }
 
         // Orga has exactly one master user so far

--- a/demosplan/DemosPlanCoreBundle/Logic/OAuth/KeycloakTokenRefreshService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OAuth/KeycloakTokenRefreshService.php
@@ -68,7 +68,7 @@ class KeycloakTokenRefreshService
      */
     public function hasValidTokens(SessionInterface $session, OAuthToken $oauthToken): bool
     {
-        $this->logger->debug('Token check threshold reached - performing validation', [
+        $this->logger->debug('oauthAuthenticator: Token check threshold reached - performing validation', [
             'user_id'      => $oauthToken->getUser()->getId(),
             'current_time' => date('Y-m-d H:i:s', time()),
         ]);
@@ -96,10 +96,10 @@ class KeycloakTokenRefreshService
     {
         $userId = $oauthToken->getUser()->getId();
 
-        $this->logger->info('Access token expired - checking refresh token', ['user_id' => $userId]);
+        $this->logger->info('oauthAuthenticator: Access token expired - checking refresh token', ['user_id' => $userId]);
 
         if ($this->tokenExpirationService->isRefreshTokenExpired($oauthToken)) {
-            $this->logger->info('Refresh token also expired', ['user_id' => $userId]);
+            $this->logger->info('oauthAuthenticator: Refresh token also expired', ['user_id' => $userId]);
 
             return false;
         }
@@ -107,12 +107,12 @@ class KeycloakTokenRefreshService
         $refreshSuccess = $this->refreshTokensForUser($userId);
 
         if (!$refreshSuccess) {
-            $this->logger->error('Token refresh failed', ['user_id' => $userId]);
+            $this->logger->error('oauthAuthenticator: Token refresh failed', ['user_id' => $userId]);
 
             return false;
         }
 
-        $this->logger->info('Token refresh successful - continuing request', ['user_id' => $userId]);
+        $this->logger->info('oauthAuthenticator: Token refresh successful - continuing request', ['user_id' => $userId]);
 
         return true;
     }
@@ -143,10 +143,10 @@ class KeycloakTokenRefreshService
         }
 
         try {
-            $this->logger->info('Starting token refresh', ['user_id' => $userId]);
+            $this->logger->info('oauthAuthenticator: Starting token refresh', ['user_id' => $userId]);
 
             if ($wasContested && $this->oauthTokenRepository->haveTokensBeenRefreshed($userId, $this->tokenTimezone)) {
-                $this->logger->info('Token already refreshed by concurrent process - skipping own KeyCloak call', [
+                $this->logger->info('oauthAuthenticator: Token already refreshed by concurrent process - skipping own KeyCloak call', [
                     'user_id' => $userId,
                 ]);
 
@@ -160,7 +160,7 @@ class KeycloakTokenRefreshService
                 // Get the OAuth2 client
                 $client = $this->clientRegistry->getClient('keycloak_ozg');
 
-                $this->logger->debug('Calling KeyCloak to refresh access token', [
+                $this->logger->debug('oauthAuthenticator: Calling KeyCloak to refresh access token', [
                     'user_id'              => $userId,
                     'refresh_token_length' => strlen($tokenData->getRefreshToken()),
                 ]);
@@ -169,7 +169,7 @@ class KeycloakTokenRefreshService
                 // This returns a new AccessToken object with ALL tokens rotated
                 $newAccessToken = $client->refreshAccessToken($tokenData->getRefreshToken());
 
-                $this->logger->info('Token refresh successful', [
+                $this->logger->info('oauthAuthenticator: Token refresh successful', [
                     'user_id'                  => $userId,
                     'new_access_token_length'  => strlen($newAccessToken->getToken()),
                     'new_refresh_token_length' => strlen($newAccessToken->getRefreshToken() ?? ''),
@@ -180,15 +180,15 @@ class KeycloakTokenRefreshService
                 // Store the new tokens (all tokens have been rotated by KeyCloak)
                 $this->tokenStorageService->storeTokens($userId, $newAccessToken);
 
-                $this->logger->info('New tokens stored successfully', ['user_id' => $userId]);
+                $this->logger->info('oauthAuthenticator: New tokens stored successfully', ['user_id' => $userId]);
 
                 return true;
             }
 
-            $this->logger->warning('No tokens or no refresh token available for user', ['user_id' => $userId]);
+            $this->logger->warning('oauthAuthenticator: No tokens or no refresh token available for user', ['user_id' => $userId]);
         } catch (IdentityProviderException $e) {
             // OAuth2-specific errors (invalid token, expired refresh token, network issues, etc.)
-            $this->logger->error('OAuth2 provider error during token refresh', [
+            $this->logger->error('oauthAuthenticator: OAuth2 provider error during token refresh', [
                 'user_id'       => $userId,
                 'error'         => $e->getMessage(),
                 'response_body' => $e->getResponseBody(),
@@ -196,7 +196,7 @@ class KeycloakTokenRefreshService
             ]);
         } catch (Exception $e) {
             // General errors (encryption, database, etc.)
-            $this->logger->error('Token refresh failed', [
+            $this->logger->error('oauthAuthenticator: Token refresh failed', [
                 'user_id'         => $userId,
                 'error'           => $e->getMessage(),
                 'exception_class' => get_class($e),

--- a/demosplan/DemosPlanCoreBundle/Logic/OAuth/OAuthTokenStorageService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OAuth/OAuthTokenStorageService.php
@@ -148,7 +148,7 @@ class OAuthTokenStorageService
 
             $this->entityManager->flush();
 
-            $this->logger->info('OAuth tokens stored', [
+            $this->logger->info('oauthAuthenticator: OAuth tokens stored', [
                 'user_id'           => $userId,
                 'has_refresh_token' => null !== $refreshTokenString,
                 'has_id_token'      => isset($values['id_token']),
@@ -164,7 +164,7 @@ class OAuthTokenStorageService
                 }
             }
         } catch (Exception $e) {
-            $this->logger->error('Failed to store OAuth tokens', [
+            $this->logger->error('oauthAuthenticator: Failed to store OAuth tokens', [
                 'user_id'         => $userId,
                 'error'           => $e->getMessage(),
                 'exception_class' => get_class($e),
@@ -209,7 +209,7 @@ class OAuthTokenStorageService
     {
         $this->oauthTokenRepository->deleteByUserId($userId);
 
-        $this->logger->info('OAuth tokens deleted', [
+        $this->logger->info('oauthAuthenticator: OAuth tokens deleted', [
             'user_id' => $userId,
         ]);
     }
@@ -232,7 +232,7 @@ class OAuthTokenStorageService
         }
 
         if ($oauthToken->hasPendingData()) {
-            $this->logger->info('OAuth token deletion skipped - pending data preserved for re-authentication', [
+            $this->logger->info('oauthAuthenticator: OAuth token deletion skipped - pending data preserved for re-authentication', [
                 'user_id'                   => $userId,
                 'pending_request_url'       => $oauthToken->getPendingRequestUrl(),
                 'pending_page_url'          => $oauthToken->getPendingPageUrl(),
@@ -244,7 +244,7 @@ class OAuthTokenStorageService
 
         $this->oauthTokenRepository->deleteByUserId($userId);
 
-        $this->logger->info('OAuth tokens deleted', ['user_id' => $userId]);
+        $this->logger->info('oauthAuthenticator: OAuth tokens deleted', ['user_id' => $userId]);
     }
 
     /**
@@ -289,7 +289,7 @@ class OAuthTokenStorageService
 
         $this->entityManager->flush();
 
-        $this->logger->info('Pending request stored', [
+        $this->logger->info('oauthAuthenticator: Pending request stored', [
             'user_id'     => $oauthToken->getUser()->getId(),
             'request_url' => $requestData->getRequestUrl(),
             'method'      => $requestData->getMethod(),
@@ -325,7 +325,7 @@ class OAuthTokenStorageService
             foreach ($violations as $violation) {
                 $errors[] = $violation->getPropertyPath().': '.$violation->getMessage();
             }
-            $this->logger->error('Pending page URL validation failed', [
+            $this->logger->error('oauthAuthenticator: Pending page URL validation failed', [
                 'user_id'  => $oauthToken->getUser()->getId(),
                 'page_url' => $pageUrl,
                 'errors'   => $errors,
@@ -335,7 +335,7 @@ class OAuthTokenStorageService
 
         $this->entityManager->flush();
 
-        $this->logger->info('Pending page URL stored for redirect-back after re-authentication', [
+        $this->logger->info('oauthAuthenticator: Pending page URL stored for redirect-back after re-authentication', [
             'user_id'  => $oauthToken->getUser()->getId(),
             'page_url' => $pageUrl,
         ]);
@@ -367,12 +367,12 @@ class OAuthTokenStorageService
 
             $this->storePendingRequest($oauthToken, $requestData);
 
-            $this->logger->info('Request buffered for replay after re-authentication', [
+            $this->logger->info('oauthAuthenticator: Request buffered for replay after re-authentication', [
                 'method' => $request->getMethod(),
                 'url'    => $request->getRequestUri(),
             ]);
         } catch (Exception $e) {
-            $this->logger->error('Failed to buffer request', ['error' => $e->getMessage()]);
+            $this->logger->error('oauthAuthenticator: Failed to buffer request', ['error' => $e->getMessage()]);
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/OAuth/TokenExpirationService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OAuth/TokenExpirationService.php
@@ -79,7 +79,7 @@ class TokenExpirationService
                     );
                 }
             } catch (Exception $e) {
-                $this->logger->error('Failed to store id_token for logout', ['error' => $e->getMessage()]);
+                $this->logger->error('oauthAuthenticator: Failed to store id_token for logout', ['error' => $e->getMessage()]);
             }
 
             $this->oauthTokenStorageService->bufferRequestIfNeeded($oauthToken);
@@ -102,7 +102,7 @@ class TokenExpirationService
                     }
                     $this->oauthTokenStorageService->storePendingPageUrl($oauthToken, $path);
                 } catch (Exception $e) {
-                    $this->logger->error('Failed to store pending page URL for redirect-back', ['error' => $e->getMessage()]);
+                    $this->logger->error('oauthAuthenticator: Failed to store pending page URL for redirect-back', ['error' => $e->getMessage()]);
                 }
             }
         }
@@ -138,7 +138,7 @@ class TokenExpirationService
 
     private function redirectToLogout(ControllerEvent $event): void
     {
-        $this->logger->info('Token expired, redirecting to logout');
+        $this->logger->info('oauthAuthenticator: Token expired, redirecting to logout');
 
         $redirectResponse = new RedirectResponse($this->router->generate('DemosPlan_user_logout'));
         $event->setController(static fn () => $redirectResponse);

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakDataMapper/DepartmentMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakDataMapper/DepartmentMapper.php
@@ -89,7 +89,7 @@ class DepartmentMapper
         $this->entityManager->persist($orga);
         $this->entityManager->flush();
 
-        $this->logger->info('Created new department for organisational unit',
+        $this->logger->info('oauthAuthenticator: Created new department for organisational unit',
             [
                 'departmentName' => $departmentNameInToken,
                 'orgaName'       => $orga->getName(),

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakDataMapper/RoleMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakDataMapper/RoleMapper.php
@@ -62,23 +62,23 @@ class RoleMapper
     {
         // If no client ID is configured, skip resource_access extraction (fallback to groups)
         if ('' === $keycloakClientId) {
-            $this->logger->info('No oauth_keycloak_client_id configured, skipping resource_access extraction');
+            $this->logger->info('oauthAuthenticator: No oauth_keycloak_client_id configured, skipping resource_access extraction');
 
             return [];
         }
 
         // Check if the configured client ID exists in resource_access
         if (!isset($resourceAccess[$keycloakClientId])) {
-            $this->logger->warning("Configured client ID '{$keycloakClientId}' not found in resource_access");
+            $this->logger->warning("oauthAuthenticator: Configured client ID '{$keycloakClientId}' not found in resource_access");
 
             return [];
         }
 
         $clientData = $resourceAccess[$keycloakClientId];
-        $this->logger->info("Found configured client '{$keycloakClientId}' in resource_access");
+        $this->logger->info("oauthAuthenticator: Found configured client '{$keycloakClientId}' in resource_access");
 
         if (!isset($clientData['roles']) || !is_array($clientData['roles'])) {
-            $this->logger->warning("No roles array found in resource_access for client: {$keycloakClientId}");
+            $this->logger->warning("oauthAuthenticator: No roles array found in resource_access for client: {$keycloakClientId}");
 
             return [];
         }
@@ -88,9 +88,9 @@ class RoleMapper
             if (array_key_exists($technicalRole, self::TECHNICAL_ROLE_TO_READABLE)) {
                 $readableRoleName = self::TECHNICAL_ROLE_TO_READABLE[$technicalRole];
                 $customerRoleRelations[$customerSubdomain][] = $readableRoleName;
-                $this->logger->info("Mapped technical role {$technicalRole} to {$readableRoleName} for customer subdomain {$customerSubdomain}");
+                $this->logger->info("oauthAuthenticator: Mapped technical role {$technicalRole} to {$readableRoleName} for customer subdomain {$customerSubdomain}");
             } else {
-                $this->logger->warning("Unknown technical role in resource_access: {$technicalRole}");
+                $this->logger->warning("oauthAuthenticator: Unknown technical role in resource_access: {$technicalRole}");
             }
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakGroupBasedRoleMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakGroupBasedRoleMapper.php
@@ -64,17 +64,17 @@ class OzgKeycloakGroupBasedRoleMapper
         );
 
         if ([] !== $unIdentifiedRoles) {
-            $this->logger->error('at least one non recognizable role was requested!', $unIdentifiedRoles);
+            $this->logger->error('oauthAuthenticator: at least one non recognizable role was requested!', $unIdentifiedRoles);
         }
 
-        $this->logger->info('Recognized Roles: ', [$recognizedRoleCodes]);
+        $this->logger->info('oauthAuthenticator: Recognized Roles: ', [$recognizedRoleCodes]);
         $requestedRoles = $this->filterNonAvailableRolesInProject($recognizedRoleCodes);
 
         if ([] === $requestedRoles) {
             throw new AuthenticationCredentialsNotFoundException('no roles could be identified');
         }
 
-        $this->logger->info('Finally recognized Roles: ', [$requestedRoles]);
+        $this->logger->info('oauthAuthenticator: Finally recognized Roles: ', [$requestedRoles]);
 
         return $requestedRoles;
     }
@@ -100,13 +100,13 @@ class OzgKeycloakGroupBasedRoleMapper
                 continue;
             }
 
-            $this->logger->info("Role found for subdomain {$subdomain}: {$roleName}");
+            $this->logger->info("oauthAuthenticator: Role found for subdomain {$subdomain}: {$roleName}");
 
             if (array_key_exists($roleName, self::ROLETITLE_TO_ROLECODE)) {
-                $this->logger->info("Role recognized: {$roleName}");
+                $this->logger->info("oauthAuthenticator: Role recognized: {$roleName}");
                 $recognizedRoleCodes[] = self::ROLETITLE_TO_ROLECODE[$roleName];
             } else {
-                $this->logger->info("Role not recognized: {$roleName}");
+                $this->logger->info("oauthAuthenticator: Role not recognized: {$roleName}");
                 $unIdentifiedRoles[] = $roleName;
             }
         }
@@ -127,17 +127,17 @@ class OzgKeycloakGroupBasedRoleMapper
         $availableRequestedRoles = [];
         foreach ($requestedRoleCodes as $roleCode) {
             if (in_array($roleCode, $this->globalConfig->getRolesAllowed(), true)) {
-                $this->logger->info('try to fetch role entity for role code', [$roleCode]);
+                $this->logger->info('oauthAuthenticator: try to fetch role entity for role code', [$roleCode]);
                 $availableRequestedRoles[] = $this->roleRepository->findOneBy(['code' => $roleCode]);
-                $this->logger->info('current available requested roles', [$availableRequestedRoles]);
+                $this->logger->info('oauthAuthenticator: current available requested roles', [$availableRequestedRoles]);
             } else {
-                $this->logger->info('try to fetch role entity for not allowed role code', [$roleCode]);
+                $this->logger->info('oauthAuthenticator: try to fetch role entity for not allowed role code', [$roleCode]);
                 $unavailableRoles[] = $this->roleRepository->findOneBy(['code' => $roleCode]);
-                $this->logger->info('current unavailable requested roles', [$unavailableRoles]);
+                $this->logger->info('oauthAuthenticator: current unavailable requested roles', [$unavailableRoles]);
             }
         }
         if ([] !== $unavailableRoles) {
-            $this->logger->info('the following requested roles are not available in project', $unavailableRoles);
+            $this->logger->info('oauthAuthenticator: the following requested roles are not available in project', $unavailableRoles);
         }
 
         return $availableRequestedRoles;

--- a/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OzgKeycloakUserDataMapper.php
@@ -143,7 +143,7 @@ class OzgKeycloakUserDataMapper
         if (!$existingUser instanceof User) {
             $user = $this->createNewUser($primaryOrga, $requestedRoles);
             $this->organisationAffiliationMapper->syncUserOrganisations($user, [], $organisations);
-            $this->logger->info('Multi-organisation user mapped', [
+            $this->logger->info('oauthAuthenticator: Multi-organisation user mapped', [
                 'userId'            => $user->getId(),
                 'organisationCount' => count($organisations),
                 'organisations'     => array_map(fn (Orga $o) => $o->getId(), $organisations),
@@ -160,7 +160,7 @@ class OzgKeycloakUserDataMapper
 
         $this->organisationAffiliationMapper->syncUserOrganisations($user, $oldOrgas, $organisations);
 
-        $this->logger->info('Multi-organisation user mapped', [
+        $this->logger->info('oauthAuthenticator: Multi-organisation user mapped', [
             'userId'            => $user->getId(),
             'organisationCount' => count($organisations),
             'organisations'     => array_map(fn (Orga $o) => $o->getId(), $organisations),
@@ -257,7 +257,7 @@ class OzgKeycloakUserDataMapper
         $isPrivatePersonByOrga = $existingOrga instanceof Orga && UserInterface::ANONYMOUS_USER_ORGA_ID === $existingOrga->getId();
 
         if ($isPrivatePersonByAttribute) {
-            $this->logger->info('User identified as private person via isPrivatePerson token attribute');
+            $this->logger->info('oauthAuthenticator: User identified as private person via isPrivatePerson token attribute');
         }
 
         if ($isPrivatePersonByAttribute || $isPrivatePersonByRole || $isPrivatePersonByOrga) {
@@ -360,7 +360,7 @@ class OzgKeycloakUserDataMapper
         $this->ensureOrgaTypesForRoles($existingOrga, $customer, $requestedRoles);
         $this->entityManager->persist($existingOrga);
 
-        $this->logger->info('Organisation updated', [
+        $this->logger->info('oauthAuthenticator: Organisation updated', [
             'orgaId' => $existingOrga->getId(),
             'gwId'   => $gwId,
             'name'   => $orgaName,
@@ -439,7 +439,7 @@ class OzgKeycloakUserDataMapper
         $orga->setDepartments([$department]);
         $this->entityManager->persist($orga);
 
-        $this->logger->info('Organisation created', [
+        $this->logger->info('oauthAuthenticator: Organisation created', [
             'orgaId' => $orga->getId(),
             'gwId'   => $gwId,
             'name'   => $orgaName,
@@ -507,7 +507,7 @@ class OzgKeycloakUserDataMapper
 
         $newUser = $this->userService->addUser($userData);
         $this->logger->info(
-            'New user was created.',
+            'oauthAuthenticator: New user was created.',
             [
                 'id'           => $newUser->getId(),
                 'userData'     => $newUser->getLastname(),
@@ -577,7 +577,7 @@ class OzgKeycloakUserDataMapper
      */
     private function getCitizenRoleForPrivatePerson(): array
     {
-        $this->logger->info('Private person detected - automatically assigning CITIZEN role');
+        $this->logger->info('oauthAuthenticator: Private person detected - automatically assigning CITIZEN role');
         $citizenRole = $this->roleRepository->findOneBy(['code' => RoleInterface::CITIZEN]);
         if (null === $citizenRole) {
             throw new AuthenticationCredentialsNotFoundException('CITIZEN role not found in system');
@@ -674,7 +674,7 @@ class OzgKeycloakUserDataMapper
         // Removed flush() call - let the main transaction handle persistence
 
         $this->logger->info(
-            'Existing user was updated.',
+            'oauthAuthenticator: Existing user was updated.',
             [
                 'id'           => $dplanUser->getId(),
                 'lastname'     => $dplanUser->getLastname(),

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakSessionManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakSessionManager.php
@@ -111,12 +111,12 @@ class OzgKeycloakSessionManager
 
             $session->set(self::EXPIRATION_TIMESTAMP, $expirationTimestamp);
 
-            $this->logger->debug('Expiration timestamp injected into session', [
+            $this->logger->debug('oauthAuthenticator: Expiration timestamp injected into session', [
                 'user_id'    => $userId,
                 'expiration' => $expirationTimestamp,
             ]);
         } catch (Exception $e) {
-            $this->logger->warning('Failed to inject expiration timestamp into session', [
+            $this->logger->warning('oauthAuthenticator: Failed to inject expiration timestamp into session', [
                 'user_id' => $userId,
                 'error'   => $e->getMessage(),
             ]);
@@ -132,7 +132,7 @@ class OzgKeycloakSessionManager
     public function storeIdTokenForLogout(SessionInterface $session, string $idToken): void
     {
         $session->set(self::KEYCLOAK_TOKEN, $idToken);
-        $this->logger->info('Storing keycloak id_token in session for logout');
+        $this->logger->info('oauthAuthenticator: Storing keycloak id_token in session for logout');
     }
 
     public function getLogoutUrl(string $logoutRoute, ?string $keycloakToken): string
@@ -194,7 +194,7 @@ class OzgKeycloakSessionManager
         $nextCheck = time() + $checkInterval;
         $session->set(self::NEXT_TOKEN_CHECK, $nextCheck);
 
-        $this->logger->debug('Session token check threshold updated', [
+        $this->logger->debug('oauthAuthenticator: Session token check threshold updated', [
             'user_id'          => $userId,
             'next_check'       => date('Y-m-d H:i:s', $nextCheck),
             'interval_seconds' => $checkInterval,
@@ -215,7 +215,7 @@ class OzgKeycloakSessionManager
 
         $session->set(self::EXPIRATION_TIMESTAMP, $expirationTimestamp->getTimestamp());
 
-        $this->logger->debug('PHP session synced with OAuth token expiration', [
+        $this->logger->debug('oauthAuthenticator: PHP session synced with OAuth token expiration', [
             'expires_at' => $expirationTimestamp->format('Y-m-d H:i:s'),
         ]);
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/AbstractOzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/AbstractOzgKeycloakAuthenticator.php
@@ -216,7 +216,7 @@ abstract class AbstractOzgKeycloakAuthenticator extends OAuth2Authenticator
 
             if ($organisations->count() > 1) {
                 if ($this->currentOrganisationService->requiresOrganisationSelection($user)) {
-                    $this->logger->info('Multi-organisation user requires organisation selection', [
+                    $this->logger->info('oauthAuthenticator: Multi-organisation user requires organisation selection', [
                         'userId'            => $user->getId(),
                         'organisationCount' => $organisations->count(),
                     ]);
@@ -231,7 +231,7 @@ abstract class AbstractOzgKeycloakAuthenticator extends OAuth2Authenticator
                 $singleOrga = $organisations->first();
                 if (false !== $singleOrga) {
                     $this->currentOrganisationService->setCurrentOrganisation($user, $singleOrga);
-                    $this->logger->info('Single organisation auto-selected', [
+                    $this->logger->info('oauthAuthenticator: Single organisation auto-selected', [
                         'userId' => $user->getId(),
                         'orgaId' => $singleOrga->getId(),
                     ]);
@@ -244,7 +244,7 @@ abstract class AbstractOzgKeycloakAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        $this->logger->warning('Keycloak login failed', ['exception' => $exception]);
+        $this->logger->warning('oauthAuthenticator: Keycloak login failed', ['exception' => $exception]);
 
         return new RedirectResponse($this->router->generate('core_login_idp_error'));
     }

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakAuthenticator.php
@@ -46,7 +46,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
     {
         $client = $this->clientRegistry->getClient('keycloak');
         $accessToken = $this->fetchAccessToken($client);
-        $this->logger->info('login attempt', ['accessToken' => $accessToken]);
+        $this->logger->info('oauthAuthenticator: login attempt', ['accessToken' => $accessToken]);
 
         $userIdentifier = $accessToken->getToken();
         $resourceOwner = $client->fetchUserFromToken($accessToken);
@@ -60,7 +60,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
     {
         /** @var User $user */
         $user = $token->getUser();
-        $this->logger->info('User was logged in via OAuth', ['id' => $user->getId(), 'roles' => $user->getDplanRolesString()]);
+        $this->logger->info('oauthAuthenticator: User was logged in via OAuth', ['id' => $user->getId(), 'roles' => $user->getDplanRolesString()]);
 
         // propagate user login to session
         $request->getSession()->set('userId', $user->getId());
@@ -73,7 +73,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        $this->logger->warning('Login via Keycloak failed', ['exception' => $exception]);
+        $this->logger->warning('oauthAuthenticator: Login via Keycloak failed', ['exception' => $exception]);
         $targetUrl = $this->router->generate('core_login_idp_error');
 
         return new RedirectResponse($targetUrl);

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/KeycloakUserBadgeCreator.php
@@ -37,22 +37,22 @@ class KeycloakUserBadgeCreator
         return new UserBadge($userIdentifier, function () use ($resourceOwner, $request) {
             try {
                 $this->entityManager->getConnection()->beginTransaction();
-                $this->logger->info('Start of doctrine transaction.');
+                $this->logger->info('oauthAuthenticator: Start of doctrine transaction.');
 
                 $this->keycloakUserData->fill($resourceOwner);
-                $this->logger->info('Found user data: '.$this->keycloakUserData);
+                $this->logger->info('oauthAuthenticator: Found user data: '.$this->keycloakUserData);
                 $user = $this->keycloakUserDataMapper->mapUserData($this->keycloakUserData);
 
                 $this->entityManager->getConnection()->commit();
-                $this->logger->info('doctrine transaction commit.');
+                $this->logger->info('oauthAuthenticator: doctrine transaction commit.');
                 $request->getSession()->set('userId', $user->getId());
 
                 return $user;
             } catch (Exception $e) {
                 $this->entityManager->getConnection()->rollBack();
-                $this->logger->info('doctrine transaction rollback.');
+                $this->logger->info('oauthAuthenticator: doctrine transaction rollback.');
                 $this->logger->error(
-                    'login failed',
+                    'oauthAuthenticator: login failed',
                     [
                         'requestValues' => $this->keycloakUserData ?? null,
                         'exception'     => $e,

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakAuthenticator.php
@@ -80,19 +80,19 @@ class OzgKeycloakAuthenticator extends AbstractOzgKeycloakAuthenticator implemen
     {
         $client = $this->ozgKeycloakClientFactory->createForCurrentCustomer();
         $accessToken = $this->fetchAccessToken($client);
-        $this->logger->info('login attempt', ['accessToken' => $accessToken]);
+        $this->logger->info('oauthAuthenticator: login attempt', ['accessToken' => $accessToken]);
 
         // Execute user creation immediately instead of deferring it
         try {
             $this->entityManager->getConnection()->beginTransaction();
-            $this->logger->info('Start of doctrine transaction.');
+            $this->logger->info('oauthAuthenticator: Start of doctrine transaction.');
 
             // Decode the JWT access token to get ALL claims including resource_access
             // Parse without verification since Keycloak signed it with its own keys
             $parser = new Parser(new JoseEncoder());
             $token = $parser->parse($accessToken->getToken());
             $decodedJwtPayload = $token->claims()->all();
-            $this->logger->info('raw token', [$decodedJwtPayload]);
+            $this->logger->info('oauthAuthenticator: raw token', [$decodedJwtPayload]);
 
             $customerSubdomain = $this->customerService->getCurrentCustomer()->getSubdomain();
             $keycloakClientId = $this->ozgKeycloakClientFactory->getClientIdForCurrentCustomer(
@@ -102,18 +102,18 @@ class OzgKeycloakAuthenticator extends AbstractOzgKeycloakAuthenticator implemen
             // Create ResourceOwner with complete JWT payload (includes resource_access)
             $resourceOwner = new KeycloakResourceOwner($decodedJwtPayload);
             $this->ozgKeycloakUserData->fill($resourceOwner, $customerSubdomain, $keycloakClientId);
-            $this->logger->info('Found user data: '.$this->ozgKeycloakUserData);
+            $this->logger->info('oauthAuthenticator: Found user data: '.$this->ozgKeycloakUserData);
             $user = $this->ozgKeycloakUserDataMapper->mapUserData($this->ozgKeycloakUserData);
 
             $this->entityManager->getConnection()->commit();
-            $this->logger->info('doctrine transaction commit.');
+            $this->logger->info('oauthAuthenticator: doctrine transaction commit.');
             $request->getSession()->set('userId', $user->getId());
             $this->pendingAccessToken = $accessToken;
         } catch (Exception $e) {
             $this->entityManager->getConnection()->rollBack();
-            $this->logger->info('doctrine transaction rollback.');
+            $this->logger->info('oauthAuthenticator: doctrine transaction rollback.');
             $this->logger->error(
-                'login failed',
+                'oauthAuthenticator: login failed',
                 [
                     'requestValues' => $this->ozgKeycloakUserData,
                     'exception'     => $e,

--- a/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakStaticAuthenticator.php
+++ b/demosplan/DemosPlanCoreBundle/Security/Authentication/Authenticator/OzgKeycloakStaticAuthenticator.php
@@ -110,14 +110,14 @@ class OzgKeycloakStaticAuthenticator extends AbstractOzgKeycloakAuthenticator
 
         if (null === $userData) {
             $availableKeys = implode(', ', $this->userDataProvider->getAvailableUserKeys());
-            $this->logger->error('Static Keycloak test user not found', [
+            $this->logger->error('oauthAuthenticator: Static Keycloak test user not found', [
                 'requestedKey'  => $testUserKey,
                 'availableKeys' => $availableKeys,
             ]);
             throw new AuthenticationException(sprintf('Test user "%s" not found. Available users: %s', $testUserKey, $availableKeys));
         }
 
-        $this->logger->info('Static Keycloak login attempt', [
+        $this->logger->info('oauthAuthenticator: Static Keycloak login attempt', [
             'testUserKey'         => $testUserKey,
             'userId'              => $userData['sub'],
             'email'               => $userData['email'],
@@ -126,7 +126,7 @@ class OzgKeycloakStaticAuthenticator extends AbstractOzgKeycloakAuthenticator
 
         try {
             $this->entityManager->getConnection()->beginTransaction();
-            $this->logger->info('Start of doctrine transaction (static Keycloak).');
+            $this->logger->info('oauthAuthenticator: Start of doctrine transaction (static Keycloak).');
 
             $customerSubdomain = $this->customerService->getCurrentCustomer()->getSubdomain();
 
@@ -135,18 +135,18 @@ class OzgKeycloakStaticAuthenticator extends AbstractOzgKeycloakAuthenticator
             // Static test users always use 'dplan-test' as client ID in resource_access
             $this->ozgKeycloakUserData->fill($resourceOwner, $customerSubdomain, 'dplan-test');
 
-            $this->logger->info('Static Keycloak user data: '.$this->ozgKeycloakUserData);
+            $this->logger->info('oauthAuthenticator: Static Keycloak user data: '.$this->ozgKeycloakUserData);
             $user = $this->ozgKeycloakUserDataMapper->mapUserData($this->ozgKeycloakUserData);
 
             $this->entityManager->getConnection()->commit();
-            $this->logger->info('Doctrine transaction commit (static Keycloak).');
+            $this->logger->info('oauthAuthenticator: Doctrine transaction commit (static Keycloak).');
 
             $request->getSession()->set('userId', $user->getId());
         } catch (Exception $e) {
             $this->entityManager->getConnection()->rollBack();
-            $this->logger->info('Doctrine transaction rollback (static Keycloak).');
+            $this->logger->info('oauthAuthenticator: Doctrine transaction rollback (static Keycloak).');
             $this->logger->error(
-                'Static Keycloak login failed',
+                'oauthAuthenticator: Static Keycloak login failed',
                 [
                     'testUserKey' => $testUserKey,
                     'exception'   => $e,
@@ -223,7 +223,7 @@ class OzgKeycloakStaticAuthenticator extends AbstractOzgKeycloakAuthenticator
 
         $this->entityManager->flush();
 
-        $this->logger->info('Static Keycloak: fake pending data created for re-auth simulation', [
+        $this->logger->info('oauthAuthenticator: Static Keycloak: fake pending data created for re-auth simulation', [
             'userId'  => $user->getId(),
             'pageUrl' => $oauthToken->getPendingPageUrl(),
             'orgaId'  => false !== $firstOrga ? $firstOrga->getId() : null,


### PR DESCRIPTION
## What

Prefixes log messages across the Keycloak/OAuth authentication flow with `oauthAuthenticator:` so they can be filtered easily in Kibana.

Touched: authenticators, Keycloak/Ozg user & role data mappers, session manager, OAuth token lifecycle services (storage/refresh/expiration), and the Keycloak logout path. 99 messages across 15 files.

## Why

Login-via-Keycloak log lines were scattered with no common token, making them hard to isolate when debugging auth issues in Kibana. A consistent prefix makes them greppable.

## Notes

- The prefix is inserted right after the opening quote, so structured context arrays are unchanged.
- The Azure AD logout log line is deliberately left untouched (not part of the Keycloak/OAuth path).