### PR TITLE
fix(refs: DPLAN-17570): use phaseDefinitionId key for original statement phase filter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFilterHandler.php
@@ -633,7 +633,7 @@ class StatementFilterHandler extends CoreHandler
                 'type'          => 'submission',
             ],
             [
-                'key'           => 'phase',
+                'key'           => 'phaseDefinitionId',
                 'hasPermission' => $permissions->hasPermission(
                     'area_admin_assessmenttable'
                 ),


### PR DESCRIPTION
### Ticket
[DPLAN-17570](https://demoseurope.youtrack.cloud/issue/DPLAN-17570)

The "Originalstellungnahmen" filter modal in the Abwägungstabelle defined its
Verfahrensschritt filter with the key `phase` instead of `phaseDefinitionId`.

As a result the filter label rendered untranslated as `phase` (the label map only
maps `phaseDefinitionId` → "Verfahrensschritt"), and the dropdown showed no
selectable entries ("Es sind keine Einträge vorhanden"), because the Elasticsearch
aggregation is only produced for `phaseDefinitionId`. The regular assessment-table
filter already uses the correct key, so this aligns the original-statement filter
with it.

### How to review/test
1. Open a procedure's Abwägungstabelle and switch to the "Originalstellungnahmen" tab.
2. Open the filter modal → the "Verfahrensschritt" field now shows a translated label
   and its available phase entries (previously: raw "phase" label and empty list).
3. Compare with the main assessment-table filter modal — behaviour matches.

### PR Checklist
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
