### PR TITLE
fix(DPLAN-17965): fix phase filter options visibility

### DIFF
--- a/client/js/bundles/procedure/publicIndexNoMap.js
+++ b/client/js/bundles/procedure/publicIndexNoMap.js
@@ -170,9 +170,9 @@ const filterProceduresByPhase = function () {
 }
 
 initialize().then(() => {
+  hideEmptyPhaseOptions()
   setSelectedOption()
   const filterPhasesSelectEl = document.getElementById('filterPhases')
 
-  filterPhasesSelectEl.addEventListener('focus', hideEmptyPhaseOptions)
   filterPhasesSelectEl.addEventListener('change', filterProceduresByPhase)
 })

--- a/client/js/bundles/procedure/publicIndexNoMap.js
+++ b/client/js/bundles/procedure/publicIndexNoMap.js
@@ -35,6 +35,25 @@ const countMatchingProcedures = function (phaseIds) {
 }
 
 /**
+ * Filters the select options to show only those that have matching procedures in the list.
+ */
+const hideEmptyPhaseOptions = function () {
+  const filterPhasesSelectEl = document.getElementById('filterPhases')
+
+  if (!filterPhasesSelectEl) {
+    return
+  }
+
+  for (const option of filterPhasesSelectEl.options) {
+    if (option.value !== 'all') {
+      const phaseIds = splitOptionValue(option.value)
+
+      option.style.display = countMatchingProcedures(phaseIds) > 0 ? '' : 'none'
+    }
+  }
+}
+
+/**
  * Splits a space-separated option value into individual phase ids.
  */
 const splitOptionValue = function (value) {
@@ -147,24 +166,13 @@ const filterProceduresByPhase = function () {
     } else {
       noResults.style.display = 'none'
     }
-
-    //  Hide options without results
-    const options = filterPhasesSelectEl.getElementsByTagName('option')
-
-    for (const option of options) {
-      //  For all options except 'all'
-      if (option.value !== 'all') {
-        const phaseIds = splitOptionValue(option.value)
-
-        if (countMatchingProcedures(phaseIds) === 0) {
-          option.style.display = 'none'
-        }
-      }
-    }
   }
 }
 
 initialize().then(() => {
   setSelectedOption()
-  document.getElementById('filterPhases').addEventListener('change', filterProceduresByPhase)
+  const filterPhasesSelectEl = document.getElementById('filterPhases')
+
+  filterPhasesSelectEl.addEventListener('focus', hideEmptyPhaseOptions)
+  filterPhasesSelectEl.addEventListener('change', filterProceduresByPhase)
 })

--- a/tests/frontend/unit/useUnsavedChangesGuard.spec.js
+++ b/tests/frontend/unit/useUnsavedChangesGuard.spec.js
@@ -7,13 +7,14 @@
  * All rights reserved
  */
 
-import { useUnsavedChangesGuard, _resetUnsavedChangesGuard } from '@DpJs/composables/useUnsavedChangesGuard'
+import { _resetUnsavedChangesGuard, useUnsavedChangesGuard } from '@DpJs/composables/useUnsavedChangesGuard'
 
 // Helper to flush all pending promises and timers
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
 
 const createLink = (href) => {
   const link = document.createElement('a')
+
   link.href = href
   document.body.appendChild(link)
 
@@ -23,6 +24,7 @@ const createLink = (href) => {
 const clickLink = (link) => {
   const event = new MouseEvent('click', { bubbles: true, cancelable: true })
   const preventDefaultSpy = jest.spyOn(event, 'preventDefault')
+
   link.dispatchEvent(event)
 
   return { event, preventDefaultSpy }
@@ -37,6 +39,7 @@ const dispatchDialogResult = (action) => {
 const dispatchBeforeUnload = () => {
   const event = new Event('beforeunload', { cancelable: true })
   const preventDefaultSpy = jest.spyOn(event, 'preventDefault')
+
   globalThis.dispatchEvent(event)
 
   return { event, preventDefaultSpy }
@@ -44,7 +47,9 @@ const dispatchBeforeUnload = () => {
 
 const initGuardedComponent = (componentOptions) => {
   const { init } = useUnsavedChangesGuard()
+
   init(componentOptions)
+
   return init
 }
 
@@ -195,6 +200,7 @@ describe('useUnsavedChangesGuard', () => {
 
       const link = createLink('https://example.com')
       const dialogShowListener = jest.fn()
+
       document.addEventListener('unsaved-changes-dialog:show', dialogShowListener)
 
       const { preventDefaultSpy } = clickLink(link)
@@ -217,6 +223,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const button = document.createElement('button')
+
       document.body.appendChild(button)
 
       const event = new MouseEvent('click', { bubbles: true, cancelable: true })
@@ -243,6 +250,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com')
+
       clickLink(link)
       dispatchDialogResult('save')
 
@@ -260,6 +268,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com')
+
       clickLink(link)
       dispatchDialogResult('discard')
 
@@ -277,6 +286,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com/discard-test')
+
       clickLink(link)
       dispatchDialogResult('discard')
 
@@ -294,6 +304,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com')
+
       clickLink(link)
       dispatchDialogResult('cancel')
 
@@ -311,6 +322,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com/cancel-test')
+
       clickLink(link)
       dispatchDialogResult('cancel')
 
@@ -341,6 +353,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com')
+
       clickLink(link)
       dispatchDialogResult('save')
 
@@ -359,6 +372,7 @@ describe('useUnsavedChangesGuard', () => {
       })
 
       const link = createLink('https://example.com/test')
+
       clickLink(link)
       dispatchDialogResult('save')
 


### PR DESCRIPTION
### Ticket
[DPLAN-17965](https://demoseurope.youtrack.cloud/issue/DPLAN-17965) Verfahrensschritt Dropdown verliert Auswahloptionen

**Description:** This PR fixes a behavior that could be confusing for users.

Previously, when opening the phase filter for the first time, users saw all available filter options, including those that had no matching procedures in the list. After applying the first filter, the dropdown was updated to display only the options that had matching procedures.

This resulted in an inconsistent user experience, as some filter options disappeared after the first interaction.

To make the behavior consistent, the filtering of phase options is now performed by a initialization. As a result, users always see only the relevant phase options with matching procedures, and empty options are never displayed.


### How to review/test
Go to the home page > open the phase filter > select different options and verify that:

- the filtering works correctly
- only relevant phase options are displayed
- no filter options disappear after the first filtering

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
