### PR TITLE
fix(DS-582): prevent OOM in tag-filtered segment export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Segment/SegmentsExportController.php
@@ -126,7 +126,7 @@ class SegmentsExportController extends BaseController
         // loaded, instead of loading every statement of the procedure and discarding the rest
         // in PHP.
         $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
-        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType, $procedureId);
 
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
@@ -207,7 +207,7 @@ class SegmentsExportController extends BaseController
         // loaded, instead of loading every statement of the procedure and discarding the rest
         // in PHP.
         $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
-        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType, $procedureId);
 
         /** @var Statement[] $statementEntities */
         $statementEntities = array_values(
@@ -283,7 +283,7 @@ class SegmentsExportController extends BaseController
         // loaded, instead of loading every statement of the procedure and discarding the rest
         // in PHP.
         $tagsFilter = $this->requestStack->getCurrentRequest()->query->all('tagsFilter');
-        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType);
+        $tagConditions = $this->statementExportTagFilter->buildStatementTagConditions($tagsFilter, $statementResourceType, $procedureId);
 
         $statementResult = $requestHandler->getObjectsByQueryParams(
             $this->requestStack->getCurrentRequest()->query,

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/Utils/HtmlHelper.php
@@ -19,21 +19,36 @@ class HtmlHelper
 {
     public const LINK_CLASS_FOR_DARSTELLUNG_STELL = 'pdf_importer_image';
 
+    /**
+     * Memoizes {@see getHtmlValidText()} results keyed by a hash of the raw input. Sanitizing is
+     * deterministic and, during a segment export, the same string (empty recommendations, boilerplate
+     * phrases) is passed thousands of times. HTMLPurifier is the dominant export cost, so collapsing
+     * duplicate inputs to a single purify call cuts it to one call per distinct string.
+     *
+     * @var array<string, string>
+     */
+    private array $validTextCache = [];
+
     public function __construct(private readonly HTMLSanitizer $htmlSanitizer)
     {
     }
 
     public function getHtmlValidText(string $text): string
     {
-        /** @var string $text $text */
-        $text = str_replace('<br>', '<br/>', $text);
+        $cacheKey = md5($text);
+        if (isset($this->validTextCache[$cacheKey])) {
+            return $this->validTextCache[$cacheKey];
+        }
+
+        /** @var string $validText */
+        $validText = str_replace('<br>', '<br/>', $text);
 
         // strip all a tags without href
         $pattern = '/<a(?![^>]*\bhref=)([^>]*)>(.*?)<\/a>/i';
-        $text = preg_replace($pattern, '$2', $text);
+        $validText = preg_replace($pattern, '$2', $validText);
 
         // avoid problems in phpword parser
-        return $this->htmlSanitizer->purify($text);
+        return $this->validTextCache[$cacheKey] = $this->htmlSanitizer->purify($validText);
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
@@ -82,9 +82,6 @@ class StatementExportTagFilter
             return $statements;
         }
 
-        // Pre-fetch all relationships to avoid N+1 queries
-        $this->initializeRelationships($statements);
-
         // the goal is to exclude all Segments from the payload that do not match the filter criteria
         // if all Segments from a parentStatement get excluded - the whole statement gets excluded as well.
         return $this->applyTagFilter($statements, $tagIds, $tagTitles, $tagTopicIds, $tagTopicTitles);
@@ -112,25 +109,77 @@ class StatementExportTagFilter
         $tagTopicIds = $tagsFilter[self::TAG_TOPIC_IDS_FILTER_KEY] ?? [];
         $tagTopicTitles = $tagsFilter[self::TAG_TOPIC_TITLES_FILTER_KEY] ?? [];
 
-        $criteria = [];
-        if ([] !== $tagIds) {
-            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagIds, $statementResourceType->segments->tags->id);
-        }
-        if ([] !== $tagTitles) {
-            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTitles, $statementResourceType->segments->tags->title);
-        }
-        if ([] !== $tagTopicIds) {
-            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTopicIds, $statementResourceType->segments->tags->topic->id);
-        }
-        if ([] !== $tagTopicTitles) {
-            $criteria[] = $this->conditionFactory->propertyHasAnyOfValues($tagTopicTitles, $statementResourceType->segments->tags->topic->title);
-        }
-
-        if ([] === $criteria) {
+        $noSupportedFilter = [] === $tagIds && [] === $tagTitles && [] === $tagTopicIds && [] === $tagTopicTitles;
+        if ($noSupportedFilter) {
             return [];
         }
 
-        return [1 === count($criteria) ? $criteria[0] : $this->conditionFactory->anyConditionApplies(...$criteria)];
+        // Resolve the IDs of the matching statements with a lean scalar query that selects ONLY the
+        // parent statement ID, then narrow the statement load with a plain `id IN (...)` condition.
+        //
+        // Expressing the criteria directly as a to-many condition on the Statement resource
+        // (segments.tags.*) makes the main statement query fetch-join through segments AND tags, so
+        // the buffered result explodes to statements x segments x tags rows, each repeating the wide
+        // Statement columns. On large procedures that exhausts memory during loading (the export dies
+        // before it even starts). A scalar id query cannot explode that way - one short UUID per row -
+        // and the `id IN (...)` condition loads the statements as leanly as the unfiltered export does.
+        $matchingStatementIds = $this->findStatementIdsMatchingTags($tagIds, $tagTitles, $tagTopicIds, $tagTopicTitles);
+
+        if ([] === $matchingStatementIds) {
+            // Criteria were given but nothing matched: force an empty result instead of
+            // silently falling back to an unfiltered full export.
+            return [$this->conditionFactory->false()];
+        }
+
+        return [$this->conditionFactory->propertyHasAnyOfValues($matchingStatementIds, $statementResourceType->id)];
+    }
+
+    /**
+     * Runs a lean scalar query returning the IDs of all statements owning at least one segment that
+     * carries a tag (or tag topic) matching any of the given criteria. Selecting only the parent
+     * statement ID keeps memory bounded even when the segment/tag join multiplies rows.
+     *
+     * @param list<string> $tagIds
+     * @param list<string> $tagTitles
+     * @param list<string> $tagTopicIds
+     * @param list<string> $tagTopicTitles
+     *
+     * @return list<string>
+     */
+    private function findStatementIdsMatchingTags(
+        array $tagIds,
+        array $tagTitles,
+        array $tagTopicIds,
+        array $tagTopicTitles,
+    ): array {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('DISTINCT IDENTITY(seg.parentStatementOfSegment) AS statementId')
+            ->from(Segment::class, 'seg')
+            ->join('seg.tags', 't')
+            ->leftJoin('t.topic', 'topic');
+
+        $orConditions = $queryBuilder->expr()->orX();
+        if ([] !== $tagIds) {
+            $orConditions->add('t.id IN (:tagIds)');
+            $queryBuilder->setParameter('tagIds', $tagIds);
+        }
+        if ([] !== $tagTitles) {
+            $orConditions->add('t.title IN (:tagTitles)');
+            $queryBuilder->setParameter('tagTitles', $tagTitles);
+        }
+        if ([] !== $tagTopicIds) {
+            $orConditions->add('topic.id IN (:tagTopicIds)');
+            $queryBuilder->setParameter('tagTopicIds', $tagTopicIds);
+        }
+        if ([] !== $tagTopicTitles) {
+            $orConditions->add('topic.title IN (:tagTopicTitles)');
+            $queryBuilder->setParameter('tagTopicTitles', $tagTopicTitles);
+        }
+        $queryBuilder->where($orConditions);
+
+        $rows = $queryBuilder->getQuery()->getScalarResult();
+
+        return array_map(static fn (array $row): string => (string) $row['statementId'], $rows);
     }
 
     public function isTagIdFilterActive(): bool
@@ -186,57 +235,6 @@ class StatementExportTagFilter
     public function getFilteredTagsWithTitles(): array
     {
         return $this->filteredTagsWithTitle;
-    }
-
-    /**
-     * Pre-fetches segments, tags, and tag topics for given statements to avoid N+1 queries.
-     *
-     * @param Statement[] $statements
-     */
-    private function initializeRelationships(array $statements): void
-    {
-        if ([] === $statements) {
-            return;
-        }
-
-        $statementIds = array_map(
-            static fn (StatementInterface $s): string => $s->getId(),
-            $statements
-        );
-
-        // Pre-warm Doctrine's identity map so the in-PHP tag filter (applyTagFilter)
-        // can call $segment->getTags() and $tag->getTopic() without triggering N+1 queries.
-        //
-        // This is intentionally split into two queries instead of a single fetch-join.
-        // Joining two independent to-many collections (segmentsOfStatement AND tags) in
-        // one query produces a cartesian product (rows = segments x tags-per-segment),
-        // and each row carries the full, wide _statement columns of both the parent
-        // statement and the segment. On large procedures that buffered result set
-        // exhausts memory (OutOfMemoryError in the DBAL PDO layer). Two single-collection
-        // queries keep the row counts additive and avoid repeating the wide parent row
-        // once per tag. Both share the same identity map, so the second query enriches
-        // the segments hydrated by the first.
-
-        // Query 1: statements with their segments (single to-many join).
-        $this->entityManager->createQueryBuilder()
-            ->select('s', 'seg')
-            ->from(Statement::class, 's')
-            ->leftJoin('s.segmentsOfStatement', 'seg')
-            ->where('s.id IN (:statementIds)')
-            ->setParameter('statementIds', $statementIds)
-            ->getQuery()
-            ->getResult();
-
-        // Query 2: those segments with their tags and tag topics (single to-many join).
-        $this->entityManager->createQueryBuilder()
-            ->select('seg', 't', 'topic')
-            ->from(Segment::class, 'seg')
-            ->leftJoin('seg.tags', 't')
-            ->leftJoin('t.topic', 'topic')
-            ->where('seg.parentStatementOfSegment IN (:statementIds)')
-            ->setParameter('statementIds', $statementIds)
-            ->getQuery()
-            ->getResult();
     }
 
     private function applyTagFilter(array $statements, array $tagIds, array $tagTitles, array $tagTopicIds, array $tagTopicTitles): array

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementExportTagFilter.php
@@ -102,7 +102,7 @@ class StatementExportTagFilter
      *
      * @return list<ClauseFunctionInterface<bool>>
      */
-    public function buildStatementTagConditions(array $tagsFilter, StatementResourceType $statementResourceType): array
+    public function buildStatementTagConditions(array $tagsFilter, StatementResourceType $statementResourceType, string $procedureId): array
     {
         $tagIds = $tagsFilter[self::TAG_IDS_FILTER_KEY] ?? [];
         $tagTitles = $tagsFilter[self::TAG_TITLES_FILTER_KEY] ?? [];
@@ -123,7 +123,12 @@ class StatementExportTagFilter
         // Statement columns. On large procedures that exhausts memory during loading (the export dies
         // before it even starts). A scalar id query cannot explode that way - one short UUID per row -
         // and the `id IN (...)` condition loads the statements as leanly as the unfiltered export does.
-        $matchingStatementIds = $this->findStatementIdsMatchingTags($tagIds, $tagTitles, $tagTopicIds, $tagTopicTitles);
+        //
+        // The scalar query is scoped to the current procedure so its result (and the resulting
+        // `id IN (...)` list) stays bounded to this procedure's statements. Tag/topic titles are not
+        // unique across procedures, so an unscoped title filter could otherwise resolve statement IDs
+        // from every procedure sharing that title before the downstream procedure filter trims them.
+        $matchingStatementIds = $this->findStatementIdsMatchingTags($tagIds, $tagTitles, $tagTopicIds, $tagTopicTitles, $procedureId);
 
         if ([] === $matchingStatementIds) {
             // Criteria were given but nothing matched: force an empty result instead of
@@ -135,9 +140,11 @@ class StatementExportTagFilter
     }
 
     /**
-     * Runs a lean scalar query returning the IDs of all statements owning at least one segment that
-     * carries a tag (or tag topic) matching any of the given criteria. Selecting only the parent
-     * statement ID keeps memory bounded even when the segment/tag join multiplies rows.
+     * Runs a lean scalar query returning the IDs of all statements of the given procedure owning at
+     * least one segment that carries a tag (or tag topic) matching any of the given criteria.
+     * Selecting only the parent statement ID keeps memory bounded even when the segment/tag join
+     * multiplies rows. Scoping on the parent statement's procedure mirrors the downstream procedure
+     * filter, so the resolved ID list stays bounded to this procedure.
      *
      * @param list<string> $tagIds
      * @param list<string> $tagTitles
@@ -151,12 +158,16 @@ class StatementExportTagFilter
         array $tagTitles,
         array $tagTopicIds,
         array $tagTopicTitles,
+        string $procedureId,
     ): array {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('DISTINCT IDENTITY(seg.parentStatementOfSegment) AS statementId')
             ->from(Segment::class, 'seg')
+            ->join('seg.parentStatementOfSegment', 'parentStatement')
             ->join('seg.tags', 't')
-            ->leftJoin('t.topic', 'topic');
+            ->leftJoin('t.topic', 'topic')
+            ->where('parentStatement.procedure = :procedureId')
+            ->setParameter('procedureId', $procedureId);
 
         $orConditions = $queryBuilder->expr()->orX();
         if ([] !== $tagIds) {
@@ -175,7 +186,7 @@ class StatementExportTagFilter
             $orConditions->add('topic.title IN (:tagTopicTitles)');
             $queryBuilder->setParameter('tagTopicTitles', $tagTopicTitles);
         }
-        $queryBuilder->where($orConditions);
+        $queryBuilder->andWhere($orConditions);
 
         $rows = $queryBuilder->getQuery()->getScalarResult();
 

--- a/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
+++ b/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
@@ -29,7 +29,6 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementExportTagFil
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
-use EDT\DqlQuerying\Functions\AnyTrue;
 use EDT\DqlQuerying\Functions\OneOf;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
@@ -376,23 +375,32 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         static::assertSame([], $conditions);
     }
 
-    public function testBuildStatementTagConditionsWithSingleCriterionReturnsRawCondition(): void
+    public function testBuildStatementTagConditionsWithSingleCriterionReturnsStatementIdCondition(): void
     {
+        // Arrange: statement1 owns a segment carrying tag1, so the id resolution finds a match
+        $this->segment1->addTag($this->tag1->_real());
+        $this->getEntityManager()->flush();
+
         // Act: exactly one criterion
         $conditions = $this->sut->buildStatementTagConditions(
             ['tagIds' => [$this->tag1->getId()]],
             $this->statementResourceType
         );
 
-        // Assert: the single condition is returned raw, not wrapped in an OR
+        // Assert: a single `statement.id IN (...)` condition (OneOf), rather than a to-many
+        // condition on segments.tags.* (which would fetch-join and exhaust memory on large procedures)
         static::assertCount(1, $conditions);
         static::assertInstanceOf(OneOf::class, $conditions[0]);
-        static::assertNotInstanceOf(AnyTrue::class, $conditions[0]);
     }
 
-    public function testBuildStatementTagConditionsWithMultipleCriteriaWrapsInOr(): void
+    public function testBuildStatementTagConditionsWithMultipleCriteriaReturnsSingleStatementIdCondition(): void
     {
-        // Act: two criteria, mirroring the OR logic of applyTagFilter()
+        // Arrange: statement1 matched by tag id, statement3 matched by topic title
+        $this->segment1->addTag($this->tag1->_real()); // Topic 1
+        $this->segment3->addTag($this->tag3->_real()); // Topic 2
+        $this->getEntityManager()->flush();
+
+        // Act: two criteria, OR-combined while resolving the matching statement ids
         $conditions = $this->sut->buildStatementTagConditions(
             [
                 'tagIds'         => [$this->tag1->getId()],
@@ -401,9 +409,23 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
             $this->statementResourceType
         );
 
-        // Assert: still a single top-level condition, but an OR-combination (AnyTrue)
+        // Assert: still a single `statement.id IN (...)` condition covering the union of both criteria
         static::assertCount(1, $conditions);
-        static::assertInstanceOf(AnyTrue::class, $conditions[0]);
+        static::assertInstanceOf(OneOf::class, $conditions[0]);
+    }
+
+    public function testBuildStatementTagConditionsWithNoMatchForcesEmptyResult(): void
+    {
+        // Act: criteria present but no segment carries the tag
+        $conditions = $this->sut->buildStatementTagConditions(
+            ['tagIds' => ['non-existent-id']],
+            $this->statementResourceType
+        );
+
+        // Assert: a single condition that matches nothing is returned, so the export yields an
+        // empty result instead of silently falling back to an unfiltered full export
+        static::assertCount(1, $conditions);
+        static::assertCount(0, $this->statementResourceType->getEntities($conditions, []));
     }
 
     public function testPushedDownFilterReturnsSameStatementsAsInPhpFilter(): void
@@ -439,8 +461,8 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
     public function testStatementWithTwoMatchingSegmentsIsReturnedOnce(): void
     {
         // Arrange: a single statement whose TWO segments both carry the filtered tag.
-        // The pushed-down condition joins segments+tags without DISTINCT; this asserts the
-        // to-many join does not surface the statement more than once.
+        // The statement-id resolution joins segments+tags; this asserts the to-many join
+        // does not surface the statement more than once (the id query is DISTINCT).
         $statement = $this->createVisibleStatement();
         $segmentA = SegmentFactory::createOne(['parentStatementOfSegment' => $statement])->_real();
         $segmentB = SegmentFactory::createOne(['parentStatementOfSegment' => $statement])->_real();

--- a/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
+++ b/tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php
@@ -29,6 +29,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementExportTagFil
 use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementResourceType;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\DqlQuerying\Functions\Constant;
 use EDT\DqlQuerying\Functions\OneOf;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\Base\FunctionalTestCase;
@@ -369,7 +370,7 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
     public function testBuildStatementTagConditionsWithEmptyFilterReturnsEmpty(): void
     {
         // Act: no supported criteria present
-        $conditions = $this->sut->buildStatementTagConditions([], $this->statementResourceType);
+        $conditions = $this->sut->buildStatementTagConditions([], $this->statementResourceType, $this->testProcedure->getId());
 
         // Assert: query is left unchanged (full export)
         static::assertSame([], $conditions);
@@ -384,7 +385,8 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Act: exactly one criterion
         $conditions = $this->sut->buildStatementTagConditions(
             ['tagIds' => [$this->tag1->getId()]],
-            $this->statementResourceType
+            $this->statementResourceType,
+            $this->testProcedure->getId()
         );
 
         // Assert: a single `statement.id IN (...)` condition (OneOf), rather than a to-many
@@ -406,7 +408,8 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
                 'tagIds'         => [$this->tag1->getId()],
                 'tagTopicTitles' => [self::TAG_TOPIC_NAME_2],
             ],
-            $this->statementResourceType
+            $this->statementResourceType,
+            $this->testProcedure->getId()
         );
 
         // Assert: still a single `statement.id IN (...)` condition covering the union of both criteria
@@ -419,13 +422,41 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Act: criteria present but no segment carries the tag
         $conditions = $this->sut->buildStatementTagConditions(
             ['tagIds' => ['non-existent-id']],
-            $this->statementResourceType
+            $this->statementResourceType,
+            $this->testProcedure->getId()
         );
 
         // Assert: a single condition that matches nothing is returned, so the export yields an
         // empty result instead of silently falling back to an unfiltered full export
         static::assertCount(1, $conditions);
         static::assertCount(0, $this->statementResourceType->getEntities($conditions, []));
+    }
+
+    public function testBuildStatementTagConditionsIgnoresMatchesFromOtherProcedures(): void
+    {
+        // Arrange: a statement in a DIFFERENT procedure carries a tag whose title also exists nowhere
+        // in the current procedure. Titles are not unique across procedures, so without procedure
+        // scoping the scalar id query would resolve this foreign statement and emit an id IN (...)
+        // list of statements the current export cannot even load.
+        $otherProcedure = ProcedureFactory::createOne();
+        $foreignTopic = TagTopicFactory::createOne(['title' => 'ForeignTopicTitle']);
+        $foreignTag = TagFactory::createOne(['title' => 'ForeignTagTitle', 'topic' => $foreignTopic->_real()]);
+        $foreignStatement = StatementFactory::createOne(['procedure' => $otherProcedure->_real()])->_real();
+        $foreignSegment = SegmentFactory::createOne(['parentStatementOfSegment' => $foreignStatement])->_real();
+        $foreignSegment->addTag($foreignTag->_real());
+        $this->getEntityManager()->flush();
+
+        // Act: filter the current procedure's export by the foreign title
+        $conditions = $this->sut->buildStatementTagConditions(
+            ['tagTitles' => ['ForeignTagTitle']],
+            $this->statementResourceType,
+            $this->testProcedure->getId()
+        );
+
+        // Assert: the foreign match is excluded by the procedure scope, so the export is forced empty
+        // (Constant `1 = 2`) instead of narrowed to a cross-procedure id IN (...) list.
+        static::assertCount(1, $conditions);
+        static::assertInstanceOf(Constant::class, $conditions[0]);
     }
 
     public function testPushedDownFilterReturnsSameStatementsAsInPhpFilter(): void
@@ -445,7 +476,7 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         );
 
         // ... and the pushed-down query filter through the resource type
-        $conditions = $this->sut->buildStatementTagConditions($tagsFilter, $this->statementResourceType);
+        $conditions = $this->sut->buildStatementTagConditions($tagsFilter, $this->statementResourceType, $this->testProcedure->getId());
         $queryFilteredIds = array_map(
             static fn (StatementInterface $s): string => $s->getId(),
             $this->statementResourceType->getEntities($conditions, [])
@@ -473,7 +504,8 @@ class SegmentsExportControllerTagFilterTest extends FunctionalTestCase
         // Act
         $conditions = $this->sut->buildStatementTagConditions(
             ['tagIds' => [$this->tag1->getId()]],
-            $this->statementResourceType
+            $this->statementResourceType,
+            $this->testProcedure->getId()
         );
         $result = $this->statementResourceType->getEntities($conditions, []);
 


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-582

Description: 

Tag-filtered segment/statement export (`.docx`/`.xlsx`/ZIP) crashed with `Allowed memory size … exhausted` **during data loading, before the export even started**. The unfiltered export of the same procedure completed fine
(slow but stable).

**Cause:** the tag filter was pushed into the main statement query as a to-many condition on `segments.tags.*`. That fetch-joins through *segments* **and** *tags*, so the buffered result set explodes to `statements × segments × tags` rows — each row repeating the wide `Statement` columns — and is hydrated all at once. On large procedures this exhausts the
memory limit. The unfiltered path was unaffected because it loads statements with no to-many join and lazy-loads segments incrementally.

**Fix:** bring the filtered path to parity with the working unfiltered path.

- `StatementExportTagFilter::buildStatementTagConditions()` now resolves the matching statement IDs via a lean scalar query (`SELECT DISTINCT IDENTITY(seg.parentStatementOfSegment)` — one short UUID per row, so the segment/tag join can't blow up memory), then narrows the load with a plain  `statement.id IN (...)` condition. When criteria match nothing it returns a
  `false()` condition, so the export yields an empty result instead of silently falling back to a full export.
- Removed the eager fetch-join pre-warming in `initializeRelationships()`; the in-PHP segment trim now relies on lazy loading, exactly like the unfiltered export.

Scoping is preserved: the `id IN (...)` condition is ANDed with the request's procedure filter and the resource access conditions in `getObjectsByQueryParams()`, so the result stays correctly scoped.

This reworks the two mechanisms introduced in commit `894205d` (the`segments.tags.*` pushdown and the eager relationship pre-warm), which addressed only the tag-filtered path's original cartesian product but left this load-phase explosion in place.



### Follow-up: export performance

While verifying the OOM fix on a large procedure (~856 statements / ~40k segments), the tag-filtered and unfiltered exports were confirmed to work but were slow (~2 min). Profiling the export showed the time split roughly as:


<img width="602" height="220" alt="image1" src="https://github.com/user-attachments/assets/445ba57c-041d-490b-9f3e-0fa0166e7c02" />


Within the build, **HTMLPurifier was the dominant cost** (~57s), not the segment loading (N+1) or PhpWord's own parser (~11s). The same strings — empty recommendations, boilerplate phrases — were being re-sanitized thousands of
times.

**Change:** `HtmlHelper::getHtmlValidText()` now memoizes its result by a hash of the raw input. Sanitization is deterministic, so each distinct string is purified once instead of once per cell. Output is unchanged.

**Result on the measured procedure:** 
<img width="539" height="253" alt="image" src="https://github.com/user-attachments/assets/0bfaa39d-ee33-45d8-b599-22bfe1d5e9fe" />


The remaining runtime is inherent to rendering ~40k unique segments (sanitizing unique text + PhpWord element building + zip). Further meaningful speedup would require moving the export to an async/background job with a
download link — tracked as a separate follow-up rather than squeezing the synchronous path here.

### How to review/test

1. Open a large procedure with segmented statements and tags 
2. Trigger **Abschnitte → Export (gruppiert)** *with a tag filter applied* (`.docx` and `.xlsx`).
   - Before: request dies with an OOM error page during loading.
   - After: export completes (comparable to the unfiltered export, which already worked).
3. Confirm the filtered document contains only statements/segments carrying the selected tag(s), and that a filter matching no tag produces an empty export (not a full one).
4. Run the functional test:  `vendor/bin/phpunit tests/backend/core/Statement/Functional/SegmentsExportControllerTagFilterTest.php`


- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly

