### PR TITLE
fix HDDP-21: prevent empty assessment table when sorting by submitter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/ElasticsearchResultCreator.php
@@ -1585,9 +1585,12 @@ class ElasticsearchResultCreator
                 'oName.sort'         => $sortDirection,
                 'dName.sort'         => $sortDirection,
                 'uName.sort'         => $sortDirection,
-                'cluster.oName.sort' => $sortDirection,
-                'cluster.dName.sort' => $sortDirection,
-                'cluster.uName.sort' => $sortDirection,
+                // The cluster fields are mapped as a nested type, so Elasticsearch requires
+                // an explicit nested context to sort on them. Without it the whole search is
+                // rejected with HTTP 400 and the assessment table shows no statements.
+                'cluster.oName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
+                'cluster.dName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
+                'cluster.uName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
             ];
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2354,9 +2354,12 @@ class StatementService implements StatementServiceInterface
                 'oName.sort'         => $sortDirection,
                 'dName.sort'         => $sortDirection,
                 'uName.sort'         => $sortDirection,
-                'cluster.oName.sort' => $sortDirection,
-                'cluster.dName.sort' => $sortDirection,
-                'cluster.uName.sort' => $sortDirection,
+                // The cluster fields are mapped as a nested type, so Elasticsearch requires
+                // an explicit nested context to sort on them. Without it the whole search is
+                // rejected with HTTP 400 and the assessment table shows no statements.
+                'cluster.oName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
+                'cluster.dName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
+                'cluster.uName.sort' => ['order' => $sortDirection, 'nested' => ['path' => 'cluster']],
             ];
         }
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/HDDP-21

Description:

Sorting the assessment table ("Abwägungstabelle") by submitter ("Auf-/Absteigend nach Einreicher*in") returned no statements, even though statements exist. All other sort options worked correctly.

**Cause:** The submitter sort is the only one that orders by fields inside the `cluster` object (`cluster.oName/dName/uName`). `cluster` is mapped as an Elasticsearch `nested` type. Elasticsearch 8 requires the nested path to be specified explicitly when sorting on a nested field (older versions inferred it automatically). The code passed these fields as plain sort keys, so after the
ES 8 upgrade Elasticsearch rejected the whole search with HTTP 400 — and a failed search returns zero results, leaving the table empty. Every other sort option uses plain top-level fields and was unaffected.

**Fix:** Add the explicit nested context (`nested: {path: 'cluster'}`) to the three `cluster.*` sort fields. The change is applied in both places that build this sort: the assessment table list (`ElasticsearchResultCreator`) and the export sort builder (`StatementService`), since the export path would fail the same way. No data change or reindex is required — it only affects the query.

### How to review/test
1. Open the assessment table of a procedure that has statements.
2. Select the sort option "Auf-/Absteigend nach Einreicher*in".
3. **Before:** the list is empty (ES returns HTTP 400 in the dev log).
   **After:** statements are listed, sorted by submitter.
4. Verify the other sort options (Datum, Priorität, Dokument) still work.

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

