### PR TITLE
feat (DPLAN-XXXXX): fix flaky test

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/SlugFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/SlugFactory.php
@@ -47,7 +47,7 @@ final class SlugFactory extends PersistentProxyObjectFactory
     protected function defaults(): array
     {
         return [
-            'name' => self::faker()->streetName(),
+            'name' => self::faker()->unique()->streetName(),
         ];
     }
 


### PR DESCRIPTION
Description:
ensures no two slug names collide within a test run regardless of the Faker seed

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
