### PR TITLE
fix(DS-548): only clear segment assignee while workflow actions are visible

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -1072,9 +1072,11 @@ export default {
            * stale `initial` baseline that setSegment never updates), so an unassign would be silently
            * omitted from saveSegmentAction's request body. Mirrors the explicit payload already used by
            * claimSegment()/unclaimSegment(). It must complete before fetchUpdatedSegment, which would
-           * otherwise re-store the stale assignee.
+           * otherwise re-store the stale assignee. Only applies while the workflow actions are visible,
+           * since `selectedAssignee` is meaningless otherwise (mirrors updateRelationships()).
            */
-          const isUnassigning = !this.selectedAssignee?.id || this.selectedAssignee.id === 'noAssigneeId'
+          const isUnassigning = this.showWorkflowActions &&
+            (!this.selectedAssignee?.id || this.selectedAssignee.id === 'noAssigneeId')
 
           return isUnassigning ?
             dpApi.patch(


### PR DESCRIPTION
Follow-up to DS-548. The explicit clear-assignee PATCH fired on every segment save when `selectedAssignee` was not initialized, even if the workflow actions were never opened. It is now guarded with `showWorkflowActions`, mirroring the existing condition in `updateRelationships()`.

Ticket: [DS-548](https://demoseurope.youtrack.cloud/tickets/DS-548/VKE-705.3-Vorgang-lasst-sich-nicht-abschliessen)