### PR TITLE
ci: sync release_diplanbau, release_diplanrog, release_diplanfest bra…

### DIFF
--- a/.github/workflows/ado_sync.yml
+++ b/.github/workflows/ado_sync.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - release
+      - release_diplanbau
+      - release_diplanrog
+      - release_diplanfest
 
 
 jobs:
@@ -14,4 +17,4 @@ jobs:
       ADO_TOKEN: ${{ secrets.ADO_SSH_KEY }}
     with:
       ADO_REPO_URL: "ssh://www.dev.diplanung.de:22/DefaultCollection/DiPlanBeteiligung/_git/diplanbeteiligung"
-      BRANCH_NAME: ${{ github.ref == 'refs/heads/main' && 'develop' || github.ref == 'refs/heads/release' && 'release' || 'other' }}
+      BRANCH_NAME: ${{ github.ref == 'refs/heads/main' && 'develop' || github.ref == 'refs/heads/release' && 'release' || github.ref == 'refs/heads/release_diplanbau' && 'release_diplanbau' || github.ref == 'refs/heads/release_diplanrog' && 'release_diplanrog' || github.ref == 'refs/heads/release_diplanfest' && 'release_diplanfest' || 'other' }}


### PR DESCRIPTION
Sync release_diplanbau, release_diplanrog, release_diplanfest branches to ADO                                                                                                                                                          
                                                                                                                                                                                                                                 Adds these three release_project branches as push triggers for the ADO sync workflow, mapping each to the ADO branch of the same name in the diplanbeteiligung ADO repo (in addition to the existing main→develop and  release→release mappings).    