### PR TITLE
fix(DS-555): prevent crash and HTML corruption when deleting segments…

### DIFF
--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -793,15 +793,19 @@ export default {
         this.prosemirror.view.dispatch(tr)
         this.updateTextualReference()
       } else {
-        // Prosemirror has no mark for this segment (e.g. it failed to parse a duplicate-ID mark).
-        // Re-serializing from Prosemirror would silently drop any other marks it also missed.
-        // Instead, strip only this segment's <segment-mark> tags directly from the stored HTML.
+        /*
+         * Prosemirror has no mark for this segment (e.g. it failed to parse a duplicate-ID mark).
+         * Re-serializing from Prosemirror would silently drop any other marks it also missed.
+         * Instead, strip only this segment's <segment-mark> tags directly from the stored HTML.
+         */
         const stripped = (this.initText || '').replace(
           new RegExp(`<segment-mark[^>]*data-segment-id="${segmentId}"[^>]*>(.*?)<\\/segment-mark>`, 'gs'),
-          '$1'
+          '$1',
         )
+
         this.setProperty({ prop: 'initText', val: stripped })
       }
+
       this.ignoreProsemirrorUpdates = false
       this.deleteSegmentAction(segmentId)
       this.isSegmentDraftUpdated = true

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -789,9 +789,20 @@ export default {
       })
 
       this.ignoreProsemirrorUpdates = true
-      this.prosemirror.view.dispatch(tr)
+      if (tr !== null) {
+        this.prosemirror.view.dispatch(tr)
+        this.updateTextualReference()
+      } else {
+        // Prosemirror has no mark for this segment (e.g. it failed to parse a duplicate-ID mark).
+        // Re-serializing from Prosemirror would silently drop any other marks it also missed.
+        // Instead, strip only this segment's <segment-mark> tags directly from the stored HTML.
+        const stripped = (this.initText || '').replace(
+          new RegExp(`<segment-mark[^>]*data-segment-id="${segmentId}"[^>]*>(.*?)<\\/segment-mark>`, 'gs'),
+          '$1'
+        )
+        this.setProperty({ prop: 'initText', val: stripped })
+      }
       this.ignoreProsemirrorUpdates = false
-      this.updateTextualReference()
       this.deleteSegmentAction(segmentId)
       this.isSegmentDraftUpdated = true
       this.setCurrentTime()


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-555

Description: 

On the first open of the segmentation editor for AI-generated proposals (demospipes), segments were being deleted from the database and textualReference was getting corrupted — before the user had done anything at all.

How the bug was found

The issue was identified by comparing the raw JSON payload received from DATA/PI (see ticket) directly against what was stored in draftsListJson in the DB after the first open of the editor (see ticket). The PI artifact contained 4 segments; the DB contained only 2. Since the backend stores the PI JSON verbatim (no transformation), the data loss had to originate in the frontend — specifically during the automatic first-open initialization before any user interaction. 

Background: How PI proposals are processed

DATA/PI sends segmentation proposals as JSON with two fields:
- segments[] — segment metadata (ID, tags, text)
- textualReference — the statement text as HTML, with <segment-mark data-segment-id="..."> wrapping each text region

The backend stores this JSON verbatim in draftsListJson. That is correct and intentional.

On first open, the frontend reads the JSON, detects hasProsemirrorIndex === false, and immediately writes it back to the DB with hasProsemirrorIndex: true — before the user clicks anything. At the same time, Prosemirror initializes the editor by parsing the textualReference HTML.

The problem: immediatelyDeleteSegment

PI can intentionally assign the same segment ID to multiple <segment-mark> elements across different <p> blocks to represent a single segment that covers two non-adjacent text regions (e.g. a heading paragraph + the body paragraph below it). This is by design.

Prosemirror works with marks at the inline level. When the same ID appears across two separate <p> blocks, Prosemirror cannot unambiguously resolve those marks internally and silently drops some of them during parsing. The segment then exists in the Vuex store but has no position in the Prosemirror document.

When immediatelyDeleteSegment was called for such a segment, two bugs were triggered:

Bug 1 — Crash:
// getSegmentMarkRangesById returns [] → forEach never runs → tr stays null
this.prosemirror.view.dispatch(tr)  // TypeError: dispatch(null)

Bug 2 — Data loss:
// Even with no tr, updateTextualReference() was called unconditionally.
// This re-serializes the entire Prosemirror document.
// Prosemirror has no knowledge of the dropped marks → their <segment-mark>
// tags are absent from the output.
// This corrupted initText is then written to the DB on the next saveSegmentsDrafts().
this.updateTextualReference()

Result: 4 segments arrived from PI; after first open only 2 remained in the DB.

The fix

In immediatelyDeleteSegment in SplitStatementView.vue:

if (tr !== null) {
  // Prosemirror found the mark → remove it normally and re-serialize
  this.prosemirror.view.dispatch(tr)
  this.updateTextualReference()
} else {
  // Prosemirror has no mark for this segment (e.g. non-contiguous marks across blocks).
  // Re-serializing would silently strip other marks Prosemirror also missed.
  // Instead: strip only this segment's <segment-mark> tags directly from the stored HTML.
  const stripped = (this.initText || '').replace(
    new RegExp(`<segment-mark[^>]*data-segment-id="${segmentId}"[^>]*>(.*?)<\\/segment-mark>`, 'gs'),
    '$1'
  )
  this.setProperty({ prop: 'initText', val: stripped })
}

- The crash is fixed — dispatch(null) no longer happens
- updateTextualReference() is only called when Prosemirror actually had the mark and just removed it — the re-serialization is safe in that case
- When Prosemirror had no mark, only the deleted segment's <segment-mark> tags are stripped via regex directly from the stored HTML — all other segments are left untouched (the g flag handles duplicate IDs, s handles multi-line content inside the tag)

---
How to review/test

1. Retrieve the raw PI artifact JSON for a statement (e.g. from the piSegmentsProposalResourceUrl stored on the statement) and note the segment count and all segment IDs
2. Open the segmentation editor for that statement
3. Compare draftsListJson in the DB after first open against the PI artifact — segment count and textualReference must be identical
4. Accept a proposal — it should save correctly
5. Reject (delete) a proposal — that segment should disappear from the sidebar and from the HTML; all others must remain intact

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

