### PR TITLE
fix(refs DS-561): fix range start handle

### DIFF
--- a/client/js/lib/prosemirror/commands.js
+++ b/client/js/lib/prosemirror/commands.js
@@ -270,11 +270,12 @@ const genEditingDecorations = (state, from, to, id, activePosition = null) => {
  * @param {prosemirror-view} view
  * @param {prosemirror-pluginkey} rangeTrackerKey
  * @param {prosemirror-pluginkey} editStateTrackerKey
- * @param {String} rangeId
- * @param {Number} activationPosition
+ * @param {String} segmentId
+ * @param {{active: Number, fixed: Number}|null} positions The active (movable) and fixed handle positions.
+ *        Defaults to activating the end handle and fixing the start handle when omitted.
  *
  */
-const activateRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, segmentId) => {
+const activateRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, segmentId, positions = null) => {
   const { state, dispatch } = view
   let tr = state.tr
 
@@ -283,10 +284,15 @@ const activateRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, segmentId
    * the editStateTracker-plugin via a meta message.
    */
   const range = rangeTrackerKey.getState(state)[segmentId]
-  const positions = { active: range.to, fixed: range.from }
 
-  tr = tr.setSelection(TextSelection.near(state.doc.resolve(range.to)))
-  tr = tr.setMeta(editStateTrackerKey, { id: segmentId, pos: positions.active, moving: true, positions })
+  /**
+   * `positions.active` is the handle that follows the cursor, `positions.fixed` stays put. When no positions are
+   * provided (edit mode is first entered), default to activating the end handle and fixing the start handle.
+   */
+  const resolvedPositions = positions ?? { active: range.to, fixed: range.from }
+
+  tr = tr.setSelection(TextSelection.near(state.doc.resolve(resolvedPositions.active)))
+  tr = tr.setMeta(editStateTrackerKey, { id: segmentId, pos: resolvedPositions.active, moving: true, positions: resolvedPositions })
   dispatch(tr)
 
   /**
@@ -330,7 +336,7 @@ const toggleRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, decorationT
   if (rangeId) {
     const { state } = view
     const pos = parseInt(target.getAttribute('data-range-widget-pos'))
-    const currentlyActivePosition = decorationTrackerKey.getState(state).activeDecorationPosition
+    const { position, activeDecorationPosition: currentlyActivePosition } = decorationTrackerKey.getState(state)
 
     /**
      * If the handle position equals the position of the currently active handle, the user clicked on the same handle
@@ -342,9 +348,15 @@ const toggleRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, decorationT
 
     /**
      * This code block is called whenever the user clicks a handle that is not already active. It moves the activation
-     * state from the handle that is currently active to the handle which was just clicked.
+     * state from the handle that is currently active to the handle which was just clicked. The active/fixed positions
+     * are derived from the *current* (possibly edited) range so that an in-progress adjustment of the other handle is
+     * preserved when switching handles.
      */
-    activateRangeEdit(view, rangeTrackerKey, editStateTrackerKey, rangeId)
+    const { from, to } = position
+    const activationPosition = currentlyActivePosition === from ? to : from
+    const fixedPosition = currentlyActivePosition === from ? from : to
+
+    activateRangeEdit(view, rangeTrackerKey, editStateTrackerKey, rangeId, { active: activationPosition, fixed: fixedPosition })
   }
 }
 

--- a/client/js/lib/prosemirror/commands.js
+++ b/client/js/lib/prosemirror/commands.js
@@ -347,14 +347,24 @@ const toggleRangeEdit = (view, rangeTrackerKey, editStateTrackerKey, decorationT
     }
 
     /**
-     * This code block is called whenever the user clicks a handle that is not already active. It moves the activation
-     * state from the handle that is currently active to the handle which was just clicked. The active/fixed positions
-     * are derived from the *current* (possibly edited) range so that an in-progress adjustment of the other handle is
-     * preserved when switching handles.
+     * If the current range positions are not available, fall back to the default activation
+     * (end handle active) rather than resolving an undefined position.
      */
     const { from, to } = position
-    const activationPosition = currentlyActivePosition === from ? to : from
-    const fixedPosition = currentlyActivePosition === from ? from : to
+
+    if (from === undefined || to === undefined) {
+      activateRangeEdit(view, rangeTrackerKey, editStateTrackerKey, rangeId)
+
+      return true
+    }
+
+    /**
+     * This code block is called whenever the user clicks a handle that is not already active. It activates the handle
+     * that was just clicked and fixes the opposite boundary. Both positions are taken from the *current* (possibly
+     * edited) range so that an in-progress adjustment of the other handle is preserved when switching handles.
+     */
+    const activationPosition = pos === from ? from : to
+    const fixedPosition = pos === from ? to : from
 
     activateRangeEdit(view, rangeTrackerKey, editStateTrackerKey, rangeId, { active: activationPosition, fixed: fixedPosition })
   }

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
@@ -250,9 +250,11 @@
     span[data-range-active='true'],
     span[data-range-selected],
     span[data-range-selected] > span {
-        // Vertical padding fills the empty space (leading) that line-height adds above and below the text
-        // (line-height 24px, font 16px) so the highlight has no gap between wrapped lines. Combined with
-        // box-decoration-break: clone, the padding is applied to each line fragment.
+        // Vertical padding fills the leading (empty space line-height adds around the text) so the highlight
+        // has no gap between wrapped lines. The leading is line-height minus the font's glyph box, which is
+        // ~14px here (smaller than the 16px font-size), i.e. ~10px total; ~5px per side is needed to reach the
+        // full 24px line-height. 4px leaves a ~2px gap. box-decoration-break: clone applies the padding to
+        // each wrapped line fragment.
         padding: 5px 0;
         background-color: $segment-highlight-bg-color;
         box-decoration-break: clone;

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
@@ -248,7 +248,12 @@
     span[data-range-active='true'],
     span[data-range-selected],
     span[data-range-selected] > span {
+        // Vertical padding fills the empty space (leading) that line-height adds above and below the text
+        // (line-height 24px, font 16px) so the highlight has no gap between wrapped lines. Combined with
+        // box-decoration-break: clone, the padding is applied to each line fragment.
+        padding: 5px 0;
         background-color: $segment-highlight-bg-color;
+        box-decoration-break: clone;
     }
 
     span[data-range-moving='true'] {

--- a/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
+++ b/demosplan/DemosPlanCoreBundle/Resources/client/scss/components/_splitstatement.scss
@@ -161,6 +161,8 @@
         .range-handle {
             position: relative;
             font-size: $dp-font-size-large;
+            // Cap the line-height at the handle's own font-size so its larger glyph does not stretch the text line it sits on
+            line-height: 1;
             color: $dp-color-interactive-default;
 
             &::before {


### PR DESCRIPTION
### Ticket
[DS-561](https://demoseurope.youtrack.cloud/tickets/DS-561/Anfang-des-markierten-Textes-beim-Aufteilen-kann-nicht-geandert-werden)

When splitting a statement into segments, the start range handle could no longer be activated and moved - this was because the range end handle was hardcoded to be movable, and the start range handle was hardcoded to be fixed.

This is fixed by setting the clicked handle as the active handle and deriving positions from the current range (rather than the stored one, because when switching the active handle, this lead to the previously active handle being reset to its original position).

There were also a few styling issues that are fixed in this PR:
- when increasing a range, the newly added selection's background now has the same padding as the previously selected range (so background heights are the same)
- when selecting a range over two lines, there was a small gap between the highlighted backgrounds; this is now fixed
- the active range selection handle no longer stretches the gap between lines

### How to review/test
- Go to the split statement view and make sure that you can use both range edit handles to edit the segment range
- there should be no gaps between the highlighted backgrounds of the range lines, and the active handle should not stretch the line that it sits on (i.e. it should not cause a bigger gap between lines)

### PR Checklist

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
