### PR TITLE
fix: Protect customFields under permission

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -560,6 +560,10 @@ export default {
     },
 
     loadCustomFieldDefinitions () {
+      if (!hasPermission('feature_organisations_custom_fields')) {
+        return Promise.resolve([])
+      }
+
       return useCustomFields().fetchCustomFields(null, {
         sourceEntity: 'CUSTOMER',
         targetEntity: 'ORGA',


### PR DESCRIPTION
Skip loading custom field definitions on the institution list when the `feature_organisations_custom_fields` permission is disabled. Previously the API call was always made, causing an error notification when the feature is intentionally turned off.

