### PR TITLE
fix add on-the-fly migration of old-format draftsListJson at read time

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
+
+/**
+ * Converts old-format draftsListJson (segments with charStart/charEnd positions, no <segment-mark>
+ * tags in textualReference) to the new format expected by the segment editor.
+ *
+ * Old format: segments carry charStart/charEnd Prosemirror positions; textualReference is plain HTML.
+ * New format: textualReference contains <segment-mark data-segment-id="..."> wrappers; no positions.
+ *
+ * Runs on-the-fly at read time — does not write back to the database.
+ */
+class DraftsListJsonMigrator
+{
+    public function needsMigration(array $data): bool
+    {
+        $segments = $data['data']['attributes']['segments'] ?? [];
+        $textualReference = $data['data']['attributes']['textualReference'] ?? '';
+
+        return !empty($segments)
+            && isset($segments[0]['charStart'])
+            && !str_contains($textualReference, '<segment-mark');
+    }
+
+    public function migrate(array $data): array
+    {
+        $segments = $data['data']['attributes']['segments'];
+        $textualReference = $data['data']['attributes']['textualReference'];
+
+        // Process in document order so substr_replace offsets stay valid after each insertion.
+        // charStart may be a Prosemirror position (not an HTML offset), but relative order is preserved.
+        usort($segments, static fn(array $a, array $b): int => ($a['charStart'] ?? 0) - ($b['charStart'] ?? 0));
+
+        foreach ($segments as $segment) {
+            $text = $segment['text'] ?? '';
+            if ('' === $text) {
+                continue;
+            }
+
+            $pos = strpos($textualReference, $text);
+            if (false === $pos) {
+                // Segment text not found verbatim — leave textualReference untouched for this segment
+                // rather than risk corrupting the HTML.
+                continue;
+            }
+
+            $marked = sprintf('<segment-mark data-segment-id="%s">%s</segment-mark>', $segment['id'], $text);
+            $textualReference = substr_replace($textualReference, $marked, $pos, strlen($text));
+        }
+
+        $data['data']['attributes']['textualReference'] = $textualReference;
+
+        $data['data']['attributes']['segments'] = array_map(static function (array $segment): array {
+            unset(
+                $segment['charStart'],
+                $segment['charEnd'],
+                $segment['charStartInit'],
+                $segment['charEndInit'],
+                $segment['hasProsemirrorIndex']
+            );
+
+            return $segment;
+        }, $segments);
+
+        return $data;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 /**
- * (c) 2010-present DEMOS plan GmbH.
+ * This file is part of the package demosplan.
  *
- * This file is part of the package demosplan,
- * for more information see the license file.
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
  *
  * All rights reserved
  */
@@ -41,7 +40,7 @@ class DraftsListJsonMigrator
 
         // Process in document order so substr_replace offsets stay valid after each insertion.
         // charStart may be a Prosemirror position (not an HTML offset), but relative order is preserved.
-        usort($segments, static fn(array $a, array $b): int => ($a['charStart'] ?? 0) - ($b['charStart'] ?? 0));
+        usort($segments, static fn (array $a, array $b): int => ($a['charStart'] ?? 0) - ($b['charStart'] ?? 0));
 
         foreach ($segments as $segment) {
             $text = $segment['text'] ?? '';

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -32,6 +32,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use demosplan\DemosPlanCoreBundle\Logic\Map\CoordinateJsonConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedurePhaseDefinitionService;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonMigrator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDeleter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
@@ -78,6 +79,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
 {
     public function __construct(
         HTMLSanitizer $htmlSanitizer,
+        private readonly DraftsListJsonMigrator $draftsListJsonMigrator,
         private readonly JsonApiEsService $jsonApiEsService,
         private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
         private readonly QueryStatement $esQuery,
@@ -393,10 +395,17 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                     return [];
                 })
                 ->aliasedPath(Paths::statement()->draftsListJson)
-                ->readable(false, static function (Statement $statement): ?array {
+                ->readable(false, function (Statement $statement): ?array {
                     $draftsListJson = $statement->getDraftsListJson();
+                    if ('' === $draftsListJson) {
+                        return null;
+                    }
+                    $data = Json::decodeToArray($draftsListJson);
+                    if ($this->draftsListJsonMigrator->needsMigration($data)) {
+                        $data = $this->draftsListJsonMigrator->migrate($data);
+                    }
 
-                    return '' === $draftsListJson ? null : Json::decodeToArray($draftsListJson);
+                    return $data;
                 });
             $configBuilder->status->readable(true, fn (Statement $statement) => $this->statementService->getProcessingStatus($statement))->filterable();
         }

--- a/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Logic\Statement;
+
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonMigrator;
+use PHPUnit\Framework\TestCase;
+
+class DraftsListJsonMigratorTest extends TestCase
+{
+    private ?DraftsListJsonMigrator $sut = null;
+
+    protected function setUp(): void
+    {
+        $this->sut = new DraftsListJsonMigrator();
+    }
+
+    // --- needsMigration ---
+
+    public function testNeedsMigrationReturnsTrueForOldFormat(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            '<p>Sky is blue.</p><p>Grass is green.</p>',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => '<p>Sky is blue.</p>'],
+                ['id' => 'seg-2', 'charStart' => 6, 'charEnd' => 10, 'text' => '<p>Grass is green.</p>'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertTrue($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenSegmentMarkAlreadyPresent(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1"><p>Sky is blue.</p></segment-mark>',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => '<p>Sky is blue.</p>'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseForEmptySegments(): void
+    {
+        // Arrange
+        $data = $this->buildData('<p>Some text.</p>', []);
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenNoCharStartField(): void
+    {
+        // Arrange — new format: segments have no charStart
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1"><p>Sky is blue.</p></segment-mark>',
+            [
+                ['id' => 'seg-1', 'text' => '<p>Sky is blue.</p>'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    // --- migrate: example 1 — plain paragraphs ---
+
+    public function testMigrateWrapsEachSegmentTextWithSegmentMark(): void
+    {
+        // Arrange
+        $textA = '<p>Sky is blue.</p>';
+        $textB = '<p>Grass is green.</p>';
+        $data = $this->buildData(
+            $textA . $textB,
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => $textA],
+                ['id' => 'seg-2', 'charStart' => 6, 'charEnd' => 10, 'text' => $textB],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertSame(
+            '<segment-mark data-segment-id="seg-1">' . $textA . '</segment-mark>'
+            . '<segment-mark data-segment-id="seg-2">' . $textB . '</segment-mark>',
+            $ref
+        );
+    }
+
+    public function testMigrateRemovesPositionFieldsFromAllSegments(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            '<p>Sky is blue.</p>',
+            [
+                [
+                    'id'                => 'seg-1',
+                    'charStart'         => 0,
+                    'charEnd'           => 5,
+                    'charStartInit'     => 0,
+                    'charEndInit'       => 5,
+                    'hasProsemirrorIndex' => true,
+                    'text'              => '<p>Sky is blue.</p>',
+                ],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $segment = $result['data']['attributes']['segments'][0];
+
+        // Assert
+        self::assertArrayNotHasKey('charStart', $segment);
+        self::assertArrayNotHasKey('charEnd', $segment);
+        self::assertArrayNotHasKey('charStartInit', $segment);
+        self::assertArrayNotHasKey('charEndInit', $segment);
+        self::assertArrayNotHasKey('hasProsemirrorIndex', $segment);
+        self::assertSame('seg-1', $segment['id']);
+    }
+
+    public function testMigrateSortsSegmentsByCharStartBeforeProcessing(): void
+    {
+        // Arrange — segments are intentionally out of document order
+        $textA = '<p>First sentence.</p>';
+        $textB = '<p>Second sentence.</p>';
+        $data = $this->buildData(
+            $textA . $textB,
+            [
+                ['id' => 'seg-b', 'charStart' => 10, 'charEnd' => 15, 'text' => $textB],
+                ['id' => 'seg-a', 'charStart' => 0,  'charEnd' => 5,  'text' => $textA],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert — both marks must be present; ordering them correctly is what prevents
+        // substr_replace from shifting offsets and breaking the second lookup
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">' . $textA . '</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">' . $textB . '</segment-mark>', $ref);
+    }
+
+    // --- migrate: example 2 — segment text contains a list ---
+
+    public function testMigrateHandlesListInSegmentText(): void
+    {
+        // Arrange
+        $textA = '<p>Intro paragraph.</p>';
+        $textB = '<ol><li>First item.</li><li>Second item.</li></ol>';
+        $textC = '<p>Closing paragraph.</p>';
+        $data = $this->buildData(
+            $textA . $textB . $textC,
+            [
+                ['id' => 'seg-a', 'charStart' => 0, 'charEnd' => 3, 'text' => $textA],
+                ['id' => 'seg-b', 'charStart' => 4, 'charEnd' => 7, 'text' => $textB],
+                ['id' => 'seg-c', 'charStart' => 8, 'charEnd' => 11, 'text' => $textC],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">' . $textA . '</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">' . $textB . '</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-c">' . $textC . '</segment-mark>', $ref);
+    }
+
+    public function testMigrateSkipsSegmentWhenTextNotFoundInTextualReference(): void
+    {
+        // Arrange — seg-b text does not appear in textualReference
+        $existingText = '<p>Only this exists.</p>';
+        $data = $this->buildData(
+            $existingText,
+            [
+                ['id' => 'seg-a', 'charStart' => 0, 'charEnd' => 5, 'text' => $existingText],
+                ['id' => 'seg-b', 'charStart' => 6, 'charEnd' => 10, 'text' => '<p>This is missing.</p>'],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">', $ref);
+        self::assertStringNotContainsString('<segment-mark data-segment-id="seg-b">', $ref);
+    }
+
+    // --- helpers ---
+
+    private function buildData(string $textualReference, array $segments): array
+    {
+        return [
+            'data' => [
+                'attributes' => [
+                    'textualReference' => $textualReference,
+                    'segments'         => $segments,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
@@ -86,7 +86,7 @@ class DraftsListJsonMigratorTest extends TestCase
         $textA = '<p>Sky is blue.</p>';
         $textB = '<p>Grass is green.</p>';
         $data = $this->buildData(
-            $textA . $textB,
+            $textA.$textB,
             [
                 ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => $textA],
                 ['id' => 'seg-2', 'charStart' => 6, 'charEnd' => 10, 'text' => $textB],
@@ -99,8 +99,8 @@ class DraftsListJsonMigratorTest extends TestCase
 
         // Assert
         self::assertSame(
-            '<segment-mark data-segment-id="seg-1">' . $textA . '</segment-mark>'
-            . '<segment-mark data-segment-id="seg-2">' . $textB . '</segment-mark>',
+            '<segment-mark data-segment-id="seg-1">'.$textA.'</segment-mark>'
+            .'<segment-mark data-segment-id="seg-2">'.$textB.'</segment-mark>',
             $ref
         );
     }
@@ -112,13 +112,13 @@ class DraftsListJsonMigratorTest extends TestCase
             '<p>Sky is blue.</p>',
             [
                 [
-                    'id'                => 'seg-1',
-                    'charStart'         => 0,
-                    'charEnd'           => 5,
-                    'charStartInit'     => 0,
-                    'charEndInit'       => 5,
+                    'id'                  => 'seg-1',
+                    'charStart'           => 0,
+                    'charEnd'             => 5,
+                    'charStartInit'       => 0,
+                    'charEndInit'         => 5,
                     'hasProsemirrorIndex' => true,
-                    'text'              => '<p>Sky is blue.</p>',
+                    'text'                => '<p>Sky is blue.</p>',
                 ],
             ]
         );
@@ -142,7 +142,7 @@ class DraftsListJsonMigratorTest extends TestCase
         $textA = '<p>First sentence.</p>';
         $textB = '<p>Second sentence.</p>';
         $data = $this->buildData(
-            $textA . $textB,
+            $textA.$textB,
             [
                 ['id' => 'seg-b', 'charStart' => 10, 'charEnd' => 15, 'text' => $textB],
                 ['id' => 'seg-a', 'charStart' => 0,  'charEnd' => 5,  'text' => $textA],
@@ -155,8 +155,8 @@ class DraftsListJsonMigratorTest extends TestCase
 
         // Assert — both marks must be present; ordering them correctly is what prevents
         // substr_replace from shifting offsets and breaking the second lookup
-        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">' . $textA . '</segment-mark>', $ref);
-        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">' . $textB . '</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">'.$textA.'</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">'.$textB.'</segment-mark>', $ref);
     }
 
     // --- migrate: example 2 — segment text contains a list ---
@@ -168,7 +168,7 @@ class DraftsListJsonMigratorTest extends TestCase
         $textB = '<ol><li>First item.</li><li>Second item.</li></ol>';
         $textC = '<p>Closing paragraph.</p>';
         $data = $this->buildData(
-            $textA . $textB . $textC,
+            $textA.$textB.$textC,
             [
                 ['id' => 'seg-a', 'charStart' => 0, 'charEnd' => 3, 'text' => $textA],
                 ['id' => 'seg-b', 'charStart' => 4, 'charEnd' => 7, 'text' => $textB],
@@ -181,9 +181,9 @@ class DraftsListJsonMigratorTest extends TestCase
         $ref = $result['data']['attributes']['textualReference'];
 
         // Assert
-        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">' . $textA . '</segment-mark>', $ref);
-        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">' . $textB . '</segment-mark>', $ref);
-        self::assertStringContainsString('<segment-mark data-segment-id="seg-c">' . $textC . '</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-a">'.$textA.'</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-b">'.$textB.'</segment-mark>', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-c">'.$textC.'</segment-mark>', $ref);
     }
 
     public function testMigrateSkipsSegmentWhenTextNotFoundInTextualReference(): void


### PR DESCRIPTION
Description: 

The segment editor frontend exclusively uses the new format where `textualReference` contains `<segment-mark data-segment-id="...">` wrappers around each segment's text. Statements segmented before this format was introduced have their data stored in the old format: segments carry `charStart`/`charEnd` Prosemirror position offsets and `textualReference` is plain HTML without any `<segment-mark>` tags. Opening such a statement in the editor crashes because the frontend can no longer work with the old format at all.

This PR adds `DraftsListJsonMigrator`, a service that converts old-format `draftsListJson` to the new format transparently at read time in `StatementResourceType`. The migrator finds each segment's `text` verbatim in `textualReference` using string
matching and wraps it with the corresponding `<segment-mark>` tag, then strips the position fields (`charStart`, `charEnd`, `charStartInit`, `charEndInit`, `hasProsemirrorIndex`) from the segment objects.

The migration happens only once per statement: on first open, the editor detects the new format and persists it back to the database automatically. All subsequent reads return the already-migrated data and the migrator is bypassed entirely.

### How to review/test

1. Find a statement that was segmented before the new format was introduced (its `drafts_list_json` contains segments with `charStart`/`charEnd` fields and no `<segment-mark>` tags in `textualReference`)
2. Open it in the segment editor — it should load without console errors and all segment cards should be visible
3. Save once — verify the database now stores the new format with `<segment-mark>` tags and no position fields
4. Reopen — confirm the editor still works and the migrator is no longer triggered

- [X] Create/Update tests
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

