### PR TITLE
F ds 563 fix segment export oom tag filter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -121,18 +121,26 @@ class SegmentsExportController extends BaseController
         /** @var array<string, string> $tableHeaders */
         $tableHeaders = $this->requestStack->getCurrentRequest()->query->all(self::TABLE_HEADERS_PARAMETER);
         $procedure = $this->procedureHandler->getProcedureWithCertainty($procedureId);
+
+        // Push the tag filter into the query so only statements carrying a matching tag are
+        // loaded, instead of loading every statement of the procedure and discarding the rest
+        // in PHP.
+        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
             $requestHandler->getObjectsByQueryParams(
                 $this->requestStack->getCurrentRequest()->query,
-                $statementResourceType
+                $statementResourceType,
+                $tagConditions
             )->getList()
         );
 
-        // Apply tag filtering after JsonAPI filtering
-        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
         $noTagsFilter = $this->requestStack->getCurrentRequest()->query->all(UrlParameter::FILTER);
 
+        // Trim each loaded statement to only its matching segments and collect the matched tag
+        // titles for the export header. Runs on the already-narrowed statement set.
         $statementEntities = $this->statementExportTagFilter->filterStatementsByTags($statementEntities, $tagsFilter);
         $exportFilteredByTagsWithTopics = $this->statementExportTagFilter->getFilteredTagsWithTitles();
         $customHeaderText = $this->requestStack->getCurrentRequest()->query->get(self::CUSTOM_HEADER_TEXT_PARAMETER) ?? '';
@@ -195,16 +203,22 @@ class SegmentsExportController extends BaseController
         StatementResourceType $statementResourceType,
         string $procedureId,
     ): StreamedResponse {
+        // Push the tag filter into the query so only statements carrying a matching tag are
+        // loaded, instead of loading every statement of the procedure and discarding the rest
+        // in PHP.
+        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
             $jsonApiActionService->getObjectsByQueryParams(
                 $this->requestStack->getCurrentRequest()->query,
-                $statementResourceType
+                $statementResourceType,
+                $tagConditions
             )->getList()
         );
 
-        // Apply tag filtering after JsonAPI filtering
-        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
+        // Trim each loaded statement to only its matching segments. Runs on the already-narrowed set.
         $statementEntities = $this->statementExportTagFilter->filterStatementsByTags($statementEntities, $tagsFilter);
 
         $response = new StreamedResponse(
@@ -265,15 +279,21 @@ class SegmentsExportController extends BaseController
         // It validates filter and search parameters and limits the returned statement entities to those
         // the user is allowed to see. The actual exporter hardcodes which segments of the statements are included
         // in the export and which properties of the statements and segments are exposed.
+        // Push the tag filter into the query so only statements carrying a matching tag are
+        // loaded, instead of loading every statement of the procedure and discarding the rest
+        // in PHP.
+        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+
         $statementResult = $requestHandler->getObjectsByQueryParams(
             $this->requestStack->getCurrentRequest()->query,
-            $statementResourceType
+            $statementResourceType,
+            $tagConditions
         );
         /** @var Statement[] $statements */
         $statements = array_values($statementResult->getList());
 
-        // Apply tag filtering after JsonAPI filtering
-        $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
+        // Trim each loaded statement to only its matching segments. Runs on the already-narrowed set.
         $statements = $this->statementExportTagFilter->filterStatementsByTags($statements, $tagsFilter);
 
         $statements = $exporter->mapStatementsToPathInZip(

--- a/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
@@ -106,14 +106,20 @@ class JsonApiActionService
     }
 
     /**
+     * @param array<int, ClauseFunctionInterface<bool>> $additionalConditions extra conditions merged
+     *                                                                         into the parsed request
+     *                                                                         filters; applied on both the
+     *                                                                         Doctrine and Elasticsearch paths
+     *
      * @throws QueryException
      * @throws UserNotFoundException
      */
     public function getObjectsByQueryParams(
         ParameterBag $query,
         ResourceTypeInterface $type,
+        array $additionalConditions = [],
     ): ApiListResult {
-        $filters = $this->getFilters($query);
+        $filters = [...$this->getFilters($query), ...$additionalConditions];
         $sortMethods = $this->getSorting($query);
 
         return $this->getObjects($type, $filters, $sortMethods, $query);

--- a/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/JsonApiActionService.php
@@ -107,9 +107,9 @@ class JsonApiActionService
 
     /**
      * @param array<int, ClauseFunctionInterface<bool>> $additionalConditions extra conditions merged
-     *                                                                         into the parsed request
-     *                                                                         filters; applied on both the
-     *                                                                         Doctrine and Elasticsearch paths
+     *                                                                        into the parsed request
+     *                                                                        filters; applied on both the
+     *                                                                        Doctrine and Elasticsearch paths
      *
      * @throws QueryException
      * @throws UserNotFoundException

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
@@ -18,8 +18,11 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\TagInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\TagTopicInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\Contracts\ClauseFunctionInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function in_array;
@@ -29,6 +32,7 @@ class StatementExportTagFilter
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly EntityManagerInterface $entityManager,
+        private readonly DqlConditionFactory $conditionFactory,
     ) {
     }
     private const TAG_IDS_FILTER_KEY = 'tagIds';
@@ -84,6 +88,49 @@ class StatementExportTagFilter
         // the goal is to exclude all Segments from the payload that do not match the filter criteria
         // if all Segments from a parentStatement get excluded - the whole statement gets excluded as well.
         return $this->applyTagFilter($statements, $tagIds, $tagTitles, $tagTopicIds, $tagTopicTitles);
+    }
+
+    /**
+     * Translates the {@see filterStatementsByTags()} criteria into query conditions on the
+     * Statement resource, so the tag filter can be pushed into the DB/Elasticsearch query
+     * instead of loading every statement of the procedure and discarding non-matching ones
+     * in PHP.
+     *
+     * The conditions target the already-filterable path `segments.tags.*`. Multiple criteria
+     * are OR-combined, mirroring the OR logic of {@see applyTagFilter()}: a statement matches
+     * if any of its segments carries a tag (or tag topic) matching any criterion.
+     *
+     * Returns an empty array when no supported criteria are present, leaving the query
+     * unchanged (full export).
+     *
+     * @return list<ClauseFunctionInterface<bool>>
+     */
+    public function buildStatementTagConditions(array $tagsFilter, StatementResourceType $statementResourceType): array
+    {
+        $tagIds = $tagsFilter[self::TAG_IDS_FILTER_KEY] ?? [];
+        $tagTitles = $tagsFilter[self::TAG_TITLES_FILTER_KEY] ?? [];
+        $tagTopicIds = $tagsFilter[self::TAG_TOPIC_IDS_FILTER_KEY] ?? [];
+        $tagTopicTitles = $tagsFilter[self::TAG_TOPIC_TITLES_FILTER_KEY] ?? [];
+
+        $criteria = [];
+        if ([] !== $tagIds) {
+            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagIds, $statementResourceType->segments->tags->id);
+        }
+        if ([] !== $tagTitles) {
+            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTitles, $statementResourceType->segments->tags->title);
+        }
+        if ([] !== $tagTopicIds) {
+            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTopicIds, $statementResourceType->segments->tags->topic->id);
+        }
+        if ([] !== $tagTopicTitles) {
+            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTopicTitles, $statementResourceType->segments->tags->topic->title);
+        }
+
+        if ([] === $criteria) {
+            return [];
+        }
+
+        return [1 === count($criteria) ? $criteria[0] : $this->conditionFactory->anyConditionApplies(...$criteria)];
     }
 
     public function isTagIdFilterActive(): bool

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
@@ -16,6 +16,7 @@ use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\TagInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\TagTopicInterface;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -156,16 +157,36 @@ class StatementExportTagFilter
             $statements
         );
 
-        // Fetch all segments with their tags and tag topics in a single query.
-        // Doctrine's identity map will cache all hydrated entities, so subsequent
-        // access to $segment->getTags() and $tag->getTopic() won't trigger additional queries.
+        // Pre-warm Doctrine's identity map so the in-PHP tag filter (applyTagFilter)
+        // can call $segment->getTags() and $tag->getTopic() without triggering N+1 queries.
+        //
+        // This is intentionally split into two queries instead of a single fetch-join.
+        // Joining two independent to-many collections (segmentsOfStatement AND tags) in
+        // one query produces a cartesian product (rows = segments x tags-per-segment),
+        // and each row carries the full, wide _statement columns of both the parent
+        // statement and the segment. On large procedures that buffered result set
+        // exhausts memory (OutOfMemoryError in the DBAL PDO layer). Two single-collection
+        // queries keep the row counts additive and avoid repeating the wide parent row
+        // once per tag. Both share the same identity map, so the second query enriches
+        // the segments hydrated by the first.
+
+        // Query 1: statements with their segments (single to-many join).
         $this->entityManager->createQueryBuilder()
-            ->select('s', 'seg', 't', 'topic')
+            ->select('s', 'seg')
             ->from(Statement::class, 's')
             ->leftJoin('s.segmentsOfStatement', 'seg')
+            ->where('s.id IN (:statementIds)')
+            ->setParameter('statementIds', $statementIds)
+            ->getQuery()
+            ->getResult();
+
+        // Query 2: those segments with their tags and tag topics (single to-many join).
+        $this->entityManager->createQueryBuilder()
+            ->select('seg', 't', 'topic')
+            ->from(Segment::class, 'seg')
             ->leftJoin('seg.tags', 't')
             ->leftJoin('t.topic', 'topic')
-            ->where('s.id IN (:statementIds)')
+            ->where('seg.parentStatementOfSegment IN (:statementIds)')
             ->setParameter('statementIds', $statementIds)
             ->getQuery()
             ->getResult();

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/TagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/TagResourceType.php
@@ -40,8 +40,9 @@ use InvalidArgumentException;
 /**
  * @template-extends DplanResourceType<Tag>
  *
- * @property-read End $title
- * @property-read End $sortIndex
+ * @property-read End                  $title
+ * @property-read End                  $sortIndex
+ * @property-read TagTopicResourceType $topic
  */
 final class TagResourceType extends DplanResourceType implements TagResourceTypeInterface
 {

--- a/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
+++ b/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
@@ -22,6 +22,7 @@ use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\TagTopicFactor
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Tag;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementExportTagFilter;
+use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
 use Zenstruck\Foundry\Persistence\Proxy;
@@ -55,7 +56,9 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Instantiate the filter service
         /** @var TranslatorInterface $translator */
         $translator = $this->getContainer()->get(TranslatorInterface::class);
-        $this->sut = new StatementExportTagFilter($translator, $this->getEntityManager());
+        /** @var DqlConditionFactory $conditionFactory */
+        $conditionFactory = $this->getContainer()->get(DqlConditionFactory::class);
+        $this->sut = new StatementExportTagFilter($translator, $this->getEntityManager(), $conditionFactory);
 
         // Create test procedure and statements used by most tests
         $testProcedure = ProcedureFactory::createOne();

--- a/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
+++ b/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
@@ -14,15 +14,23 @@ namespace Tests\Core\Statement\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\SegmentInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureSettingsFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\TagFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\TagTopicFactory;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Tag;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementExportTagFilter;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\Functions\AnyTrue;
+use EDT\DqlQuerying\Functions\OneOf;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
 use Zenstruck\Foundry\Persistence\Proxy;
@@ -37,6 +45,9 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
      */
     protected $sut;
 
+    private ?StatementResourceType $statementResourceType = null;
+    private ?DqlConditionFactory $conditionFactory = null;
+    private Proxy|Procedure|null $testProcedure = null;
     private Proxy|TagTopic|null $tagTopic1 = null;
     private Proxy|TagTopic|null $tagTopic2 = null;
     private Proxy|Tag|null $tag1 = null;
@@ -56,15 +67,22 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Instantiate the filter service
         /** @var TranslatorInterface $translator */
         $translator = $this->getContainer()->get(TranslatorInterface::class);
-        /** @var DqlConditionFactory $conditionFactory */
-        $conditionFactory = $this->getContainer()->get(DqlConditionFactory::class);
-        $this->sut = new StatementExportTagFilter($translator, $this->getEntityManager(), $conditionFactory);
+        $this->conditionFactory = $this->getContainer()->get(DqlConditionFactory::class);
+        $this->statementResourceType = $this->getContainer()->get(StatementResourceType::class);
+        $this->sut = new StatementExportTagFilter($translator, $this->getEntityManager(), $this->conditionFactory);
 
-        // Create test procedure and statements used by most tests
-        $testProcedure = ProcedureFactory::createOne();
-        $this->statement1 = StatementFactory::createOne(['procedure' => $testProcedure->_real()]);
-        $this->statement2 = StatementFactory::createOne(['procedure' => $testProcedure->_real()]);
-        $this->statement3 = StatementFactory::createOne(['procedure' => $testProcedure->_real()]);
+        // Create a procedure owned by the test user's orga, with settings, so the
+        // StatementResourceType access conditions allow querying its statements. This is
+        // required by the query-path tests that exercise buildStatementTagConditions()
+        // through StatementResourceType::getEntities().
+        $currentCustomer = $this->getContainer()->get(CustomerService::class)->getCurrentCustomer();
+        $orga = OrgaFactory::createOne();
+        $this->testProcedure = ProcedureFactory::createOne(['orga' => $orga, 'customer' => $currentCustomer]);
+        ProcedureSettingsFactory::createOne(['procedure' => $this->testProcedure]);
+
+        $this->statement1 = StatementFactory::createOne(['procedure' => $this->testProcedure->_real()]);
+        $this->statement2 = StatementFactory::createOne(['procedure' => $this->testProcedure->_real()]);
+        $this->statement3 = StatementFactory::createOne(['procedure' => $this->testProcedure->_real()]);
 
         // Create test tag topics and tags
         $this->tagTopic1 = TagTopicFactory::createOne(['title' => self::TAG_TOPIC_NAME_1]);
@@ -78,6 +96,19 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         $this->segment1 = SegmentFactory::createOne(['parentStatementOfSegment' => $this->statement1->_real()])->_real();
         $this->segment2 = SegmentFactory::createOne(['parentStatementOfSegment' => $this->statement2->_real()])->_real();
         $this->segment3 = SegmentFactory::createOne(['parentStatementOfSegment' => $this->statement3->_real()])->_real();
+
+        // Make the procedure current and log in a user of its orga, so getEntities() on the
+        // StatementResourceType resolves against this procedure in the query-path tests.
+        $this->getUserReference('testUser')->setOrga($orga->_real());
+        $currentProcedureService = $this->getContainer()->get(CurrentProcedureService::class);
+        $currentProcedureService->setProcedure($this->testProcedure->_real());
+        $this->statementResourceType->setCurrentProcedureService($currentProcedureService);
+        $this->loginTestUser();
+        $this->enablePermissions([
+            'feature_json_api_statement',
+            'feature_json_api_procedure',
+            'feature_json_api_original_statement',
+        ]);
     }
 
     public function testFilterStatementsByTagIds(): void
@@ -334,5 +365,123 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Verify statement1 was excluded entirely
         $filteredIds = array_map(fn ($s) => $s->getId(), $filtered);
         static::assertNotContains($this->statement1->_real()->getId(), $filteredIds, 'Statement1 should be excluded');
+    }
+
+    public function testBuildStatementTagConditionsWithEmptyFilterReturnsEmpty(): void
+    {
+        // Act: no supported criteria present
+        $conditions = $this->sut->buildStatementTagConditions([], $this->statementResourceType);
+
+        // Assert: query is left unchanged (full export)
+        static::assertSame([], $conditions);
+    }
+
+    public function testBuildStatementTagConditionsWithSingleCriterionReturnsRawCondition(): void
+    {
+        // Act: exactly one criterion
+        $conditions = $this->sut->buildStatementTagConditions(
+            ['tagIds' => [$this->tag1->getId()]],
+            $this->statementResourceType
+        );
+
+        // Assert: the single condition is returned raw, not wrapped in an OR
+        static::assertCount(1, $conditions);
+        static::assertInstanceOf(OneOf::class, $conditions[0]);
+        static::assertNotInstanceOf(AnyTrue::class, $conditions[0]);
+    }
+
+    public function testBuildStatementTagConditionsWithMultipleCriteriaWrapsInOr(): void
+    {
+        // Act: two criteria, mirroring the OR logic of applyTagFilter()
+        $conditions = $this->sut->buildStatementTagConditions(
+            [
+                'tagIds'         => [$this->tag1->getId()],
+                'tagTopicTitles' => [self::TAG_TOPIC_NAME_2],
+            ],
+            $this->statementResourceType
+        );
+
+        // Assert: still a single top-level condition, but an OR-combination (AnyTrue)
+        static::assertCount(1, $conditions);
+        static::assertInstanceOf(AnyTrue::class, $conditions[0]);
+    }
+
+    public function testPushedDownFilterReturnsSameStatementsAsInPhpFilter(): void
+    {
+        // Arrange: three visible (non-original) statements, each with one tagged segment
+        $stmtWithTag1 = $this->createVisibleStatementWithTaggedSegment($this->tag1->_real());
+        $stmtWithTag2 = $this->createVisibleStatementWithTaggedSegment($this->tag2->_real());
+        $stmtWithTag3 = $this->createVisibleStatementWithTaggedSegment($this->tag3->_real());
+        $this->getEntityManager()->flush();
+
+        $tagsFilter = ['tagIds' => [$this->tag1->getId()]];
+
+        // Act: in-PHP filter over the full candidate set ...
+        $phpFilteredIds = array_map(
+            static fn (StatementInterface $s): string => $s->getId(),
+            $this->sut->filterStatementsByTags([$stmtWithTag1, $stmtWithTag2, $stmtWithTag3], $tagsFilter)
+        );
+
+        // ... and the pushed-down query filter through the resource type
+        $conditions = $this->sut->buildStatementTagConditions($tagsFilter, $this->statementResourceType);
+        $queryFilteredIds = array_map(
+            static fn (StatementInterface $s): string => $s->getId(),
+            $this->statementResourceType->getEntities($conditions, [])
+        );
+
+        // Assert: both paths select the same statement, and only that one
+        sort($phpFilteredIds);
+        sort($queryFilteredIds);
+        static::assertSame([$stmtWithTag1->getId()], $phpFilteredIds);
+        static::assertSame($phpFilteredIds, $queryFilteredIds);
+    }
+
+    public function testStatementWithTwoMatchingSegmentsIsReturnedOnce(): void
+    {
+        // Arrange: a single statement whose TWO segments both carry the filtered tag.
+        // The pushed-down condition joins segments+tags without DISTINCT; this asserts the
+        // to-many join does not surface the statement more than once.
+        $statement = $this->createVisibleStatement();
+        $segmentA = SegmentFactory::createOne(['parentStatementOfSegment' => $statement])->_real();
+        $segmentB = SegmentFactory::createOne(['parentStatementOfSegment' => $statement])->_real();
+        $segmentA->addTag($this->tag1->_real());
+        $segmentB->addTag($this->tag1->_real());
+        $this->getEntityManager()->flush();
+
+        // Act
+        $conditions = $this->sut->buildStatementTagConditions(
+            ['tagIds' => [$this->tag1->getId()]],
+            $this->statementResourceType
+        );
+        $result = $this->statementResourceType->getEntities($conditions, []);
+
+        // Assert: exactly one statement, no duplicate ids
+        $ids = array_map(static fn (StatementInterface $s): string => $s->getId(), $result);
+        static::assertCount(1, $result);
+        static::assertSame([$statement->getId()], $ids);
+        static::assertSame($ids, array_values(array_unique($ids)));
+    }
+
+    /**
+     * Creates a statement that passes the StatementResourceType access conditions:
+     * non-deleted, in the current procedure, and a copy (has an original).
+     */
+    private function createVisibleStatement(): StatementInterface
+    {
+        $original = StatementFactory::createOne(['procedure' => $this->testProcedure->_real()])->_real();
+
+        return StatementFactory::createOne([
+            'procedure' => $this->testProcedure->_real(),
+            'original'  => $original,
+        ])->_real();
+    }
+
+    private function createVisibleStatementWithTaggedSegment(Tag $tag): StatementInterface
+    {
+        $statement = $this->createVisibleStatement();
+        $segment = SegmentFactory::createOne(['parentStatementOfSegment' => $statement])->_real();
+        $segment->addTag($tag);
+
+        return $statement;
     }
 }


### PR DESCRIPTION
Ticket

DS-563

When exporting the segment list ("Einwendungsmanagement" / Abschnitte) filtered by a tag (Schlagwort) to Excel, Word, or ZIP, users received the generic "Ein Fehler ist aufgetreten" page instead of a file. This PR fixes the crash and makes the export substantially faster.

1. Fix: OutOfMemoryError on large procedures

The export crashed with OutOfMemoryError (2 GB exhausted, thrown deep in the DBAL PDO layer). Root cause: StatementExportTagFilter::initializeRelationships() pre-warmed the relationships with a single query that fetch-joined two independent to-many collections (segmentsOfStatement and tags) plus topic. Joining two to-many relations in one query produces a cartesian product — the row count multiplies (segments × tags-per-segment) and every row drags along the full, wide _statement columns of both the parent statement and the segment, duplicated once per tag. On a large procedure the buffered result set exceeded the memory limit.

Fix: split the one fetch-join into two single-collection queries sharing the same Doctrine identity map (statements ⋈ segments, then segments ⋈ tags ⋈ topic). Row counts become additive instead of multiplicative and the wide parent row is no longer repeated per tag, while the in-PHP filter still runs without N+1 queries.

2. Improvement: only load the statements that match the filter

Even after the crash was fixed, the export was slow because the tag filter was applied in PHP after loading — so it always loaded every statement of the procedure (and all their segments) and then discarded the non-matching ones. Filtering to a single Schlagwort did not reduce the query at all.

We now push the tag filter into the query using the already-filterable segments.tags.* paths, so only statements that actually carry a matching tag are ever loaded. Permission scoping and Elasticsearch search are preserved: getObjectsByQueryParams() gained an optional conditions argument that is merged into the parsed request filters on both the Doctrine and Elasticsearch paths. The in-PHP filter is kept, but now only trims each (already-narrowed) statement to its matching segments and collects the tag titles for the export header.

Measured on the reporting procedure filtered by "Landschaftsbild": statements loaded dropped from 969 to 140 (~7×), with a corresponding drop in hydration and document-generation work.

---
How to review/test

1. Open a procedure with many segmented statements ("Abschnitte"), filter by a Schlagwort, and export as Excel, Word, and ZIP — all should complete instead of showing the error page, and noticeably faster than before.
2. Verify a full export (no tag filter) is unchanged and still contains everything.
3. Verify export with a search term typed in the list still works (Elasticsearch path).
4. Open an exported file and confirm no statement/segment appears twice (to-many filter de-duplication).

- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

