### PR TITLE
chore: bump demosplan-ui from 0.22.0 to 0.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.22.0",
+    "@demos-europe/demosplan-ui": "0.23.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/tests/frontend/unit/__snapshots__/SearchModal.spec.js.snap
+++ b/tests/frontend/unit/__snapshots__/SearchModal.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`SearchModal renders the correct markup for activated field_statement_municipality 1`] = `
 "<div class="flex">
   <!-- Search Field --><label class="relative u-m-0"><button class="btn-icns fa fa-search c-at__controls-input-button" data-cy="searchAssessmentWordButton"></button>
-    <dp-input-stub id="searchterm" autocomplete="" datacounter="" datacy="searchAssessmentWordField" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="true" label="[object Object]" modelvalue="" name="search_word2" pattern="" placeholder="searchterm" preventdefaultonenter="true" required="true" rounded="full" type="text" width="w-12" aria-label="search.assessment.table"></dp-input-stub>
+    <dp-input-stub id="searchterm" autocomplete="" datacounter="" datacy="searchAssessmentWordField" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="true" label="[object Object]" modelvalue="" name="search_word2" pattern="" placeholder="searchterm" preventdefaultonenter="true" required="true" rounded="full" invalid="false" type="text" width="w-12" aria-label="search.assessment.table"></dp-input-stub>
   </label><!-- Advanced Search button to open modal --><button type="button" data-cy="searchAdvanced" class="btn--blank o-link--default inline-block u-m-0 u-p-0 u-ml-0_5">search.advanced</button><!-- Modal content -->
   <dp-modal-stub arialabel="" contentbodyclasses="" contentclasses="u-4-of-8-wide u-2-of-3-desk-down" contentheaderclasses=""></dp-modal-stub>
 </div>"
@@ -12,11 +12,11 @@ exports[`SearchModal renders the correct markup for activated field_statement_mu
 exports[`SearchModal renders the correct markup with deactivated feature_statements_tag and feature_statement_fragments_tag 1`] = `
 "<div class="flex">
   <!-- Search Field --><label class="relative u-m-0"><button class="btn-icns fa fa-search c-at__controls-input-button" data-cy="searchAssessmentWordButton"></button>
-    <dp-input-stub id="searchterm" autocomplete="" datacounter="" datacy="searchAssessmentWordField" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="true" label="[object Object]" modelvalue="" name="search_word2" pattern="" placeholder="searchterm" preventdefaultonenter="true" required="true" rounded="full" type="text" width="w-12" aria-label="search.assessment.table"></dp-input-stub>
+    <dp-input-stub id="searchterm" autocomplete="" datacounter="" datacy="searchAssessmentWordField" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="true" label="[object Object]" modelvalue="" name="search_word2" pattern="" placeholder="searchterm" preventdefaultonenter="true" required="true" rounded="full" invalid="false" type="text" width="w-12" aria-label="search.assessment.table"></dp-input-stub>
   </label><!-- Advanced Search button to open modal --><button type="button" data-cy="searchAdvanced" class="btn--blank o-link--default inline-block u-m-0 u-p-0 u-ml-0_5">search.advanced</button><!-- Modal content -->
   <dp-modal-stub arialabel="" contentbodyclasses="" contentclasses="u-4-of-8-wide u-2-of-3-desk-down" contentheaderclasses="">
     <h2>search.advanced</h2><!-- Search Field --><label class="layout__item u-pl-0 u-mb-0_25 u-mt-0_75 relative">
-      <dp-input-stub id="searchterm2" autocomplete="" datacounter="" datacy="searchModal:searchAssessmentTableAdvanced" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="false" label="[object Object]" modelvalue="" name="search_word" pattern="" placeholder="searchterm" preventdefaultonenter="true" rounded="full" type="text" width="w-full" aria-label="search.assessment.table"></dp-input-stub>
+      <dp-input-stub id="searchterm2" autocomplete="" datacounter="" datacy="searchModal:searchAssessmentTableAdvanced" datadpvalidateerror="" datadpvalidateerrorfieldname="" datadpvalidateif="" datadpvalidateshouldequal="" hasicon="false" label="[object Object]" modelvalue="" name="search_word" pattern="" placeholder="searchterm" preventdefaultonenter="true" rounded="full" invalid="false" type="text" width="w-full" aria-label="search.assessment.table"></dp-input-stub>
     </label><!-- search hint -->
     <p class="lbl__hint u-pt-0 u-mt-0 u-pb-0_5">assessmenttable.searchfield.characters</p><!-- Search options and special characters -->
     <div class="space-stack-s">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.22.0":
-  version: 0.22.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.22.0"
+"@demos-europe/demosplan-ui@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.23.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2849,12 +2849,12 @@ __metadata:
     "@uppy/drag-drop": "npm:^4.1.2"
     "@uppy/progress-bar": "npm:^4.2.1"
     "@uppy/tus": "npm:^4.2.2"
-    "@vue/server-renderer": "npm:3.5.24"
+    "@vue/server-renderer": "npm:3.5.33"
     "@vueuse/components": "npm:^14.0.0"
     "@vueuse/integrations": "npm:^14.0.0"
     a11y-datepicker: "npm: ^0.9.0"
     dayjs: "npm:^1.11.5"
-    dompurify: "npm:^3.0.0"
+    dompurify: "npm:^3.4.5"
     fscreen: "npm:^1.2.0"
     ismobilejs: "npm:^1.1.1"
     lscache: "npm:^1.3.2"
@@ -2862,12 +2862,12 @@ __metadata:
     qs: "npm:^6.14.2"
     sortablejs: "npm:^1.15.3"
     tippy.js: "npm:^6.3.7"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^13.0.2"
     v-tooltip: "npm:2.1.3"
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/0d3ad0269c5c4874e26fd9914cfef09db3035eac622c15a856540f23ec0e4e57c5f1d78882ad10bf49e8d4afbf5c410d2d6a50f2905a444b6277b3e9612d1e12
+  checksum: 10c0/64c9a0f3268a7848b766f8fa8b16befcb5298a66c0605a897e718f125b514bb3fdcb881b91c8ed0e78f33e184d6fc97fbba8e96651c28fd43aa5ef1bc5c379a3
   languageName: node
   linkType: hard
 
@@ -5333,19 +5333,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.5.24":
-  version: 3.5.24
-  resolution: "@vue/compiler-core@npm:3.5.24"
-  dependencies:
-    "@babel/parser": "npm:^7.28.5"
-    "@vue/shared": "npm:3.5.24"
-    entities: "npm:^4.5.0"
-    estree-walker: "npm:^2.0.2"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/d5b1421c0c0cfdff6b6ae2ef3d59b5901f0fec8ad2fa153f5ae1ec8487b898c92766353c661f68b892580ab0eacbc493632c946af8141045d6e76d67797b8a84
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-core@npm:3.5.26":
   version: 3.5.26
   resolution: "@vue/compiler-core@npm:3.5.26"
@@ -5379,16 +5366,6 @@ __metadata:
     "@vue/compiler-core": "npm:3.5.13"
     "@vue/shared": "npm:3.5.13"
   checksum: 10c0/8f424a71883c9ef4abdd125d2be8d12dd8cf94ba56089245c88734b1f87c65e10597816070ba2ea0a297a2f66dc579f39275a9a53ef5664c143a12409612cd72
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-dom@npm:3.5.24":
-  version: 3.5.24
-  resolution: "@vue/compiler-dom@npm:3.5.24"
-  dependencies:
-    "@vue/compiler-core": "npm:3.5.24"
-    "@vue/shared": "npm:3.5.24"
-  checksum: 10c0/d49cb715f2e1cb2272ede2e41901282fb3f6fbdf489c8aa737e60c68e21216e07b72942695a80430fee8f11e5933e36fc90615b146b189cac925bf32f2727c95
   languageName: node
   linkType: hard
 
@@ -5485,16 +5462,6 @@ __metadata:
     "@vue/compiler-dom": "npm:3.5.13"
     "@vue/shared": "npm:3.5.13"
   checksum: 10c0/67621337b12fc414fcf9f16578961850724713a9fb64501136e432c2dfe95de99932c46fa24be9820f8bcdf8e7281f815f585b519a95ea979753bafd637dde1b
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-ssr@npm:3.5.24":
-  version: 3.5.24
-  resolution: "@vue/compiler-ssr@npm:3.5.24"
-  dependencies:
-    "@vue/compiler-dom": "npm:3.5.24"
-    "@vue/shared": "npm:3.5.24"
-  checksum: 10c0/2b513dabe04e58c4a71355b1e2bfb3a235b267ea6f77f6009aa5df5972fa87d9e8fa4849d5e8fb232c7a7308d28c5ac1cd0b30492422ed82380ec423b4e3ce3b
   languageName: node
   linkType: hard
 
@@ -5599,18 +5566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/server-renderer@npm:3.5.24":
-  version: 3.5.24
-  resolution: "@vue/server-renderer@npm:3.5.24"
-  dependencies:
-    "@vue/compiler-ssr": "npm:3.5.24"
-    "@vue/shared": "npm:3.5.24"
-  peerDependencies:
-    vue: 3.5.24
-  checksum: 10c0/05b99a3fb2fcbea54caaa78cdd70dff641d804f2edaa8168a295f27b6bc6d69ded2a2b772044646a7571e4a7cfd610000464f2c66ba11268a515c83bb64b3f26
-  languageName: node
-  linkType: hard
-
 "@vue/server-renderer@npm:3.5.33":
   version: 3.5.33
   resolution: "@vue/server-renderer@npm:3.5.33"
@@ -5627,13 +5582,6 @@ __metadata:
   version: 3.5.13
   resolution: "@vue/shared@npm:3.5.13"
   checksum: 10c0/2c940ef907116f1c2583ca1d7733984e5705983ab07054c4e72f1d95eb0f7bdf4d01efbdaee1776c2008f79595963f44e98fced057f5957d86d57b70028f5025
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.5.24":
-  version: 3.5.24
-  resolution: "@vue/shared@npm:3.5.24"
-  checksum: 10c0/4fd5665539fa5be3d12280c1921a8db3a707115fef54d22d83ce347ea06e3b1089dfe07292e0c46bbebf23553c7c1ec98010972ebccf10532db82422801288ff
   languageName: node
   linkType: hard
 
@@ -7994,7 +7942,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.22.0"
+    "@demos-europe/demosplan-ui": "npm:0.23.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"
@@ -8190,7 +8138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.0, dompurify@npm:^3.0.2, dompurify@npm:^3.4.0":
+"dompurify@npm:^3.0.2, dompurify@npm:^3.4.0":
   version: 3.4.2
   resolution: "dompurify@npm:3.4.2"
   dependencies:
@@ -8199,6 +8147,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10c0/23ab3ab079480a49e1426c4ee7279e393913fa7f2193c4142a5be54d4163dbdd969558675876c6b8bbcbf2ad5d1bc3e00bf902acf142fff12e50274a65ae95b3
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.4.5":
+  version: 3.4.9
+  resolution: "dompurify@npm:3.4.9"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/e03d88d5959dcaae172357002d74e47e66fc6685cac8928fe4b02982f7b4051e2b8ff70279e4e6fb13be112c0e5cae11439ab960c06c487cb91a3c1a18baed49
   languageName: node
   linkType: hard
 
@@ -16056,12 +16016,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
+"uuid@npm:^13.0.2":
+  version: 13.0.2
+  resolution: "uuid@npm:13.0.2"
   bin:
     uuid: dist-node/bin/uuid
-  checksum: 10c0/950e4c18d57fef6c69675344f5700a08af21e26b9eff2bf2180427564297368c538ea11ac9fb2e6528b17fc3966a9fd2c5049361b0b63c7d654f3c550c9b3d67
+  checksum: 10c0/32c7ee84fa7c7966cc09b3a1514a752a8e2f609f15c00033fbaedc0255d577d1877b839f11ee537f37e587bbc620bbb98c3b3a1482931b8ed47d79497cd7a7cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
new version contains these changes:
- DpIcon: new icons 'folders' and 'arrow-square-out'
- DpDataTable: 'lockMessageBy' prop for per-row locked-checkbox tooltips, 'flyoutWidth' prop for the flyout column, 'lockCheckboxHint' prop
- DpApi: jsonapi headers are now sent for api/3.0 requests
- DpInput: new 'invalid' prop
- DpConfirmDialog: optional 'icon' prop for icon rendered in front of the header text
- DpBulkEditHeader: buttons are reordered so abort button sits left
- DpTableRow: new 'prohibit' icon for locked rows
- several dependency updates, fixing the remaining security alerts in demosplan-ui
