### PR TITLE
feat(DPLAN-17966): log aborted statement imports and enrich import er…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ImportError.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/ImportError.php
@@ -49,16 +49,23 @@ class ImportError
     }
 
     /**
-     * @return array{id: int, currentWorksheet: string, lineNumber: int, message: string}
+     * @return array{id: int, currentWorksheet: string, lineNumber: int, message: string, field: string, invalidValue: bool|float|int|string}
      */
     public function toArray(int $key): array
     {
+        // getInvalidValue() may return an entity/array (e.g. when a whole statement
+        // fails validation); reduce non-scalars to their type so the result stays
+        // safely serializable for both the log context and the JSON error response.
+        $invalidValue = $this->violation->getInvalidValue();
+
         return
             [
                 'id'               => $key,
                 'currentWorksheet' => $this->getWorksheetTitle(),
                 'lineNumber'       => $this->getLineNumber(),
                 'message'          => $this->getMessage(),
+                'field'            => $this->violation->getPropertyPath(),
+                'invalidValue'     => is_scalar($invalidValue) ? $invalidValue : get_debug_type($invalidValue),
             ];
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxStatementImport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/XlsxStatementImport.php
@@ -74,6 +74,14 @@ class XlsxStatementImport
             $generatedStatements = $this->xlsxStatementImporter->getGeneratedStatements();
             if ($this->hasErrors()) {
                 $doctrineConnection->rollBack();
+                $this->logger->warning(
+                    'Statement xlsx import aborted: validation errors, no statements were created.',
+                    [
+                        'errorCount' => count($this->xlsxStatementImporter->getErrors()),
+                        'errors'     => $this->xlsxStatementImporter->getErrorsAsArray(),
+                        'skipped'    => $this->xlsxStatementImporter->getSkippedStatements(),
+                    ]
+                );
 
                 return;
             }


### PR DESCRIPTION
Ticket: DPLAN-17966

Description:
When a statement xlsx / participation import is rolled back due to per-row validation errors (e.g. an attachment reference that isn't present in the ZIP), the importer returned silently: nothing was logged and the whole batch was discarded with no server-side trace, which made such failures very hard to diagnose.

This PR improves observability only — it does **not** change import outcomes:

- `XlsxStatementImport::importFromFile()` now logs a `warning` (error count, per-row errors, skipped counts) before the rollback, instead of returning silently.
- `ImportError::toArray()` now also exposes `field` (the violation property path) and a scalar-safe `invalidValue`, so both the JSON error response and  the new log identify the offending column and value.

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly

