### PR TITLE
feat (DPLAN-17492): initially lock all solved segments.

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615133023.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615133023.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615133023.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615133023.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260615133023 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-17492: set locked = true on all workflow_place rows named Abgeschlossen';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql("UPDATE workflow_place SET locked = 1 WHERE name = 'Abgeschlossen'");
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql("UPDATE workflow_place SET locked = 0 WHERE name = 'Abgeschlossen'");
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-17492

### Description
initially lock all solved segments

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
