### PR TITLE
chore: bump sass-loader from 16.0.7 to 17.0.0

### DIFF
--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -101,9 +101,6 @@ function createProgressPlugin (options, progressBar, webpackRunner) {
 
     if (percentage === 1.0 && options.mode !== 'watch') {
       progressBar.stop()
-
-      // Yay, we done
-      log(chalk.green('\\o/'))
     }
   }).apply(webpackRunner)
 }
@@ -231,7 +228,24 @@ function printStatsMessageList (messageList, colorFunction) {
 function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConfig, webpackRunner) {
   if (mode === 'build') {
     log(chalk.green(`Begin ${chalk.bold('building')} frontend assets for ${chalk.bold(project)} in ${chalk.bold(webpackConfig[0].mode)} mode`))
-    webpackRunner.run(userFeedbackCallback)
+    webpackRunner.run((err, stats) => {
+      userFeedbackCallback(err, stats)
+
+      // Yay, we done - printed once for the whole (multi-compiler) build
+      if (!err && stats && !stats.hasErrors()) {
+        log(chalk.green(String.raw`\o/`))
+      }
+
+      /*
+       * Close the compiler once the build has finished so webpack fires its shutdown
+       * hooks and loaders/plugins can dispose their resources.
+       */
+      webpackRunner.close(closeError => {
+        if (closeError) {
+          log(chalk.red(closeError.stack || closeError))
+        }
+      })
+    })
   }
 
   if (mode === 'watch') {

--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -190,7 +190,7 @@ function showErrorMessage (err, stats) {
 
   const info = stats.toJson()
 
-  if (err || stats.hasErrors() || stats.hasWarnings()) {
+  if (err || stats.hasErrors()) {
     log(chalk.red('Build failed'))
   }
 
@@ -231,7 +231,15 @@ function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConf
     webpackRunner.run((err, stats) => {
       userFeedbackCallback(err, stats)
 
-      // Yay, we done - printed once for the whole (multi-compiler) build
+      /*
+       * A failed compile must break the build; webpack's Node API does not set an exit code itself, so an errored build
+       * would otherwise exit 0. Warnings are intentionally not treated as a failure.
+       */
+      if (err || (stats?.hasErrors())) {
+        process.exitCode = 1
+      }
+
+      // Yay, we done - printed once for the whole (multi-compiler) build; warnings do not count as a failed build
       if (!err && stats && !stats.hasErrors()) {
         log(chalk.green(String.raw`\o/`))
       }
@@ -242,7 +250,9 @@ function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConf
        */
       webpackRunner.close(closeError => {
         if (closeError) {
-          log(chalk.red(closeError.stack || closeError))
+          // Surface cleanup failures instead of exiting 0 and hiding them
+          process.exitCode = 1
+          log(chalk.red(closeError.stack ?? String(closeError)))
         }
       })
     })

--- a/client/fe/webpack/runWebpack.js
+++ b/client/fe/webpack/runWebpack.js
@@ -239,10 +239,7 @@ function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConf
         process.exitCode = 1
       }
 
-      // Yay, we done - printed once for the whole (multi-compiler) build; warnings do not count as a failed build
-      if (!err && stats && !stats.hasErrors()) {
-        log(chalk.green(String.raw`\o/`))
-      }
+      const buildSucceeded = !err && stats && !stats.hasErrors()
 
       /*
        * Close the compiler once the build has finished so webpack fires its shutdown
@@ -253,6 +250,16 @@ function showWebpackRunMessage (userFeedbackCallback, mode, project, webpackConf
           // Surface cleanup failures instead of exiting 0 and hiding them
           process.exitCode = 1
           log(chalk.red(closeError.stack ?? String(closeError)))
+
+          return
+        }
+
+        /*
+         * Yay, we done - printed once for the whole (multi-compiler) build, and only  after a clean shutdown, so a
+         * failed close() is never reported as success. Warnings do not count as a failed build.
+         */
+        if (buildSucceeded) {
+          log(chalk.green(String.raw`\o/`))
         }
       })
     })

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "postcss-prefix-selector": "^2.1.1",
     "postcss-preset-env": "^10.4.0",
     "sass-embedded": "^1.98.0",
-    "sass-loader": "^16.0.7",
+    "sass-loader": "^17.0.0",
     "source-map-loader": "^5.0.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard-scss": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8098,7 +8098,7 @@ __metadata:
     proj4: "npm:^2.20.2"
     qs: "npm:^6.15.2"
     sass-embedded: "npm:^1.98.0"
-    sass-loader: "npm:^16.0.7"
+    sass-loader: "npm:^17.0.0"
     source-map-loader: "npm:^5.0.0"
     source-sans-pro: "npm:^3.6.0"
     string_decoder: "npm:^1.3.0"
@@ -14562,21 +14562,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^16.0.7":
-  version: 16.0.7
-  resolution: "sass-loader@npm:16.0.7"
-  dependencies:
-    neo-async: "npm:^2.6.2"
+"sass-loader@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "sass-loader@npm:17.0.0"
   peerDependencies:
     "@rspack/core": 0.x || ^1.0.0 || ^2.0.0-0
-    node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     sass: ^1.3.0
     sass-embedded: "*"
     webpack: ^5.0.0
   peerDependenciesMeta:
     "@rspack/core":
-      optional: true
-    node-sass:
       optional: true
     sass:
       optional: true
@@ -14584,7 +14579,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/eb352777cb3aff4bf0029c88e276a37ca10f415de0765eb1276f742455ebb152faffc2417770bf4a26da389d6115e27dd6c8e66c8b71396b21811f6e4d1b4eea
+  checksum: 10c0/fe65b1b75ac9e4c35c82ee507ad1273919646ef19b589a1366bbae5c3d4a23ff69b8b5d891103735f059d2fc5c4bb564d0e716989adfe60aede4658f2fabfad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- sass-loader is bumped from 16.0.7 to 17.0.0
- sass-loader 17.0.0 defaults to `api: 'auto'`, and because we're using sass-embedded, it switches to the modern dart sass api which reuses a single long-running compiler instance that only closes if webpack fires its shutdown hooks; if it doesn't, the build process hangs at 100% and never exits
- `webpackRunner.close()` is now called once the build finishes, and the "\o/" success message is moved to be only printed once for the whole multi-compiler build

### Linked PRs
- Replaces https://github.com/demos-europe/demosplan-core/pull/6470

