### PR TITLE
fix(DS-548): persist segment assignee removal on first save

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -900,7 +900,23 @@ export default {
             }) :
             Promise.resolve()
 
-          return saveCustomFields
+          /*
+           * Clearing the assignee ("nicht zugewiesen") is sent as a separate explicit PATCH for the
+           * same reason: the vuex-json-api diff drops a to-one relationship set to `{ data: null }`
+           * (it diffs against a stale `initial` baseline that setSegment never updates), so an unassign
+           * would be silently omitted from saveSegmentAction's request body. Mirrors the explicit
+           * payload already used by claimSegment()/unclaimSegment().
+           */
+          const isUnassigning = !this.selectedAssignee?.id || this.selectedAssignee.id === 'noAssigneeId'
+          const clearAssignee = isUnassigning ?
+            dpApi.patch(
+              Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }),
+              {},
+              { data: { type: 'StatementSegment', id: this.segment.id, relationships: { assignee: { data: null } } } },
+            ) :
+            Promise.resolve()
+
+          return Promise.all([saveCustomFields, clearAssignee])
             .then(() => {
               dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
               this.isFullscreen = false


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-548

Desciption:
Clearing a segment's assignee ("nicht zugewiesen") via the segment save dialog did not persist on the first attempt: the PATCH returned 204, but the database row was unchanged and the list still showed the old assignee after a reload. A second attempt worked. Assigning a user was never affected — only clearing the assignee.

Cause: 
the save dialog routes the assignee change through the @efrane/vuex-json-api save action, which builds the PATCH body as a diff against a baseline (initial[id]). That baseline is only refreshed by full loads (set/setAll), never by setSegment (setItem), so it goes stale after a claim. A to-one relationship set to { data: null } is then not detected as a change and is dropped from the request body, so the unassign is silently omitted and the backend correctly does nothing. The change only "appeared" to work on the second try because an intervening list reload had refreshed the stale baseline.

Fix: 
send the assignee clear as an explicit { data: null } PATCH, bypassing the diff — the same approach already used by claimSegment() / unclaimSegment() in the same component (and documented in the comment on toggleClaimSegment, which explains the lib is unreliable for null relationships). The explicit PATCH only fires when unassigning; assigning a user is unchanged.

How to review/test

1. Open a procedure's segment list (/abschnitte).
2. Assign a segment to a user.
3. Set the same segment's assignee to "nicht zugewiesen" and save.
4. Expected: the assignee is cleared on the first attempt — verify the segment shows unassigned after a page reload, and that assignee_id is NULL in the DB.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
