### PR TITLE
fix(cors): expose tus upload headers so resumable uploads succeed

### DIFF
--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -7,4 +7,16 @@ nelmio_cors:
         expose_headers: ['Link']
         max_age: 3600
     paths:
+        # The tus resumable-upload endpoint sets its own CORS headers (see TusCors
+        # middleware + tus-php defaults). Without this dedicated rule the global '^/'
+        # policy below overwrites Access-Control-Expose-Headers with just ['Link'],
+        # hiding Upload-Offset from the browser so uploads fail with
+        # "tus: invalid or missing offset value". Wildcards are avoided because the
+        # uploader sends credentials, which forbids '*' for allow-headers/origin.
+        '^/_tus':
+            allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
+            allow_methods: ['GET', 'POST', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+            allow_headers: ['Origin', 'X-Requested-With', 'Content-Type', 'Content-Length', 'Authorization', 'Upload-Length', 'Upload-Offset', 'Upload-Key', 'Upload-Checksum', 'Upload-Metadata', 'Tus-Version', 'Tus-Resumable', 'x-demosplan-file-hash', 'x-demosplan-file-id', 'x-demosplan-procedure-id']
+            expose_headers: ['Location', 'Upload-Offset', 'Upload-Length', 'Upload-Metadata', 'Upload-Expires', 'Upload-Concat', 'Upload-Defer-Length', 'Tus-Version', 'Tus-Resumable', 'Tus-Extension', 'Tus-Max-Size', 'x-demosplan-file-hash', 'x-demosplan-file-id']
+            max_age: 3600
         '^/': null


### PR DESCRIPTION
### Ticket
DPLAN-17129

The global nelmio CORS policy set `Access-Control-Expose-Headers` to `['Link']` on **every** path (`^/`), including the tus resumable-upload endpoint. This overwrote the CORS headers that tus-php (+ the `TusCors` middleware) sets, hiding `Upload-Offset` from the browser. As a result `tus-js-client` (Uppy) failed cross-origin uploads with `tus: invalid or missing offset value` — the server sent the offset, but JS could not read it.

This adds a dedicated `^/_tus` rule, matched **before** the catch-all `^/` (nelmio is first-match), that:
- exposes the tus headers (`Upload-Offset`, `Upload-Length`, `Location`, `Tus-Resumable`, …) plus the `x-demosplan-file-*` headers, and
- sets a correct preflight `allow_methods`/`allow_headers` (incl. `HEAD`/`PATCH` and the `Tus-*`/`Upload-*` request headers).

Explicit header lists are used rather than `*` because the uploader sends credentials, which forbids wildcard `allow-headers`/`allow-origin` under the CORS spec.

### How to review/test
1. Upload a file via the frontend uploader (e.g. Planunterlagen) on an environment where the tus endpoint is served cross-origin.
2. Without the fix the upload aborts with `invalid or missing offset value`; with it the upload completes.
3. `curl -I` a tus upload URL and confirm `access-control-expose-headers` now includes `upload-offset` (previously only `link`).

### PR Checklist
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly