### PR TITLE
feat(DPLAN-18005): Fix default values

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615120000.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/06/Version20260615120000.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260615120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'refs DPLAN-18005: Fix default values for public participation publication and feedback flags';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        // The DPLAN-16042 migration (Version20250703101620) introduced this column with
+        // DEFAULT 0, contradicting the ORM annotation (DEFAULT 1) and BauGB requirements.
+        // All rows received 0 at introduction time; there is no way to distinguish
+        // intentional 0 from the bug-induced default, so all rows are corrected to 1.
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure_settings
+                MODIFY _p_public_participation_feedback_enabled TINYINT(1) DEFAULT 1 NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE _procedure_settings SET _p_public_participation_feedback_enabled = 1
+        SQL);
+
+        // Column default has been DEFAULT 1 since the initial 2020 migration.
+        // Opt-in semantics are required for Bauleitplanverfahren (DPLAN-18005).
+        // Only blueprint procedures are corrected — real procedures keep their
+        // planner-configured values. Projects without
+        // feature_toggle_public_participation_publication self-correct their blueprint
+        // to 1 on the next edit save (hidden input always submits value=1).
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure
+                MODIFY _p_public_participation_publication_enabled TINYINT(1) DEFAULT 0 NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE _procedure
+            SET _p_public_participation_publication_enabled = 0
+            WHERE _p_master != 0
+               OR master_template = 1
+        SQL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure_settings
+                MODIFY _p_public_participation_feedback_enabled TINYINT(1) DEFAULT 0 NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE _procedure_settings SET _p_public_participation_feedback_enabled = 0
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE _procedure
+                MODIFY _p_public_participation_publication_enabled TINYINT(1) DEFAULT 1 NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE _procedure
+            SET _p_public_participation_publication_enabled = 1
+            WHERE _p_master != 0
+               OR master_template = 1
+        SQL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -229,8 +229,8 @@ class Procedure extends SluggedEntity implements ProcedureInterface
      *
      * @var bool
      */
-    #[ORM\Column(name: '_p_public_participation_publication_enabled', type: 'boolean', nullable: false, options: ['default' => true])]
-    protected $publicParticipationPublicationEnabled = true;
+    #[ORM\Column(name: '_p_public_participation_publication_enabled', type: 'boolean', nullable: false, options: ['default' => false])]
+    protected $publicParticipationPublicationEnabled = false;
 
     /**
      * @var string

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/ProcedureSettings.php
@@ -258,7 +258,7 @@ class ProcedureSettings extends CoreEntity implements UuidEntityInterface, Proce
      * Enable publication of Feedback possibility.
      */
     #[ORM\Column(name: '_p_public_participation_feedback_enabled', type: 'boolean', nullable: false, options: ['default' => true])]
-    protected bool $publicParticipationFeedbackEnabled = false;
+    protected bool $publicParticipationFeedbackEnabled = true;
 
     public function __construct()
     {


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-18005/ADO-55976-Default-Einstellung-zu-Beteiligungsschritt-Offentlichkeit-anpassen

Two checkboxes in the public participation settings had wrong default values when creating a new procedure:

- "Veröffentlichung von Stellungnahmen" was checked by default — it should be unchecked (planners must opt in)
- "Rückmeldung zu Stellungnahme" was unchecked by default — it should be checked (required by BauGB)

Both are fixed via a migration that corrects the column defaults and backfills existing data.

**Note for deployers: After running the migration, blueprint procedures in all projects will have the publication checkbox unchecked. Projects that want it checked by default (e.g. robobsh) need to update their blueprint once via the UI.**

**How to review/test**

1. Create a new procedure in diplanbau
2. Open the procedure settings → "Verfahrensschritt Öffentlichkeit"
3. "Veröffentlichung von Stellungnahmen" → should be unchecked
4. "Rückmeldung zu Stellungnahme" → should be checked