### PR TITLE
fix(refs DPLAN-18125): correct manual sort event shape in element admin edit

### DIFF
--- a/client/js/components/document/ElementAdminEdit.vue
+++ b/client/js/components/document/ElementAdminEdit.vue
@@ -154,10 +154,10 @@ export default {
       this.closeOnSelect = true
     },
 
-    saveManualSort (val) {
+    saveManualSort ({ newIndex, oldIndex }) {
       const initialSort = structuredClone(this.tableElements)
 
-      this.tableElements.splice(val.moved.newIndex, 0, this.tableElements.splice(val.moved.oldIndex, 1)[0])
+      this.tableElements.splice(newIndex, 0, this.tableElements.splice(oldIndex, 1)[0])
 
       const payload = {
         r_sorting: this.currentSort,


### PR DESCRIPTION
## Summary
- Fixes a crash when manually reordering documents in the element admin edit list: `saveManualSort` was reading `oldIndex`/`newIndex` from a nested `moved` object that the current drag component no longer emits.
- Updated to destructure `oldIndex`/`newIndex` directly from the event, matching how other consumers of the same `changed-order` event already handle it.

## Ticket
[DPLAN-18125](https://demoseurope.youtrack.cloud/issue/DPLAN-18125)

## Test plan
- [x] Manually reorder documents via drag-and-drop in the element admin edit list and confirm the sort saves without a console error