### PR TITLE
F dplan 17492 activate content change history for locked segments

### DIFF
--- a/config/entity_content_change_fields_mapping.yml
+++ b/config/entity_content_change_fields_mapping.yml
@@ -26,7 +26,6 @@ parameters:
             locked:
                 fieldType: "string"
                 translationKey: "segment.locked"
-                getterMethod: "isLocked"
                 noHighlighting: true
             text:
                 fieldType: "tipTapHtmlString"

--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -312,8 +312,7 @@ class SegmentsExportController extends BaseController
                             $tableHeaders,
                             $censorCitizenData,
                             $censorInstitutionData,
-                            $obscureParameter,
-                            $this->statementExportTagFilter->getFilteredTagsWithTitles()
+                            $obscureParameter
                         );
                         $writer = IOFactory::createWriter($docx);
                         $zipExportService->addWriterToZipStream(

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Segment.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Segment.php
@@ -116,10 +116,8 @@ class Segment extends Statement implements SegmentInterface
     }
 
     /**
-     * Referenced as `getterMethod` for the `locked` field in
-     * `entity_content_change_fields_mapping.yml`. The mapping is read
-     * reflectively, so static analysis will not surface a caller — keep this
-     * method even though no PHP code invokes it directly.
+     * Used by the segment lock content change display — no PHP code calls this
+     * directly, so static analysis will not surface a caller.
      */
     public function isLocked(): bool
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeDisplayService.php
@@ -116,13 +116,11 @@ class EntityContentChangeDisplayService
         }
 
         /*
-         * Segment-lock feature: {{ @link Segment::isLocked }} exists and is
-         * wired as the getterMethod for `locked` in the mapping yaml, but it
-         * returns a bool. The stored content_change uses the translated
-         * full-word vocabulary ("Gesperrt"/"Entsperrt") chosen for
-         * readability. Feeding a string-cast bool ("1"/"") into a rollback
-         * walk over translated strings would corrupt the trace, so we bypass
-         * the generic path — see
+         * Segment-lock feature: {{ @link Segment::isLocked }} returns a bool,
+         * but the stored content_change uses the translated full-word
+         * vocabulary ("Gesperrt"/"Entsperrt"). Feeding a string-cast bool
+         * ("1"/"") into a rollback walk over translated strings would corrupt
+         * the trace, so we bypass the generic path — see
          * {{ @link EntityContentChangeDisplayService::renderLockByPlaceSwitchesJson }}.
          */
         if ('locked' === $fieldName) {
@@ -285,9 +283,9 @@ class EntityContentChangeDisplayService
      *
      * The rollback path needs the current entity value in the same
      * vocabulary as the stored diffs so it can walk backwards through them.
-     * {{ @see Segment::isLocked }} exists and is mapped as the getter for
-     * `locked`, but it returns a bool — and the stored content_change uses
-     * the translated full-word vocabulary ("Gesperrt"/"Entsperrt") chosen by
+     * {{ @see Segment::isLocked }} returns a bool, but the stored
+     * content_change uses the translated full-word vocabulary
+     * ("Gesperrt"/"Entsperrt") chosen by
      * {@link EntityContentChangeService::lockedDiffOptions} to keep the
      * diff readable on a binary toggle. The two don't compose: the rollback
      * walk would start from "1"/"" and try to apply diffs recorded as

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -208,7 +208,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         array $tableHeaders,
         bool $censorCitizenData,
         bool $censorInstitutionData,
-        bool $obscureParameter
+        bool $obscureParameter,
     ): PhpWord {
         $censored = $this->needsToBeCensored(
             $statement,

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -208,8 +208,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         array $tableHeaders,
         bool $censorCitizenData,
         bool $censorInstitutionData,
-        bool $obscureParameter,
-        array $exportFilteredByTagsWithTopics = [],
+        bool $obscureParameter
     ): PhpWord {
         $censored = $this->needsToBeCensored(
             $statement,


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-17492

### Description
activate content change history for locked segments.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
