### PR TITLE
fix HDDP-25: sanitize zip entry names for Windows extraction

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -45,6 +45,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureHandler;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ServiceOutput;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\CountyService;
 use demosplan\DemosPlanCoreBundle\Logic\User\BrandingService;
+use demosplan\DemosPlanCoreBundle\Logic\ZipExportService;
 use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use demosplan\DemosPlanCoreBundle\Services\Breadcrumb\Breadcrumb;
 use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
@@ -1794,12 +1795,12 @@ class DemosPlanDocumentController extends BaseController
      * @throws MessageBagException
      */
     #[Route(name: 'DemosPlan_document_zip_files', path: '/verfahren/{procedureId}/planunterlagen/zipfiles', options: ['expose' => true])]
-    public function zipFilesAction(Request $request, TranslatorInterface $translator, string $procedureId)
+    public function zipFilesAction(Request $request, TranslatorInterface $translator, ZipExportService $zipExportService, string $procedureId)
     {
         try {
             $filesInfo = $this->getFilesInfo($request, $procedureId);
 
-            return new StreamedResponse(function () use ($filesInfo, $translator) {
+            return new StreamedResponse(function () use ($filesInfo, $translator, $zipExportService) {
                 $zip = new ZipStream(
                     sendHttpHeaders: true,
                     outputName: $translator->trans('plandocument.zip.file.name'),
@@ -1809,7 +1810,7 @@ class DemosPlanDocumentController extends BaseController
                 foreach ($filesInfo as $fileInfo) {
                     try {
                         $streamRead = $this->defaultStorage->readStream($fileInfo['fullPath']);
-                        $zip->addFileFromStream((new UnicodeString($fileInfo['namedPath']))->ascii()->toString(), $streamRead);
+                        $zip->addFileFromStream($zipExportService->sanitizeZipPath($fileInfo['namedPath']), $streamRead);
                     } catch (Exception $e) {
                         $this->getLogger()->error($e->getMessage(), $e->getTrace());
                     }

--- a/demosplan/DemosPlanCoreBundle/Logic/FileResponseGenerator/ZipResponseGenerator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/FileResponseGenerator/ZipResponseGenerator.php
@@ -32,8 +32,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 use ZipStream\ZipStream;
 
-use function Symfony\Component\String\u;
-
 class ZipResponseGenerator extends FileResponseGeneratorAbstract
 {
     private const FIILE_NOT_FOUND_OR_READABLE = 'Unable to load or read file from path.';
@@ -107,7 +105,7 @@ class ZipResponseGenerator extends FileResponseGeneratorAbstract
         foreach ($file['originalStatementsAsPdfs'] as $pdf) {
             $pdf['name'] = str_replace('Originalstellungnahmen', 'Originalstellungnahme', $pdf['name']);
             $zipStream->addFile(
-                $file['zipFileName'].'/'.$pdf['externId'].$pdf['name'],
+                $this->zipExportService->sanitizeZipPath($file['zipFileName'].'/'.$pdf['externId'].$pdf['name']),
                 $pdf['content']
             );
         }
@@ -160,11 +158,10 @@ class ZipResponseGenerator extends FileResponseGeneratorAbstract
                     );
                 }
                 if (is_array($originalAttachment)) {
-                    $content = u(
-                        $file['zipFileName'].'/'.$originalAttachment['fileHash'].'_'.$originalAttachment['name']
-                    )->ascii();
                     $zipStream->addFile(
-                        $content->toString(),
+                        $this->zipExportService->sanitizeZipPath(
+                            $file['zipFileName'].'/'.$originalAttachment['fileHash'].'_'.$originalAttachment['name']
+                        ),
                         $originalAttachment['content']
                     );
                 }

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -248,7 +248,7 @@ class ZipExportService
         $zipPath = (new UnicodeString($zipPath))->ascii()->toString();
 
         $segments = array_map(
-            static fn (string $segment): string => rtrim(trim($segment), " ."),
+            static fn (string $segment): string => rtrim(trim($segment), ' .'),
             explode('/', $zipPath)
         );
 

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -97,8 +97,12 @@ class ZipExportService
         ZipStream $zip,
         string $fileNamePrefix,
     ): void {
-        $path = (new UnicodeString($folderPath.$fileNamePrefix.$fileInfo->getFileName()))->ascii()->toString();
-        $pathHash = md5((string) $path);
+        // Hash the sanitized path so the dedup guard matches the entry name that
+        // is actually written. Otherwise two titles differing only by a trailing
+        // space (or dot) would hash differently, both pass this guard, then
+        // sanitize to the same entry name and collide as a duplicate ZIP entry.
+        $path = $this->sanitizeZipPath($folderPath.$fileNamePrefix.$fileInfo->getFileName());
+        $pathHash = md5($path);
         if (in_array($pathHash, $this->filesAdded, true)) {
             $this->logger->warning('File already present in Zip', ['path' => $path]);
 
@@ -250,6 +254,16 @@ class ZipExportService
         $segments = array_map(
             static fn (string $segment): string => rtrim(trim($segment), " ."),
             explode('/', $zipPath)
+        );
+
+        // Drop segments that trimmed to nothing (e.g. a title of only spaces or
+        // dots). Keeping them would re-introduce empty path components such as
+        // "proc//file.pdf", which is exactly the kind of malformed entry name
+        // Windows rejects on extraction. Compared explicitly against '' so a
+        // legitimate segment named "0" is not dropped by array_filter.
+        $segments = array_filter(
+            $segments,
+            static fn (string $segment): bool => '' !== $segment
         );
 
         return implode('/', $segments);

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -73,7 +73,7 @@ class ZipExportService
      */
     public function addFileToZipStream(string $filePath, string $zipPath, ZipStream $zip): void
     {
-        $zipPath = (new UnicodeString($zipPath))->ascii()->toString();
+        $zipPath = $this->sanitizeZipPath($zipPath);
         $fs = new Filesystem();
         if ($this->defaultStorage->fileExists($filePath)) {
             $zip->addFileFromStream($zipPath, $this->defaultStorage->readStream($filePath));
@@ -148,7 +148,7 @@ class ZipExportService
         $streamRead = fopen('php://temp', 'rwb');
         fwrite($streamRead, $string);
         rewind($streamRead);
-        $zip->addFileFromStream((new UnicodeString($filename))->ascii()->toString(), $streamRead);
+        $zip->addFileFromStream($this->sanitizeZipPath($filename), $streamRead);
         fclose($streamRead);
     }
 
@@ -225,5 +225,33 @@ class ZipExportService
         if (!($writer instanceof WriterInterface || $writer instanceof PDF)) {
             throw InvalidParameterTypeException::fromTypes($writer::class, [WriterInterface::class, PDF::class]);
         }
+    }
+
+    /**
+     * Normalizes a ZIP entry name so it stays valid on Windows.
+     *
+     * Besides folding to ASCII, each path segment is trimmed of surrounding
+     * whitespace and trailing dots. Windows silently strips trailing spaces and
+     * dots from file/directory names on extraction; the resulting mismatch
+     * between the archive's entry names and the paths actually created makes the
+     * built-in Windows extractor (and PowerShell's Expand-Archive) report the
+     * archive as invalid ("Der zip-komprimierte Ordner ist ungültig"), even
+     * though tools like 7-zip open it fine. Interior dots (e.g. "Kapitel 4.5.1"
+     * or the ".pdf" extension) are preserved because only trailing dots are
+     * stripped.
+     *
+     * Public so other ZIP-building sites (e.g. ZipResponseGenerator,
+     * DemosPlanDocumentController) can reuse the same normalization.
+     */
+    public function sanitizeZipPath(string $zipPath): string
+    {
+        $zipPath = (new UnicodeString($zipPath))->ascii()->toString();
+
+        $segments = array_map(
+            static fn (string $segment): string => rtrim(trim($segment), " ."),
+            explode('/', $zipPath)
+        );
+
+        return implode('/', $segments);
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipExportService.php
@@ -97,18 +97,17 @@ class ZipExportService
         ZipStream $zip,
         string $fileNamePrefix,
     ): void {
-        // Hash the sanitized path so the dedup guard matches the entry name that
-        // is actually written. Otherwise two titles differing only by a trailing
-        // space (or dot) would hash differently, both pass this guard, then
+        // Dedup on the sanitized path so the guard matches the entry name that is
+        // actually written. Otherwise two titles differing only by a trailing
+        // space (or dot) would compare as distinct, both pass this guard, then
         // sanitize to the same entry name and collide as a duplicate ZIP entry.
         $path = $this->sanitizeZipPath($folderPath.$fileNamePrefix.$fileInfo->getFileName());
-        $pathHash = md5($path);
-        if (in_array($pathHash, $this->filesAdded, true)) {
+        if (in_array($path, $this->filesAdded, true)) {
             $this->logger->warning('File already present in Zip', ['path' => $path]);
 
             return;
         }
-        $this->filesAdded[] = $pathHash;
+        $this->filesAdded[] = $path;
 
         $this->logger->info(
             'Try to add File to Zip',

--- a/tests/backend/core/Logic/ZipExportServiceTest.php
+++ b/tests/backend/core/Logic/ZipExportServiceTest.php
@@ -77,4 +77,28 @@ class ZipExportServiceTest extends FunctionalTestCase
             $this->sut->sanitizeZipPath('procedure/Planungsdokumente/file.pdf')
         );
     }
+
+    public function testDropsSegmentConsistingOnlyOfSpacesOrDots(): void
+    {
+        // A title of only spaces ("   ") or dots ("...") trims to an empty
+        // segment; keeping it would yield a "proc//file.pdf" double slash, the
+        // very malformed entry name Windows rejects. The empty segment is dropped.
+        self::assertSame(
+            'proc/file.pdf',
+            $this->sut->sanitizeZipPath('proc/   /file.pdf')
+        );
+        self::assertSame(
+            'proc/file.pdf',
+            $this->sut->sanitizeZipPath('proc/.../file.pdf')
+        );
+    }
+
+    public function testKeepsSegmentNamedZero(): void
+    {
+        // Guard against a naive array_filter dropping the falsy "0" segment.
+        self::assertSame(
+            'proc/0/file.pdf',
+            $this->sut->sanitizeZipPath('proc/0/file.pdf')
+        );
+    }
 }

--- a/tests/backend/core/Logic/ZipExportServiceTest.php
+++ b/tests/backend/core/Logic/ZipExportServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Logic;
+
+use demosplan\DemosPlanCoreBundle\Logic\ZipExportService;
+use Tests\Base\FunctionalTestCase;
+
+class ZipExportServiceTest extends FunctionalTestCase
+{
+    /**
+     * @var ZipExportService|null
+     */
+    protected $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = $this->getContainer()->get(ZipExportService::class);
+    }
+
+    public function testTrimsTrailingSpaceFromDirectorySegment(): void
+    {
+        self::assertSame(
+            'Amtliche Bekanntmachung Beteiligungsverfahren/file.pdf',
+            $this->sut->sanitizeZipPath('Amtliche Bekanntmachung Beteiligungsverfahren /file.pdf')
+        );
+    }
+
+    public function testTrimsLeadingSpaceFromDirectorySegment(): void
+    {
+        self::assertSame(
+            'Dokumente/Dokumenter pa dansk/file.pdf',
+            $this->sut->sanitizeZipPath('Dokumente/ Dokumenter pa dansk/file.pdf')
+        );
+    }
+
+    public function testStripsTrailingDotFromSegment(): void
+    {
+        self::assertSame(
+            'category/file.pdf',
+            $this->sut->sanitizeZipPath('category./file.pdf')
+        );
+    }
+
+    public function testPreservesInteriorDots(): void
+    {
+        self::assertSame(
+            'Kapitel 4.5.1.1/Udkast_plantekst.pdf',
+            $this->sut->sanitizeZipPath('Kapitel 4.5.1.1/Udkast_plantekst.pdf')
+        );
+    }
+
+    public function testFoldsNonAsciiCharacters(): void
+    {
+        // "ä"/"ö" fold to "a"/"o", "ü" to "u".
+        self::assertSame(
+            'danischer/Ollegard.pdf',
+            $this->sut->sanitizeZipPath('dänischer/Öllegård.pdf')
+        );
+    }
+
+    public function testLeavesAlreadyValidPathUntouched(): void
+    {
+        self::assertSame(
+            'procedure/Planungsdokumente/file.pdf',
+            $this->sut->sanitizeZipPath('procedure/Planungsdokumente/file.pdf')
+        );
+    }
+}

--- a/tests/backend/core/Procedure/Functional/ExportServiceTest.php
+++ b/tests/backend/core/Procedure/Functional/ExportServiceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\Core\Procedure\Functional;
 
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ExportService;
+use demosplan\DemosPlanCoreBundle\Logic\ZipExportService;
 use Tests\Base\FunctionalTestCase;
 
 class ExportServiceTest extends FunctionalTestCase
@@ -22,16 +23,36 @@ class ExportServiceTest extends FunctionalTestCase
      */
     protected $sut;
 
+    protected ?ZipExportService $zipExportService = null;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sut = $this->getContainer()->get(ExportService::class);
+        $this->zipExportService = $this->getContainer()->get(ZipExportService::class);
     }
 
     public function testGetInstitutionListPhrase(): void
     {
         $phrase = $this->sut->getInstitutionListPhrase();
         self::assertSame('Institution-Liste', $phrase);
+    }
+
+    /**
+     * Zip entry paths in the procedure export are built from user-entered
+     * element/category titles (see ExportService). A title with a leading or
+     * trailing space, or a trailing dot, produces a directory segment that
+     * Windows rejects on extraction (HDDP-25). Verify the service pulled from
+     * the real container trims such segments while preserving interior dots.
+     */
+    public function testSanitizeZipPathTrimsWindowsInvalidSegments(): void
+    {
+        self::assertSame(
+            'Amtliche Bekanntmachung Beteiligungsverfahren/Kapitel 4.5.1/file.pdf',
+            $this->zipExportService->sanitizeZipPath(
+                'Amtliche Bekanntmachung Beteiligungsverfahren / Kapitel 4.5.1./file.pdf'
+            )
+        );
     }
 }


### PR DESCRIPTION
### Ticket
HDDP-25

Procedure exports produced ZIP archives that Windows refused to open ("Der zip-komprimierte Ordner ist ungültig" / PowerShell `Expand-Archive` reporting missing paths). Not every export was affected, and 7-zip opened them fine.

**Cause:** ZIP entry paths are built from user-entered planning-document / element titles. When a title carries a leading/trailing space or a trailing dot, that leaks verbatim into a path segment. Windows silently strips trailing spaces and dots from file/directory names on extraction, so the path it actually creates no longer matches the archive's entry name — and
its built-in extractor then declares the whole archive invalid. 7-zip does not normalize names, which is why it works. The existing ASCII-folding (`9a7d47aec`) fixed non-ASCII characters but did not trim whitespace/dots, so this survived it.

**Fix:** A new public `ZipExportService::sanitizeZipPath()` folds to ASCII and trims each path segment of surrounding whitespace and trailing dots.
Interior dots (e.g. `Kapitel 4.5.1`, the `.pdf` extension) are preserved. All ZIP-entry-name construction is routed through it at every site: `ZipExportService` (both choke points), `ZipResponseGenerator`, and the plandocument bulk download in `DemosPlanDocumentController`.

Only newly created archives are corrected; existing broken exports must be re-created 

### How to review/test
1. Create a procedure and give a planning-document category/element a title with a trailing space (e.g. `Amtliche  Beteiligungsverfahren Beispiele `).
2. Add a document/file under it and run the procedure export.
3. On Windows, open the resulting ZIP via Explorer or  `Expand-Archive` — it should extract without the "ungültig" error.
4. Automated coverage:  
ZipExportServiceTest.php t
ExportServiceTest.php`




- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

