### PR TITLE
fix: include place in fetch of updated segments

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -877,6 +877,13 @@ export default {
             'submitter',
             'place',
           ].join(','),
+          Place: [
+            'description',
+            ...(hasPermission('feature_segment_lock_by_workflow_place') ? ['locked'] : []),
+            'name',
+            'solved',
+            'sortIndex',
+          ].join(','),
           RecommendationVersion: [
             'versionNumber',
             'recommendationText',


### PR DESCRIPTION
Assigning a segment to a locked place didn't update the lock badge until reload. The post-save refetch used a sparse fieldset missing `locked`, which wiped the attribute from the store. Added `locked` to the fieldset.

### How to review/test
Go to "Erwiderungen verfassen", set the place for a segment to 'Abgeschlossen' -> ui should show locked icon after save without reload.