### PR TITLE
Fix(DPLAN-17833): disappearing segments after assignment

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
+++ b/client/js/components/procedure/StatementSegmentsList/SegmentsRecommendations.vue
@@ -380,9 +380,11 @@ export default {
           AssignableUser: [
             'firstname',
             'lastname',
+            'orga',
           ].join(),
+          Orga: ['name'].join(),
         },
-        include: 'department',
+        include: 'orga',
         sort: 'lastname',
       })
 


### PR DESCRIPTION
### Ticket
[DPLAN-17833](https://demoseurope.youtrack.cloud/issue/DPLAN-17833) Dev/Stage: Angezeigt Abschnitte verschwinden nach Zuweisung aus Detailansicht

**Description:**  This PR fixes an issue with disappearing segments after assignment:
1. The parent component `StatementSegmentsList.vue` fetches correctly AssignableUsers with `orga` relationship
2. But when user navigates from ListStatements to the Recommendation page, the _recommendation_ tab `SegmentsRecommendations.vue` fetches `AssignableUsers` but includes `department` instead of `orga`
3. This overwrites the store with `AssignableUser` entities that don't have the `orga` relationship
4. When user then clicks the _details_ tab, `StatementSegmentsEdit.vue` tries to use the same `AssignableUser` from the store, but the `orga` data is gone

Fix: Include `orga` instead of `department`


### How to review/test
The issue only occurs when navigating from the Statement List to the Recommendation page, and only for segments that have not yet been assigned.

1. Create a new STN
2. Split the Statement
3. Navigate to the Statement List
4. Select the newly split STN
5. Open STN Actions → _Details und Erwiderung_
6. Open the _Details_ tab
7. Scroll to the Segments section
8. Assign a user to one of the unassigned segments

**Expected result:**

- The assignment is saved successfully.
- The segment remains visible in the list after the assignment.
- No segments disappear from the view.

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
