### PR TITLE
fix(refs DPLAN-17527): Hide delete-button for the release

### DIFF
--- a/client/js/components/procedurePhasesDefinition/ProcedurePhasesDefinition.vue
+++ b/client/js/components/procedurePhasesDefinition/ProcedurePhasesDefinition.vue
@@ -119,7 +119,6 @@ All rights reserved
           <div class="overflow-x-auto pb-3 has-scrollable-content">
             <dp-data-table
               :data-cy="`procedurePhases:dataTable:${section.audience}`"
-              :flyout-width="flyoutWidth"
               :header-fields="headerFields"
               :items="section.audiencePhases"
               density="spacious"
@@ -222,7 +221,7 @@ All rights reserved
                       :aria-label="Translator.trans('item.delete')"
                       :data-cy="`procedurePhases:delete:${rowData.id}`"
                       :title="Translator.trans('delete')"
-                      class="btn--blank o-link--default"
+                      class="btn--blank o-link--default hidden"
                       disabled
                     >
                       <dp-icon
@@ -322,7 +321,7 @@ export default {
       { label: Translator.trans('permissionset.write'), value: 'write' },
     ]
 
-    const flyoutWidth = ref('80px')
+    // const flyoutWidth = ref('80px')
     const hasAttemptedSubmit = ref(false)
 
     const isNewPhaseNameInvalid = computed(() =>
@@ -838,7 +837,7 @@ export default {
       draftCoreRowValue,
       editingRowId,
       findPermissionSetOption,
-      flyoutWidth,
+      // flyoutWidth,
       handleAddonEditChange,
       handleAddonEditStart,
       handleSaveEditClick,

--- a/client/js/components/procedurePhasesDefinition/ProcedurePhasesDefinition.vue
+++ b/client/js/components/procedurePhasesDefinition/ProcedurePhasesDefinition.vue
@@ -321,7 +321,7 @@ export default {
       { label: Translator.trans('permissionset.write'), value: 'write' },
     ]
 
-    // const flyoutWidth = ref('80px')
+    //  Uncomment once delete functionality implemented: const flyoutWidth = ref('80px')
     const hasAttemptedSubmit = ref(false)
 
     const isNewPhaseNameInvalid = computed(() =>
@@ -837,7 +837,7 @@ export default {
       draftCoreRowValue,
       editingRowId,
       findPermissionSetOption,
-      // flyoutWidth,
+      // Uncomment once delete functionality implemented: flyoutWidth,
       handleAddonEditChange,
       handleAddonEditStart,
       handleSaveEditClick,


### PR DESCRIPTION
### Ticket
[DPLAN-17527](https://demoseurope.youtrack.cloud/issue/DPLAN-17527/Altes-ticket-ADO-50748-Bearbeiten-von-custom-Verfahrensschritten)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR hides the delete-icon in DpDataTable and applies the default flyout-width (removes the prop for now). These will be reintroduced (code uncommented) once the delete functionality has been implemented.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

### Linked PRs 
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
https://github.com/demos-europe/demosplan-core/pull/6347



