### PR TITLE
fix(refs DS-573): guard segmentation editor against segments without a document mark

### DIFF
--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -422,6 +422,15 @@ export default {
 
     determineDisplayScrollButton () {
       const segmentSpans = document.querySelectorAll('span[data-range-active="true"]')
+
+      /**
+       * Without an active segment span in the document (e.g. a segment without a mark is being
+       * edited), there is nothing to scroll to, so no scroll button is shown.
+       */
+      if (!segmentSpans.length) {
+        return false
+      }
+
       const lastSegmentSpan = segmentSpans[segmentSpans.length - 1]
       const segmentBottom = lastSegmentSpan.getBoundingClientRect().bottom
       const headerHeight = document.getElementById('header').getBoundingClientRect().height
@@ -483,11 +492,18 @@ export default {
         this.stateBeforeEditing = null
       }
 
-      this.ignoreProsemirrorUpdates = true
       const { rangeTrackerKey, editingDecorationsKey } = this.prosemirror.keyAccess
 
-      setRangeEditingState(this.prosemirror.view, rangeTrackerKey, editingDecorationsKey)(this.editingSegment.id, false)
-      this.ignoreProsemirrorUpdates = false
+      /**
+       * Only reset the range editing state for segments that actually have a range in the document.
+       * Segments without a mark (metadata-only edits) have nothing to reset.
+       */
+      if (this.editingSegment && rangeTrackerKey.getState(this.prosemirror.view.state)[this.editingSegment.id]) {
+        this.ignoreProsemirrorUpdates = true
+        setRangeEditingState(this.prosemirror.view, rangeTrackerKey, editingDecorationsKey)(this.editingSegment.id, false)
+        this.ignoreProsemirrorUpdates = false
+      }
+
       this.setProperty({ prop: 'editingSegment', val: null })
       this.setProperty({ prop: 'editModeActive', val: false })
     },
@@ -506,6 +522,14 @@ export default {
       this.stateBeforeEditing = rangeTrackerKey.getState(state)
       this.setProperty({ prop: 'editingSegment', val: this.segmentById(id) })
       this.setProperty({ prop: 'editModeActive', val: true })
+
+      /**
+       * Segments whose mark is missing from the document have no range to edit. Allow editing their
+       * metadata (tags, place, assignee) but skip range activation, which requires an existing range.
+       */
+      if (!rangeTrackerKey.getState(state)[id]) {
+        return
+      }
 
       this.ignoreProsemirrorUpdates = true
       setRangeEditingState(this.prosemirror.view, rangeTrackerKey, editingDecorationsKey)(id, true)

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -424,8 +424,9 @@ export default {
       const segmentSpans = document.querySelectorAll('span[data-range-active="true"]')
 
       /**
-       * Without an active segment span in the document (e.g. a segment without a mark is being
-       * edited), there is nothing to scroll to, so no scroll button is shown.
+       * Normally every segment is marked in the document, but broken drafts can contain a segment
+       * without a mark. While such a segment is being edited there is no active span to scroll to,
+       * so no scroll button is shown.
        */
       if (!segmentSpans.length) {
         return false
@@ -453,9 +454,7 @@ export default {
         }
       }
 
-      return segmentSpans.length ?
-        segmentIsAtTop || segmentIsAtBottom :
-        false
+      return segmentIsAtTop || segmentIsAtBottom
     },
 
     determineIfStatementReady (counter = 0) {
@@ -495,8 +494,9 @@ export default {
       const { rangeTrackerKey, editingDecorationsKey } = this.prosemirror.keyAccess
 
       /**
-       * Only reset the range editing state for segments that actually have a range in the document.
-       * Segments without a mark (metadata-only edits) have nothing to reset.
+       * Normally every segment has a range in the document, but a broken draft can contain a segment
+       * without a mark. Only reset the range editing state for segments that actually have a range;
+       * mark-less segments (metadata-only edits) have nothing to reset.
        */
       if (this.editingSegment && rangeTrackerKey.getState(this.prosemirror.view.state)[this.editingSegment.id]) {
         this.ignoreProsemirrorUpdates = true
@@ -524,8 +524,9 @@ export default {
       this.setProperty({ prop: 'editModeActive', val: true })
 
       /**
-       * Segments whose mark is missing from the document have no range to edit. Allow editing their
-       * metadata (tags, place, assignee) but skip range activation, which requires an existing range.
+       * Normally every segment is marked in the document. When a broken draft contains a segment
+       * whose mark is missing, it has no range to edit: allow editing its metadata (tags, place,
+       * assignee) but skip range activation, which requires an existing range.
        */
       if (!rangeTrackerKey.getState(state)[id]) {
         return

--- a/client/js/lib/prosemirror/commands.js
+++ b/client/js/lib/prosemirror/commands.js
@@ -43,8 +43,21 @@ const applySelectionChange = (view, editStateTrackerKey, rangeTrackerKey) => {
    */
   const nodes = flattenNode(state.doc)
   const marks = getMarks(nodes, 'rangeselection', 'rangeType')
-  const { from, to } = marks.selection
   let tr = state.tr
+
+  /**
+   * When there is no active range selection, the segment being edited has no adjustable boundary in
+   * the document (e.g. its segmentMark is missing from the textual reference, or only metadata such
+   * as tags or place was changed). There is nothing to apply to the document: stop the range edit
+   * cleanly and let the caller persist the segment metadata instead of throwing.
+   */
+  if (!marks.selection) {
+    dispatch(disableRangeEdit(view, editStateTrackerKey, tr))
+
+    return true
+  }
+
+  const { from, to } = marks.selection
 
   if (to - from < 10) {
     dplan.notify.notify('warning', Translator.trans('warning.segment.too_short'))

--- a/tests/frontend/unit/SplitStatementView.editMode.spec.js
+++ b/tests/frontend/unit/SplitStatementView.editMode.spec.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for the range-less-segment guards in SplitStatementView's enter/leave edit-mode methods.
+ * A segment whose mark is missing from the document has no range in the range tracker; the range
+ * machinery (`setRangeEditingState`, `activateRangeEdit`) must be skipped for it so that its
+ * metadata can still be edited, while normal (marked) segments keep the full range-editing flow.
+ */
+
+// Mock the prosemirror commands so we can assert whether the range machinery is invoked.
+jest.mock('@DpJs/lib/prosemirror/commands', () => ({
+  activateRangeEdit: jest.fn(),
+  applySelectionChange: jest.fn(),
+  removeRange: jest.fn(),
+  setRange: jest.fn(),
+  // `setRangeEditingState` is curried: setRangeEditingState(view, ...)(id, state).
+  setRangeEditingState: jest.fn(() => jest.fn()),
+}))
+
+import { activateRangeEdit, setRangeEditingState } from '@DpJs/lib/prosemirror/commands'
+import SplitStatementView from '@DpJs/components/statement/splitStatement/SplitStatementView'
+
+const { enableEditMode, disableEditMode } = SplitStatementView.methods
+
+/**
+ * Builds a mock component context. `ranges` maps segmentId → range object; a segment absent from
+ * it has no range in the document (i.e. its mark is missing).
+ */
+const buildContext = (ranges = {}) => ({
+  editModeActive: false,
+  editingSegment: null,
+  ignoreProsemirrorUpdates: false,
+  stateBeforeEditing: null,
+  prosemirror: {
+    view: { state: {} },
+    keyAccess: {
+      rangeTrackerKey: { getState: () => ranges },
+      editingDecorationsKey: {},
+      editStateTrackerKey: {},
+    },
+  },
+  segmentById: id => ({ id, tags: [] }),
+  setProperty: jest.fn(),
+})
+
+describe('SplitStatementView edit-mode range-less guards', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe('enableEditMode', () => {
+    it('opens the editor but skips range activation for a segment without a range', () => {
+      const context = buildContext({}) // No ranges → segment has no mark
+
+      expect(() => enableEditMode.call(context, 'segment-without-range')).not.toThrow()
+
+      // The metadata editor is opened (segment selected, edit mode on) ...
+      expect(context.setProperty).toHaveBeenCalledWith({ prop: 'editingSegment', val: { id: 'segment-without-range', tags: [] } })
+      expect(context.setProperty).toHaveBeenCalledWith({ prop: 'editModeActive', val: true })
+      // ... but the range machinery is not touched.
+      expect(setRangeEditingState).not.toHaveBeenCalled()
+      expect(activateRangeEdit).not.toHaveBeenCalled()
+    })
+
+    it('activates range editing for a segment that has a range', () => {
+      const context = buildContext({ 'segment-with-range': { from: 1, to: 20, isConfirmed: true } })
+
+      enableEditMode.call(context, 'segment-with-range')
+
+      expect(setRangeEditingState).toHaveBeenCalled()
+      expect(activateRangeEdit).toHaveBeenCalled()
+    })
+  })
+
+  describe('disableEditMode', () => {
+    it('skips range reset for an edited segment without a range', () => {
+      const context = buildContext({})
+
+      context.editingSegment = { id: 'segment-without-range' }
+
+      expect(() => disableEditMode.call(context)).not.toThrow()
+
+      expect(setRangeEditingState).not.toHaveBeenCalled()
+      // Edit state is still cleared.
+      expect(context.setProperty).toHaveBeenCalledWith({ prop: 'editingSegment', val: null })
+      expect(context.setProperty).toHaveBeenCalledWith({ prop: 'editModeActive', val: false })
+    })
+
+    it('resets range editing for an edited segment that has a range', () => {
+      const context = buildContext({ 'segment-with-range': { from: 1, to: 20, isConfirmed: true } })
+
+      context.editingSegment = { id: 'segment-with-range' }
+
+      disableEditMode.call(context)
+
+      expect(setRangeEditingState).toHaveBeenCalled()
+      expect(context.setProperty).toHaveBeenCalledWith({ prop: 'editingSegment', val: null })
+    })
+  })
+})

--- a/tests/frontend/unit/applySelectionChange.spec.js
+++ b/tests/frontend/unit/applySelectionChange.spec.js
@@ -1,0 +1,93 @@
+/**
+ * Tests for the `applySelectionChange` guard that keeps the segmentation editor from crashing
+ * when the segment being edited has no active range selection in the document (e.g. a segment
+ * whose mark is missing from the textual reference, or a metadata-only edit). In that case the
+ * command must stop the range edit cleanly and report success so the caller can persist the
+ * segment metadata instead of throwing `TypeError: marks.selection is undefined`.
+ */
+
+/*
+ * `applySelectionChange` derives the current range selection from the document via `getMarks`.
+ * Mock the utilities module so each test controls whether a selection exists.
+ */
+jest.mock('@DpJs/lib/prosemirror/utilities', () => ({
+  flattenNode: jest.fn(() => []),
+  getMarks: jest.fn(),
+  splitsExistingRange: jest.fn(() => false),
+}))
+
+import { applySelectionChange } from '@DpJs/lib/prosemirror/commands'
+import { getMarks } from '@DpJs/lib/prosemirror/utilities'
+
+/**
+ * Builds a minimal ProseMirror-like view. `state.tr` is a chainable stub that records the meta
+ * set on it, so we can assert the transaction that gets dispatched.
+ */
+const buildView = () => {
+  const dispatchedMeta = []
+  const tr = {
+    setMeta (key, value) {
+      dispatchedMeta.push({ key, value })
+
+      return tr
+    },
+  }
+  const state = { doc: {}, tr }
+  const dispatch = jest.fn()
+
+  return { view: { state, dispatch }, dispatch, tr, dispatchedMeta }
+}
+
+const editStateTrackerKey = { getState: () => ({ id: 'segment-without-range' }) }
+// The edited segment has no tracked range (its mark is absent from the document).
+const rangeTrackerKey = { getState: () => ({}) }
+
+describe('applySelectionChange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // `dplan.notify` / `Translator` are used by the "segment too short" branch.
+    global.dplan = { notify: { notify: jest.fn() } }
+    global.Translator = { trans: jest.fn(key => key) }
+  })
+
+  it('does not throw and returns true when there is no active range selection', () => {
+    // No `rangeselection` mark in the document → getMarks yields an object without `.selection`.
+    getMarks.mockReturnValue({})
+
+    const { view } = buildView()
+
+    let result
+
+    expect(() => {
+      result = applySelectionChange(view, editStateTrackerKey, rangeTrackerKey)
+    }).not.toThrow()
+    expect(result).toBe(true)
+  })
+
+  it('stops the range edit (dispatches a stop-editing transaction) when no selection exists', () => {
+    getMarks.mockReturnValue({})
+
+    const { view, dispatch, dispatchedMeta } = buildView()
+
+    applySelectionChange(view, editStateTrackerKey, rangeTrackerKey)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    // The dispatched transaction carries the editStateTracker "stop-editing" meta.
+    expect(dispatchedMeta).toContainEqual({ key: editStateTrackerKey, value: 'stop-editing' })
+  })
+
+  it('does not persist a boundary change (returns false) for a genuine but too-short selection', () => {
+    /*
+     * A real selection shorter than the minimum segment length must be rejected — proving the
+     * guard only short-circuits the missing-selection case and leaves normal validation intact.
+     */
+    getMarks.mockReturnValue({ selection: { from: 0, to: 5 } })
+
+    const { view } = buildView()
+
+    const result = applySelectionChange(view, editStateTrackerKey, rangeTrackerKey)
+
+    expect(result).toBe(false)
+    expect(global.dplan.notify.notify).toHaveBeenCalledWith('warning', 'warning.segment.too_short')
+  })
+})

--- a/tests/frontend/unit/determineDisplayScrollButton.spec.js
+++ b/tests/frontend/unit/determineDisplayScrollButton.spec.js
@@ -1,0 +1,33 @@
+/**
+ * Tests for the `determineDisplayScrollButton` guard in SplitStatementView. When the segment
+ * currently being edited has no active span in the document (e.g. a segment whose mark is missing
+ * from the textual reference), scrolling must not crash with
+ * `TypeError: can't access property "getBoundingClientRect", lastSegmentSpan is undefined`.
+ * The method must return false instead.
+ */
+
+import SplitStatementView from '@DpJs/components/statement/splitStatement/SplitStatementView'
+
+const determineDisplayScrollButton = SplitStatementView.methods.determineDisplayScrollButton
+
+describe('SplitStatementView.determineDisplayScrollButton', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns false and does not throw when no active segment span exists', () => {
+    // No `span[data-range-active="true"]` in the document.
+    document.body.innerHTML = '<div id="header"></div><p>Some unsegmented text</p>'
+
+    const context = { scrollButtonPosition: null }
+
+    let result
+
+    expect(() => {
+      result = determineDisplayScrollButton.call(context)
+    }).not.toThrow()
+    expect(result).toBe(false)
+    // The scroll position must be left untouched when there is nothing to scroll to.
+    expect(context.scrollButtonPosition).toBeNull()
+  })
+})


### PR DESCRIPTION
### Ticket
DS-573

### Description
Segments that exist in the draft segments array but have no `segmentMark` in the textual reference have no range in the ProseMirror document. The range-editing code assumed every edited segment has a range, so opening, saving or scrolling such a segment threw uncaught `TypeError`s (`marks.selection is undefined`, `getBoundingClientRect` on `undefined`), blocking metadata edits (e.g. adding a tag).

This adds guards so a segment without a document mark can still have its metadata edited:

- `applySelectionChange`: when there is no active range selection, stop range editing cleanly and return success instead of applying a boundary change — so metadata-only edits still persist.
- `enableEditMode`: open the metadata editor without activating range editing when the segment has no range.
- `disableEditMode`: only reset range-editing state when the segment actually has a range.
- `determineDisplayScrollButton`: show no scroll button when there is no active segment span.

Normal (marked) segments are unaffected; the guards only trigger when a range is absent.

### How to review/test
Open a statement in the segmentation editor whose draft contains a segment that is present in the segments list but not marked in the text. Opening that segment, scrolling, and saving a metadata change (e.g. adding a tag) must no longer crash and must persist the change. Unit tests cover each guard for both the range-less path and the normal path.

### PR Checklist
- [x] Create/Update tests
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets