### PR TITLE
fix(DPLAN-17972): tooltip prevents measurement

### DIFF
--- a/client/js/components/map/publicdetail/Map.vue
+++ b/client/js/components/map/publicdetail/Map.vue
@@ -700,8 +700,9 @@ export default {
 
       this.measureTooltip = new Overlay({
         element: this.measureTooltipElement,
-        offset: [0, -15],
+        offset: [0, -35],
         positioning: 'bottom-center',
+        stopEvent: false,
       })
       this.map.addOverlay(this.measureTooltip)
       this.measureTooltipElement.parentNode.classList.add(this.prefixClass('pointer-events-none'))


### PR DESCRIPTION
### Ticket
[DPLAN-17972](https://demoseurope.youtrack.cloud/issue/DPLAN-17972) Messungsfeld verhindert klick auf Karte

**Description:** This PR fixes an issue where the measurement tooltip could sometimes prevent users from closing a polygon. The tooltip appeared above the current measurement point and could overlap the polygon's starting point, intercepting the final click needed to complete the measurement.

The fix adds the `stopEvent: false` property to the measurement tooltip overlay, allowing click events to pass through the tooltip to the map. This ensures that users can close the polygon even when the tooltip is positioned over the starting point.

Increasing the tooltip's offset alone was also considered. However, regardless of the offset, there are always scenarios where the tooltip can overlap the polygon, depending on its size and shape. Therefore, allowing click events to pass through the tooltip is a more robust and reliable solution.

Additionally, the tooltip offset has been increased slightly to provide more space between the measurement point and the tooltip, improving the overall user experience.

### How to review/test
Go to the public detail page > draw a triangle starting from the top corner > ensure the tooltip overlaps the first point > close the polygon > the polygon should close successfully.

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
