### PR TITLE
fix: restore automatic OpenAPI spec generation for the json:api

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -10,6 +10,10 @@ services:
 
     Cocur\Slugify\Slugify: ~
 
+    demosplan\DemosPlanCoreBundle\ApiDocumentation\OpenApiSpecGenerator:
+        arguments:
+            $resourceTypes: !tagged_iterator dplan.resourceType
+
     demosplan\DemosPlanCoreBundle\Transformers\AssessmentTable\StatementBulkEditTransformer:
         tags:
             - name: dplan.json_api_transformer

--- a/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/GetActionConfig.php
+++ b/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/GetActionConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration;
+
+use EDT\JsonApi\ApiDocumentation\ActionConfigInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * This class is provided to allow easy access to the previous behavior for `get` actions in the {@link OpenApiDocumentBuilder}.
+ */
+class GetActionConfig implements ActionConfigInterface
+{
+    public function __construct(
+        protected readonly RouterInterface $router,
+        protected readonly TranslatorInterface $translator,
+    ) {}
+
+    public function getOperationDescription(string $typeName): string
+    {
+        return $this->translator->trans(
+            'method.get.description',
+            ['type' => $typeName]
+        );
+    }
+
+    public function getPathDescription(): string
+    {
+        return $this->translator->trans('resource.id');
+    }
+
+    public function getSelfLink(string $typeName): string
+    {
+        return $this->router->generate(
+                'api_resource_list',
+                ['resourceType' => $typeName]
+            ) . '/{resourceId}';
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/ListActionConfig.php
+++ b/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/ListActionConfig.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration;
+
+use EDT\JsonApi\ApiDocumentation\ActionConfigInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This class is provided to allow easy access to the previous behavior for `list` actions in the {@link OpenApiDocumentBuilder}.
+ */
+class ListActionConfig implements ActionConfigInterface
+{
+    public function __construct(
+        protected readonly RouterInterface $router,
+        protected readonly TranslatorInterface $translator
+    ) {}
+
+    public function getOperationDescription(string $typeName): string
+    {
+        return $this->translator->trans(
+            'method.list.description',
+            ['type' => $typeName]
+        );
+    }
+
+    public function getPathDescription(): string
+    {
+        return $this->translator->trans('resource.id');
+    }
+
+    public function getSelfLink(string $typeName): string
+    {
+        $link = $this->router->generate(
+            'api_resource_list',
+            ['resourceType' => $typeName]
+        );
+        Assert::stringNotEmpty($link);
+
+        return $link;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/OpenApiTranslator.php
+++ b/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/OpenApiTranslator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class OpenApiTranslator implements TranslatorInterface
+{
+    public function __construct(
+        protected readonly TranslatorInterface $translator
+    ) {}
+
+    public function trans(string $id, array $parameters = [], ?string $domain = 'openapi', ?string $locale = 'en'): string
+    {
+        return trim($this->translator->trans($id, $parameters, $domain, $locale));
+    }
+
+    public function getLocale(): string
+    {
+        return $this->translator->getLocale();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/OpenApiWording.php
+++ b/demosplan/DemosPlanCoreBundle/ApiDocumentation/EDTIntegration/OpenApiWording.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration;
+
+use EDT\JsonApi\ApiDocumentation\OpenApiWordingInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This class is provided to allow easy access to the previous behavior of the {@link OpenApiDocumentBuilder}.
+ */
+class OpenApiWording implements OpenApiWordingInterface
+{
+    public function __construct(
+        protected readonly TranslatorInterface $translator
+    ) {}
+
+    public function getOpenApiDescription(): string
+    {
+        return $this->translator->trans('description');
+    }
+
+    public function getOpenApiTitle(): string
+    {
+        $value = $this->translator->trans('title');
+        Assert::stringNotEmpty($value);
+
+        return $value;
+    }
+
+    public function getIncludeParameterDescription(): string
+    {
+        return $this->translator->trans('parameter.query.include');
+    }
+
+    public function getExcludeParameterDescription(): string
+    {
+        return $this->translator->trans('parameter.query.exclude');
+    }
+
+    public function getPageNumberParameterDescription(): string
+    {
+        return $this->translator->trans('parameter.query.page_number');
+    }
+
+    public function getPageSizeParameterDescription(): string
+    {
+        return $this->translator->trans('parameter.query.page_size');
+    }
+
+    public function getFilterParameterDescription(): string
+    {
+        return $this->translator->trans('parameter.query.filter');
+    }
+
+    public function getTagName(string $typeName): string
+    {
+        $value = $this->translator->trans(
+            'resource.section',
+            ['type' => $typeName]
+        );
+        Assert::stringNotEmpty($value);
+
+        return $value;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/ApiDocumentation/OpenApiSpecGenerator.php
+++ b/demosplan/DemosPlanCoreBundle/ApiDocumentation/OpenApiSpecGenerator.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace demosplan\DemosPlanCoreBundle\ApiDocumentation;
+
+use cebe\openapi\exceptions\TypeErrorException;
+use cebe\openapi\spec\OpenApi;
+use demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration\GetActionConfig;
+use demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration\ListActionConfig;
+use demosplan\DemosPlanCoreBundle\ApiDocumentation\EDTIntegration\OpenApiWording;
+use demosplan\DemosPlanCoreBundle\Exception\ProcedureNotFoundException;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\ConsultationTokenResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\CustomFieldResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\FaqCategoryResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\InvitedPublicAgencyResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\SingleDocumentReportEntryResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\SingleDocumentResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\TagTopicResourceType;
+use EDT\JsonApi\Manager;
+use EDT\JsonApi\ResourceTypes\ResourceTypeInterface;
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class OpenApiSpecGenerator
+{
+    /**
+     * Some resource types are currently not documentable because their field configuration
+     * requires e.g. a current procedure.
+     *
+     * @var \class-string[]
+     */
+    private const UNDOCUMENTABLE_RESOURCE_TYPES = [
+        ConsultationTokenResourceType::class, // no procedure available
+        CustomFieldResourceType::class, // property name has no discernible type
+        FaqCategoryResourceType::class, // resource config builder fails
+        InvitedPublicAgencyResourceType::class, // callable-typed virtual property has no discernible type
+    ];
+
+    public function __construct(
+        private readonly Manager             $manager,
+        private readonly RouterInterface     $router,
+        private readonly TranslatorInterface $translator,
+        private readonly RewindableGenerator $resourceTypes,
+    )
+    {
+    }
+
+    /**
+     * Build an OpenApi spec with the most permissive permissions configuration possible.
+     *
+     * A user who is logged in in any role and has all available permissions enabled
+     * should result in all (non-procedure) permission checks evaluating true.
+     *
+     * With this user, all possible ResourceTypes should be included in the spec build.
+     *
+     * @throws TypeErrorException
+     */
+    public function generate(): OpenApi
+    {
+        $types = $this->getTypes();
+
+        $this->manager->setPaginationDefaultPageSize(25);
+        $this->manager->registerGetableTypes($types);
+
+        $schemaGenerator = $this->manager->createOpenApiDocumentBuilder();
+
+        $schemaGenerator->setGetActionConfig(new GetActionConfig($this->router, $this->translator));
+        $schemaGenerator->setListActionConfig(new ListActionConfig($this->router, $this->translator));
+
+        $openApiSpec = $schemaGenerator->buildDocument(new OpenApiWording($this->translator));
+
+        return $openApiSpec;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTypes(): array
+    {
+        return collect(iterator_to_array($this->resourceTypes))
+            ->filter(static function (ResourceTypeInterface $resourceType) {
+                return !in_array($resourceType::class, self::UNDOCUMENTABLE_RESOURCE_TYPES);
+            })
+            ->toArray();
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FrontendIntegratorCommand.php
@@ -13,19 +13,12 @@ namespace demosplan\DemosPlanCoreBundle\Command;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\Writer;
-use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\ApiDocumentation\OpenApiSpecGenerator;
 use demosplan\DemosPlanCoreBundle\Application\DemosPlanKernel;
-use demosplan\DemosPlanCoreBundle\Entity\User\FunctionalUser;
-use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Logic\ApiDocumentation\JsApiResourceDefinitionBuilder;
-use demosplan\DemosPlanCoreBundle\Permissions\Permissions;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
-use EDT\JsonApi\ApiDocumentation\GetActionConfig;
-use EDT\JsonApi\ApiDocumentation\ListActionConfig;
-use EDT\JsonApi\ApiDocumentation\OpenApiWording;
-use EDT\JsonApi\Manager;
 use EFrane\ConsoleAdditions\Batch\Batch;
 use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -35,9 +28,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Yaml\Yaml;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function file_put_contents;
 use function str_replace;
@@ -54,12 +44,9 @@ class FrontendIntegratorCommand extends CoreCommand
     private const RESOURCE_TYPES_FILE = 'client/js/generated/ResourceTypes.js';
 
     public function __construct(
-        private readonly CurrentUserInterface $currentUser,
+        private readonly OpenApiSpecGenerator $specGenerator,
         private readonly JsApiResourceDefinitionBuilder $resourceDefinitionBuilder,
-        private readonly Manager $manager,
         ParameterBagInterface $parameterBag,
-        private readonly RouterInterface $router,
-        private readonly TranslatorInterface $translator,
         ?string $name = null,
     ) {
         parent::__construct($parameterBag, $name);
@@ -67,6 +54,9 @@ class FrontendIntegratorCommand extends CoreCommand
 
     public function configure(): void
     {
+        $this->setName('dplan:frontend:integrator');
+        $this->setDescription('This command outputs a bunch of data needed by the FE tooling');
+
         $this->addOption('debug-additional-data', '', InputOption::VALUE_NONE, 'Debug additional data fetch');
     }
 
@@ -131,44 +121,6 @@ class FrontendIntegratorCommand extends CoreCommand
         }
     }
 
-    /**
-     * Build an OpenApi spec with the most permissive permissions configuration possible.
-     *
-     * A user who is logged in in any role and has all available permissions enabled
-     * should result in all (non-procedure) permission checks evaluating true.
-     *
-     * With this user, all possible ResourceTypes should be included in the spec build.
-     *
-     * @throws TypeErrorException
-     */
-    private function getOpenApiSpec(): OpenApi
-    {
-        $user = new FunctionalUser();
-        $user->setDplanroles([Role::CITIZEN]);
-
-        $this->currentUser->setUser($user);
-        $this->currentUser->getPermissions()->initPermissions($user);
-
-        $allPermissions = Yaml::parseFile(DemosPlanPath::getConfigPath(Permissions::PERMISSIONS_YML));
-        $this->currentUser->getPermissions()->enablePermissions(array_keys($allPermissions));
-
-        $schemaGenerator = $this->manager->createOpenApiDocumentBuilder();
-
-        $schemaGenerator->setGetActionConfig(
-            new GetActionConfig($this->router, $this->translator)
-        );
-        $schemaGenerator->setListActionConfig(
-            new ListActionConfig($this->router, $this->translator)
-        );
-
-        $openApiSpec = $schemaGenerator->buildDocument(new OpenApiWording($this->translator));
-
-        // just to be safe, reset permissions after getting everything we want
-        $this->currentUser->getPermissions()->initPermissions($user);
-
-        return $openApiSpec;
-    }
-
     private function saveOpenApiSpec(OpenApi $openApiSpec): void
     {
         // local file is valid, no need for flysystem
@@ -180,10 +132,12 @@ class FrontendIntegratorCommand extends CoreCommand
 
     /**
      * Update coding support files for our EDT-based {json:api}.
+     *
+     * @throws TypeErrorException
      */
     private function updateApiCodingSupport(): void
     {
-        $openApiSpec = $this->getOpenApiSpec();
+        $openApiSpec = $this->specGenerator->generate();
 
         $this->saveOpenApiSpec($openApiSpec);
         $this->resourceDefinitionBuilder->build($openApiSpec, self::RESOURCE_TYPES_FILE);

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ConsultationTokenResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ConsultationTokenResourceType.php
@@ -50,6 +50,21 @@ final class ConsultationTokenResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('area_admin_consultations');
     }
 
+    /**
+     * Condition to check if the current user is in the procedure of the original statement.
+     *
+     * @return \EDT\DqlQuerying\Contracts\ClauseFunctionInterface|\EDT\Querying\Contracts\PathsBasedInterface
+     * @throws \EDT\Querying\Contracts\PathException
+     * @throws \demosplan\DemosPlanCoreBundle\Exception\ProcedureNotFoundException
+     */
+    public function isInCurrentProcedureCondition(): \EDT\DqlQuerying\Contracts\ClauseFunctionInterface|\EDT\Querying\Contracts\PathsBasedInterface
+    {
+        return $this->conditionFactory->propertyHasValue(
+            $this->currentProcedureService->getProcedureWithCertainty('No authorization for any procedure.')->getId(),
+            Paths::consultationToken()->originalStatement->procedure->id
+        );
+    }
+
     protected function getAccessConditions(): array
     {
         $procedure = $this->currentProcedureService->getProcedure();
@@ -63,17 +78,17 @@ final class ConsultationTokenResourceType extends DplanResourceType
         )];
     }
 
+    /**
+     * @return array|\EDT\JsonApi\PropertyConfig\Builder\AttributeConfigBuilder[]|\EDT\JsonApi\PropertyConfig\Builder\ToManyRelationshipConfigBuilder[]|\EDT\JsonApi\PropertyConfig\Builder\ToOneRelationshipConfigBuilder[]
+     * @throws \EDT\Querying\Contracts\PathException
+     * @throws \demosplan\DemosPlanCoreBundle\Exception\ProcedureNotFoundException
+     */
     protected function getProperties(): array
     {
-        // Check if the current user is allowed to update the entity.
-        $inCurrentProcedureCondition = $this->conditionFactory->propertyHasValue(
-            $this->currentProcedureService->getProcedureWithCertainty('No authorization for any procedure.')->getId(),
-            Paths::consultationToken()->originalStatement->procedure->id
-        );
-
         return [
             $this->createIdentifier()->readable()->sortable()->filterable(),
-            $this->createAttribute($this->note)->readable(true)->sortable()->filterable()->updatable([$inCurrentProcedureCondition]),
+            $this->createAttribute($this->note)->readable(true)->sortable()->filterable()->updatable(
+                [$this->isInCurrentProcedureCondition()]),
             $this->createAttribute($this->token)->readable(true)->sortable()->filterable(),
             $this->createToOneRelationship($this->statement)->readable()->sortable()->filterable(),
             $this->createAttribute($this->usedEmailAddress)->readable()->sortable()->filterable()

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/ProcedurePhaseResourceType.php
@@ -63,6 +63,8 @@ final class ProcedurePhaseResourceType extends DplanResourceType
 
     protected function getProperties(): array
     {
-        return [];
+        return [
+            $this->createIdentifier()->readable(),
+        ];
     }
 }

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/SingleDocumentResourceType.php
@@ -32,10 +32,6 @@ use EDT\PathBuilding\End;
  */
 final class SingleDocumentResourceType extends DplanResourceType
 {
-    public function __construct(private readonly SingleDocumentService $singleDocumentService)
-    {
-    }
-
     public static function getName(): string
     {
         return 'SingleDocument';
@@ -75,11 +71,11 @@ final class SingleDocumentResourceType extends DplanResourceType
 
     protected function getProperties(): array
     {
-        $properties = [];
+        $properties = [$this->createIdentifier()->readable()->filterable()];
 
         if ($this->currentUser->hasPermission('field_procedure_documents')) {
             $properties = array_merge($properties, [
-                $this->createIdentifier()->readable()->filterable(),
+
                 $this->createAttribute($this->parentId)
                     ->readable(true)->filterable()->sortable()->aliasedPath($this->element->id),
                 $this->createAttribute($this->title)

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/TagTopicResourceType.php
@@ -19,6 +19,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Tag;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\TagService;
 use demosplan\DemosPlanCoreBundle\Repository\TagTopicRepository;
 use EDT\JsonApi\ApiDocumentation\DefaultField;
@@ -43,8 +44,8 @@ use Webmozart\Assert\Assert;
 final class TagTopicResourceType extends DplanResourceType
 {
     public function __construct(
-        private readonly TagService $tagService,
-        protected TagTopicRepository $tagTopicRepository,
+        private readonly TagService  $tagService,
+        protected TagTopicRepository $tagTopicRepository
     ) {
     }
 
@@ -74,6 +75,18 @@ final class TagTopicResourceType extends DplanResourceType
             'feature_json_api_tag_topic',
             'area_statement_segmentation'
         );
+    }
+
+    /**
+     * @return bool
+     */
+    public function getMaster(): bool
+    {
+        if (!$this->currentProcedureService->getProcedure()) {
+            return false;
+        }
+
+        return $this->currentProcedureService->getProcedure()->getMaster();
     }
 
     protected function getAccessConditions(): array
@@ -145,12 +158,12 @@ final class TagTopicResourceType extends DplanResourceType
             )
         );
 
-        if ($this->currentProcedureService->getProcedure()->getMaster()) {
+        if ($this->getMaster()) {
             $configBuilder->procedure
                 ->setRelationshipType($this->resourceTypeStore->getProcedureTemplateResourceType())
                 ->setReadableByPath()->setSortable()->setFilterable()->initializable();
         }
-        if (!$this->currentProcedureService->getProcedure()->getMaster()) {
+        if (!$this->getMaster()) {
             $configBuilder->procedure
                 ->setRelationshipType($this->resourceTypeStore->getProcedureResourceType())
                 ->setReadableByPath()->setSortable()->setFilterable()->initializable();


### PR DESCRIPTION
Description:  
Automatic OpenAPI generation for the generic `{json:api}` (EDT) is broken on `main`: 
 `php bin/<project> dplan:frontend:integrator` writes an **empty** spec to `client/js/generated/openApi.json` (`paths: {}`), so both the generated API definition and the derived FE ResourceTypes mapping are effectively unusable.

**Root cause:** the EDT `Manager` starts with empty getable/listable type lists and only documents types that were registered via `registerGetableTypes()` first. Nothing on `main` performs that registration, so `createOpenApiDocumentBuilder()` builds against an empty list and emits an empty document. (This is unrelated to permissions or the caught "Customer has no
identifier" warning.)

**This PR** restores generation by introducing an `OpenApiSpecGenerator` that collects all resource types via the `dplan.resourceType` tagged iterator, filters out the ones that can't be documented, registers them on the `Manager`,
and builds the spec. The command now delegates to it.

Changes:
- Add `OpenApiSpecGenerator` + EDTIntegration helpers (GetActionConfig,  ListActionConfig, OpenApiTranslator, OpenApiWording).
- Wire `OpenApiSpecGenerator` in `services.yml` (tagged iterator).
- Rework `FrontendIntegratorCommand` to use the generator; remove the old non-functional `getOpenApiSpec()`.
- ResourceType fixes so their properties are typeable (ConsultationToken, ProcedurePhase, SingleDocument, TagTopic).
- Exclude `InvitedPublicAgencyResourceType` from documentation — its virtual property `hasReceivedInvitationMailInCurrentProcedurePhase` uses a callable with no discernible type, which aborts the build.

Result: the command regenerates a complete spec (~85 paths / 86 schemas).

**Provenance:** the generation core is cherry-picked from commit `ab5e2e896` ("Fix openapi documentation generation"), which was never merged to `main`. The `InvitedPublicAgency` exclusion is new on top of it, needed to complete the
build against the current codebase.

**Out of scope:** the dev-only live endpoint `/api/openapi.json` (`APIDocumentationController`) still returns an empty spec because it builds against an unregistered `Manager`. Wiring it to `OpenApiSpecGenerator` is a follow-up.

### How to review/test
1. Check out the branch, then run: docker compose exec development su -l $USER -s /usr/bin/zsh -c
     'cd /srv/www && php bin/<projectName>  cache:clear --env=dev --no-warmup && php bin/<projectName> dplan:frontend:integrator'
Expected: prints the project-config JSON line, **no** `Error:` line.
2. Verify content:  python3 -c "import json; d=json.load(open('client/js/generated/openApi.json')); print('paths', len(d['paths']), 'schemas', len(d['components']['schemas']))". Expected: ~85 paths / 86 schemas (was 0 before).
3. To inspect the generated spec visually, we imported `client/js/generated/openApi.json` into https://editor.swagger.io/
(File → Import file), which renders the full, clickable API documentation.


- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

