### PR TITLE
fix(refs: DPLAN-17993): fix name and tooltip for custom header in export

### DIFF
--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -976,8 +976,8 @@ docx.export.file_name: "Dateinamen einzelner DOCX-Dateien"
 docx.export.file_name.hint: "Um den Dateinamen dynamisch zu erstellen, verwenden Sie folgende Platzhalter:<br>'{ID}' - die ID der Stellungnahme in EWM<br>'{NAME}' - der Name der einreichenden Person oder Organisation<br>'{EINGANGSNR}' - die vergebene Eingangsnummer<br>Wenn Sie weder '{ID}', '{NAME}' noch '{EINGANGSNR}' verwenden, wird dem Dateinamen eine einzigartige Nummer angehängt."
 docx.export.file_name.placeholder: "'{ID}'_'{NAME}'_'{EINGANGSNR}'"
 docx.export.filtered: "<p>Angewendete Schlagwortfilter: </p> <br>"
-docx.export.header.custom: "Kopfzeile anpassen"
-docx.export.header.custom.hint: "Der individuelle Kopfzeilentext erscheint in der DOCX-Datei. Um die Kopfzeile auf den Ursprungswert zurückzusetzen, entfernen Sie den Eintrag im Textfeld."
+docx.export.header.custom: "Titelzusatz vergeben"
+docx.export.header.custom.hint: "Untertitel, der im exportierten docx-Dokument auf allen Seiten rechtsbündig unter dem Verfahrensnamen erscheint. Der Standard-Untertitel kann hier angepasst werden."
 docx.export.header.custom.placeholder: |
   {isPartialExport, select,
       true {Teilexport Synopse {procedureName}}


### PR DESCRIPTION
### Ticket
DPLAN-17993

The label and tooltip for the custom header field was adjusted to be more user friendly.

### How to review/test
Go to STN list, click export, check that label and tooltip for the custom header are what is written in the ticket.
