### PR TITLE
Prevent doubled subdomain in Keycloak logout redirect URI

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakSessionManager.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OzgKeycloakSessionManager.php
@@ -139,11 +139,16 @@ class OzgKeycloakSessionManager
     {
         $currentCustomer = $this->customerService->getCurrentCustomer();
 
-        $logoutRoute = str_replace(
-            self::POST_LOGOUT_REDIRECT_URI,
-            self::POST_LOGOUT_REDIRECT_URI.$currentCustomer->getSubdomain().'.',
-            $logoutRoute
-        );
+        // skip injection when the configured route already contains the subdomain,
+        // otherwise a fully qualified template would end up with a doubled subdomain
+        $subdomainPrefix = self::POST_LOGOUT_REDIRECT_URI.$currentCustomer->getSubdomain().'.';
+        if (!str_contains($logoutRoute, $subdomainPrefix)) {
+            $logoutRoute = str_replace(
+                self::POST_LOGOUT_REDIRECT_URI,
+                $subdomainPrefix,
+                $logoutRoute
+            );
+        }
 
         if ($keycloakToken) {
             $logoutRoute = str_replace(

--- a/tests/backend/core/Core/Unit/Logic/User/OzgKeycloakSessionManagerTest.php
+++ b/tests/backend/core/Core/Unit/Logic/User/OzgKeycloakSessionManagerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Unit\Logic\User;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\Logic\User\OzgKeycloakSessionManager;
+use demosplan\DemosPlanCoreBundle\Repository\CustomerOAuthConfigRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class OzgKeycloakSessionManagerTest extends TestCase
+{
+    private ?OzgKeycloakSessionManager $sut = null;
+
+    protected function setUp(): void
+    {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getSubdomain')->willReturn('hh');
+
+        $customerService = $this->createMock(CustomerService::class);
+        $customerService->method('getCurrentCustomer')->willReturn($customer);
+
+        $this->sut = new OzgKeycloakSessionManager(
+            $this->createMock(KernelInterface::class),
+            $this->createMock(LoggerInterface::class),
+            $customerService,
+            $this->createMock(ParameterBagInterface::class),
+            $this->createMock(CustomerOAuthConfigRepository::class),
+        );
+    }
+
+    public function testGetLogoutUrlInjectsSubdomainIntoRedirectUri(): void
+    {
+        $logoutRoute = 'https://auth.example.com/logout?post_logout_redirect_uri=https://beteiligung.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=';
+
+        $result = $this->sut->getLogoutUrl($logoutRoute, 'token123');
+
+        self::assertSame(
+            'https://auth.example.com/logout?post_logout_redirect_uri=https://hh.beteiligung.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=token123',
+            $result
+        );
+    }
+
+    public function testGetLogoutUrlDoesNotDoubleSubdomainWhenAlreadyPresent(): void
+    {
+        $logoutRoute = 'https://auth.example.com/logout?post_logout_redirect_uri=https://hh.beteiligung.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=';
+
+        $result = $this->sut->getLogoutUrl($logoutRoute, 'token123');
+
+        self::assertSame(
+            'https://auth.example.com/logout?post_logout_redirect_uri=https://hh.beteiligung.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=token123',
+            $result
+        );
+    }
+
+    public function testGetLogoutUrlInjectsSubdomainWhenDomainSharesSubdomainLetters(): void
+    {
+        // host starts with the same letters as the subdomain but is not subdomain-qualified
+        $logoutRoute = 'https://auth.example.com/logout?post_logout_redirect_uri=https://hhsomething.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=';
+
+        $result = $this->sut->getLogoutUrl($logoutRoute, null);
+
+        self::assertSame(
+            'https://auth.example.com/logout?post_logout_redirect_uri=https://hh.hhsomething.example.com/connect/keycloak_ozg&client_id=client&id_token_hint=',
+            $result
+        );
+    }
+}


### PR DESCRIPTION
### Ticket
ado-55757

`OzgKeycloakSessionManager::getLogoutUrl()` injects the current customer's subdomain into the `post_logout_redirect_uri` of the configured Keycloak logout route via a blind `str_replace` on the prefix `post_logout_redirect_uri=https://`. When the configured logout route template (global parameter or per-customer config) already contains the subdomain-qualified host, the subdomain is prepended a second time (e.g. `https://xx.xx.example.com`), which Keycloak rejects as an invalid redirect URI.

The injection is now skipped when the route already contains the subdomain-qualified redirect host. The check is anchored on the full parameter prefix including the trailing dot, so hosts merely starting with the same letters as the subdomain still get the subdomain injected correctly.

### How to review/test
Unit tests cover injection, idempotency, and the letter-collision edge case:

```
./vendor/bin/phpunit tests/backend/core/Core/Unit/Logic/User/OzgKeycloakSessionManagerTest.php
```

### PR Checklist
- [x] Create/Update tests
- [x] Link all relevant tickets