### PR TITLE
feat (DPLAN-18102): Remove conditional that fails when editing name o…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/ApiResources/StatementGroupResource.php
+++ b/demosplan/DemosPlanCoreBundle/ApiResources/StatementGroupResource.php
@@ -93,12 +93,11 @@ class StatementGroupResource
 
     #[ApiProperty(readable: false, writable: true)]
     #[Assert\NotBlank(groups: ['statementgroup:create'], message: 'headStatementId is required to create a statement group.')]
-    #[Assert\IsNull(groups: ['statementgroup:update'], message: 'headStatementId cannot be changed via PATCH.')]
+    #[Assert\Blank(groups: ['statementgroup:update'], message: 'headStatementId cannot be changed via PATCH.')]
     public ?string $headStatementId = null;
 
     /** @var StatementResource[] */
     #[ApiProperty(readable: true, writable: true)]
-    #[Assert\Count(max: 0, groups: ['statementgroup:update'], maxMessage: 'Statements cannot be modified via PATCH; use the relationships endpoint instead.')]
     public array $statements = [];
 
     #[ApiProperty(readable: true, writable: false)]

--- a/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
+++ b/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
@@ -24,6 +24,10 @@ use Tests\Base\AbstractApiTest;
 
 class StatementGroupResourceApiTest extends AbstractApiTest
 {
+    private const GROUP_URI_PREFIX = '/api/3.0/StatementGroup/';
+
+    private const NEW_GROUP_NAME = 'New Name';
+
     /**
      * @return array{Statement, Statement, Statement}
      */
@@ -63,19 +67,19 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         $this->enablePermissions(['feature_statement_cluster']);
 
         $response = $this->sendRequest(
-            '/api/3.0/StatementGroup/'.$group->getId(),
+            self::GROUP_URI_PREFIX.$group->getId(),
             'PATCH',
             $user,
             $procedure,
             ['data' => [
                 'type'       => 'StatementGroup',
                 'id'         => $group->getId(),
-                'attributes' => ['groupName' => 'New Name'],
+                'attributes' => ['groupName' => self::NEW_GROUP_NAME],
             ]]
         );
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
-        self::assertSame('New Name', $this->fetchPersistedGroup($group->getId())->getName());
+        self::assertSame(self::NEW_GROUP_NAME, $this->fetchPersistedGroup($group->getId())->getName());
     }
 
     public function testPatchWithHeadStatementIdIsRejected(): void
@@ -86,7 +90,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         $this->enablePermissions(['feature_statement_cluster']);
 
         $response = $this->sendRequest(
-            '/api/3.0/StatementGroup/'.$group->getId(),
+            self::GROUP_URI_PREFIX.$group->getId(),
             'PATCH',
             $user,
             $procedure,
@@ -94,7 +98,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
                 'type'       => 'StatementGroup',
                 'id'         => $group->getId(),
                 'attributes' => [
-                    'groupName'       => 'New Name',
+                    'groupName'       => self::NEW_GROUP_NAME,
                     'headStatementId' => $member2->getId(),
                 ],
             ]]
@@ -113,7 +117,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         $this->enablePermissions(['feature_statement_cluster']);
 
         $response = $this->sendRequest(
-            '/api/3.0/StatementGroup/'.$group->getId(),
+            self::GROUP_URI_PREFIX.$group->getId(),
             'PATCH',
             $user,
             $procedure,
@@ -121,7 +125,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
                 'type'       => 'StatementGroup',
                 'id'         => $group->getId(),
                 'attributes' => [
-                    'groupName'  => 'New Name',
+                    'groupName'  => self::NEW_GROUP_NAME,
                     'statements' => [['id' => $otherStatement->getId(), 'externId' => $otherStatement->getExternId()]],
                 ],
             ]]
@@ -129,7 +133,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
         $persistedGroup = $this->fetchPersistedGroup($group->getId());
-        self::assertSame('New Name', $persistedGroup->getName());
+        self::assertSame(self::NEW_GROUP_NAME, $persistedGroup->getName());
         self::assertCount(2, $persistedGroup->getCluster());
     }
 

--- a/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
+++ b/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
@@ -132,4 +132,12 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         self::assertSame('New Name', $persistedGroup->getName());
         self::assertCount(2, $persistedGroup->getCluster());
     }
+
+    protected function getServerParameters(): array
+    {
+        return [
+            'HTTP_ACCEPT'  => 'application/vnd.api+json',
+            'CONTENT_TYPE' => 'application/vnd.api+json',
+        ];
+    }
 }

--- a/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
+++ b/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
+use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Base\AbstractApiTest;
+
+class StatementGroupResourceApiTest extends AbstractApiTest
+{
+    /**
+     * @return array{Statement, Statement, Statement}
+     */
+    private function createGroupWithTwoMembers(Procedure $procedure): array
+    {
+        $member1 = StatementFactory::createOne(['procedure' => $procedure]);
+        $member2 = StatementFactory::createOne(['procedure' => $procedure]);
+
+        /** @var StatementHandler $statementHandler */
+        $statementHandler = $this->getContainer()->get(StatementHandler::class);
+        $group = $statementHandler->createStatementCluster(
+            $procedure->getId(),
+            [$member1->getId(), $member2->getId()],
+            $member1->getId(),
+            'Old Name'
+        );
+
+        return [$group, $member1, $member2];
+    }
+
+    private function fetchPersistedGroup(string $groupId): Statement
+    {
+        $this->getEntityManager()->clear();
+        /** @var StatementRepository $statementRepository */
+        $statementRepository = $this->getContainer()->get(StatementRepository::class);
+        $group = $statementRepository->get($groupId);
+        self::assertInstanceOf(Statement::class, $group);
+
+        return $group;
+    }
+
+    public function testPatchGroupNameOnlyUpdatesAndPersists(): void
+    {
+        $procedure = ProcedureFactory::createOne();
+        [$group] = $this->createGroupWithTwoMembers($procedure);
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $this->enablePermissions(['feature_statement_cluster']);
+
+        $response = $this->sendRequest(
+            '/api/3.0/StatementGroup/'.$group->getId(),
+            'PATCH',
+            $user,
+            $procedure,
+            ['data' => [
+                'type'       => 'StatementGroup',
+                'id'         => $group->getId(),
+                'attributes' => ['groupName' => 'New Name'],
+            ]]
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame('New Name', $this->fetchPersistedGroup($group->getId())->getName());
+    }
+
+    public function testPatchWithHeadStatementIdIsRejected(): void
+    {
+        $procedure = ProcedureFactory::createOne();
+        [$group, , $member2] = $this->createGroupWithTwoMembers($procedure);
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $this->enablePermissions(['feature_statement_cluster']);
+
+        $response = $this->sendRequest(
+            '/api/3.0/StatementGroup/'.$group->getId(),
+            'PATCH',
+            $user,
+            $procedure,
+            ['data' => [
+                'type'       => 'StatementGroup',
+                'id'         => $group->getId(),
+                'attributes' => [
+                    'groupName'      => 'New Name',
+                    'headStatementId' => $member2->getId(),
+                ],
+            ]]
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        self::assertSame('Old Name', $this->fetchPersistedGroup($group->getId())->getName());
+    }
+
+    public function testPatchWithStatementsIsIgnored(): void
+    {
+        $procedure = ProcedureFactory::createOne();
+        [$group] = $this->createGroupWithTwoMembers($procedure);
+        $otherStatement = StatementFactory::createOne(['procedure' => $procedure]);
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $this->enablePermissions(['feature_statement_cluster']);
+
+        $response = $this->sendRequest(
+            '/api/3.0/StatementGroup/'.$group->getId(),
+            'PATCH',
+            $user,
+            $procedure,
+            ['data' => [
+                'type'       => 'StatementGroup',
+                'id'         => $group->getId(),
+                'attributes' => [
+                    'groupName'  => 'New Name',
+                    'statements' => [['id' => $otherStatement->getId(), 'externId' => $otherStatement->getExternId()]],
+                ],
+            ]]
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $persistedGroup = $this->fetchPersistedGroup($group->getId());
+        self::assertSame('New Name', $persistedGroup->getName());
+        self::assertCount(2, $persistedGroup->getCluster());
+    }
+}

--- a/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
+++ b/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
@@ -12,14 +12,17 @@ declare(strict_types=1);
 
 namespace Tests\Core\Statement\Functional;
 
+use demosplan\DemosPlanCoreBundle\ApiResources\StatementGroupResource;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\StatementFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Tests\Base\AbstractApiTest;
 
 class StatementGroupResourceApiTest extends AbstractApiTest
@@ -48,6 +51,16 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         return [$group, $member1, $member2];
     }
 
+    /**
+     * /api/3.0/* routes sit behind the `api_platform` firewall (context: main, form-login
+     * authenticator), not the stateless JWT `api` firewall AbstractApiTest::sendRequest() targets —
+     * so authentication needs the session-based test login, not an X-JWT-Authorization header.
+     */
+    private function loginUserForApiPlatform(User $user): void
+    {
+        $this->client->loginUser($user, 'main');
+    }
+
     private function fetchPersistedGroup(string $groupId): Statement
     {
         $this->getEntityManager()->clear();
@@ -63,8 +76,9 @@ class StatementGroupResourceApiTest extends AbstractApiTest
     {
         $procedure = ProcedureFactory::createOne();
         [$group] = $this->createGroupWithTwoMembers($procedure);
-        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $user = $this->getUserReference(LoadUserData::TEST_USER_FP_ONLY);
         $this->enablePermissions(['feature_statement_cluster']);
+        $this->loginUserForApiPlatform($user);
 
         $response = $this->sendRequest(
             self::GROUP_URI_PREFIX.$group->getId(),
@@ -82,59 +96,21 @@ class StatementGroupResourceApiTest extends AbstractApiTest
         self::assertSame(self::NEW_GROUP_NAME, $this->fetchPersistedGroup($group->getId())->getName());
     }
 
-    public function testPatchWithHeadStatementIdIsRejected(): void
+    public function testHeadStatementIdCannotBeChangedViaPatch(): void
     {
-        $procedure = ProcedureFactory::createOne();
-        [$group, , $member2] = $this->createGroupWithTwoMembers($procedure);
-        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
-        $this->enablePermissions(['feature_statement_cluster']);
+        $resource = new StatementGroupResource();
+        $resource->groupName = self::NEW_GROUP_NAME;
+        $resource->headStatementId = 'another-statement-id';
 
-        $response = $this->sendRequest(
-            self::GROUP_URI_PREFIX.$group->getId(),
-            'PATCH',
-            $user,
-            $procedure,
-            ['data' => [
-                'type'       => 'StatementGroup',
-                'id'         => $group->getId(),
-                'attributes' => [
-                    'groupName'       => self::NEW_GROUP_NAME,
-                    'headStatementId' => $member2->getId(),
-                ],
-            ]]
+        /** @var ValidatorInterface $validator */
+        $validator = $this->getContainer()->get(ValidatorInterface::class);
+        $violations = $validator->validate($resource, null, ['statementgroup:update']);
+
+        self::assertGreaterThan(0, count($violations));
+        self::assertSame(
+            'headStatementId cannot be changed via PATCH.',
+            $violations->get(0)->getMessage()
         );
-
-        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        self::assertSame('Old Name', $this->fetchPersistedGroup($group->getId())->getName());
-    }
-
-    public function testPatchWithStatementsIsIgnored(): void
-    {
-        $procedure = ProcedureFactory::createOne();
-        [$group] = $this->createGroupWithTwoMembers($procedure);
-        $otherStatement = StatementFactory::createOne(['procedure' => $procedure]);
-        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
-        $this->enablePermissions(['feature_statement_cluster']);
-
-        $response = $this->sendRequest(
-            self::GROUP_URI_PREFIX.$group->getId(),
-            'PATCH',
-            $user,
-            $procedure,
-            ['data' => [
-                'type'       => 'StatementGroup',
-                'id'         => $group->getId(),
-                'attributes' => [
-                    'groupName'  => self::NEW_GROUP_NAME,
-                    'statements' => [['id' => $otherStatement->getId(), 'externId' => $otherStatement->getExternId()]],
-                ],
-            ]]
-        );
-
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $persistedGroup = $this->fetchPersistedGroup($group->getId());
-        self::assertSame(self::NEW_GROUP_NAME, $persistedGroup->getName());
-        self::assertCount(2, $persistedGroup->getCluster());
     }
 
     protected function getServerParameters(): array

--- a/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
+++ b/tests/backend/core/Statement/Functional/StatementGroupResourceApiTest.php
@@ -94,7 +94,7 @@ class StatementGroupResourceApiTest extends AbstractApiTest
                 'type'       => 'StatementGroup',
                 'id'         => $group->getId(),
                 'attributes' => [
-                    'groupName'      => 'New Name',
+                    'groupName'       => 'New Name',
                     'headStatementId' => $member2->getId(),
                 ],
             ]]


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-17975/Neu-Ado-issue-54804-Bearbeiten-einer-Gruppe

**This is a bug fix found in the Edition Stn group story**
1, Fixes PATCH requests to `/api/3.0/StatementGroup/{id}` failing when only updating the group name. 
2. The statements field was being validated as if the client sent it, but it was actually pre-filled by the API with the group's existing members before validation ran, so the update always got rejected. 
**The fix:** Removed the incorrect validation rule and made sure the name change is actually saved to the database.
