### PR TITLE
feat(DPLAN-16354): Delete custom fields only when it does not have st…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -2186,4 +2186,18 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
             'completed'  => $completed,
         ];
     }
+
+    public function findStatementsWithCustomField(string $customFieldId): array
+    {
+        $searchPattern = '%"id":"'.$customFieldId.'"%';
+
+        return $this->getEntityManager()->createQueryBuilder()
+            ->select('statement')
+            ->from(Statement::class, 'statement')
+            ->where('statement.customFields IS NOT NULL')
+            ->andWhere('statement.customFields LIKE :customFieldSearch')
+            ->setParameter('customFieldSearch', $searchPattern)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/CustomFieldDeleter.php
@@ -16,10 +16,12 @@ use DemosEurope\DemosplanAddon\Contracts\Services\TransactionServiceInterface;
 use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
+use demosplan\DemosPlanCoreBundle\Utils\CustomField\Constraint\ProcedureWithStatementsCustomFieldConstraint;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\Factory\EntityCustomFieldUsageStrategyFactory;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CustomFieldDeleter
 {
@@ -27,6 +29,7 @@ class CustomFieldDeleter
         private readonly CustomFieldConfigurationRepository $customFieldConfigurationRepository,
         private readonly EntityCustomFieldUsageStrategyFactory $entityCustomFieldUsageStrategyFactory,
         private readonly TransactionServiceInterface $transactionService,
+        private readonly ValidatorInterface $validator,
     ) {
     }
 
@@ -39,7 +42,6 @@ class CustomFieldDeleter
     {
         $this->transactionService->executeAndFlushInTransaction(
             function () use ($entityId): void {
-                // Get the CustomFieldConfiguration from database
                 /** @var CustomFieldConfiguration $customFieldConfiguration */
                 $customFieldConfiguration = $this->customFieldConfigurationRepository->find($entityId);
 
@@ -47,11 +49,18 @@ class CustomFieldDeleter
                     throw new InvalidArgumentException("CustomFieldConfiguration with ID '{$entityId}' not found");
                 }
 
-                // 1. Entity-specific cleanup (replaces hardcoded removeSegmentUsages)
+                $violations = $this->validator->validate(
+                    $customFieldConfiguration,
+                    [new ProcedureWithStatementsCustomFieldConstraint(['message' => 'CustomField cannot be deleted: Procedure with statements'])]
+                );
+
+                if ($violations->count() > 0) {
+                    throw new InvalidArgumentException((string) $violations);
+                }
+
                 $entityStrategy = $this->entityCustomFieldUsageStrategyFactory->createUsageRemovalStrategy($customFieldConfiguration->getTargetEntityClass());
                 $entityStrategy->removeUsages($entityId);
 
-                // 2. Delete the custom field configuration
                 $this->customFieldConfigurationRepository->deleteObject($customFieldConfiguration);
             }
         );

--- a/demosplan/DemosPlanCoreBundle/Utils/CustomField/Strategy/StatementCustomFieldUsageRemovalStrategy.php
+++ b/demosplan/DemosPlanCoreBundle/Utils/CustomField/Strategy/StatementCustomFieldUsageRemovalStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Utils\CustomField\Strategy;
+
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValue;
+use demosplan\DemosPlanCoreBundle\CustomField\CustomFieldValuesList;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
+
+class StatementCustomFieldUsageRemovalStrategy implements EntityCustomFieldUsageRemovalStrategyInterface
+{
+    public function __construct(
+        private readonly StatementRepository $statementRepository,
+    ) {
+    }
+
+    public function supports(string $targetEntityClass): bool
+    {
+        return 'STATEMENT' === $targetEntityClass;
+    }
+
+    public function removeUsages(string $customFieldId): void
+    {
+        $statements = $this->statementRepository->findStatementsWithCustomField($customFieldId);
+
+        foreach ($statements as $statement) {
+            $this->removeCustomFieldFromStatement($statement, $customFieldId);
+        }
+    }
+
+    public function removeOptionUsages(string $customFieldId, array $deletedOptionIds): void
+    {
+        // Statement custom fields cannot be updated when the procedure has statements
+        // (blocked by ProcedureWithStatementsCustomFieldConstraint in CustomFieldUpdater),
+        // so this path is unreachable in production.
+    }
+
+    private function removeCustomFieldFromStatement(Statement $statement, string $customFieldId): void
+    {
+        $originalCustomFields = $statement->getCustomFields();
+        if (!$originalCustomFields instanceof CustomFieldValuesList) {
+            return;
+        }
+        $customFields = clone $originalCustomFields;
+        $customFieldValue = $customFields->findById($customFieldId);
+        if ($customFieldValue instanceof CustomFieldValue) {
+            $customFields->removeCustomFieldValue($customFieldValue);
+            $customFields->reindexValues();
+            $statement->setCustomFields($customFields);
+        }
+    }
+}

--- a/tests/backend/core/CustomField/CustomFieldDeleterTest.php
+++ b/tests/backend/core/CustomField/CustomFieldDeleterTest.php
@@ -23,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
 use demosplan\DemosPlanCoreBundle\Repository\OrgaRepository;
 use demosplan\DemosPlanCoreBundle\Repository\SegmentRepository;
-use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\CustomFieldDeleter;
 use Tests\Base\UnitTestCase;
 

--- a/tests/backend/core/CustomField/CustomFieldDeleterTest.php
+++ b/tests/backend/core/CustomField/CustomFieldDeleterTest.php
@@ -18,10 +18,12 @@ use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\CustomFields\CustomField
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidArgumentException;
 use demosplan\DemosPlanCoreBundle\Repository\CustomFieldConfigurationRepository;
 use demosplan\DemosPlanCoreBundle\Repository\OrgaRepository;
 use demosplan\DemosPlanCoreBundle\Repository\SegmentRepository;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use demosplan\DemosPlanCoreBundle\Utils\CustomField\CustomFieldDeleter;
 use Tests\Base\UnitTestCase;
 
@@ -215,6 +217,52 @@ class CustomFieldDeleterTest extends UnitTestCase
         self::assertNull(
             $refreshedOrga2->getCustomFields()?->findById($customFieldId),
             'Orga 2 should no longer have the custom field value'
+        );
+    }
+
+    public function testDeleteStatementCustomFieldThrowsWhenProcedureHasStatements(): void
+    {
+        // Arrange: procedure with statements
+        $procedure = ProcedureFactory::createOne();
+        $statementOriginal = StatementFactory::createOne(['procedure' => $procedure->_real()]);
+        StatementFactory::createOne([
+            'procedure' => $procedure->_real(),
+            'original'  => $statementOriginal->_real(),
+        ]);
+
+        $customField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($procedure->_real())
+            ->withRelatedTargetEntity('STATEMENT')
+            ->asMultiSelect('Color1')
+            ->create();
+
+        // Assert & Act
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CustomField cannot be deleted: Procedure with statements');
+
+        $this->sut->deleteCustomField($customField->getId());
+    }
+
+    public function testDeleteStatementCustomFieldSucceedsWhenProcedureHasNoStatements(): void
+    {
+        // Arrange: procedure with no statements
+        $procedure = ProcedureFactory::createOne();
+
+        $customField = CustomFieldConfigurationFactory::new()
+            ->withRelatedProcedure($procedure->_real())
+            ->withRelatedTargetEntity('STATEMENT')
+            ->asMultiSelect('Color1')
+            ->create();
+
+        $entityId = $customField->getId();
+
+        // Act
+        $this->sut->deleteCustomField($entityId);
+
+        // Assert
+        self::assertNull(
+            $this->repository->find($entityId),
+            'CustomFieldConfiguration should be deleted when procedure has no statements'
         );
     }
 }


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-16354/ADO-43310-Konfigurierbare-Felder-in-Stellungnahmen-Part-5-FP-kann-Multiselect-Custom-Fields-loschen

The same restriction that already applies to creating and updating statement custom fields now also applies to deletion: if the procedure has statements, the delete request is rejected with a validation error.

### How to review/test

1. Open a procedure that already has at least one statement.
2. Go to the custom fields configuration for that procedure.
3. Try to delete a multiselect custom field that targets statements.
4. Expected: deletion is blocked with an error message.
5. Open a procedure that has **no** statements.
6. Try to delete a multiselect custom field targeting statements.
7. Expected: deletion succeeds.

### Linked PRs (optional)
- Related: #6351 (adds statement custom field deletion support — this PR adds the guard on top of it)