### PR TITLE
fix(refs: DPLAN-17617): add title to admin custom fields list

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2471,7 +2471,10 @@ class DemosPlanProcedureController extends BaseController
         $templateVars['procedureId'] = $procedureId;
 
         return $this->render('@DemosPlanCore/DemosPlanProcedure/administration_custom_fields_list.html.twig',
-            ['templateVars' => $templateVars]);
+            [
+                'templateVars' => $templateVars,
+                'title'        => 'procedure.custom.fields',
+            ]);
     }
 
     /**

--- a/translations/page-title+intl-icu.de.yml
+++ b/translations/page-title+intl-icu.de.yml
@@ -122,6 +122,7 @@ procedure.analysis: Auswertung
 procedure.boilerplates: Textbausteine
 procedure.boilerplate.edit: Textbaustein bearbeiten
 procedure.boilerplateGroup.edit: Textbausteingruppe bearbeiten
+procedure.custom.fields: Konfigurierbare Felder
 procedure.list: Beteiligung
 procedure.mail.submitters.send: E-Mail an alle Einreichenden verfassen
 procedure.mail.submitters.send.confirm: E-Mail an alle Einreichenden versenden


### PR DESCRIPTION
### Ticket
DPLAN-17617

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds a title to the admin custom fields list, that is used as final breadcrumb for this page

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as admin and go to a procedure
2. Go to the custom fields definition dialog of the procedure
3. Check if the last breadcrumb at this page is "Konfigurierbare Felder"

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Move the tickets on the board accordingly
