### PR TITLE
perf(elasticsearch): page large result sets via search_after

### DIFF
--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -300,9 +300,14 @@ parameters:
     #  Set shard settings to dev settings. When use in cluster with 3 nodes use 3 shards, 2 replicas
     elasticsearch_number_of_shards: "1"
     elasticsearch_number_of_replicas: "1"
-    # High result window applied at index creation so deep paginating exports (size up to 1_000_000)
-    # work even before a full populate completes. Replaces the runtime PopulateElasticaListener setting.
-    elasticsearch_max_result_window: "1000000"
+    # Result window applied at index creation (index.max_result_window). The ES default of 10000 is
+    # enough because "fetch everything" paths (exports, no-pager lists) page through results via
+    # search_after instead of a single from+size query. Raise only if a paged query legitimately needs
+    # from+size beyond this; keep batch size <= this value.
+    elasticsearch_max_result_window: 10000
+    # Per-request page size for the search_after batched fetch used when a caller requests more than
+    # max_result_window results at once. Must be <= elasticsearch_max_result_window.
+    elasticsearch_search_after_batch_size: 1000
     # Major version of elasticsearch
     elasticsearch_major_version: 6
     # Number of workers to use during populate in command dplan:elasticsearch:populate

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticSearchService.php
@@ -25,6 +25,7 @@ use Elastica\Query\BoolQuery;
 use Elastica\Query\Exists;
 use Elastica\Query\QueryString;
 use Elastica\Query\Terms;
+use Elastica\SearchableInterface;
 use Exception;
 
 use function array_key_exists;
@@ -47,6 +48,70 @@ class ElasticSearchService
         private readonly UserService $userService,
         private readonly ProfilerService $profilerService,
     ) {
+    }
+
+    /**
+     * Retrieves every hit matching the query by paging with Elasticsearch `search_after`, instead
+     * of a single from+size request that would require an inflated index.max_result_window.
+     *
+     * The accumulated result keeps the exact shape downstream code expects from a normal search
+     * response: ['hits' => ['total' => ['value' => N, ...], 'hits' => [...all hit docs...]]].
+     * Aggregations are computed once (from the first batch) and dropped from subsequent batches.
+     *
+     * The passed $query is mutated (from/size/sort/track_total_hits/search_after); pass a query
+     * that is not reused afterwards.
+     *
+     * @return array{result: array, aggregations: array}
+     */
+    public function fetchAllHitsViaSearchAfter(
+        SearchableInterface $search,
+        Query $query,
+        int $batchSize,
+    ): array {
+        // search_after needs a deterministic total order; append the unique `id` as tiebreaker.
+        $query->addSort(['id' => 'asc']);
+        // Without this ES caps the reported total at 10000, which would corrupt the hit count.
+        $query->setTrackTotalHits(true);
+        $query->setFrom(0);
+        $query->setSize($batchSize);
+
+        $allHits = [];
+        $firstData = ['hits' => ['total' => ['value' => 0], 'hits' => []]];
+        $aggregations = [];
+        $searchAfter = null;
+        $isFirstBatch = true;
+
+        do {
+            if (null !== $searchAfter) {
+                $query->setParam('search_after', $searchAfter);
+            }
+
+            $resultSet = $search->search($query);
+            $data = $resultSet->getResponse()->getData();
+            $batchHits = $data['hits']['hits'] ?? [];
+
+            if ($isFirstBatch) {
+                $firstData = $data;
+                $aggregations = $resultSet->getAggregations();
+                $isFirstBatch = false;
+                // Aggregations are needed only once; drop them so ES does not recompute per batch.
+                $query->setParams(array_diff_key($query->getParams(), ['aggs' => null]));
+            }
+
+            foreach ($batchHits as $hit) {
+                $allHits[] = $hit;
+            }
+
+            $lastHit = end($batchHits);
+            $searchAfter = (false !== $lastHit && isset($lastHit['sort'])) ? $lastHit['sort'] : null;
+        } while (count($batchHits) === $batchSize && null !== $searchAfter);
+
+        // Total comes from the first batch (accurate thanks to track_total_hits); replace the
+        // single-batch hit slice with the full accumulated set.
+        $result = $firstData;
+        $result['hits']['hits'] = $allHits;
+
+        return ['result' => $result, 'aggregations' => $aggregations];
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -37,6 +37,7 @@ use Exception;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Pagerfanta\Exception\NotValidCurrentPageException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Traversable;
 
@@ -118,6 +119,10 @@ class ElasticsearchResultCreator
         private readonly DepartmentRepository $departmentRepository,
         private readonly ProfilerService $profilerService,
         private readonly LoggerInterface $logger,
+        #[Autowire(param: 'elasticsearch_max_result_window')]
+        private readonly int $elasticsearchMaxResultWindow,
+        #[Autowire(param: 'elasticsearch_search_after_batch_size')]
+        private readonly int $searchAfterBatchSize,
     ) {
     }
 
@@ -677,16 +682,25 @@ class ElasticsearchResultCreator
             }
 
             try {
-                /** @var array|Traversable $resultSet */
-                $resultSet = $paginator->getCurrentPageResults();
-                $result = $resultSet->getResponse()->getData();
-                $elasticsearchResultStatement->setHits($result['hits']);
+                if ((int) $limit > $this->elasticsearchMaxResultWindow) {
+                    // "Fetch everything" path (exports, no-pager lists): a single from+size query
+                    // would exceed index.max_result_window, so page through all hits via search_after.
+                    $batch = $this->elasticSearchService->fetchAllHitsViaSearchAfter($search, $query, $this->searchAfterBatchSize);
+                    $result = $batch['result'];
+                    $elasticsearchResultStatement->setHits($result['hits']);
+                    $esResultAggregations = $batch['aggregations'];
+                } else {
+                    /** @var array|Traversable $resultSet */
+                    $resultSet = $paginator->getCurrentPageResults();
+                    $result = $resultSet->getResponse()->getData();
+                    $elasticsearchResultStatement->setHits($result['hits']);
+                    $esResultAggregations = $resultSet->getAggregations();
+                }
             } catch (ClientException $e) {
                 $this->logger->error('Elasticsearch probably hit a timeout: ', [$e]);
                 throw $e;
             }
 
-            $esResultAggregations = $resultSet->getAggregations();
             $totalHits = $result['hits']['total'];
             if (is_array($totalHits) && array_key_exists('value', $totalHits) && 0 === $totalHits['value']) {
                 $esResultAggregations = $this->addFilterToAggregationsWhenCausedResultIsEmpty(

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -79,6 +79,7 @@ use Exception;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Pagerfanta\Exception\NotValidCurrentPageException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StatementFragmentService
@@ -145,6 +146,10 @@ class StatementFragmentService
         private readonly LoggerInterface $logger,
         private readonly ManagerRegistry $doctrine,
         private readonly ProfilerService $profilerService,
+        #[Autowire(param: 'elasticsearch_max_result_window')]
+        private readonly int $elasticsearchMaxResultWindow,
+        #[Autowire(param: 'elasticsearch_search_after_batch_size')]
+        private readonly int $searchAfterBatchSize,
     ) {
         $this->assignService = $assignService;
         $this->elementService = $elementService;
@@ -1410,17 +1415,25 @@ class StatementFragmentService
                 $paginator->setCurrentPage(1);
             }
             try {
-                // When we click on a dropdown filter (just to open it) we come here and get statement ids
-                /** @var ResultSet $resultSet */
-                $resultSet = $paginator->getCurrentPageResults();
-                $result = $resultSet->getResponse()->getData();
-                $elasticsearchResultStatement->setHits($result['hits']);
+                if ((int) $limit > $this->elasticsearchMaxResultWindow) {
+                    // "Fetch everything" path (e.g. all fragment assignments): a single from+size
+                    // query would exceed index.max_result_window, so page via search_after.
+                    $batch = $this->searchService->fetchAllHitsViaSearchAfter($search, $query, $this->searchAfterBatchSize);
+                    $result = $batch['result'];
+                    $elasticsearchResultStatement->setHits($result['hits']);
+                    $aggregations = $batch['aggregations'];
+                } else {
+                    // When we click on a dropdown filter (just to open it) we come here and get statement ids
+                    /** @var ResultSet $resultSet */
+                    $resultSet = $paginator->getCurrentPageResults();
+                    $result = $resultSet->getResponse()->getData();
+                    $elasticsearchResultStatement->setHits($result['hits']);
+                    $aggregations = $resultSet->getAggregations();
+                }
             } catch (ClientException $e) {
                 $this->logger->warning('Elasticsearch probably hit a timeout: ', [$e]);
                 throw $e;
             }
-
-            $aggregations = $resultSet->getAggregations();
 
             $voteAdviceLabelMap = $this->getVoteLabelMap();
 

--- a/tests/backend/core/Statement/Unit/ElasticSearchServiceSearchAfterTest.php
+++ b/tests/backend/core/Statement/Unit/ElasticSearchServiceSearchAfterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Unit;
+
+use demosplan\DemosPlanCoreBundle\Logic\Statement\ElasticSearchService;
+use Elastica\Aggregation\Terms;
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+use Elastica\SearchableInterface;
+use Tests\Base\UnitTestCase;
+
+/**
+ * Verifies that ElasticSearchService::fetchAllHitsViaSearchAfter accumulates every hit, advances
+ * the search_after cursor, captures aggregations once, and reproduces the legacy response shape.
+ */
+class ElasticSearchServiceSearchAfterTest extends UnitTestCase
+{
+    /** @var ElasticSearchService */
+    protected $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = self::getContainer()->get(ElasticSearchService::class);
+    }
+
+    public function testFetchAllHitsViaSearchAfterAccumulatesAllBatches(): void
+    {
+        $batchSize = 2;
+        $aggregations = ['publicStatement' => ['buckets' => [['key' => 'x', 'doc_count' => 5]]]];
+
+        // 3 batches: [2, 2, 1] hits → 5 total; the last (partial) batch terminates the loop.
+        $resultSets = [
+            $this->buildResultSet([['_id' => 'a', 'sort' => [1, 'a']], ['_id' => 'b', 'sort' => [2, 'b']]], 5, $aggregations),
+            $this->buildResultSet([['_id' => 'c', 'sort' => [3, 'c']], ['_id' => 'd', 'sort' => [4, 'd']]], 5, []),
+            $this->buildResultSet([['_id' => 'e', 'sort' => [5, 'e']]], 5, []),
+        ];
+
+        // The query is mutated in place between batches, so snapshot the params at each call.
+        $paramSnapshots = [];
+        $search = $this->createMock(SearchableInterface::class);
+        $search->method('search')->willReturnCallback(
+            static function (Query $query) use (&$paramSnapshots, &$resultSets): ResultSet {
+                $paramSnapshots[] = $query->getParams();
+
+                return array_shift($resultSets);
+            }
+        );
+
+        // Query carries an aggregation so we can assert it is dropped on follow-up batches.
+        $query = new Query();
+        $query->addAggregation((new Terms('publicStatement'))->setField('publicStatement'));
+
+        $output = $this->sut->fetchAllHitsViaSearchAfter($search, $query, $batchSize);
+
+        // All hits accumulated, in order.
+        $hits = $output['result']['hits']['hits'];
+        static::assertCount(5, $hits);
+        static::assertSame(['a', 'b', 'c', 'd', 'e'], array_column($hits, '_id'));
+
+        // Total comes from the first batch.
+        static::assertSame(5, $output['result']['hits']['total']['value']);
+
+        // Aggregations captured once, from the first batch.
+        static::assertSame($aggregations, $output['aggregations']);
+
+        // Exactly three requests were issued.
+        static::assertCount(3, $paramSnapshots);
+
+        // Common query setup applied on every batch.
+        foreach ($paramSnapshots as $params) {
+            static::assertSame($batchSize, $params['size']);
+            static::assertSame(0, $params['from']);
+            static::assertTrue($params['track_total_hits']);
+            static::assertContains(['id' => 'asc'], $params['sort'], 'id tiebreaker must be present');
+        }
+
+        // First batch: aggregations requested, no cursor yet.
+        static::assertArrayHasKey('aggs', $paramSnapshots[0]);
+        static::assertArrayNotHasKey('search_after', $paramSnapshots[0]);
+
+        // Follow-up batches: cursor = previous batch last hit sort, aggregations dropped.
+        static::assertSame([2, 'b'], $paramSnapshots[1]['search_after']);
+        static::assertArrayNotHasKey('aggs', $paramSnapshots[1]);
+        static::assertSame([4, 'd'], $paramSnapshots[2]['search_after']);
+        static::assertArrayNotHasKey('aggs', $paramSnapshots[2]);
+    }
+
+    public function testFetchAllHitsViaSearchAfterHandlesEmptyResult(): void
+    {
+        $search = $this->createMock(SearchableInterface::class);
+        $search->expects(static::once())->method('search')->willReturn(
+            $this->buildResultSet([], 0, [])
+        );
+
+        $output = $this->sut->fetchAllHitsViaSearchAfter($search, new Query(), 100);
+
+        static::assertSame([], $output['result']['hits']['hits']);
+        static::assertSame(0, $output['result']['hits']['total']['value']);
+        static::assertSame([], $output['aggregations']);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $hits
+     */
+    private function buildResultSet(array $hits, int $total, array $aggregations): ResultSet
+    {
+        $data = [
+            'hits'         => ['total' => ['value' => $total], 'hits' => $hits],
+            'aggregations' => $aggregations,
+        ];
+
+        return new ResultSet(new Response($data), new Query(), []);
+    }
+}


### PR DESCRIPTION
DPLAN-17942

### Description
Exports (assessment table DOCX/PDF/XLSX, original statements) and "no-pager" statement/fragment listings fetched **all** matching documents in a single `from + size` Elasticsearch query (`size` up to 1,000,000). That forced every index's `index.max_result_window` to be inflated to 1,000,000 and materialized the whole result set at once. A freshly created/restored index without that inflated setting returns HTTP 400 ("Result window is too large").

This replaces the single huge query with bounded `search_after` deep pagination:

- New shared helper `ElasticSearchService::fetchAllHitsViaSearchAfter()` pages through **all** hits in batches (default 1000), using a stable `id` tiebreaker sort, `track_total_hits`, and capturing aggregations once (from the first batch). It returns the exact legacy response shape (`['hits' => ['total' => …, 'hits' => […]]]`), so nothing downstream changes.
- Both fetch-everything paths route through it when the requested limit exceeds the window: statements (`ElasticsearchResultCreator::getElasticsearchResult`) and statement-fragments (`StatementFragmentService::getElasticsearchStatementFragmentResult`). Normal paged requests (limit ≤ window) keep the existing Pagerfanta path unchanged.
- `index.max_result_window` is lowered to the ES default **10000** (configurable via `elasticsearch_max_result_window`), with a configurable `elasticsearch_search_after_batch_size`.

An audit confirmed these are the only two paginated ES paths that can exceed 10000; all other large `size` values are aggregation bucket sizes (unaffected) or Doctrine/array pagination (not ES).

> Rollout note: existing indices keep their current window until reindexed; repopulate so they pick up `max_result_window: 10000`. The lowered window is harmless beforehand because the code no longer requests `from + size > 10000`.

### How to review/test
- Unit test `ElasticSearchServiceSearchAfterTest` covers accumulation across batches, cursor advance, aggregations-once, total, and the empty-result case.
- End-to-end: on an index with `max_result_window=10000`, open the assessment table / run an export on a procedure with >10000 statements — it completes with all rows and ordering unchanged. Validated a real 2-batch `search_after` against a 1923-doc index (1000 + 923 = 1923, accurate total, no 400).

### PR Checklist
- [x] Create/Update tests
- [ ] Link all relevant tickets