### PR TITLE
fix(DPLAN-18094): fix position-matching bugs found in review of draft…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonMigrator.php
@@ -16,13 +16,22 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
  * Converts old-format draftsListJson (segments with charStart/charEnd positions, no <segment-mark>
  * tags in textualReference) to the new format expected by the segment editor.
  *
- * Old format: segments carry charStart/charEnd Prosemirror positions; textualReference is plain HTML.
- * New format: textualReference contains <segment-mark data-segment-id="..."> wrappers; no positions.
+ * Old format: segments carry charStart/charEnd Prosemirror positions plus a verbatim `text`
+ * snapshot; textualReference is plain HTML. New format: textualReference contains
+ * <segment-mark data-segment-id="..."> wrappers; no positions.
+ *
+ * Handles only records whose segments carry a `text` snapshot. Records without `text` (only
+ * positions) are handled by {@see DraftsListJsonPositionMigrator}.
  *
  * Runs on-the-fly at read time — does not write back to the database.
  */
 class DraftsListJsonMigrator
 {
+    public function __construct(
+        private readonly DraftsListJsonSegmentFields $segmentFields,
+    ) {
+    }
+
     public function needsMigration(array $data): bool
     {
         $segments = $data['data']['attributes']['segments'] ?? [];
@@ -30,6 +39,7 @@ class DraftsListJsonMigrator
 
         return !empty($segments)
             && array_key_exists('charStart', $segments[0])
+            && $this->segmentFields->anySegmentHasText($segments)
             && !str_contains($textualReference, '<segment-mark');
     }
 
@@ -62,18 +72,10 @@ class DraftsListJsonMigrator
         }
 
         $data['data']['attributes']['textualReference'] = $textualReference;
-
-        $data['data']['attributes']['segments'] = array_map(static function (array $segment): array {
-            unset(
-                $segment['charStart'],
-                $segment['charEnd'],
-                $segment['charStartInit'],
-                $segment['charEndInit'],
-                $segment['hasProsemirrorIndex']
-            );
-
-            return $segment;
-        }, $segments);
+        $data['data']['attributes']['segments'] = array_map(
+            $this->segmentFields->stripPositionFields(...),
+            $segments
+        );
 
         return $data;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonPositionMigrator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonPositionMigrator.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
+
+/**
+ * Converts the oldest legacy draftsListJson variant to the new format expected by the segment
+ * editor: segments carry only charStart/charEnd/charStartInit/charEndInit positions, with no
+ * `text` snapshot at all, and textualReference has no <segment-mark> tags.
+ *
+ * charStartInit/charEndInit are preferred over charStart/charEnd for placement: on production
+ * records, charStart/charEnd had drifted to Prosemirror document positions (unusable as raw
+ * string offsets into textualReference), while charStartInit/charEndInit still matched the
+ * stored textualReference verbatim. The two are never mixed field-by-field — either both Init
+ * fields are present and used together, or both legacy fields are used together — since a hybrid
+ * boundary would match neither variant.
+ *
+ * Segments whose positions are missing, out of bounds, or overlap the previous segment are left
+ * unwrapped rather than guessed at — no character of textualReference is ever dropped, it just
+ * isn't attributed to a segment mark.
+ *
+ * Handles only records whose segments have no `text` snapshot. Records with `text` are handled
+ * by {@see DraftsListJsonMigrator}.
+ *
+ * Runs on-the-fly at read time — does not write back to the database.
+ */
+class DraftsListJsonPositionMigrator
+{
+    public function __construct(
+        private readonly DraftsListJsonSegmentFields $segmentFields,
+    ) {
+    }
+
+    public function needsMigration(array $data): bool
+    {
+        $segments = $data['data']['attributes']['segments'] ?? [];
+        $textualReference = $data['data']['attributes']['textualReference'] ?? '';
+
+        return !empty($segments)
+            && array_key_exists('charStart', $segments[0])
+            && !$this->segmentFields->anySegmentHasText($segments)
+            && !str_contains($textualReference, '<segment-mark');
+    }
+
+    public function migrate(array $data): array
+    {
+        $segments = $data['data']['attributes']['segments'];
+        $textualReference = $data['data']['attributes']['textualReference'];
+
+        // Sort by the same resolved start used for placement below — sorting by a different
+        // field (e.g. the raw charStart) than the one used to place segments can put a segment
+        // in the wrong slot and cause it to be skipped as "overlapping" during wrapping. A
+        // segment with no usable position (null start) sorts as 0; harmless, since it gets
+        // skipped without advancing the cursor during wrapping regardless of its sort position.
+        usort($segments, fn (array $a, array $b): int => ($this->resolvedRange($a)[0] ?? 0) - ($this->resolvedRange($b)[0] ?? 0));
+
+        $data['data']['attributes']['textualReference'] = $this->wrapUsingPositions($segments, $textualReference);
+        $data['data']['attributes']['segments'] = array_map(
+            $this->segmentFields->stripPositionFields(...),
+            $segments
+        );
+
+        return $data;
+    }
+
+    private function wrapUsingPositions(array $segments, string $textualReference): string
+    {
+        $length = mb_strlen($textualReference, 'UTF-8');
+        $result = '';
+        $cursor = 0;
+
+        foreach ($segments as $segment) {
+            [$start, $end] = $this->resolvedRange($segment);
+
+            if (null === $start || null === $end || $start < $cursor || $end > $length || $start >= $end) {
+                continue;
+            }
+
+            $result .= mb_substr($textualReference, $cursor, $start - $cursor, 'UTF-8');
+            $text = mb_substr($textualReference, $start, $end - $start, 'UTF-8');
+            $result .= sprintf('<segment-mark data-segment-id="%s">%s</segment-mark>', $segment['id'], $text);
+            $cursor = $end;
+        }
+
+        $result .= mb_substr($textualReference, $cursor, null, 'UTF-8');
+
+        return $result;
+    }
+
+    /**
+     * Resolves a segment's [start, end] boundary, preferring the charStartInit/charEndInit pair
+     * over charStart/charEnd. The two pairs are never mixed field-by-field — if either Init value
+     * is missing or null, both legacy fields are used together instead, rather than combining one
+     * Init value with one legacy value into a boundary that matches neither variant. Returns
+     * [null, null] when neither pair is fully usable; callers must check for that.
+     */
+    private function resolvedRange(array $segment): array
+    {
+        $initStart = $segment['charStartInit'] ?? null;
+        $initEnd = $segment['charEndInit'] ?? null;
+
+        if (null !== $initStart && null !== $initEnd) {
+            return [$initStart, $initEnd];
+        }
+
+        $legacyStart = $segment['charStart'] ?? null;
+        $legacyEnd = $segment['charEnd'] ?? null;
+
+        if (null !== $legacyStart && null !== $legacyEnd) {
+            return [$legacyStart, $legacyEnd];
+        }
+
+        return [null, null];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonSegmentFields.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonSegmentFields.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
+
+/**
+ * Shared helpers for the two legacy draftsListJson migrators ({@see DraftsListJsonMigrator} and
+ * {@see DraftsListJsonPositionMigrator}), which must agree on format detection so a given array
+ * of segments is routed to exactly one of them.
+ */
+class DraftsListJsonSegmentFields
+{
+    /**
+     * True if any segment carries a verbatim `text` snapshot. Checking all segments (not just the
+     * first) matters because a record could otherwise have its first segment's `text` explicitly
+     * empty while later segments do carry a reliable snapshot.
+     */
+    public function anySegmentHasText(array $segments): bool
+    {
+        foreach ($segments as $segment) {
+            if ('' !== ($segment['text'] ?? '')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function stripPositionFields(array $segment): array
+    {
+        unset(
+            $segment['charStart'],
+            $segment['charEnd'],
+            $segment['charStartInit'],
+            $segment['charEndInit'],
+            $segment['hasProsemirrorIndex']
+        );
+
+        return $segment;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -33,6 +33,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Map\CoordinateJsonConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedurePhaseDefinitionService;
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonMigrator;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonPositionMigrator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDeleter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
@@ -80,6 +81,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
     public function __construct(
         HTMLSanitizer $htmlSanitizer,
         private readonly DraftsListJsonMigrator $draftsListJsonMigrator,
+        private readonly DraftsListJsonPositionMigrator $draftsListJsonPositionMigrator,
         private readonly JsonApiEsService $jsonApiEsService,
         private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
         private readonly QueryStatement $esQuery,
@@ -403,6 +405,8 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                     $data = Json::decodeToArray($draftsListJson);
                     if ($this->draftsListJsonMigrator->needsMigration($data)) {
                         $data = $this->draftsListJsonMigrator->migrate($data);
+                    } elseif ($this->draftsListJsonPositionMigrator->needsMigration($data)) {
+                        $data = $this->draftsListJsonPositionMigrator->migrate($data);
                     }
 
                     return $data;

--- a/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\Core\Logic\Statement;
 
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonMigrator;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonSegmentFields;
 use PHPUnit\Framework\TestCase;
 
 class DraftsListJsonMigratorTest extends TestCase
@@ -21,7 +22,7 @@ class DraftsListJsonMigratorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->sut = new DraftsListJsonMigrator();
+        $this->sut = new DraftsListJsonMigrator(new DraftsListJsonSegmentFields());
     }
 
     // --- needsMigration ---
@@ -86,6 +87,22 @@ class DraftsListJsonMigratorTest extends TestCase
             '<p>Sky is blue.</p>',
             [
                 ['id' => 'seg-1', 'charStart' => null, 'charEnd' => null, 'text' => '<p>Sky is blue.</p>'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertTrue($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsTrueWhenOnlyALaterSegmentHasText(): void
+    {
+        // Arrange — segment[0] has no text snapshot, but seg-2 does; must still be routed here
+        // rather than to DraftsListJsonPositionMigrator, which would ignore seg-2's reliable text.
+        $data = $this->buildData(
+            '<p>Sky is blue.</p><p>Grass is green.</p>',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => ''],
+                ['id' => 'seg-2', 'charStart' => 6, 'charEnd' => 10, 'text' => '<p>Grass is green.</p>'],
             ]
         );
 

--- a/tests/backend/core/Logic/Statement/DraftsListJsonPositionMigratorTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonPositionMigratorTest.php
@@ -306,13 +306,13 @@ class DraftsListJsonPositionMigratorTest extends TestCase
             $textualReference,
             [
                 [
-                    'id' => '41d2d28e-3110-4563-b39b-187918160033',
-                    'charStart' => 0, 'charEnd' => 560,
+                    'id'            => '41d2d28e-3110-4563-b39b-187918160033',
+                    'charStart'     => 0, 'charEnd' => 560,
                     'charStartInit' => 0, 'charEndInit' => 563,
                 ],
                 [
-                    'id' => '1e85e538-ab51-4ad8-9ae6-b2fa1d9b0608',
-                    'charStart' => 564, 'charEnd' => 620,
+                    'id'            => '1e85e538-ab51-4ad8-9ae6-b2fa1d9b0608',
+                    'charStart'     => 564, 'charEnd' => 620,
                     'charStartInit' => 570, 'charEndInit' => 638,
                 ],
             ]

--- a/tests/backend/core/Logic/Statement/DraftsListJsonPositionMigratorTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonPositionMigratorTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Logic\Statement;
+
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonPositionMigrator;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonSegmentFields;
+use PHPUnit\Framework\TestCase;
+
+class DraftsListJsonPositionMigratorTest extends TestCase
+{
+    private ?DraftsListJsonPositionMigrator $sut = null;
+
+    protected function setUp(): void
+    {
+        $this->sut = new DraftsListJsonPositionMigrator(new DraftsListJsonSegmentFields());
+    }
+
+    // --- needsMigration ---
+
+    public function testNeedsMigrationReturnsTrueWhenSegmentsHaveNoTextField(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            'Sehr geehrter Herr Fischer.Freundliche Gruesse.',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 27],
+                ['id' => 'seg-2', 'charStart' => 27, 'charEnd' => 47],
+            ]
+        );
+
+        // Act & Assert
+        self::assertTrue($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenSegmentsHaveTextField(): void
+    {
+        // Arrange — handled by DraftsListJsonMigrator instead
+        $data = $this->buildData(
+            '<p>Sky is blue.</p>',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'text' => '<p>Sky is blue.</p>'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenSegmentMarkAlreadyPresent(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1">Sky is blue.</segment-mark>',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseForEmptySegments(): void
+    {
+        // Arrange
+        $data = $this->buildData('Some text.', []);
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenNoCharStartField(): void
+    {
+        // Arrange — new format: segments have no charStart
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1">Sky is blue.</segment-mark>',
+            [
+                ['id' => 'seg-1'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsFalseWhenOnlyALaterSegmentHasText(): void
+    {
+        // Arrange — segment[0] has no text, but seg-2 does; must not be claimed here, since
+        // DraftsListJsonMigrator can wrap seg-2 using its reliable text snapshot.
+        $data = $this->buildData(
+            'Sky is blue.Grass is green.',
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 13],
+                ['id' => 'seg-2', 'charStart' => 13, 'charEnd' => 28, 'text' => 'Grass is green.'],
+            ]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->needsMigration($data));
+    }
+
+    public function testNeedsMigrationReturnsTrueWhenCharStartIsNull(): void
+    {
+        // Arrange — charStart key exists but is null; isset()/?? would return false here,
+        // array_key_exists() correctly returns true. Mirrors the equivalent fix that was needed
+        // in DraftsListJsonMigrator.
+        $data = $this->buildData(
+            'Sky is blue.',
+            [
+                ['id' => 'seg-1', 'charStart' => null, 'charEnd' => null],
+            ]
+        );
+
+        // Act & Assert
+        self::assertTrue($this->sut->needsMigration($data));
+    }
+
+    // --- migrate ---
+
+    public function testMigrateWrapsUsingPositionsWhenTextFieldMissing(): void
+    {
+        // Arrange — legacy record: segments carry only charStart/charEnd, no `text` snapshot
+        $textualReference = 'Sehr geehrter Herr Fischer.Freundliche Gruesse.';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 27, 'charStartInit' => 0, 'charEndInit' => 27],
+                ['id' => 'seg-2', 'charStart' => 27, 'charEnd' => 47, 'charStartInit' => 27, 'charEndInit' => 47],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertSame(
+            '<segment-mark data-segment-id="seg-1">Sehr geehrter Herr Fischer.</segment-mark>'
+            .'<segment-mark data-segment-id="seg-2">Freundliche Gruesse.</segment-mark>',
+            $ref
+        );
+    }
+
+    public function testMigratePrefersCharStartInitOverCharStartWhenBothPresent(): void
+    {
+        // Arrange — charStart/charEnd are stale Prosemirror positions (garbled if used as string
+        // offsets); charStartInit/charEndInit still align with the actual textualReference.
+        $textualReference = 'AAAAABBBBB';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 2, 'charEnd' => 8, 'charStartInit' => 0, 'charEndInit' => 5],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertSame('<segment-mark data-segment-id="seg-1">AAAAA</segment-mark>BBBBB', $ref);
+    }
+
+    public function testMigrateFallsBackToCharStartWhenInitFieldsMissing(): void
+    {
+        // Arrange — no charStartInit/charEndInit at all
+        $textualReference = 'Hello World';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertSame('<segment-mark data-segment-id="seg-1">Hello</segment-mark> World', $ref);
+    }
+
+    public function testMigrateFallsBackToLegacyPairWhenOnlyOneInitFieldIsPresent(): void
+    {
+        // Arrange — charStartInit is present but charEndInit is not. Combining charStartInit (2)
+        // with charEnd (5) would wrap the wrong substring ("llo") — the Init pair must be treated
+        // as all-or-nothing and fall back to the full charStart/charEnd pair instead.
+        $textualReference = 'Hello World';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'charStartInit' => 2],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert
+        self::assertSame('<segment-mark data-segment-id="seg-1">Hello</segment-mark> World', $ref);
+    }
+
+    public function testMigrateSortsByTheSamePositionFieldUsedForPlacement(): void
+    {
+        // Arrange — charStart (drifted Prosemirror positions) disagrees with charStartInit
+        // (true document order) on which segment comes first. Sorting by charStart while placing
+        // by charStartInit would process seg-2 first, advance the cursor past seg-1's start, and
+        // cause seg-1 to be silently skipped as "overlapping".
+        $textualReference = 'Hello World';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 100, 'charStartInit' => 0, 'charEndInit' => 5],
+                ['id' => 'seg-2', 'charStart' => 50, 'charStartInit' => 6, 'charEndInit' => 11],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert — both segments are wrapped, in true document order
+        self::assertSame(
+            '<segment-mark data-segment-id="seg-1">Hello</segment-mark> '
+            .'<segment-mark data-segment-id="seg-2">World</segment-mark>',
+            $ref
+        );
+    }
+
+    public function testMigrateSkipsSegmentWithOverlappingPositionAndKeepsAllText(): void
+    {
+        // Arrange — seg-2 overlaps seg-1 (its start is before seg-1's end)
+        $textualReference = 'Hello World';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                ['id' => 'seg-1', 'charStart' => 0, 'charEnd' => 5, 'charStartInit' => 0, 'charEndInit' => 5],
+                ['id' => 'seg-2', 'charStart' => 3, 'charEnd' => 8, 'charStartInit' => 3, 'charEndInit' => 8],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert — seg-2 is skipped rather than corrupting the output, but no character is lost
+        self::assertStringContainsString('<segment-mark data-segment-id="seg-1">Hello</segment-mark>', $ref);
+        self::assertStringNotContainsString('seg-2', $ref);
+        self::assertSame($textualReference, preg_replace('/<segment-mark[^>]*>|<\/segment-mark>/', '', $ref));
+    }
+
+    public function testMigrateRemovesPositionFieldsFromAllSegments(): void
+    {
+        // Arrange
+        $data = $this->buildData(
+            'Hello World',
+            [
+                [
+                    'id'                  => 'seg-1',
+                    'charStart'           => 0,
+                    'charEnd'             => 5,
+                    'charStartInit'       => 0,
+                    'charEndInit'         => 5,
+                    'hasProsemirrorIndex' => true,
+                ],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $segment = $result['data']['attributes']['segments'][0];
+
+        // Assert
+        self::assertArrayNotHasKey('charStart', $segment);
+        self::assertArrayNotHasKey('charEnd', $segment);
+        self::assertArrayNotHasKey('charStartInit', $segment);
+        self::assertArrayNotHasKey('charEndInit', $segment);
+        self::assertArrayNotHasKey('hasProsemirrorIndex', $segment);
+        self::assertSame('seg-1', $segment['id']);
+    }
+
+    public function testMigrateHandlesRealWorldRecordWithoutTextField(): void
+    {
+        // Arrange — reproduces a production draftsListJson record: segments carry only
+        // charStart/charEnd/charStartInit/charEndInit, no `text` key, and charStart/charEnd
+        // have drifted from raw string offsets while charStartInit/charEndInit have not.
+        $textualReference = 'Sehr geehrter Herr Fischer,<br>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '
+            .'sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. '
+            .'At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata '
+            .'sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed '
+            .'diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At '
+            .'vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren?<br>Freundliche '
+            .'Grüße,<br>Theodor Müller<br><br>Strase 1<br>12345 Berlin';
+        $data = $this->buildData(
+            $textualReference,
+            [
+                [
+                    'id' => '41d2d28e-3110-4563-b39b-187918160033',
+                    'charStart' => 0, 'charEnd' => 560,
+                    'charStartInit' => 0, 'charEndInit' => 563,
+                ],
+                [
+                    'id' => '1e85e538-ab51-4ad8-9ae6-b2fa1d9b0608',
+                    'charStart' => 564, 'charEnd' => 620,
+                    'charStartInit' => 570, 'charEndInit' => 638,
+                ],
+            ]
+        );
+
+        // Act
+        $result = $this->sut->migrate($data);
+        $ref = $result['data']['attributes']['textualReference'];
+
+        // Assert — both segments are wrapped, using the trustworthy Init positions
+        self::assertStringContainsString('<segment-mark data-segment-id="41d2d28e-3110-4563-b39b-187918160033">', $ref);
+        self::assertStringContainsString('<segment-mark data-segment-id="1e85e538-ab51-4ad8-9ae6-b2fa1d9b0608">', $ref);
+        self::assertStringEndsWith('</segment-mark>', $ref);
+        // No character is lost — stripping the inserted marks reproduces the original text
+        self::assertSame($textualReference, preg_replace('/<segment-mark[^>]*>|<\/segment-mark>/', '', $ref));
+
+        foreach ($result['data']['attributes']['segments'] as $segment) {
+            self::assertArrayNotHasKey('charStart', $segment);
+            self::assertArrayNotHasKey('charStartInit', $segment);
+        }
+    }
+
+    // --- helpers ---
+
+    private function buildData(string $textualReference, array $segments): array
+    {
+        return [
+            'data' => [
+                'attributes' => [
+                    'textualReference' => $textualReference,
+                    'segments'         => $segments,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION

### Ticket
DPLAN-18094

Some legacy `draftsListJson` statements never stored a `text` snapshot per segment — only `charStart`/`charEnd`/`charStartInit`/`charEndInit` positions. `DraftsListJsonMigrator` only knew how to wrap segments by searching for their verbatim `text` in `textualReference`, so for these records it silently did nothing: `needsMigration()` said "yes", but `migrate()` skipped every segment (no `text` to search for) and still stripped the position fields — leaving
`textualReference` with zero `<segment-mark>` tags and no way to recover the segment boundaries afterwards. The segment editor then had nothing to render.

**Fix:** added `DraftsListJsonPositionMigrator`, a dedicated migrator for this variant. It rebuilds `textualReference` directly from position offsets instead of a text search. Investigation showed `charStartInit`/`charEndInit` are the reliable raw string offsets — `charStart`/`charEnd` had been overwritten by since-removed frontend code (`transformHTMLPositionsToProsemirrorPositions`,
deleted in an earlier DPLAN-18094 commit) with Prosemirror document positions, which don't map onto `textualReference` as string offsets. So the new migrator prefers Init fields and falls back to the legacy pair only when Init is unavailable. Segments with unusable/overlapping positions are left unwrapped rather than guessed at — no character of the original text is ever dropped.

Both migrators are wired into `StatementResourceType`'s `draftsListJson` read closure and are mutually exclusive by design (one requires a text snapshot, the other requires its absence).

A follow-up review pass caught three real bugs in the first version, all fixed:
- Segments were sorted by `charStart` but placed by `charStartInit`/`charEndInit` — when the two  disagreed on order, a valid segment could be silently skipped as "overlapping". Now both sorting  and placement use the same resolved value.
- `charStartInit`/`charEndInit` were resolved independently per field, so a segment with only one  of the two could combine an Init value with a legacy value into a wrong boundary. Init is now all-or-nothing.
- Format detection (`needsMigration`) only inspected the first segment, so a record where segment 0 lacked `text` but a later segment had it would be misrouted to the position migrator, losing a reliable text snapshot. Now checks all segments.

The shared strip/detection logic between the two migrators was extracted into `DraftsListJsonSegmentFields`, injected into both rather than duplicated.

### How to review/test
- Run the two migrator test suites:
  vendor/bin/phpunit tests/backend/core/Logic/Statement/DraftsListJsonMigratorTest.php tests/backend/core/Logic/Statement/DraftsListJsonPositionMigratorTest.php
- Manually: open a legacy statement whose `drafts_info_json` has segments with only position fields (no `text`) in the segment editor and confirm all segments render with correct

- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

