### PR TITLE
fix(refs: DPLAN-17957): notification about faulty api request in insti list

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -462,6 +462,7 @@ export default {
     },
 
     getInstitutionsByPage (page) {
+      const customFields = hasPermission('feature_organisations_custom_fields') ? ['customFields'] : []
       const args = {
         page: {
           number: page,
@@ -473,7 +474,7 @@ export default {
             'name',
             'createdDate',
             'assignedTags',
-            'customFields',
+            ...customFields,
           ].join(),
           InstitutionTag: [
             'category',

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -368,7 +368,10 @@ export default {
     isActive (newValue) {
       if (newValue) {
         this.getInstitutionTagCategories()
-        this.loadCustomFieldDefinitions()
+
+        if (hasPermission('feature_organisations_custom_fields')) {
+          this.loadCustomFieldDefinitions()
+        }
       }
     },
   },
@@ -560,10 +563,6 @@ export default {
     },
 
     loadCustomFieldDefinitions () {
-      if (!hasPermission('feature_organisations_custom_fields')) {
-        return Promise.resolve([])
-      }
-
       return useCustomFields().fetchCustomFields(null, {
         sourceEntity: 'CUSTOMER',
         targetEntity: 'ORGA',
@@ -673,10 +672,11 @@ export default {
   },
 
   mounted () {
+    const customFields = hasPermission('feature_organisations_custom_fields') ? [this.loadCustomFieldDefinitions()] : []
     const promises = [
       this.getInstitutionsByPage(1),
       this.getInstitutionTagCategories(true),
-      this.loadCustomFieldDefinitions(),
+      ...customFields
     ]
 
     Promise.allSettled(promises)

--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -673,11 +673,11 @@ export default {
   },
 
   mounted () {
-    const customFields = hasPermission('feature_organisations_custom_fields') ? [this.loadCustomFieldDefinitions()] : []
+    const customFieldPromises = hasPermission('feature_organisations_custom_fields') ? [this.loadCustomFieldDefinitions()] : []
     const promises = [
       this.getInstitutionsByPage(1),
       this.getInstitutionTagCategories(true),
-      ...customFields
+      ...customFieldPromises,
     ]
 
     Promise.allSettled(promises)


### PR DESCRIPTION
### Ticket
DPLAN-17957


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds permission checks for the institution custom fields in the institution list. It prevents calling the custom fields for the list, if the permission is not set. It also adjusts the permission handling for loading the custom fields definitions a bit that was fixed in https://github.com/demos-europe/demosplan-core/pull/6373 before. This is done to separate concerns and be nearer to the rest of the code base.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

1. Login as M-A and open "Institutionen verschlagworten"
2. Check for notifications

1. Login as FP-A  open "Institutionen Verwalten"
2. Check for notifications

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn lint`
- [x] Move the tickets on the board accordingly
