### PR TITLE
F ds 490 reject authored after submitted on statement create (6408)

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentController.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Controller\Statement;
 
+use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Annotation\DplanPermissions;
@@ -28,6 +29,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\CountyService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\MunicipalityService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\PriorityAreaService;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDateOrderValidator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
@@ -154,6 +156,7 @@ class DemosPlanAssessmentController extends BaseController
         FileUploadService $fileUploadService,
         Request $request,
         ServiceOutput $serviceOutput,
+        StatementDateOrderValidator $statementDateOrderValidator,
         StatementHandler $statementHandler,
         StatementService $statementService,
         AssessmentHandler $assessmentHandler,
@@ -162,7 +165,12 @@ class DemosPlanAssessmentController extends BaseController
         $rParams = $request->request->all();
         $fParams = $fileUploadService->prepareFilesUpload($request, 'r_upload');
 
-        if (array_key_exists('r_action', $rParams) && 'new' === $rParams['r_action']) {
+        if (array_key_exists('r_action', $rParams) && 'new' === $rParams['r_action']
+            && $this->isAuthoredDateAfterSubmittedDate($rParams, $statementDateOrderValidator)) {
+            // authoredDate (Verfassungsdatum) must not be later than submittedDate (Einreichungsdatum);
+            // skip creation and re-render the form so the user can correct the dates.
+            $this->getMessageBag()->add('error', 'error.date.authored.after.submitted');
+        } elseif (array_key_exists('r_action', $rParams) && 'new' === $rParams['r_action']) {
             try {
                 if (null !== $fParams && '' !== $fParams) {
                     $rParams['fileupload'] = $fParams;
@@ -213,6 +221,26 @@ class DemosPlanAssessmentController extends BaseController
                 'templateVars' => $templateVars,
                 'title'        => 'statement.new',
             ]
+        );
+    }
+
+    /**
+     * Manual statement creation must reject an authoredDate (Verfassungsdatum) that is later than the
+     * submittedDate (Einreichungsdatum). The frontend datepicker already caps the selectable range, but
+     * a user can bypass that by typing directly into the input, so the order is enforced on the backend
+     * too. Both inputs are submitted in d.m.Y format. The actual comparison is delegated to the shared
+     * validator that the edit route uses as well, so the rule cannot drift between create and edit.
+     *
+     * @param array<string, mixed> $rParams
+     */
+    private function isAuthoredDateAfterSubmittedDate(array $rParams, StatementDateOrderValidator $validator): bool
+    {
+        $authored = DateTime::createFromFormat('d.m.Y', (string) ($rParams['r_authored_date'] ?? ''));
+        $submitted = DateTime::createFromFormat('d.m.Y', (string) ($rParams['r_submitted_date'] ?? ''));
+
+        return $validator->isAuthoredAfterSubmitted(
+            $authored instanceof DateTime ? $authored : null,
+            $submitted instanceof DateTime ? $submitted : null,
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceStorage.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceStorage.php
@@ -33,6 +33,7 @@ use demosplan\DemosPlanCoreBundle\Logic\FileService;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\PrepareReportFromProcedureService;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDateOrderValidator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDeleter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementEmailSender;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
@@ -108,6 +109,7 @@ class AssessmentTableServiceStorage
         private readonly StatementDeleter $statementDeleter,
         FileService $fileService,
         UserService $userService, private readonly StatementEmailSender $statementEmailSender,
+        private readonly StatementDateOrderValidator $statementDateOrderValidator,
     ) {
         $this->config = $config;
         $this->mailService = $mailService;
@@ -416,7 +418,7 @@ class AssessmentTableServiceStorage
             return false;
         }
 
-        return $proposedAuthored->format('Ymd') > $proposedSubmitted->format('Ymd');
+        return $this->statementDateOrderValidator->isAuthoredAfterSubmitted($proposedAuthored, $proposedSubmitted);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDateOrderValidator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDateOrderValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
+
+use DateTimeInterface;
+
+/**
+ * Single source of truth for the cross-field rule shared by the statement create and edit routes:
+ * the authoredDate (Verfassungsdatum) must not be later than the submittedDate (Einreichungsdatum).
+ *
+ * Callers are responsible for parsing their own input (raw request params vs. statement array) and
+ * for deciding whether the check applies at all (e.g. the edit route skips it when neither date
+ * changed, so a Bestandsstatement with pre-existing invalid dates stays editable). The actual
+ * comparison lives here so it cannot drift between the two routes.
+ */
+class StatementDateOrderValidator
+{
+    /**
+     * Day-precise comparison. If either date is missing/unparseable there is nothing to compare,
+     * so the order is considered valid.
+     */
+    public function isAuthoredAfterSubmitted(?DateTimeInterface $authored, ?DateTimeInterface $submitted): bool
+    {
+        if (!$authored instanceof DateTimeInterface || !$submitted instanceof DateTimeInterface) {
+            return false;
+        }
+
+        return $authored->format('Ymd') > $submitted->format('Ymd');
+    }
+}

--- a/tests/backend/core/Statement/Unit/StatementDateOrderValidatorTest.php
+++ b/tests/backend/core/Statement/Unit/StatementDateOrderValidatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Unit;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDateOrderValidator;
+use PHPUnit\Framework\TestCase;
+
+class StatementDateOrderValidatorTest extends TestCase
+{
+    private StatementDateOrderValidator $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = new StatementDateOrderValidator();
+    }
+
+    /**
+     * @dataProvider authoredAfterSubmittedProvider
+     */
+    public function testIsAuthoredAfterSubmitted(
+        ?DateTimeInterface $authored,
+        ?DateTimeInterface $submitted,
+        bool $expected,
+    ): void {
+        self::assertSame($expected, $this->sut->isAuthoredAfterSubmitted($authored, $submitted));
+    }
+
+    /**
+     * @return array<string, array{0: ?DateTimeInterface, 1: ?DateTimeInterface, 2: bool}>
+     */
+    public static function authoredAfterSubmittedProvider(): array
+    {
+        return [
+            'authored after submitted -> true' => [
+                new DateTime('2020-01-10'), new DateTime('2020-01-05'), true,
+            ],
+            'authored equals submitted (same day, different time) -> false' => [
+                new DateTime('2020-01-05 00:00:00'), new DateTime('2020-01-05 12:00:00'), false,
+            ],
+            'authored before submitted -> false' => [
+                new DateTime('2020-01-01'), new DateTime('2020-01-05'), false,
+            ],
+            'immutable inputs are accepted' => [
+                new DateTimeImmutable('2020-02-02'), new DateTimeImmutable('2020-01-01'), true,
+            ],
+            'missing authored -> false' => [
+                null, new DateTime('2020-01-05'), false,
+            ],
+            'missing submitted -> false' => [
+                new DateTime('2020-01-05'), null, false,
+            ],
+            'both missing -> false' => [
+                null, null, false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-490/BOB-SH-ROBOB-Stage-Beim-nachtraglichen-Andern-einer-STN-kann-Verfassungsdatum-grosser-Einreichungsdatum-eingetragen-werden

Description: picked from https://github.com/demos-europe/demosplan-core/pull/6408



- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
-
