### PR TITLE
f DS-568 exclude identity-provider users from inactivity deletion

### DIFF
--- a/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/AccountDeletionRunMessageHandler.php
@@ -108,6 +108,15 @@ final class AccountDeletionRunMessageHandler
 
     private function processCandidate(UserInterface $user): void
     {
+        // Accounts provisioned by an external identity provider are never soft-deleted
+        // by the inactivity cascade — their lifecycle is owned by the IdP. They are
+        // already excluded from the candidate query; this guard is the defensive belt
+        // in case such a user reaches the handler by another path. Removal of these
+        // accounts, if ever needed, is handled manually via the deletion command.
+        if ($user->isProvidedByIdentityProvider()) {
+            return;
+        }
+
         $tracking = $this->trackingRepository->findOneByUser($user);
         $step = $this->activityChecker->evaluateInactivityStep($user, $tracking);
 

--- a/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/UserRepository.php
@@ -765,7 +765,9 @@ class UserRepository extends CoreRepository implements ArrayInterface, ObjectInt
     /**
      * Returns active users whose effective inactivity reference (`lastLogin` if set,
      * else `createdDate`) is at or before the cutoff. Excludes deleted users, the
-     * AI API user (by login — its row ID is random per project), and any further
+     * AI API user (by login — its row ID is random per project), users provisioned
+     * by an external identity provider (their lifecycle is owned by the IdP, so they
+     * must never be soft-deleted by the inactivity cascade), and any further
      * protected IDs supplied by the caller (typically the anonymous-user constant
      * plus project-specific protected accounts).
      *
@@ -783,6 +785,7 @@ class UserRepository extends CoreRepository implements ArrayInterface, ObjectInt
             ->where(self::WHERE_NOT_DELETED)
             ->andWhere('COALESCE(u.lastLogin, u.createdDate) <= :cutoff')
             ->andWhere('u.login != :aiApiUserLogin')
+            ->andWhere('u.providedByIdentityProvider = false')
             ->setParameter('cutoff', $cutoff)
             ->setParameter('aiApiUserLogin', AiApiUser::AI_API_USER_LOGIN);
 

--- a/tests/backend/core/MessageHandler/AccountDeletionRunMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/AccountDeletionRunMessageHandlerTest.php
@@ -259,6 +259,24 @@ class AccountDeletionRunMessageHandlerTest extends UnitTestCase
         ($this->sut)(new AccountDeletionRunMessage());
     }
 
+    public function testIdentityProviderUserIsSkippedBeforeAnyDeletionStep(): void
+    {
+        $user = $this->buildUserMock();
+        $user->method('isProvidedByIdentityProvider')->willReturn(true);
+
+        $this->userRepository->method('findInactivityDeletionCandidates')->willReturn([$user]);
+
+        // The IdP guard short-circuits at the top of processCandidate: no step
+        // evaluation, no tracking lookup, no mail, no soft-deletion, no flush.
+        $this->trackingRepository->expects($this->never())->method('findOneByUser');
+        $this->activityChecker->expects($this->never())->method('evaluateInactivityStep');
+        $this->mailService->expects($this->never())->method('sendMail');
+        $user->expects($this->never())->method('setDeleted');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        ($this->sut)(new AccountDeletionRunMessage());
+    }
+
     /**
      * @return User&MockObject
      */


### PR DESCRIPTION
Ticket : DS-568

Description:
Users provisioned by an external identity provider (`provided_by_identity_provider = true`) were being picked up by the inactivity-based account deletion workflow and soft-deleted after the warning cascade. Their lifecycle is owned by the IdP, so they must never be deleted by this job.

This PR excludes IdP-provided users from the deletion workflow on two levels:

- **Primary guard** — `UserRepository::findInactivityDeletionCandidates()` now filters out users with `providedByIdentityProvider = true`. They never become candidates, so they receive no warning mails, get no tracking row, and are never soft-deleted.
- **Defensive guard** — `AccountDeletionRunMessageHandler::processCandidate()` short-circuits for IdP users in case such a user reaches the handler by another path (e.g. the `dplan:account-deletion:prepare-test` QA command, which invokes the same handler).

No dedicated CLI deletion command exists for this feature; the only deletion path is the handler's soft-delete, which both guards now cover.


- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

