### PR TITLE
feat (DPLAN-17697): introduce parameter to set as reply to address for account deletion mails

### DIFF
--- a/.env
+++ b/.env
@@ -124,6 +124,12 @@ LOCK_DSN=flock
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###
 
+###> account_deletion ###
+# Support e-mail shown in warning mails and used as replyTo address.
+# Falls back to the system e-mail when unset or empty.
+ACCOUNT_DELETION_SUPPORT_EMAIL=
+###< account_deletion ###
+
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -63,6 +63,9 @@ parameters:
     account_deletion.first_warning_days: ~
     account_deletion.warning_step_days: 30
     account_deletion.additional_protected_user_ids: []
+    # Support e-mail shown in warning mails and used as replyTo.
+    # Override per project in parameters_default_project.yml.
+    account_deletion.support_email: 'youtrack.helpdesk@demos-deutschland.de'
 
     # Route and parameters for the public index page
     #

--- a/config/parameters_default.yml
+++ b/config/parameters_default.yml
@@ -64,8 +64,9 @@ parameters:
     account_deletion.warning_step_days: 30
     account_deletion.additional_protected_user_ids: []
     # Support e-mail shown in warning mails and used as replyTo.
-    # Override per project in parameters_default_project.yml.
-    account_deletion.support_email: 'youtrack.helpdesk@demos-deutschland.de'
+    # Set ACCOUNT_DELETION_SUPPORT_EMAIL env var per instance; falls back to
+    # the system e-mail address when the env var is unset or empty.
+    account_deletion.support_email: '%env(default::ACCOUNT_DELETION_SUPPORT_EMAIL)%'
 
     # Route and parameters for the public index page
     #

--- a/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
@@ -252,17 +252,19 @@ final class AccountDeletionRunMessageHandler
         array $vars = [],
     ): ?MailSend {
         try {
+            $supportEmail = (string) $this->parameterBag->get('account_deletion.support_email');
+
             $body = $this->twig->load($bodyTemplate)->renderBlock(
                 'body_plain',
                 [
                     'templateVars' => array_merge(
                         [
-                            'firstname' => $user->getFirstname(),
-                            'lastname'  => $user->getLastname(),
+                            'firstname'     => $user->getFirstname(),
+                            'lastname'      => $user->getLastname(),
+                            'support_email' => $supportEmail,
                         ],
                         $vars,
                     ),
-                    'projectName'  => $this->globalConfig->getProjectName(),
                 ],
             );
             $subject = $this->translator->trans($subjectKey, $vars);
@@ -271,7 +273,7 @@ final class AccountDeletionRunMessageHandler
                 'dm_stellungnahme',
                 'de_DE',
                 $user->getEmail(),
-                '',
+                $supportEmail,
                 '',
                 '',
                 MailSend::MAIL_SCOPE_EXTERN,

--- a/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
@@ -253,6 +253,7 @@ final class AccountDeletionRunMessageHandler
     ): ?MailSend {
         try {
             $supportEmail = (string) $this->parameterBag->get('account_deletion.support_email');
+            $replyTo = '' !== $supportEmail ? $supportEmail : $this->globalConfig->getEmailSystem();
 
             $body = $this->twig->load($bodyTemplate)->renderBlock(
                 'body_plain',
@@ -273,7 +274,7 @@ final class AccountDeletionRunMessageHandler
                 'dm_stellungnahme',
                 'de_DE',
                 $user->getEmail(),
-                $supportEmail,
+                $replyTo,
                 '',
                 '',
                 MailSend::MAIL_SCOPE_EXTERN,

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_completed.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_completed.html.twig
@@ -5,7 +5,9 @@ Sehr geehrte/r {{ templateVars.firstname }} {{ templateVars.lastname }},
 
 Ihr Konto wurde aufgrund von Inaktivität gemäß den geltenden Datenschutzrichtlinien gelöscht.
 
+Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
+
 Mit freundlichen Grüßen
-Ihr Support-Team {{ projectName }}
+Ihr DEMOS Support Team
 
 {% endblock body_plain %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_completed.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_completed.html.twig
@@ -5,8 +5,10 @@ Sehr geehrte/r {{ templateVars.firstname }} {{ templateVars.lastname }},
 
 Ihr Konto wurde aufgrund von Inaktivität gemäß den geltenden Datenschutzrichtlinien gelöscht.
 
+{% if templateVars.support_email %}
 Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
 
+{% endif %}
 Mit freundlichen Grüßen
 Ihr DEMOS Support Team
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_first.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_first.html.twig
@@ -7,8 +7,10 @@ Ihr Konto ist seit längerer Zeit inaktiv. Aus datenschutzrechtlichen Gründen w
 
 Um Ihr Konto zu erhalten, melden Sie sich bitte erneut an.{{ templateVars.link_section|raw }}
 
+{% if templateVars.support_email %}
 Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
 
+{% endif %}
 Mit freundlichen Grüßen
 Ihr DEMOS Support Team
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_first.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_first.html.twig
@@ -7,7 +7,9 @@ Ihr Konto ist seit längerer Zeit inaktiv. Aus datenschutzrechtlichen Gründen w
 
 Um Ihr Konto zu erhalten, melden Sie sich bitte erneut an.{{ templateVars.link_section|raw }}
 
+Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
+
 Mit freundlichen Grüßen
-Ihr Support-Team {{ projectName }}
+Ihr DEMOS Support Team
 
 {% endblock body_plain %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_second.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_second.html.twig
@@ -7,8 +7,10 @@ wir hatten Sie bereits darauf hingewiesen, dass Ihr Konto wegen Inaktivität gel
 
 Ihr Konto wird am {{ templateVars.deletion_date }} gelöscht, sofern Sie sich bis dahin nicht anmelden.{{ templateVars.link_section|raw }}
 
+{% if templateVars.support_email %}
 Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
 
+{% endif %}
 Mit freundlichen Grüßen
 Ihr DEMOS Support Team
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_second.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_account_deletion_warning_second.html.twig
@@ -7,7 +7,9 @@ wir hatten Sie bereits darauf hingewiesen, dass Ihr Konto wegen Inaktivität gel
 
 Ihr Konto wird am {{ templateVars.deletion_date }} gelöscht, sofern Sie sich bis dahin nicht anmelden.{{ templateVars.link_section|raw }}
 
+Bei Fragen stehen wir Ihnen gerne unter <a href="mailto:{{ templateVars.support_email }}">{{ templateVars.support_email }}</a> zur Verfügung.
+
 Mit freundlichen Grüßen
-Ihr Support-Team {{ projectName }}
+Ihr DEMOS Support Team
 
 {% endblock body_plain %}

--- a/tests/backend/core/MessageHandler/AccountDeletionRunMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/AccountDeletionRunMessageHandlerTest.php
@@ -80,6 +80,7 @@ class AccountDeletionRunMessageHandlerTest extends UnitTestCase
         $this->parameterBag->method('get')->willReturnCallback(
             static fn (string $name) => match ($name) {
                 'account_deletion.first_warning_days' => 30,
+                'account_deletion.support_email'      => 'support@test.example',
                 default                               => null,
             }
         );
@@ -140,7 +141,7 @@ class AccountDeletionRunMessageHandlerTest extends UnitTestCase
                 $this->callback(fn (array $mail) => 'email.subject.account_deletion.warning_first' === ($mail['mailsubject'] ?? null)
                     && str_contains($mail['mailbody'] ?? '', 'Test')
                     && str_contains($mail['mailbody'] ?? '', 'User')
-                    && str_contains($mail['mailbody'] ?? '', 'Support-Team'))
+                    && str_contains($mail['mailbody'] ?? '', 'DEMOS Support Team'))
             )
             ->willReturn($mailSend);
 


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-17697

### Description
swap out reply to address for account deletion mails - also plug that address into the mail twig templates - adjust wording


- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog 
