### PR TITLE
feat (DPLAN-12697): merge adjacent segment-marks into one segment, preserve HTML

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
@@ -45,7 +45,7 @@ class SegmentMarkParser
      * Parse HTML with <segment-mark data-segment-id="..."> elements.
      *
      * @return array<int, array{segmentId: string, text: string}> One entry per
-     *                                                             segment, ordered by document position
+     *                                                            segment, ordered by document position
      */
     public function parse(string $html): array
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
@@ -12,24 +12,40 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 
-use DOMDocument;
 use DOMElement;
-use DOMXPath;
+use DOMNode;
 use Masterminds\HTML5;
+use SplObjectStorage;
 
 /**
- * Parses textualReference HTML containing <segment-mark> elements
- * and extracts segment IDs with their text content.
+ * Parses textualReference HTML containing <segment-mark> elements and
+ * reconstructs the HTML of each segment.
  *
- * Each <segment-mark data-segment-id="uuid"> wraps the text of one segment.
- * The order of segments is determined by their position in the HTML document.
+ * A single segment may be represented by multiple adjacent <segment-mark>
+ * elements that share the same data-segment-id: the inline mark is closed and
+ * reopened at every block boundary (paragraph, list item) and around inline
+ * formatting (bold, italic). All marks of one segment are therefore merged
+ * back into a single segment, preserving the surrounding ancestor structure
+ * (e.g. <ul><li><p>…</p></li></ul>) so the stored text keeps the same rich-text
+ * format used everywhere else for segment text.
+ *
+ * Reconstruction keeps, for each segment, the content inside its marks plus the
+ * full ancestor chain up to the parsing container, drops everything else
+ * (other segments' marks, unsegmented text), and unwraps the marks themselves.
+ * Two marks under the same ancestor node collapse into it; two marks under
+ * different ancestors keep both — which is exactly what tells "one paragraph
+ * with a bold run" apart from "two paragraphs around a bold run".
  */
 class SegmentMarkParser
 {
+    private const SEGMENT_MARK_TAG = 'segment-mark';
+    private const SEGMENT_ID_ATTRIBUTE = 'data-segment-id';
+
     /**
      * Parse HTML with <segment-mark data-segment-id="..."> elements.
      *
-     * @return array<int, array{segmentId: string, text: string}> Ordered by document position
+     * @return array<int, array{segmentId: string, text: string}> One entry per
+     *                                                             segment, ordered by document position
      */
     public function parse(string $html): array
     {
@@ -38,39 +54,144 @@ class SegmentMarkParser
         }
 
         $parser = new HTML5();
-        $dom = $parser->loadHTML('<div>'.$html.'</div>');
+        $document = $parser->loadHTML('<html><body>'.$html.'</body></html>');
+        $body = $document->getElementsByTagName('body')->item(0);
+        if (!$body instanceof DOMElement) {
+            return [];
+        }
 
-        $xpath = new DOMXPath($dom);
-        $xpath->registerNamespace('html', 'http://www.w3.org/1999/xhtml');
-        $nodes = $xpath->query('//html:segment-mark');
         $results = [];
-
-        foreach ($nodes as $node) {
-            if (!$node instanceof DOMElement) {
-                continue;
-            }
-
-            $segmentId = $node->getAttribute('data-segment-id');
-            if ('' === $segmentId) {
-                continue;
-            }
-
+        foreach ($this->collectSegmentIdsInDocumentOrder($body) as $segmentId) {
             $results[] = [
                 'segmentId' => $segmentId,
-                'text'      => trim(strip_tags($this->getInnerHtml($node, $dom))),
+                'text'      => $this->reconstructSegmentHtml($body, $segmentId),
             ];
         }
 
         return $results;
     }
 
-    private function getInnerHtml(DOMElement $element, DOMDocument $dom): string
+    /**
+     * Collects the distinct segment ids in the order their first mark appears.
+     * Marks without an id are skipped.
+     *
+     * @return array<int, string>
+     */
+    private function collectSegmentIdsInDocumentOrder(DOMElement $body): array
     {
-        $innerHTML = '';
-        foreach ($element->childNodes as $child) {
-            $innerHTML .= $dom->saveHTML($child);
+        $orderedIds = [];
+        foreach ($this->collectMarks($body) as $mark) {
+            $segmentId = $mark->getAttribute(self::SEGMENT_ID_ATTRIBUTE);
+            if ('' !== $segmentId) {
+                $orderedIds[$segmentId] = true;
+            }
         }
 
-        return $innerHTML;
+        return array_keys($orderedIds);
+    }
+
+    /**
+     * Rebuilds the HTML of a single segment from all its marks.
+     */
+    private function reconstructSegmentHtml(DOMElement $body, string $segmentId): string
+    {
+        /** @var DOMElement $container */
+        $container = $body->cloneNode(true);
+
+        $keptNodes = new SplObjectStorage();
+        foreach ($this->collectMarks($container) as $mark) {
+            if ($mark->getAttribute(self::SEGMENT_ID_ATTRIBUTE) !== $segmentId) {
+                continue;
+            }
+            $this->keepNodeWithDescendants($mark, $keptNodes);
+            $this->keepAncestors($mark, $container, $keptNodes);
+        }
+
+        $this->pruneToKeptNodes($container, $keptNodes);
+        $this->unwrapMarks($container);
+
+        return trim($this->serializeChildren($container));
+    }
+
+    /**
+     * Returns all <segment-mark> descendants of the given node in document order.
+     *
+     * @return array<int, DOMElement>
+     */
+    private function collectMarks(DOMNode $node): array
+    {
+        $marks = [];
+        foreach ($node->childNodes as $child) {
+            if (!$child instanceof DOMElement) {
+                continue;
+            }
+            if (self::SEGMENT_MARK_TAG === $child->localName) {
+                $marks[] = $child;
+            }
+            $marks = [...$marks, ...$this->collectMarks($child)];
+        }
+
+        return $marks;
+    }
+
+    private function keepNodeWithDescendants(DOMNode $node, SplObjectStorage $keptNodes): void
+    {
+        $keptNodes->attach($node);
+        foreach ($node->childNodes as $child) {
+            $this->keepNodeWithDescendants($child, $keptNodes);
+        }
+    }
+
+    private function keepAncestors(DOMNode $node, DOMNode $boundary, SplObjectStorage $keptNodes): void
+    {
+        $ancestor = $node->parentNode;
+        while (null !== $ancestor && $ancestor !== $boundary) {
+            $keptNodes->attach($ancestor);
+            $ancestor = $ancestor->parentNode;
+        }
+    }
+
+    private function pruneToKeptNodes(DOMNode $node, SplObjectStorage $keptNodes): void
+    {
+        foreach (iterator_to_array($node->childNodes) as $child) {
+            if ($keptNodes->contains($child)) {
+                $this->pruneToKeptNodes($child, $keptNodes);
+                continue;
+            }
+            $node->removeChild($child);
+        }
+    }
+
+    /**
+     * Replaces every remaining <segment-mark> with its child nodes, so the
+     * marks no longer appear in the reconstructed HTML.
+     */
+    private function unwrapMarks(DOMNode $container): void
+    {
+        foreach ($this->collectMarks($container) as $mark) {
+            $parent = $mark->parentNode;
+            if (null === $parent) {
+                continue;
+            }
+            while (null !== $mark->firstChild) {
+                $parent->insertBefore($mark->firstChild, $mark);
+            }
+            $parent->removeChild($mark);
+        }
+    }
+
+    private function serializeChildren(DOMNode $container): string
+    {
+        $document = $container->ownerDocument;
+        if (null === $document) {
+            return '';
+        }
+
+        $serialized = '';
+        foreach ($container->childNodes as $child) {
+            $serialized .= $document->saveHTML($child);
+        }
+
+        return $serialized;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/SegmentMarkParser.php
@@ -80,7 +80,7 @@ class SegmentMarkParser
     private function collectSegmentIdsInDocumentOrder(DOMElement $body): array
     {
         $orderedIds = [];
-        foreach ($this->collectMarks($body) as $mark) {
+        foreach ($this->collectSegmentMarks($body) as $mark) {
             $segmentId = $mark->getAttribute(self::SEGMENT_ID_ATTRIBUTE);
             if ('' !== $segmentId) {
                 $orderedIds[$segmentId] = true;
@@ -99,7 +99,7 @@ class SegmentMarkParser
         $container = $body->cloneNode(true);
 
         $keptNodes = new SplObjectStorage();
-        foreach ($this->collectMarks($container) as $mark) {
+        foreach ($this->collectSegmentMarks($container) as $mark) {
             if ($mark->getAttribute(self::SEGMENT_ID_ATTRIBUTE) !== $segmentId) {
                 continue;
             }
@@ -108,7 +108,7 @@ class SegmentMarkParser
         }
 
         $this->pruneToKeptNodes($container, $keptNodes);
-        $this->unwrapMarks($container);
+        $this->unwrapSegmentMarks($container);
 
         return trim($this->serializeChildren($container));
     }
@@ -118,7 +118,7 @@ class SegmentMarkParser
      *
      * @return array<int, DOMElement>
      */
-    private function collectMarks(DOMNode $node): array
+    private function collectSegmentMarks(DOMNode $node): array
     {
         $marks = [];
         foreach ($node->childNodes as $child) {
@@ -128,7 +128,7 @@ class SegmentMarkParser
             if (self::SEGMENT_MARK_TAG === $child->localName) {
                 $marks[] = $child;
             }
-            $marks = [...$marks, ...$this->collectMarks($child)];
+            $marks = [...$marks, ...$this->collectSegmentMarks($child)];
         }
 
         return $marks;
@@ -136,7 +136,7 @@ class SegmentMarkParser
 
     private function keepNodeWithDescendants(DOMNode $node, SplObjectStorage $keptNodes): void
     {
-        $keptNodes->attach($node);
+        $keptNodes[$node] = true;
         foreach ($node->childNodes as $child) {
             $this->keepNodeWithDescendants($child, $keptNodes);
         }
@@ -146,7 +146,7 @@ class SegmentMarkParser
     {
         $ancestor = $node->parentNode;
         while (null !== $ancestor && $ancestor !== $boundary) {
-            $keptNodes->attach($ancestor);
+            $keptNodes[$ancestor] = true;
             $ancestor = $ancestor->parentNode;
         }
     }
@@ -154,7 +154,7 @@ class SegmentMarkParser
     private function pruneToKeptNodes(DOMNode $node, SplObjectStorage $keptNodes): void
     {
         foreach (iterator_to_array($node->childNodes) as $child) {
-            if ($keptNodes->contains($child)) {
+            if (isset($keptNodes[$child])) {
                 $this->pruneToKeptNodes($child, $keptNodes);
                 continue;
             }
@@ -166,9 +166,9 @@ class SegmentMarkParser
      * Replaces every remaining <segment-mark> with its child nodes, so the
      * marks no longer appear in the reconstructed HTML.
      */
-    private function unwrapMarks(DOMNode $container): void
+    private function unwrapSegmentMarks(DOMNode $container): void
     {
-        foreach ($this->collectMarks($container) as $mark) {
+        foreach ($this->collectSegmentMarks($container) as $mark) {
             $parent = $mark->parentNode;
             if (null === $parent) {
                 continue;

--- a/tests/backend/core/Statement/Unit/SegmentMarkParserTest.php
+++ b/tests/backend/core/Statement/Unit/SegmentMarkParserTest.php
@@ -38,7 +38,7 @@ class SegmentMarkParserTest extends TestCase
         self::assertSame([], $this->sut->parse($html));
     }
 
-    public function testSingleSegmentMark(): void
+    public function testSingleSegmentMarkKeepsItsBlock(): void
     {
         $html = '<p><segment-mark data-segment-id="5c1a0233-60d3-46d5-95b1-1e79a9649e8a">Die Nähe zum FFH-Gebiet</segment-mark></p>';
 
@@ -46,7 +46,7 @@ class SegmentMarkParserTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('5c1a0233-60d3-46d5-95b1-1e79a9649e8a', $result[0]['segmentId']);
-        self::assertSame('Die Nähe zum FFH-Gebiet', $result[0]['text']);
+        self::assertSame('<p>Die Nähe zum FFH-Gebiet</p>', $result[0]['text']);
     }
 
     public function testMultipleSegmentMarksPreserveDocumentOrder(): void
@@ -61,9 +61,9 @@ class SegmentMarkParserTest extends TestCase
         self::assertSame('aaa-111', $result[0]['segmentId']);
         self::assertSame('bbb-222', $result[1]['segmentId']);
         self::assertSame('ccc-333', $result[2]['segmentId']);
-        self::assertSame('First segment', $result[0]['text']);
-        self::assertSame('Second segment', $result[1]['text']);
-        self::assertSame('Third segment', $result[2]['text']);
+        self::assertSame('<p>First segment</p>', $result[0]['text']);
+        self::assertSame('<p>Second segment</p>', $result[1]['text']);
+        self::assertSame('<p>Third segment</p>', $result[2]['text']);
     }
 
     public function testUnsegmentedTextIsIgnored(): void
@@ -73,17 +73,17 @@ class SegmentMarkParserTest extends TestCase
         $result = $this->sut->parse($html);
 
         self::assertCount(1, $result);
-        self::assertSame('Segmented text', $result[0]['text']);
+        self::assertSame('<p>Segmented text</p>', $result[0]['text']);
     }
 
-    public function testSegmentMarkWithInnerHtmlStripsTagsForText(): void
+    public function testSegmentMarkPreservesInlineFormatting(): void
     {
         $html = '<p><segment-mark data-segment-id="aaa-111">Text with <strong>bold</strong> and <em>italic</em> formatting</segment-mark></p>';
 
         $result = $this->sut->parse($html);
 
         self::assertCount(1, $result);
-        self::assertSame('Text with bold and italic formatting', $result[0]['text']);
+        self::assertSame('<p>Text with <strong>bold</strong> and <em>italic</em> formatting</p>', $result[0]['text']);
     }
 
     public function testSegmentMarkWithoutIdIsSkipped(): void
@@ -94,6 +94,92 @@ class SegmentMarkParserTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('aaa-111', $result[0]['segmentId']);
+        self::assertSame('<p>Valid segment</p>', $result[0]['text']);
+    }
+
+    /**
+     * One paragraph that encloses a bold run: the inline mark is closed and
+     * reopened around the bold, producing three adjacent same-id marks that all
+     * share the same <p>. They must merge back into a single paragraph.
+     */
+    public function testAdjacentMarksInOneParagraphMergeIntoOneBlock(): void
+    {
+        $html = '<p>'
+            .'<segment-mark data-segment-id="aaa-111">text </segment-mark>'
+            .'<segment-mark data-segment-id="aaa-111"><strong>bold</strong></segment-mark>'
+            .'<segment-mark data-segment-id="aaa-111"> more</segment-mark>'
+            .'</p>';
+
+        $result = $this->sut->parse($html);
+
+        self::assertCount(1, $result);
+        self::assertSame('aaa-111', $result[0]['segmentId']);
+        self::assertSame('<p>text <strong>bold</strong> more</p>', $result[0]['text']);
+    }
+
+    /**
+     * Two paragraphs surrounding a bold run carry the same set of marks as the
+     * single-paragraph case, but each mark lives in its own <p>. The block
+     * boundaries must be preserved.
+     */
+    public function testAdjacentMarksAcrossParagraphsKeepBlockBoundaries(): void
+    {
+        $html = '<p><segment-mark data-segment-id="aaa-111">text</segment-mark></p>'
+            .'<p><segment-mark data-segment-id="aaa-111"><strong>bold</strong></segment-mark></p>'
+            .'<p><segment-mark data-segment-id="aaa-111">more</segment-mark></p>';
+
+        $result = $this->sut->parse($html);
+
+        self::assertCount(1, $result);
+        self::assertSame('aaa-111', $result[0]['segmentId']);
+        self::assertSame('<p>text</p><p><strong>bold</strong></p><p>more</p>', $result[0]['text']);
+    }
+
+    public function testListItemSegmentKeepsListStructure(): void
+    {
+        $html = '<ul><li><p><segment-mark data-segment-id="aaa-111"><strong>listenelement</strong></segment-mark></p></li></ul>';
+
+        $result = $this->sut->parse($html);
+
+        self::assertCount(1, $result);
+        self::assertSame('<ul><li><p><strong>listenelement</strong></p></li></ul>', $result[0]['text']);
+    }
+
+    /**
+     * Marks placed inside a shared inline element keep that element as a common
+     * ancestor that is emitted once.
+     */
+    public function testMarksInsideSharedInlineElementMerge(): void
+    {
+        $html = '<ul><li><p><strong>'
+            .'<segment-mark data-segment-id="aaa-111">Lis</segment-mark>'
+            .'<segment-mark data-segment-id="aaa-111">ten</segment-mark>'
+            .'</strong></p></li></ul>';
+
+        $result = $this->sut->parse($html);
+
+        self::assertCount(1, $result);
+        self::assertSame('<ul><li><p><strong>Listen</strong></p></li></ul>', $result[0]['text']);
+    }
+
+    /**
+     * Two segments inside the same list each get their own single-item list,
+     * because the other segment's <li> is not on their ancestor chain.
+     */
+    public function testSharedListSplitsIntoPerSegmentLists(): void
+    {
+        $html = '<ul>'
+            .'<li><p><segment-mark data-segment-id="aaa-111">item 1</segment-mark></p></li>'
+            .'<li><p><segment-mark data-segment-id="bbb-222">item 2</segment-mark></p></li>'
+            .'</ul>';
+
+        $result = $this->sut->parse($html);
+
+        self::assertCount(2, $result);
+        self::assertSame('aaa-111', $result[0]['segmentId']);
+        self::assertSame('<ul><li><p>item 1</p></li></ul>', $result[0]['text']);
+        self::assertSame('bbb-222', $result[1]['segmentId']);
+        self::assertSame('<ul><li><p>item 2</p></li></ul>', $result[1]['text']);
     }
 
     public function testRealWorldExampleFromPrDescription(): void
@@ -107,12 +193,21 @@ class SegmentMarkParserTest extends TestCase
         self::assertCount(3, $result);
 
         self::assertSame('5c1a0233-60d3-46d5-95b1-1e79a9649e8a', $result[0]['segmentId']);
-        self::assertStringContainsString('Die Nähe zum FFH-Gebiet', $result[0]['text']);
+        self::assertSame(
+            '<p>Die Nähe zum FFH-Gebiet und das dortige Vorkommen des Rotmilans als charakteristische Art gibt zu Bedenken Anlass, zumindest im nördlichen Erweiterungsteil.</p>',
+            $result[0]['text']
+        );
 
         self::assertSame('1ce76fde-3e9b-4afa-afc7-5c863c365923', $result[1]['segmentId']);
-        self::assertStringContainsString('Dies gilt z.T. auch für Fledermäuse', $result[1]['text']);
+        self::assertSame(
+            '<p>Dies gilt z.T. auch für Fledermäuse und Gastvögel.</p>',
+            $result[1]['text']
+        );
 
         self::assertSame('625f4aba-f2ff-439d-8345-851629f5f130', $result[2]['segmentId']);
-        self::assertStringContainsString('Aber auch die Gefahren durch Anlagenbrände', $result[2]['text']);
+        self::assertSame(
+            '<ul><li><p>Aber auch die Gefahren durch Anlagenbrände sind gerade durch die starken Größenzuwächse der Anlagen enorm gestiegen.</p></li></ul>',
+            $result[2]['text']
+        );
     }
 }


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-12697/Abstimmung-Austauschformat-Slicing-Tagging-PRE-AI

### Description
merge adjacent segment-marks into one segment, preserve HTML

SegmentMarkParser now treats <segment-mark> as the inline mark it is: a
single segment can be represented by several adjacent marks sharing one
data-segment-id (the mark closes and reopens at every block boundary and
around inline formatting). The parser groups all marks of an id and
reconstructs the segment's HTML from the original tree — keeping each
mark's content plus its ancestor chain, pruning everything else — instead
of emitting one entry per mark with strip_tags.

This fixes two issues in the new exchange format:
- multiple marks per id no longer create duplicate Segment primary keys
- segment text keeps its block/inline structure ```(<p>, <ul><li>, <strong>)``` ,  matching how segment text is stored elsewhere and rendered in the export

DraftsInfoToSegmentTransformer needs no change: it receives one merged
entry per id, so the per-id metadata/tag lookup stays 1:1.