### PR TITLE
build(docker): use project-local var/tmp for PHP temp dir

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
@@ -44,8 +44,14 @@ class OdtBorderedWriter implements WriterInterface
     public function save(string $filename): void
     {
         $targetIsOutputStream = 'php://output' === $filename || 'php://stdout' === $filename;
-        $workFile = $targetIsOutputStream ? DemosPlanPath::getTemporaryPath('odtb_') : $filename;
 
+        try {
+            $tempDir = DemosPlanPath::getTemporaryPath();
+        } catch (\Throwable) {
+            throw OdtProcessingException::processingFailed('Could not allocate temp file for ODT writer.');
+        }
+
+        $workFile = $targetIsOutputStream ? \tempnam($tempDir, 'odtb_') : $filename;
         if (false === $workFile) {
             throw OdtProcessingException::processingFailed('Could not allocate temp file for ODT writer.');
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Writer\ODText;
 use PhpOffice\PhpWord\Writer\WriterInterface;
+use Throwable;
 use ZipArchive;
 
 /**
@@ -47,7 +48,7 @@ class OdtBorderedWriter implements WriterInterface
 
         try {
             $tempDir = DemosPlanPath::getTemporaryPath();
-        } catch (\Throwable) {
+        } catch (Throwable) {
             throw OdtProcessingException::processingFailed('Could not allocate temp file for ODT writer.');
         }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/Odt/OdtBorderedWriter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Logic\Export\Odt;
 
 use demosplan\DemosPlanCoreBundle\Exception\OdtProcessingException;
+use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Writer\ODText;
 use PhpOffice\PhpWord\Writer\WriterInterface;
@@ -43,7 +44,7 @@ class OdtBorderedWriter implements WriterInterface
     public function save(string $filename): void
     {
         $targetIsOutputStream = 'php://output' === $filename || 'php://stdout' === $filename;
-        $workFile = $targetIsOutputStream ? \tempnam(\sys_get_temp_dir(), 'odtb_') : $filename;
+        $workFile = $targetIsOutputStream ? DemosPlanPath::getTemporaryPath('odtb_') : $filename;
 
         if (false === $workFile) {
             throw OdtProcessingException::processingFailed('Could not allocate temp file for ODT writer.');

--- a/docker/demosplan-production/Dockerfile
+++ b/docker/demosplan-production/Dockerfile
@@ -96,11 +96,13 @@ RUN mkdir -p /srv/www/public/js && \
     mkdir -p /srv/www/var/cache && \
     mkdir -p /srv/www/var/log && \
     mkdir -p /srv/www/var/certs && \
+    mkdir -p /srv/www/var/tmp && \
     mkdir -p /srv/www/client/css/generated && \
     chown -R www-data /srv/www/public && \
     chown -R www-data /srv/www/var/cache && \
     chown -R www-data /srv/www/var/log && \
     chown -R www-data /srv/www/var/certs && \
+    chown -R www-data /srv/www/var/tmp && \
     chown -R www-data /srv/www/client/css/generated && \
 # define doctrine in memory database for the asset build \
     mv /srv/www/config/packages/doctrine.yaml /tmp/doctrine.yaml
@@ -202,6 +204,8 @@ RUN rm -rf /srv/www/var/cache/* && \
     # ensure tmp directory exists and is writable for Symfony XML schema validation \
     mkdir -p /srv/www/tmp && \
     chown -R www-data:www-data /srv/www/tmp && \
+    # sys_get_temp_dir() points here (see sys_temp_dir in zzz-dplan.ini) \
+    mkdir -p /srv/www/var/tmp && \
     chown -R www-data:www-data /srv/www/var && \
     # link the custom squid root ca to the system that is mounted as a secret \
     # use a dummy file during link creation to prevent the error if the secret is not mounted \

--- a/docker/demosplan-production/zzz-dplan-cli.ini
+++ b/docker/demosplan-production/zzz-dplan-cli.ini
@@ -1,6 +1,9 @@
 upload_max_filesize = 10G
 post_max_size = 11G
 
+; project-local temp dir used by sys_get_temp_dir(); kept inside the writable var/ tree
+sys_temp_dir = /srv/www/var/tmp
+
 max_execution_time = 3600
 memory_limit = 6G
 

--- a/docker/demosplan-production/zzz-dplan.ini
+++ b/docker/demosplan-production/zzz-dplan.ini
@@ -1,5 +1,10 @@
 upload_max_filesize = 10G
+upload_tmp_dir = /srv/www/var/tmp
 post_max_size = 11G
+
+; project-local temp dir used by sys_get_temp_dir() (and thus upload_tmp_dir above);
+; kept inside the writable var/ tree instead of the shared /tmp
+sys_temp_dir = /srv/www/var/tmp
 
 max_execution_time = 1800
 memory_limit = 2G


### PR DESCRIPTION
## Description
Point PHP's temp directory at the project-local, writable `var/` tree instead of the shared `/tmp` in the production image.

- Set `sys_temp_dir` (and `upload_tmp_dir`) to `/srv/www/var/tmp` in the fpm and cli PHP config.
- Create `var/tmp` and set `www-data` ownership during the image build.
- Add `var/tmp/.gitkeep` so the directory ships with the repo.

## Why
`sys_get_temp_dir()` previously resolved to `/tmp`, which is shared and not guaranteed writable/owned by the runtime user. Keeping temp files in the app-owned `var/` tree matches the existing `var/cache` / `var/log` convention.

Ref: DPLAN-17966