### PR TITLE
fix(refs: DPLAN-18169): add gap between checkboxes

### DIFF
--- a/client/js/components/statement/StatementExportModal.vue
+++ b/client/js/components/statement/StatementExportModal.vue
@@ -75,7 +75,7 @@
       </fieldset>
 
       <fieldset v-if="isSingleStatementExport">
-        <div class="flex mt-1 mb-5">
+        <div class="flex mt-1 mb-5 gap-2">
           <dp-checkbox
             id="singleStatementCitizen"
             v-model="isCitizenDataCensored"


### PR DESCRIPTION
### Ticket
[DPLAN-18169](https://demoseurope.youtrack.cloud/issue/DPLAN-18169/Einzelexport-Abstand-der-Auswahlkastchen-anpassen)

Adds a gap between the checkboxes.

### How to review/test
navigate to single statement export and check gap between checkboxes. bug only showed on larger screens, so resize the window until there are no line breaks in the checkbox labels.