### PR TITLE
refactor: extract RecommendationConverter from SegmentsByStatementsExporter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/RecommendationConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/RecommendationConverter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export;
+
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
+use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
+
+class RecommendationConverter
+{
+    public function __construct(private readonly ImageLinkConverter $imageLinkConverter)
+    {
+    }
+
+    /**
+     * @param Segment[] $sortedSegments
+     *
+     * @return array<string, ConvertedSegment> - key is externId, value is ConvertedSegment
+     */
+    public function convertImagesToReferencesInRecommendations(array $sortedSegments): array
+    {
+        $convertedSegments = [];
+        foreach ($sortedSegments as $segment) {
+            $externId = $segment->getExternId();
+            $convertedSegments[$externId] = $this->imageLinkConverter->convert(
+                $segment,
+                $externId,
+                false
+            );
+        }
+        $this->imageLinkConverter->resetImages();
+
+        return $convertedSegments;
+    }
+
+    /**
+     * @param array<string, mixed>            $segmentsOrStatements
+     * @param array<string, ConvertedSegment> $convertedSegments
+     *
+     * @return array<string, mixed>
+     */
+    public function updateRecommendationsWithTextReferences(
+        array $segmentsOrStatements,
+        array $convertedSegments,
+    ): array {
+        foreach ($segmentsOrStatements as $key => $segmentOrStatement) {
+            $isNotSegment = !array_key_exists('recommendation', $segmentOrStatement);
+            $externIdIsNotOfSegment = !array_key_exists($segmentOrStatement['externId'], $convertedSegments);
+            if ($isNotSegment || $externIdIsNotOfSegment) {
+                continue;
+            }
+
+            $segmentOrStatement['text'] = $convertedSegments[$segmentOrStatement['externId']]->getText();
+            $segmentOrStatement['recommendation'] =
+                $convertedSegments[$segmentOrStatement['externId']]->getRecommendationText();
+            $segmentsOrStatements[$key] = $segmentOrStatement;
+        }
+
+        return $segmentsOrStatements;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -26,6 +26,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Export\DocumentWriterSelector;
 use demosplan\DemosPlanCoreBundle\Logic\Export\PhpWordConfigurator;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageLinkConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\ImageManager;
+use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\RecommendationConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\StyleInitializer;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
@@ -56,6 +57,7 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         HtmlHelper $htmlHelper,
         protected ImageManager $imageManager,
         ImageLinkConverter $imageLinkConverter,
+        private readonly RecommendationConverter $recommendationConverter,
         Slugify $slugify,
         StyleInitializer $styleInitializer,
         TranslatorInterface $translator,
@@ -128,7 +130,9 @@ class SegmentsByStatementsExporter extends SegmentsExporter
             if (!$statement->getSegmentsOfStatement()->isEmpty()) {
                 $segmentsOrStatements = $statement->getSegmentsOfStatement();
                 $convertedSegments[] =
-                    $this->convertImagesToReferencesInRecommendations($segmentsOrStatements->toArray());
+                    $this->recommendationConverter->convertImagesToReferencesInRecommendations(
+                        $this->sortSegmentsByOrderInProcedure($segmentsOrStatements->toArray())
+                    );
             }
             foreach ($segmentsOrStatements as $segmentOrStatement) {
                 $convertedData = $this->statementArrayConverter->convertIntoExportableArray($segmentOrStatement);
@@ -142,7 +146,10 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         }
 
         foreach ($convertedSegments as $convertedSegment) {
-            $exportData = $this->updateRecommendationsWithTextReferences($exportData, $convertedSegment);
+            $exportData = $this->recommendationConverter->updateRecommendationsWithTextReferences(
+                $exportData,
+                $convertedSegment
+            );
         }
 
         $columnsDefinition = $this->assessmentTableXlsExporter->selectFormat('segments');
@@ -155,48 +162,6 @@ class SegmentsByStatementsExporter extends SegmentsExporter
         $this->assessmentTableXlsExporter->addFilterInfoSheet($writer, $tagFilter);
 
         return $writer;
-    }
-
-    private function convertImagesToReferencesInRecommendations(array $segments): array
-    {
-        $sortedSegments = $this->sortSegmentsByOrderInProcedure($segments);
-
-        $convertedSegments = [];
-        /** @var Segment $segment */
-        foreach ($sortedSegments as $segment) {
-            $externId = $segment->getExternId();
-            $convertedSegment = $this->imageLinkConverter->convert($segment, $externId, false);
-            $convertedSegments[$externId] = $convertedSegment;
-        }
-        $this->imageLinkConverter->resetImages();
-
-        return $convertedSegments;
-    }
-
-    /**
-     * @param array<string, mixed>            $segmentsOrStatements
-     * @param array<string, ConvertedSegment> $convertedSegments
-     *
-     * @return array<string, mixed>
-     */
-    private function updateRecommendationsWithTextReferences(
-        array $segmentsOrStatements,
-        array $convertedSegments,
-    ): array {
-        foreach ($segmentsOrStatements as $key => $segmentOrStatement) {
-            $isNotSegment = !array_key_exists('recommendation', $segmentOrStatement);
-            $externIdIsNotOfSegment = !array_key_exists($segmentOrStatement['externId'], $convertedSegments);
-            if ($isNotSegment || $externIdIsNotOfSegment) {
-                continue;
-            }
-
-            $segmentOrStatement['text'] = $convertedSegments[$segmentOrStatement['externId']]->getText();
-            $segmentOrStatement['recommendation'] =
-                $convertedSegments[$segmentOrStatement['externId']]->getRecommendationText();
-            $segmentsOrStatements[$key] = $segmentOrStatement;
-        }
-
-        return $segmentsOrStatements;
     }
 
     public function exportStatementSegmentsInSeparateDocx(

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentsByStatementsExporter.php
@@ -32,7 +32,6 @@ use demosplan\DemosPlanCoreBundle\Logic\Segment\Export\Utils\HtmlHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementArrayConverter;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\Exporter\StatementExportTagFilter;
-use demosplan\DemosPlanCoreBundle\ValueObject\SegmentExport\ConvertedSegment;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use PhpOffice\PhpWord\Element\Footer;
 use PhpOffice\PhpWord\Element\Section;


### PR DESCRIPTION
### Ticket
Part of the ongoing segment export refactoring (refs PR #3462).

This PR continues the refactoring from PR #3462. It extracts `convertImagesToReferencesInRecommendations` and `updateRecommendationsWithTextReferences` from `SegmentsByStatementsExporter` into a dedicated `RecommendationConverter` class.

Changes:
- `RecommendationConverter` now owns the image-link conversion and recommendation text-reference update logic
- `SegmentsByStatementsExporter` delegates to `RecommendationConverter` via constructor injection
- The implementation is adapted to the current `ImageLinkConverter::convert()` API, which takes a full `Segment` object and returns a `ConvertedSegment` (instead of the plain string from the original commit)

### How to review/test
Existing tests in `SegmentsByStatementsExporterTest` cover the XLSX export path.

### PR Checklist
- [x] Create/Update tests