### PR TITLE
feat(refs DPLAN-17527): make procedure phase definitions editable

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhaseDefinition.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedurePhaseDefinition.php
@@ -172,6 +172,16 @@ class ProcedurePhaseDefinition extends CoreEntity implements UuidEntityInterface
         $this->orderInAudience = $orderInAudience;
     }
 
+    /**
+     * The configuration phase ("Konfiguration") is always the first phase within its audience.
+     * There is exactly one per audience and, unlike other phases, only its name may be edited -
+     * its permissionSet and participationState are fixed.
+     */
+    public function isConfigurationPhase(): bool
+    {
+        return 0 === $this->orderInAudience;
+    }
+
     public function getCustomer(): ?CustomerInterface
     {
         return $this->customer;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseDefinitionResourceType.php
@@ -206,10 +206,6 @@ final class ProcedurePhaseDefinitionResourceType extends DplanResourceType imple
             return ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN;
         }
 
-        throw new BadRequestException(sprintf(
-            'Invalid participationState; allowed values are null, "%s" or "%s".',
-            ProcedureInterface::PARTICIPATIONSTATE_FINISHED,
-            ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN
-        ));
+        throw new BadRequestException(sprintf('Invalid participationState; allowed values are null, "%s" or "%s".', ProcedureInterface::PARTICIPATIONSTATE_FINISHED, ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN));
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseDefinitionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseDefinitionResourceType.php
@@ -12,14 +12,18 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\ResourceType\ProcedurePhaseDefinitionResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhaseDefinition;
+use demosplan\DemosPlanCoreBundle\Exception\AccessDeniedException;
+use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Repository\ProcedurePhaseDefinitionRepository;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\ProcedurePhaseDefinitionResourceConfigBuilder;
 use EDT\JsonApi\ApiDocumentation\DefaultField;
 use EDT\JsonApi\ApiDocumentation\OptionalField;
 use EDT\Wrapping\EntityDataInterface;
+use EDT\Wrapping\PropertyBehavior\Attribute\CallbackAttributeSetBehavior;
 use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
 
 /**
@@ -57,6 +61,11 @@ final class ProcedurePhaseDefinitionResourceType extends DplanResourceType imple
         return $this->currentUser->hasPermission('area_customer_procedure_phase_definitions');
     }
 
+    public function isUpdateAllowed(): bool
+    {
+        return $this->currentUser->hasPermission('area_customer_procedure_phase_definitions');
+    }
+
     protected function getAccessConditions(): array
     {
         $customerId = $this->currentCustomerService->getCurrentCustomer()->getId();
@@ -79,22 +88,52 @@ final class ProcedurePhaseDefinitionResourceType extends DplanResourceType imple
             ->setReadableByPath(DefaultField::YES)
             ->setSortable()
             ->setFilterable()
-            ->addPathCreationBehavior();
+            ->addPathCreationBehavior()
+            ->addPathUpdateBehavior();
 
         $configBuilder->audience
             ->setReadableByPath(DefaultField::YES)
             ->setFilterable()
             ->addPathCreationBehavior();
 
+        // permissionSet and participationState are editable for regular phases, but fixed for the
+        // configuration phase (orderInAudience 0), where only the name may be changed. Entity conditions
+        // on an update behavior would be merged across all properties and block even a name-only update,
+        // so the restriction is enforced per-attribute via a callback that only runs when the attribute
+        // is part of the request.
         $configBuilder->permissionSet
             ->setReadableByPath(DefaultField::YES)
             ->setFilterable()
-            ->addPathCreationBehavior();
+            ->addPathCreationBehavior()
+            ->addUpdateBehavior(
+                CallbackAttributeSetBehavior::createFactory(
+                    [],
+                    function (ProcedurePhaseDefinition $phaseDefinition, mixed $value): array {
+                        $this->guardConfigurationPhaseNotEditable($phaseDefinition);
+                        $phaseDefinition->setPermissionSet((string) $value);
+
+                        return [];
+                    },
+                    OptionalField::YES
+                )
+            );
 
         $configBuilder->participationState
             ->setReadableByPath(DefaultField::YES)
             ->setFilterable()
-            ->addPathCreationBehavior();
+            ->addPathCreationBehavior()
+            ->addUpdateBehavior(
+                CallbackAttributeSetBehavior::createFactory(
+                    [],
+                    function (ProcedurePhaseDefinition $phaseDefinition, mixed $value): array {
+                        $this->guardConfigurationPhaseNotEditable($phaseDefinition);
+                        $phaseDefinition->setParticipationState($this->resolveParticipationState($value));
+
+                        return [];
+                    },
+                    OptionalField::YES
+                )
+            );
 
         $configBuilder->closingPhase
             ->setReadableByPath(DefaultField::YES)
@@ -130,5 +169,47 @@ final class ProcedurePhaseDefinitionResourceType extends DplanResourceType imple
         );
 
         return $configBuilder;
+    }
+
+    /**
+     * Rejects any attempt to set a field that is fixed for the configuration phase.
+     */
+    private function guardConfigurationPhaseNotEditable(ProcedurePhaseDefinition $phaseDefinition): void
+    {
+        if ($phaseDefinition->isConfigurationPhase()) {
+            throw new BadRequestException('Only the name of the configuration phase can be changed; permissionSet and participationState are fixed.');
+        }
+    }
+
+    /**
+     * Validates the requested participation state. Allowed values are null,
+     * {@see ProcedureInterface::PARTICIPATIONSTATE_FINISHED} and
+     * {@see ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN}; the latter additionally
+     * requires the 'area_customer_procedure_phase_participation_token' permission.
+     */
+    private function resolveParticipationState(mixed $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (ProcedureInterface::PARTICIPATIONSTATE_FINISHED === $value) {
+            return ProcedureInterface::PARTICIPATIONSTATE_FINISHED;
+        }
+
+        if (ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN === $value) {
+            $tokenPermission = 'area_customer_procedure_phase_participation_token';
+            if (!$this->currentUser->hasPermission($tokenPermission)) {
+                throw AccessDeniedException::missingPermissions(null, [$tokenPermission]);
+            }
+
+            return ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN;
+        }
+
+        throw new BadRequestException(sprintf(
+            'Invalid participationState; allowed values are null, "%s" or "%s".',
+            ProcedureInterface::PARTICIPATIONSTATE_FINISHED,
+            ProcedureInterface::PARTICIPATIONSTATE_PARTICIPATE_WITH_TOKEN
+        ));
     }
 }


### PR DESCRIPTION
### Ticket
[DPLAN-17963](https://demoseurope.youtrack.cloud/issue/DPLAN-17963)

Custom procedure phase definitions ("Verfahrensschritte") could only be created and read. This makes them editable via the `ProcedurePhaseDefinition` resource type:

- `name`, `permissionSet` and `participationState` are now updatable (gated by `area_customer_procedure_phase_definitions`).
- The configuration phase (`orderInAudience` 0) only allows changing its `name`; `permissionSet` and `participationState` stay fixed.
- `participationState` is validated against its allowed values (`null`, `finished`, `participateWithToken`); `participateWithToken` additionally requires the `area_customer_procedure_phase_participation_token` permission.

### How to review/test
PATCH `/api/2.0/ProcedurePhaseDefinition/{id}` (JSON:API, id matching in URL and body) and verify:
- editing `name`/`permissionSet`/`participationState` on a regular phase persists;
- editing `permissionSet`/`participationState` on the configuration phase (order 0) is rejected (400), while `name` succeeds;
- an invalid `participationState` value returns 400;
- `participateWithToken` without the permission returns 403.

### PR Checklist
- [ ] Create/Update tests
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly