### PR TITLE
chore(refs: DPLAN-17918): add targeted babel TypeScript override for .vue and .ts

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,7 +24,7 @@ const config = {
   ],
   overrides: [
     {
-      test: /\.vue/,
+      test: /\.vue$/,
       presets: [['@babel/preset-typescript', { allExtensions: true }]],
     },
     {

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,22 +16,31 @@ const config = {
       corejs: '3.9',
       useBuiltIns: 'usage',
     }],
-    '@babel/preset-typescript',
   ],
   plugins: [
     '@babel/transform-runtime',
     '@babel/proposal-object-rest-spread',
     '@babel/syntax-dynamic-import',
   ],
-  overrides: [{
-    plugins: [
-      '@babel/transform-runtime',
-      '@babel/proposal-object-rest-spread',
-      '@babel/syntax-dynamic-import',
-      '@babel/transform-object-assign',
-      '@babel/transform-modules-commonjs',
-    ],
-  }],
+  overrides: [
+    {
+      test: /\.vue/,
+      presets: [['@babel/preset-typescript', { allExtensions: true }]],
+    },
+    {
+      test: /\.[mc]?tsx?$/,
+      presets: ['@babel/preset-typescript'],
+    },
+    {
+      plugins: [
+        '@babel/transform-runtime',
+        '@babel/proposal-object-rest-spread',
+        '@babel/syntax-dynamic-import',
+        '@babel/transform-object-assign',
+        '@babel/transform-modules-commonjs',
+      ],
+    },
+  ],
 }
 
 module.exports = config


### PR DESCRIPTION
<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adds targeted Babel TypeScript overrides for .vue and .ts files instead of a single global preset. This is needed, because we decided to write new components in composition API with TypeScript (like in DPLAN-17918 now needed). The .vue override uses `allExtensions: true` so Babel processes TypeScript syntax (interfaces, generics) inside `<script lang="ts">` blocks. The .ts override applies standard TypeScript without "allExtensions".

This is a prerequisite for using TypeScript syntax in vue files in this project and it limits TypeScript processing to the relevant file types only, .vue, .ts, .tsx, .cts and .mts.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

Build should work fine even if TypeScript is used in vue files

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
