### PR TITLE
chore: add stylelint group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,9 @@ updates:
       sentry:
         patterns:
           - "@sentry/*"
+      stylelint:
+        patterns:
+          - "stylelint*"
       uppy:
         patterns:
           - "@uppy/*"


### PR DESCRIPTION
stylelint and stylelint-config-standard-scss should always be updated together