### PR TITLE
fix(refs DPLAN-18125): Correct manual sort event shape in element admin edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## UNRELEASED
 
+### Fixed 
+- Manual drag-and-drop reordering of documents in the plan document category admin now saves correctly
+
 ## v4.45.0 (2026-06-19)
 ### Added
 - Delete Institution Text CustomFields

--- a/client/js/components/document/ElementAdminEdit.vue
+++ b/client/js/components/document/ElementAdminEdit.vue
@@ -154,10 +154,10 @@ export default {
       this.closeOnSelect = true
     },
 
-    saveManualSort (val) {
+    saveManualSort ({ newIndex, oldIndex }) {
       const initialSort = structuredClone(this.tableElements)
 
-      this.tableElements.splice(val.moved.newIndex, 0, this.tableElements.splice(val.moved.oldIndex, 1)[0])
+      this.tableElements.splice(newIndex, 0, this.tableElements.splice(oldIndex, 1)[0])
 
       const payload = {
         r_sorting: this.currentSort,


### PR DESCRIPTION
### Ticket
[DPLAN-18125](https://demoseurope.youtrack.cloud/issue/DPLAN-18125)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
- Fixes a crash when manually reordering documents in the element admin edit list: `saveManualSort` was reading `oldIndex`/`newIndex` from a nested `moved` object that the current drag component no longer emits.
- Updated to destructure `oldIndex`/`newIndex` directly from the event, matching how other consumers of the same `changed-order` event already handle it.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
Manually reorder documents via drag-and-drop in the element admin edit list (FP-A) and confirm the sort saves without a console error

### Linked PRs
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->
the fix was originally introduced in this PR: https://github.com/demos-europe/demosplan-core/pull/6504

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Update changelog 
