### PR TITLE
fix(refs: DPLAN-18002): guard GdprConsent user lookup against null or empty submitter id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## UNRELEASED
 
+### Fixed
+- Submitting a public statement as an anonymous citizen no longer fails with a Doctrine `MissingIdentifierField` exception (DPLAN-18002)
+
 ## v4.44.0 (2026-06-05)
 
 ## v4.43.0 (2026-06-05)

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -332,10 +332,9 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
                 $gdprConsent->setConsentReceivedDate($statement->getSubmitObject());
                 $gdprConsent->setConsentReceived(true);
             }
-            try {
+            $submitConsentee = null;
+            if (null !== $consenteeIds['submitter'] && '' !== $consenteeIds['submitter']) {
                 $submitConsentee = $em->getRepository(User::class)->find($consenteeIds['submitter']);
-            } catch (ORMException) {
-                $submitConsentee = null;
             }
 
             $gdprConsent->setConsentee($submitConsentee);


### PR DESCRIPTION
### Ticket
DPLAN-18002

Cherry-pick of commit a95edf9f2 from main.

After the Doctrine ORM upgrade, `MissingIdentifierField` no longer extends `ORMException`, so passing `null` to `EntityManager::find()` was no longer silently caught. Anonymous public statement submissions always have a null submitter id — the null check was missing, causing the entire statement submission to fail.

### How to review/test
Submit a public statement as an anonymous citizen via the public participation form.

### PR Checklist
- [x] Link all relevant tickets