### PR TITLE
fix(refs: DPLAN-17776): catch Error from uninitialized lazy proxy properties on procedure update

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
@@ -16,8 +16,8 @@ use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Events\PostProcedureUpdatedEventInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Event\DPlanEvent;
-use Exception;
 use ReflectionClass;
+use Throwable;
 
 class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdatedEventInterface
 {
@@ -82,10 +82,18 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
                 continue;
             }
 
+            // Skip uninitialized typed properties (e.g. Doctrine lazy proxies backed by
+            // Symfony's LazyObjectState), whose access would throw an Error, not an Exception.
+            if (!$property->isInitialized($oldObject) || !$property->isInitialized($newObject)) {
+                $this->fieldsNotPresentInNewProcedure[$propertyName] = ['old' => $oldObject, 'new' => $newObject];
+
+                continue;
+            }
+
             try {
                 $oldValue = $property->getValue($oldObject);
                 $newValue = $property->getValue($newObject);
-            } catch (Exception) {
+            } catch (Throwable) {
                 // The property can not be accessed or does not exist within newObject
                 // store it and continue with other properties
                 $this->fieldsNotPresentInNewProcedure[$propertyName] = ['old' => $oldObject, 'new' => $newObject];

--- a/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
+++ b/demosplan/DemosPlanCoreBundle/Event/Procedure/PostProcedureUpdatedEvent.php
@@ -24,7 +24,6 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
     public function __construct(
         protected readonly Procedure $procedureBeforeUpdate,
         protected readonly Procedure $procedureAfterUpdate,
-        private array $fieldsNotPresentInNewProcedure = [],
     ) {
     }
 
@@ -44,14 +43,6 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
     public function getModifiedValues(): array
     {
         return $this->determineModifiedValues($this->procedureBeforeUpdate, $this->procedureAfterUpdate);
-    }
-
-    /** Some properties might not exist for both objects (old and new) and can not be compared - of Proxy as example
-     * this method provides access to those properties to be able to check them manually.
-     */
-    public function getPropertiesFailedToCompare(): array
-    {
-        return $this->fieldsNotPresentInNewProcedure;
     }
 
     /**
@@ -85,8 +76,6 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
             // Skip uninitialized typed properties (e.g. Doctrine lazy proxies backed by
             // Symfony's LazyObjectState), whose access would throw an Error, not an Exception.
             if (!$property->isInitialized($oldObject) || !$property->isInitialized($newObject)) {
-                $this->fieldsNotPresentInNewProcedure[$propertyName] = ['old' => $oldObject, 'new' => $newObject];
-
                 continue;
             }
 
@@ -94,10 +83,8 @@ class PostProcedureUpdatedEvent extends DPlanEvent implements PostProcedureUpdat
                 $oldValue = $property->getValue($oldObject);
                 $newValue = $property->getValue($newObject);
             } catch (Throwable) {
-                // The property can not be accessed or does not exist within newObject
-                // store it and continue with other properties
-                $this->fieldsNotPresentInNewProcedure[$propertyName] = ['old' => $oldObject, 'new' => $newObject];
-
+                // The property can not be accessed or does not exist within newObject,
+                // skip it and continue with other properties.
                 continue;
             }
 


### PR DESCRIPTION
### Ticket
DPLAN-17776

Saving a procedure pictogram (alt text + copyright) failed on procedure update with:

> `Error: Typed property Symfony\Component\VarExporter\Internal\LazyObjectState::$realInstance must not be accessed before initialization`

`PostProcedureUpdatedEvent::determineModifiedValues()` compares the procedure state before/after an update via reflection. When recursing into a nested object that is a Doctrine lazy proxy (now backed by Symfony's `LazyObjectState` since the ORM 3 upgrade), reflection enumerates the proxy's uninitialized typed property `$realInstance`. Reading it throws a PHP `Error` — but the existing guard only caught `Exception`, so the error escaped and aborted the entire procedure save.

This regressed when Doctrine ORM was upgraded from 2.x to 3.x: ORM 3 replaced the old proxy mechanism with Symfony native lazy objects, which throw `Error` (not `Exception`) on uninitialized typed-property access.

Fix:
- Skip uninitialized typed properties up front via `ReflectionProperty::isInitialized()` (recorded in `fieldsNotPresentInNewProcedure`, the existing "couldn't compare" mechanism).
- Broaden the `catch` from `Exception` to `Throwable` as a safety net.

### How to review/test
On a procedure with a pictogram, set an alternative text and copyright and save. Before the fix this throws the `LazyObjectState` error and the values are not persisted; after the fix the save succeeds.