### PR TITLE
Improve access conditions of File resource type

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ResourceAccess/FileAccessChecker.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceAccess/FileAccessChecker.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\ResourceAccess;
+
+use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\IsFileAvailableEventInterface;
+use DemosEurope\DemosplanAddon\Contracts\Events\IsFileDirectlyAccessibleEventInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Event\IsFileAvailableEvent;
+use demosplan\DemosPlanCoreBundle\Event\IsFileDirectlyAccessibleEvent;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Encapsulates the access control of the {@link \demosplan\DemosPlanCoreBundle\ResourceTypes\FileResourceType}
+ * so it stays independent of the EDT resource type implementation and can be reused
+ * once the resource type is migrated to API Platform 3.0.
+ */
+class FileAccessChecker
+{
+    public function __construct(
+        private readonly CurrentUserInterface $currentUser,
+        private readonly CurrentProcedureService $currentProcedureService,
+        private readonly DqlConditionFactory $conditionFactory,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
+    ) {
+    }
+
+    public function isAvailable(): bool
+    {
+        // Currently the File resource needs to be exposed for statement import and assessment table.
+        $event = new IsFileAvailableEvent();
+        $this->eventDispatcher->dispatch($event, IsFileAvailableEventInterface::class);
+
+        return $event->isFileAvailable() || $this->currentUser->hasAnyPermissions(
+            'area_admin_assessmenttable',
+            'area_admin_globalnews',
+            'feature_platform_logo_edit',
+            'feature_read_source_statement_via_api',
+            'field_sign_language_overview_video_edit',
+        );
+    }
+
+    public function isDirectlyAccessible(): bool
+    {
+        $event = new IsFileDirectlyAccessibleEvent();
+        $this->eventDispatcher->dispatch($event, IsFileDirectlyAccessibleEventInterface::class);
+
+        return $event->isFileDirectlyAccessible() || $this->currentUser->hasAnyPermissions(
+            'area_admin_assessmenttable',
+            'field_sign_language_overview_video_edit'
+        );
+    }
+
+    /**
+     * Accessible are files without procedure (global assets) or files of a procedure
+     * the user has access to. Scoping is required here because this resource type
+     * exposes the file hash, which grants access to the file bytes.
+     *
+     * @return list<ClauseFunctionInterface<bool>>
+     */
+    public function getAccessConditions(): array
+    {
+        $procedureConditions = [$this->conditionFactory->propertyIsNull(['procedure'])];
+
+        $currentProcedure = $this->currentProcedureService->getProcedure();
+        $user = $this->currentUser->getUser();
+        if ($currentProcedure instanceof Procedure && $user instanceof User) {
+            // same procedure scope as statements: current procedure plus
+            // procedures configured for cross-procedure segment access
+            $configuredProcedures = array_filter(
+                $currentProcedure->getSettings()->getAllowedSegmentAccessProcedures()->getValues(),
+                static fn (ProcedureInterface $procedure): bool => $procedure instanceof Procedure
+            );
+            $allowedProcedureIds = $this->procedureAccessEvaluator->filterNonOwnedProcedureIds(
+                $user,
+                ...$configuredProcedures
+            );
+            $allowedProcedureIds[] = $currentProcedure->getId();
+            $procedureConditions[] = $this->conditionFactory->propertyHasAnyOfValues(
+                $allowedProcedureIds,
+                ['procedure', 'id']
+            );
+        }
+
+        return [
+            $this->conditionFactory->propertyHasValue(false, ['deleted']),
+            $this->conditionFactory->anyConditionApplies(...$procedureConditions),
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
@@ -13,13 +13,17 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\FileInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\IsFileAvailableEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\Events\IsFileDirectlyAccessibleEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\ResourceType\FileResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Entity\File;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Event\IsFileAvailableEvent;
 use demosplan\DemosPlanCoreBundle\Event\IsFileDirectlyAccessibleEvent;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
+use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use EDT\PathBuilding\End;
 
 /**
@@ -31,9 +35,15 @@ use EDT\PathBuilding\End;
  * @property-read End $hash
  * @property-read End $created
  * @property-read End $mimetype
+ * @property-read ProcedureResourceType $procedure
  */
 final class FileResourceType extends DplanResourceType implements FileResourceTypeInterface
 {
+    public function __construct(
+        private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
+    ) {
+    }
+
     public function getEntityClass(): string
     {
         return File::class;
@@ -65,13 +75,38 @@ final class FileResourceType extends DplanResourceType implements FileResourceTy
     }
 
     /**
-     * This method does not check for {@link File::$procedure}, because it depends on where
-     * the file is used if access should be restricted. Also note that this property is
-     * checked when the actual file bytes are requested.
+     * Accessible are files without procedure (global assets) or files of a procedure
+     * the user has access to. Scoping is required here because this resource type
+     * exposes the file hash, which grants access to the file bytes.
      */
     protected function getAccessConditions(): array
     {
-        return [$this->conditionFactory->propertyHasValue(false, $this->deleted)];
+        $procedureConditions = [$this->conditionFactory->propertyIsNull($this->procedure)];
+
+        $currentProcedure = $this->currentProcedureService->getProcedure();
+        $user = $this->currentUser->getUser();
+        if ($currentProcedure instanceof Procedure && $user instanceof User) {
+            // same procedure scope as statements: current procedure plus
+            // procedures configured for cross-procedure segment access
+            $configuredProcedures = array_filter(
+                $currentProcedure->getSettings()->getAllowedSegmentAccessProcedures()->getValues(),
+                static fn (ProcedureInterface $procedure): bool => $procedure instanceof Procedure
+            );
+            $allowedProcedureIds = $this->procedureAccessEvaluator->filterNonOwnedProcedureIds(
+                $user,
+                ...$configuredProcedures
+            );
+            $allowedProcedureIds[] = $currentProcedure->getId();
+            $procedureConditions[] = $this->conditionFactory->propertyHasAnyOfValues(
+                $allowedProcedureIds,
+                $this->procedure->id
+            );
+        }
+
+        return [
+            $this->conditionFactory->propertyHasValue(false, $this->deleted),
+            $this->conditionFactory->anyConditionApplies(...$procedureConditions),
+        ];
     }
 
     protected function isDirectlyAccessible(): bool

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/FileResourceType.php
@@ -13,17 +13,10 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\ResourceTypes;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\FileInterface;
-use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
-use DemosEurope\DemosplanAddon\Contracts\Events\IsFileAvailableEventInterface;
-use DemosEurope\DemosplanAddon\Contracts\Events\IsFileDirectlyAccessibleEventInterface;
 use DemosEurope\DemosplanAddon\Contracts\ResourceType\FileResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Entity\File;
-use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
-use demosplan\DemosPlanCoreBundle\Entity\User\User;
-use demosplan\DemosPlanCoreBundle\Event\IsFileAvailableEvent;
-use demosplan\DemosPlanCoreBundle\Event\IsFileDirectlyAccessibleEvent;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
-use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
+use demosplan\DemosPlanCoreBundle\ResourceAccess\FileAccessChecker;
 use EDT\PathBuilding\End;
 
 /**
@@ -40,7 +33,7 @@ use EDT\PathBuilding\End;
 final class FileResourceType extends DplanResourceType implements FileResourceTypeInterface
 {
     public function __construct(
-        private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
+        private readonly FileAccessChecker $fileAccessChecker,
     ) {
     }
 
@@ -61,63 +54,17 @@ final class FileResourceType extends DplanResourceType implements FileResourceTy
 
     public function isAvailable(): bool
     {
-        // Currently the File resource needs to be exposed for statement import and assessment table.
-        $event = new IsFileAvailableEvent();
-        $this->eventDispatcher->dispatch($event, IsFileAvailableEventInterface::class);
-
-        return $event->isFileAvailable() || $this->currentUser->hasAnyPermissions(
-            'area_admin_assessmenttable',
-            'area_admin_globalnews',
-            'feature_platform_logo_edit',
-            'feature_read_source_statement_via_api',
-            'field_sign_language_overview_video_edit',
-        );
+        return $this->fileAccessChecker->isAvailable();
     }
 
-    /**
-     * Accessible are files without procedure (global assets) or files of a procedure
-     * the user has access to. Scoping is required here because this resource type
-     * exposes the file hash, which grants access to the file bytes.
-     */
     protected function getAccessConditions(): array
     {
-        $procedureConditions = [$this->conditionFactory->propertyIsNull($this->procedure)];
-
-        $currentProcedure = $this->currentProcedureService->getProcedure();
-        $user = $this->currentUser->getUser();
-        if ($currentProcedure instanceof Procedure && $user instanceof User) {
-            // same procedure scope as statements: current procedure plus
-            // procedures configured for cross-procedure segment access
-            $configuredProcedures = array_filter(
-                $currentProcedure->getSettings()->getAllowedSegmentAccessProcedures()->getValues(),
-                static fn (ProcedureInterface $procedure): bool => $procedure instanceof Procedure
-            );
-            $allowedProcedureIds = $this->procedureAccessEvaluator->filterNonOwnedProcedureIds(
-                $user,
-                ...$configuredProcedures
-            );
-            $allowedProcedureIds[] = $currentProcedure->getId();
-            $procedureConditions[] = $this->conditionFactory->propertyHasAnyOfValues(
-                $allowedProcedureIds,
-                $this->procedure->id
-            );
-        }
-
-        return [
-            $this->conditionFactory->propertyHasValue(false, $this->deleted),
-            $this->conditionFactory->anyConditionApplies(...$procedureConditions),
-        ];
+        return $this->fileAccessChecker->getAccessConditions();
     }
 
     protected function isDirectlyAccessible(): bool
     {
-        $event = new IsFileDirectlyAccessibleEvent();
-        $this->eventDispatcher->dispatch($event, IsFileDirectlyAccessibleEventInterface::class);
-
-        return $event->isFileDirectlyAccessible() || $this->currentUser->hasAnyPermissions(
-            'area_admin_assessmenttable',
-            'field_sign_language_overview_video_edit'
-        );
+        return $this->fileAccessChecker->isDirectlyAccessible();
     }
 
     public function isGetAllowed(): bool

--- a/tests/backend/core/JsonApi/Functional/FileResourceTypeTest.php
+++ b/tests/backend/core/JsonApi/Functional/FileResourceTypeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\JsonApi\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\FileFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureSettingsFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
+use demosplan\DemosPlanCoreBundle\Entity\File;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\FileResourceType;
+use Tests\Base\FunctionalTestCase;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+class FileResourceTypeTest extends FunctionalTestCase
+{
+    protected ?FileResourceType $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = $this->getContainer()->get(FileResourceType::class);
+    }
+
+    public function testListIsScopedToCurrentProcedure(): void
+    {
+        // Arrange
+        $procedure = $this->createProcedure();
+        $foreignProcedure = $this->createProcedure();
+        $procedureFile = $this->createFile($procedure);
+        $foreignFile = $this->createFile($foreignProcedure);
+        $globalFile = $this->createFile(null);
+
+        $user = UserFactory::createOne(['deleted' => false]);
+        $this->logIn($user->_real());
+        $this->enablePermissions(['area_admin_assessmenttable']);
+        $this->getContainer()->get(CurrentProcedureService::class)->setProcedure($procedure->_real());
+
+        // Act
+        $files = $this->sut->getEntities([], []);
+
+        // Assert
+        $fileIds = array_map(static fn (File $file): string => $file->getIdent(), $files);
+        self::assertContains($procedureFile->getIdent(), $fileIds);
+        self::assertContains($globalFile->getIdent(), $fileIds);
+        self::assertNotContains($foreignFile->getIdent(), $fileIds);
+    }
+
+    public function testListWithoutProcedureContextExcludesProcedureBoundFiles(): void
+    {
+        // Arrange
+        $procedure = $this->createProcedure();
+        $procedureFile = $this->createFile($procedure);
+        $globalFile = $this->createFile(null);
+
+        $user = UserFactory::createOne(['deleted' => false]);
+        $this->logIn($user->_real());
+        $this->enablePermissions(['area_admin_assessmenttable']);
+
+        // Act
+        $files = $this->sut->getEntities([], []);
+
+        // Assert
+        $fileIds = array_map(static fn (File $file): string => $file->getIdent(), $files);
+        self::assertContains($globalFile->getIdent(), $fileIds);
+        self::assertNotContains($procedureFile->getIdent(), $fileIds);
+    }
+
+    private function createProcedure(): Proxy
+    {
+        $procedure = ProcedureFactory::createOne();
+        ProcedureSettingsFactory::createOne(['procedure' => $procedure]);
+
+        return $procedure;
+    }
+
+    private function createFile(?Proxy $procedure): Proxy
+    {
+        $attributes = [
+            'hash'     => md5(uniqid('', true)),
+            'filename' => 'test.txt',
+            'mimetype' => 'text/plain',
+        ];
+        if (null !== $procedure) {
+            $attributes['procedure'] = $procedure->_real();
+        }
+
+        return FileFactory::createOne($attributes);
+    }
+}

--- a/tests/backend/core/JsonApi/Functional/FileResourceTypeTest.php
+++ b/tests/backend/core/JsonApi/Functional/FileResourceTypeTest.php
@@ -87,7 +87,7 @@ class FileResourceTypeTest extends FunctionalTestCase
     private function createFile(?Proxy $procedure): Proxy
     {
         $attributes = [
-            'hash'     => md5(uniqid('', true)),
+            'hash'     => bin2hex(random_bytes(16)),
             'filename' => 'test.txt',
             'mimetype' => 'text/plain',
         ];


### PR DESCRIPTION
### Ticket
n/a (code improvement, no ticket)

The JSON:API `File` resource type returned every undeleted file regardless of procedure context, exposing file metadata (including the hash used by the file download routes) across procedures.

The access conditions now mirror the procedure scoping already used for statements: accessible are files without a procedure (global assets such as logos, news images or sign language videos) and files belonging to the current procedure, including procedures configured for cross-procedure segment access. Without a procedure context only procedure-less files are returned.

The current procedure can be trusted here because `AccessProcedureListener` already denies the request if the user may not enter the procedure given in the request.

### How to review/test
- `tests/backend/core/JsonApi/Functional/FileResourceTypeTest.php` covers both cases (with and without procedure context); the assertions fail against the previous access conditions.
- As a user with assessment table access, `GET /api/2.0/File` should only return files of the current procedure and procedure-less files.

### PR Checklist
- [x] Create/Update tests