### PR TITLE
fix use flattened phase definition keys in statement report

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Report/StatementReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/StatementReportEntryFactory.php
@@ -410,8 +410,8 @@ class StatementReportEntryFactory extends AbstractReportEntryFactory
             $statement['procedure'] = [
                 'id'                       => $statement['procedure']['id'],
                 'name'                     => $statement['procedure']['name'],
-                'phase'                    => $statement['procedure']['phaseDefinitionName'] ?? null,
-                'publicParticipationPhase' => $statement['procedure']['publicParticipationPhaseDefinitionName'] ?? null,
+                'phase'                    => $statement['procedure']['phaseDefinitionName'],
+                'publicParticipationPhase' => $statement['procedure']['publicParticipationPhaseDefinitionName'],
             ];
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/StatementReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/StatementReportEntryFactory.php
@@ -410,8 +410,8 @@ class StatementReportEntryFactory extends AbstractReportEntryFactory
             $statement['procedure'] = [
                 'id'                       => $statement['procedure']['id'],
                 'name'                     => $statement['procedure']['name'],
-                'phase'                    => $statement['procedure']['phaseObject']['phaseDefinition']['name'],
-                'publicParticipationPhase' => $statement['procedure']['publicParticipationPhaseObject']['phaseDefinition']['name'],
+                'phase'                    => $statement['procedure']['phaseDefinitionName'] ?? null,
+                'publicParticipationPhase' => $statement['procedure']['publicParticipationPhaseDefinitionName'] ?? null,
             ];
         }
 


### PR DESCRIPTION
Description: 

The procedure phase-definition refactor (commit a9e6b34051) changed StatementReportEntryFactory::stripStatementReportData() to read the procedure phase via the nested paths procedure.phaseObject.phaseDefinition.name and procedure.publicParticipationPhaseObject.phaseDefinition.name.

However, the array passed into that method is produced by StatementToLegacyConverter, which never sets those nested keys — it exposes the same phase-definition names under the flattened keys phaseDefinitionName and publicParticipationPhaseDefinitionName. As a result, every statement-report entry (statement created / submitted) emitted an Undefined array key "publicParticipationPhaseObject" warning and silently stored null for the phase in the report message.

This PR points the consumer at the flattened keys the converter actually provides (which hold exactly the value the broken code intended), and guards them with null coalescing for the edge case where procedure conversion failed and the keys are absent. The output keys written to the report (phase / publicParticipationPhase) are unchanged, so the report display side is unaffected.
