### PR TITLE
fix(DS-576): reset unconvertible legacy segment draft to null

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -3999,7 +3999,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
         return null;
     }
 
-    public function setDraftsListJson(string $json): void
+    public function setDraftsListJson(?string $json): void
     {
         $this->draftsListJson = $json;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonSegmentFields.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftsListJsonSegmentFields.php
@@ -35,6 +35,24 @@ class DraftsListJsonSegmentFields
         return false;
     }
 
+    /**
+     * True if every segment ended up wrapped in a <segment-mark> in textualReference, i.e. the
+     * legacy draft was fully converted to the new format. A migrator leaves a segment unwrapped
+     * when its text no longer matches textualReference verbatim, or its positions are missing /
+     * out of bounds / overlapping. A partially converted draft is treated as a conversion failure
+     * by callers, which then drop it rather than render a document the segment editor can't sync
+     * with. Each wrapped segment contributes exactly one `<segment-mark data-segment-id=` opener,
+     * and textualReference is guaranteed mark-free before migration, so counting openers against
+     * the segment count is exact.
+     */
+    public function allSegmentsWrapped(array $data): bool
+    {
+        $segments = $data['data']['attributes']['segments'] ?? [];
+        $textualReference = $data['data']['attributes']['textualReference'] ?? '';
+
+        return count($segments) === substr_count($textualReference, '<segment-mark data-segment-id=');
+    }
+
     public function stripPositionFields(array $segment): array
     {
         unset(

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/StatementResourceType.php
@@ -34,6 +34,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedurePhaseDefinitionServic
 use demosplan\DemosPlanCoreBundle\Logic\ProcedureAccessEvaluator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonMigrator;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonPositionMigrator;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonSegmentFields;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementDeleter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use demosplan\DemosPlanCoreBundle\Repository\FileContainerRepository;
@@ -82,6 +83,7 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
         HTMLSanitizer $htmlSanitizer,
         private readonly DraftsListJsonMigrator $draftsListJsonMigrator,
         private readonly DraftsListJsonPositionMigrator $draftsListJsonPositionMigrator,
+        private readonly DraftsListJsonSegmentFields $draftsListJsonSegmentFields,
         private readonly JsonApiEsService $jsonApiEsService,
         private readonly ProcedureAccessEvaluator $procedureAccessEvaluator,
         private readonly QueryStatement $esQuery,
@@ -403,10 +405,30 @@ final class StatementResourceType extends AbstractStatementResourceType implemen
                         return null;
                     }
                     $data = Json::decodeToArray($draftsListJson);
-                    if ($this->draftsListJsonMigrator->needsMigration($data)) {
+
+                    $needsMigration = $this->draftsListJsonMigrator->needsMigration($data);
+                    $needsPositionMigration = $this->draftsListJsonPositionMigrator->needsMigration($data);
+
+                    if ($needsMigration) {
                         $data = $this->draftsListJsonMigrator->migrate($data);
-                    } elseif ($this->draftsListJsonPositionMigrator->needsMigration($data)) {
+                    } elseif ($needsPositionMigration) {
                         $data = $this->draftsListJsonPositionMigrator->migrate($data);
+                    }
+
+                    // A legacy draft that neither migrator could fully convert to the new
+                    // <segment-mark> format is dropped: a partially wrapped document desyncs the
+                    // segment editor (a card without a matching mark crashes on delete). The stale
+                    // draft is also reset to null in the database so the statement matches one that
+                    // never had a draft — the segmentation pipeline (demospipes) only requests fresh
+                    // proposals when the stored draft is empty, and its request guard reads the raw
+                    // column, not this migrated view. Returning null then lets the frontend request
+                    // those fresh proposals in the new format.
+                    if (($needsMigration || $needsPositionMigration)
+                        && !$this->draftsListJsonSegmentFields->allSegmentsWrapped($data)) {
+                        $statement->setDraftsListJson(null);
+                        $this->getEntityManager()->flush();
+
+                        return null;
                     }
 
                     return $data;

--- a/tests/backend/core/Logic/Statement/DraftsListJsonSegmentFieldsTest.php
+++ b/tests/backend/core/Logic/Statement/DraftsListJsonSegmentFieldsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Logic\Statement;
+
+use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftsListJsonSegmentFields;
+use PHPUnit\Framework\TestCase;
+
+class DraftsListJsonSegmentFieldsTest extends TestCase
+{
+    private ?DraftsListJsonSegmentFields $sut = null;
+
+    protected function setUp(): void
+    {
+        $this->sut = new DraftsListJsonSegmentFields();
+    }
+
+    // --- allSegmentsWrapped ---
+
+    public function testAllSegmentsWrappedReturnsTrueWhenEverySegmentHasAMark(): void
+    {
+        // Arrange — two segments, two marks
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1"><p>A.</p></segment-mark>'
+            .'<segment-mark data-segment-id="seg-2"><p>B.</p></segment-mark>',
+            [['id' => 'seg-1'], ['id' => 'seg-2']]
+        );
+
+        // Act & Assert
+        self::assertTrue($this->sut->allSegmentsWrapped($data));
+    }
+
+    public function testAllSegmentsWrappedReturnsFalseWhenASegmentIsUnwrapped(): void
+    {
+        // Arrange — two segments but only one could be wrapped (e.g. text drifted / position out of bounds)
+        $data = $this->buildData(
+            '<segment-mark data-segment-id="seg-1"><p>A.</p></segment-mark><p>B.</p>',
+            [['id' => 'seg-1'], ['id' => 'seg-2']]
+        );
+
+        // Act & Assert
+        self::assertFalse($this->sut->allSegmentsWrapped($data));
+    }
+
+    public function testAllSegmentsWrappedReturnsFalseWhenNoSegmentIsWrapped(): void
+    {
+        // Arrange — plain textualReference, no marks at all
+        $data = $this->buildData('<p>A.</p><p>B.</p>', [['id' => 'seg-1'], ['id' => 'seg-2']]);
+
+        // Act & Assert
+        self::assertFalse($this->sut->allSegmentsWrapped($data));
+    }
+
+    private function buildData(string $textualReference, array $segments): array
+    {
+        return [
+            'data' => [
+                'attributes' => [
+                    'textualReference' => $textualReference,
+                    'segments'         => $segments,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-576

Description:
When a legacy drafts_info_json cannot be fully converted to the new <segment-mark> format, the stored draft is reset to null and null is returned to the client instead of a partially converted document.

Why

Some legacy drafts have a segment text snapshot that no longer matches textualReference (e.g. re-serialized <img> tags), or unusable positions. The read-time migrators then leave one or more segments unwrapped. The segment editor renders a card with no matching mark in the ProseMirror document, and deleting that card dispatches a null transaction → can't access property "before", tr is null crash.

How

- DraftsListJsonSegmentFields::allSegmentsWrapped() — checks every segment ended up wrapped (count(segments) === count of <segment-mark data-segment-id=).
- StatementResourceType (segmentDraftList readable): after attempting migration, if it was a legacy format and not fully wrapped → setDraftsListJson(null) + flush() and return null. Nulling the raw column makes the record look like a never-drafted statement, so the segmentation pipeline (demospipes) requests fresh proposals in the new format; the pipeline result overwrites the draft unconditionally.
- Statement::setDraftsListJson() widened string → ?string to match the nullable drafts_info_json column.


Testing

- DraftsListJsonSegmentFieldsTest (unit).

- [X] Create/Update tests
- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
