### PR TITLE
refactor: remove unused StatementService from StatementArrayConverter

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
@@ -18,7 +18,6 @@ use demosplan\DemosPlanCoreBundle\Entity\Statement\Segment;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\TagTopic;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
-use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
 use Doctrine\Common\Collections\ArrayCollection;
 use ReflectionException;
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/Exporter/StatementArrayConverter.php
@@ -32,7 +32,6 @@ class StatementArrayConverter
 {
     public function __construct(
         private readonly EntityHelper $entityHelper,
-        private readonly StatementService $statementService,
     ) {
     }
 


### PR DESCRIPTION
### Ticket
Part of the ongoing segment export refactoring (refs PR #3462).

`StatementService` was injected into `StatementArrayConverter` but never used. This removes the dead dependency.

### How to review/test
Run `StatementArrayConverterTest` (10 tests, all passing).

### PR Checklist
- [x] Create/Update tests