### PR TITLE
feat (DPLAN-17476): resolve image src URLs without a procedure segment

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementViaTemplateExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementViaTemplateExporter.php
@@ -261,7 +261,7 @@ class StatementViaTemplateExporter
         // Two legacy-compatible forms exist:
         //   /file/{hash}                  (old format — no procedureId)
         //   /file/{procedureId}/{hash}    (current format)
-        if (!preg_match('#/file/(?:[^/]+/)?([0-9a-f]{32,64})(?:[/?#]|$)#', $srcMatches[1], $hashMatch)) {
+        if (!preg_match('~/file/(?:[^/]+/)?([0-9a-f]{32,64})(?:[/?#]|$)~', $srcMatches[1], $hashMatch)) {
             $this->logger->warning(
                 'Unrecognised image src in segment HTML — only dplan file-hash URLs are supported',
                 ['src' => $srcMatches[1]]

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementViaTemplateExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementViaTemplateExporter.php
@@ -258,7 +258,10 @@ class StatementViaTemplateExporter
         }
 
         // Only dplan file-hash URLs are supported.
-        if (!preg_match('#/file/[^/]+/([0-9a-f]{32,64})#', $srcMatches[1], $hashMatch)) {
+        // Two legacy-compatible forms exist:
+        //   /file/{hash}                  (old format — no procedureId)
+        //   /file/{procedureId}/{hash}    (current format)
+        if (!preg_match('#/file/(?:[^/]+/)?([0-9a-f]{32,64})(?:[/?#]|$)#', $srcMatches[1], $hashMatch)) {
             $this->logger->warning(
                 'Unrecognised image src in segment HTML — only dplan file-hash URLs are supported',
                 ['src' => $srcMatches[1]]


### PR DESCRIPTION
### Ticket
https://demoseurope.youtrack.cloud/issue/DPLAN-17476

### Description
Extend the regex in resolveImageInfo to make the procedure ID path
segment optional, so legacy /file/{hash} URLs are matched alongside
the current /file/{procedureId}/{hash} format.

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
