### PR TITLE
fix: enforce procedure access on statement copy/move endpoints

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -33,11 +33,13 @@ use demosplan\DemosPlanCoreBundle\Logic\JsonApiPaginationParser;
 use demosplan\DemosPlanCoreBundle\Logic\LinkMessageSerializable;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
+use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementFragmentService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementMover;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\HeadStatementResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
@@ -56,6 +58,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -102,7 +105,14 @@ class DemosPlanStatementAPIController extends APIController
      */
     #[DplanPermissions('feature_statement_copy_to_procedure')]
     #[Route(path: '/api/1.0/statements/{statementId}/copy/{procedureId}', name: 'dplan_api_statement_copy_to_procedure', options: ['expose' => true], methods: ['POST'])]
-    public function copyStatement(ProcedureHandler $procedureHandler, Request $request, StatementHandler $statementHandler, string $statementId): APIResponse
+    public function copyStatement(
+        CurrentProcedureService $currentProcedureService,
+        CurrentUserService $currentUser,
+        ProcedureAccessEvaluator $procedureAccessEvaluator,
+        ProcedureHandler $procedureHandler,
+        Request $request,
+        StatementHandler $statementHandler,
+        string $statementId): APIResponse
     {
         try {
             $targetProcedureId = $request->query->get('targetProcedureId');
@@ -114,19 +124,24 @@ class DemosPlanStatementAPIController extends APIController
                 throw new Exception('CopyStatement: Could not find Statement ID: '.$statementId);
             }
 
+            // the procedure access check on kernel level only covers the procedure given in the route,
+            // hence the statement to copy must belong to that procedure
+            if ($currentProcedureService->getProcedureIdWithCertainty() !== $statementToCopy->getProcedureId()) {
+                throw new AccessDeniedException('ProcedureId of given Statement is not equal to given procedureId');
+            }
+
+            $ownsTargetProcedure = $procedureAccessEvaluator->isOwningProcedure($currentUser->getUser(), $targetProcedure);
+            if (!$ownsTargetProcedure
+                && !$this->permissions->hasPermission('feature_statement_copy_to_foreign_procedure')) {
+                throw new AccessDeniedException('Current user may not copy statements into the given target procedure');
+            }
+
             // actual copy of statement:
             $copiedStatement = $statementHandler->copyStatementToProcedure($statementToCopy, $targetProcedure);
 
             // generate message + create response:
             if ($copiedStatement instanceof Statement) {
                 // create normal or linked message depending on own or foreign procedure:
-
-                // To check specific procedure with ownsProcedure(), it is necessary to set procedure of permissions,
-                // because ownsProcedure(), use procedure which is set in permissions object.
-                // Reset currentProcedure after check of specific procedure
-                $this->permissions->setProcedure($targetProcedure);
-                $ownsRemoteProcedure = $this->permissions->ownsProcedure();
-
                 $message = 'confirm.statement.copy';
                 $routeName = $copiedStatement->isClusterStatement() ? 'DemosPlan_cluster_view' : 'dm_plan_assessment_single_view';
                 $messageParameters = [
@@ -135,7 +150,7 @@ class DemosPlanStatementAPIController extends APIController
                     'newExternId'     => $copiedStatement->getExternId(),
                 ];
 
-                if ($ownsRemoteProcedure) {
+                if ($ownsTargetProcedure) {
                     $this->messageBag->addObject(
                         LinkMessageSerializable::createLinkMessage(
                             'confirm',
@@ -178,6 +193,8 @@ class DemosPlanStatementAPIController extends APIController
             }
 
             return $this->createResponse($response, 200);
+        } catch (AccessDeniedException $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->messageBag->add('error', 'error.statement.move');
 
@@ -195,6 +212,8 @@ class DemosPlanStatementAPIController extends APIController
     #[Route(path: '/api/1.0/statements/{statementId}/move/{procedureId}', name: 'dplan_api_statement_move', options: ['expose' => true], methods: ['POST'])]
     public function moveStatement(
         CurrentProcedureService $currentProcedureService,
+        CurrentUserService $currentUser,
+        ProcedureAccessEvaluator $procedureAccessEvaluator,
         ProcedureHandler $procedureHandler,
         Request $request,
         StatementHandler $statementHandler,
@@ -212,7 +231,21 @@ class DemosPlanStatementAPIController extends APIController
             $statementToMove = $statementHandler->getStatement($statementId);
             if (!$statementToMove instanceof Statement) {
                 throw new Exception('MoveStatement: Could not find Statement ID: '.$statementId);
-            } // In case of statement will be moved to his "origin" procedure,
+            }
+
+            // the procedure access check on kernel level only covers the procedure given in the route,
+            // hence the statement to move must belong to that procedure
+            if ($currentProcedureService->getProcedureIdWithCertainty() !== $statementToMove->getProcedureId()) {
+                throw new AccessDeniedException('ProcedureId of given Statement is not equal to given procedureId');
+            }
+
+            $ownsTargetProcedure = $procedureAccessEvaluator->isOwningProcedure($currentUser->getUser(), $targetProcedure);
+            if (!$ownsTargetProcedure
+                && !$this->permissions->hasPermission('feature_statement_move_to_foreign_procedure')) {
+                throw new AccessDeniedException('Current user may not move statements into the given target procedure');
+            }
+
+            // In case of statement will be moved to his "origin" procedure,
             // the statement will be not longer marked as moved statement.
             // Therefore there is no placeholder statement and no "former extern Id" to access.
             // To avoid get null value in case of statement is moved "back" to the origin procedure,
@@ -225,12 +258,7 @@ class DemosPlanStatementAPIController extends APIController
                 $storedExternId = $statementToMove->getExternId();
             } // actual move of statement:
             $movedStatement = $statementMover->moveStatementToProcedure($statementToMove, $targetProcedure, $deleteVersionHistory); // generate message + create response:
-            if ($movedStatement instanceof Statement) { // To check specific procedure with ownsProcedure(), it is necessary to set procedure of permissions,
-                // because ownsProcedure(), use procedure which is set in permissions object.
-                // Reset currentProcedure after check of specific procedure
-                $this->permissions->setProcedure($procedureHandler->getProcedure($targetProcedureId));
-                $ownsRemoteProcedure = $this->permissions->ownsProcedure();
-                $this->permissions->setProcedure($currentProcedureService->getProcedure());
+            if ($movedStatement instanceof Statement) {
                 $message = $movedToFirstProcedure ? 'confirm.statement.move.first' : 'confirm.statement.move';
                 $formerExternId = $movedStatement->getFormerExternId(); // In case of movedToFirstProcedure, there is no formerExternId, because statement seems to be never moved.
                 $formerExternId = $movedToFirstProcedure ? $storedExternId : $formerExternId;
@@ -239,7 +267,7 @@ class DemosPlanStatementAPIController extends APIController
                     'externId'        => $formerExternId,
                     'newExternId'     => $movedStatement->getExternId(),
                 ];
-                if ($ownsRemoteProcedure) {
+                if ($ownsTargetProcedure) {
                     $this->messageBag->addObject(
                         LinkMessageSerializable::createLinkMessage(
                             'confirm',
@@ -274,6 +302,8 @@ class DemosPlanStatementAPIController extends APIController
             }
 
             return $this->createResponse($response, 200);
+        } catch (AccessDeniedException $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->messageBag->add('error', 'error.statement.move');
 

--- a/tests/backend/core/Statement/Functional/DemosPlanStatementAPIControllerTest.php
+++ b/tests/backend/core/Statement/Functional/DemosPlanStatementAPIControllerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadProcedureData;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadStatementData;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Base\AbstractApiTest;
+
+class DemosPlanStatementAPIControllerTest extends AbstractApiTest
+{
+    public function testCopyStatementIsRejectedForStatementOutsideRouteProcedure(): void
+    {
+        // Arrange
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $ownProcedure = $this->getProcedureReference(LoadProcedureData::TESTPROCEDURE);
+        $foreignStatement = $this->createForeignStatement();
+        $this->enablePermissions(['feature_statement_copy_to_procedure']);
+        $statementCountBefore = $this->countEntries(Statement::class);
+
+        // Act: foreign source statement, route + target = own procedure
+        $response = $this->sendRequest(
+            $this->buildUrl('copy', $foreignStatement->getId(), $ownProcedure->getId(), $ownProcedure->getId()),
+            'POST',
+            $user,
+            $ownProcedure
+        );
+
+        // Assert: request rejected, no statement copied
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame($statementCountBefore, $this->countEntries(Statement::class));
+    }
+
+    public function testCopyStatementIsRejectedForNotOwnedTargetProcedure(): void
+    {
+        // Arrange
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $ownProcedure = $this->getProcedureReference(LoadProcedureData::TESTPROCEDURE);
+        $ownStatement = $this->getStatementReference(LoadStatementData::TEST_STATEMENT);
+        $foreignProcedure = $this->createForeignProcedure();
+        $this->enablePermissions(['feature_statement_copy_to_procedure']);
+        $statementCountBefore = $this->countEntries(Statement::class);
+
+        // Act: own source statement, target = not-owned procedure
+        $response = $this->sendRequest(
+            $this->buildUrl('copy', $ownStatement->getId(), $ownProcedure->getId(), $foreignProcedure->getId()),
+            'POST',
+            $user,
+            $ownProcedure
+        );
+
+        // Assert: request rejected, no statement copied
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame($statementCountBefore, $this->countEntries(Statement::class));
+    }
+
+    public function testMoveStatementIsRejectedForStatementOutsideRouteProcedure(): void
+    {
+        // Arrange
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $ownProcedure = $this->getProcedureReference(LoadProcedureData::TESTPROCEDURE);
+        $foreignStatement = $this->createForeignStatement();
+        $foreignProcedureId = $foreignStatement->getProcedureId();
+        $this->enablePermissions(['feature_statement_move_to_procedure']);
+
+        // Act: foreign source statement, route + target = own procedure
+        $response = $this->sendRequest(
+            $this->buildUrl('move', $foreignStatement->getId(), $ownProcedure->getId(), $ownProcedure->getId()),
+            'POST',
+            $user,
+            $ownProcedure,
+            ['deleteVersionHistory' => false]
+        );
+
+        // Assert: request rejected, statement stayed in its procedure
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $unmovedStatement = $this->find(Statement::class, $foreignStatement->getId());
+        self::assertSame($foreignProcedureId, $unmovedStatement->getProcedureId());
+    }
+
+    public function testMoveStatementIsRejectedForNotOwnedTargetProcedure(): void
+    {
+        // Arrange
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $ownProcedure = $this->getProcedureReference(LoadProcedureData::TESTPROCEDURE);
+        $ownStatement = $this->getStatementReference(LoadStatementData::TEST_STATEMENT);
+        $foreignProcedure = $this->createForeignProcedure();
+        $this->enablePermissions(['feature_statement_move_to_procedure']);
+
+        // Act: own source statement, target = not-owned procedure
+        $response = $this->sendRequest(
+            $this->buildUrl('move', $ownStatement->getId(), $ownProcedure->getId(), $foreignProcedure->getId()),
+            'POST',
+            $user,
+            $ownProcedure,
+            ['deleteVersionHistory' => false]
+        );
+
+        // Assert: request rejected, statement stayed in its procedure
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $unmovedStatement = $this->find(Statement::class, $ownStatement->getId());
+        self::assertSame($ownProcedure->getId(), $unmovedStatement->getProcedureId());
+    }
+
+    /**
+     * The copy/move guards allow the action only when the current user owns the target
+     * procedure (or holds the *_to_foreign_procedure permission). This verifies the
+     * ownership predicate the guards rely on: allow for an owned target, deny for a
+     * foreign one.
+     */
+    public function testTargetProcedureOwnershipGate(): void
+    {
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $ownedTargetProcedure = $this->getProcedureReference(LoadProcedureData::TEST_PROCEDURE_2);
+        $foreignProcedure = $this->createForeignProcedure();
+        $this->logIn($user);
+
+        /** @var ProcedureAccessEvaluator $accessEvaluator */
+        $accessEvaluator = $this->getContainer()->get(ProcedureAccessEvaluator::class);
+
+        self::assertTrue($accessEvaluator->isOwningProcedure($user, $ownedTargetProcedure));
+        self::assertFalse($accessEvaluator->isOwningProcedure($user, $foreignProcedure));
+    }
+
+    protected function getServerParameters(): array
+    {
+        return [];
+    }
+
+    private function buildUrl(string $action, string $statementId, string $routeProcedureId, string $targetProcedureId): string
+    {
+        return sprintf(
+            '/api/1.0/statements/%s/%s/%s?targetProcedureId=%s',
+            $statementId,
+            $action,
+            $routeProcedureId,
+            $targetProcedureId
+        );
+    }
+
+    private function createForeignProcedure(): Procedure
+    {
+        return ProcedureFactory::createOne()->_real();
+    }
+
+    private function createForeignStatement(): Statement
+    {
+        return StatementFactory::createOne(['procedure' => $this->createForeignProcedure()])->_real();
+    }
+}


### PR DESCRIPTION
The `copyStatement` / `moveStatement` API handlers loaded the source statement
by the route id and the target procedure by the `targetProcedureId` query string
without checking either against the user's procedure access. The kernel-level
procedure gate only validates the procedure named in the route, which the caller
chooses — so a user could copy/move a foreign statement into a procedure they
control (reading foreign content) or write into a procedure they do not own.

Both handlers now assert, right after loading:
1. the source statement belongs to the current (route) procedure, and
2. the user owns the target procedure (unless they hold the respective
   `feature_statement_{copy,move}_to_foreign_procedure` permission).

The ownership result also replaces the previous `permissions->setProcedure()`
switching used to pick the linked confirmation message.

### How to review/test
`DemosPlanStatementAPIControllerTest` covers both endpoints (foreign source
statement and not-owned target procedure) plus the ownership predicate. The
HTTP tests were verified to fail against the unpatched controller — a
foreign-statement move returned 200 and actually moved the statement
cross-procedure — and now return a rejection.

### PR Checklist
- [x] Create/Update tests
