### PR TITLE
fix: declare timestamps as attributes to fix validation

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
@@ -20,7 +20,7 @@ use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Repository\SupportContactRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\UniqueConstraint;
-use Gedmo\Timestampable\Traits\TimestampableEntity;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[SupportContactConstraint]
@@ -29,8 +29,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: SupportContactRepository::class)]
 class SupportContact extends CoreEntity implements UuidEntityInterface, SupportContactInterface
 {
-    use TimestampableEntity;
-
     /**
      * These constants represent all possible values the property
      * {@link SupportContact::$supportType} can hold. This type is used to distinguish between support contacts used in
@@ -48,6 +46,14 @@ class SupportContact extends CoreEntity implements UuidEntityInterface, SupportC
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UuidV4Generator::class)]
     private ?string $id = null;
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(name: 'created_at', type: 'datetime')]
+    protected ?\DateTime $createdAt = null;
+
+    #[Gedmo\Timestampable(on: 'update')]
+    #[ORM\Column(name: 'updated_at', type: 'datetime')]
+    protected ?\DateTime $updatedAt = null;
 
     public function __construct(
         #[Assert\Choice(choices: [
@@ -75,6 +81,30 @@ class SupportContact extends CoreEntity implements UuidEntityInterface, SupportC
     public function getId(): ?string
     {
         return $this->id;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTime $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     public function getSupportType(): string

--- a/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/SupportContact.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Entity\User;
 
+use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Entities\SupportContactInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UuidEntityInterface;
 use demosplan\DemosPlanCoreBundle\Constraint\SupportContactConstraint;
@@ -49,11 +50,11 @@ class SupportContact extends CoreEntity implements UuidEntityInterface, SupportC
 
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(name: 'created_at', type: 'datetime')]
-    protected ?\DateTime $createdAt = null;
+    protected ?DateTime $createdAt = null;
 
     #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(name: 'updated_at', type: 'datetime')]
-    protected ?\DateTime $updatedAt = null;
+    protected ?DateTime $updatedAt = null;
 
     public function __construct(
         #[Assert\Choice(choices: [
@@ -83,24 +84,24 @@ class SupportContact extends CoreEntity implements UuidEntityInterface, SupportC
         return $this->id;
     }
 
-    public function getCreatedAt(): ?\DateTime
+    public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTime $createdAt): self
+    public function setCreatedAt(DateTime $createdAt): self
     {
         $this->createdAt = $createdAt;
 
         return $this;
     }
 
-    public function getUpdatedAt(): ?\DateTime
+    public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(\DateTime $updatedAt): self
+    public function setUpdatedAt(DateTime $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
 


### PR DESCRIPTION
- editing or creating a support contact threw an AnnotationException: the symfony validator's annotation reader parsed the TimestampableEntity trait's legacy @ORM\Column docblock, which is invalid under attribute-only Doctrine ORM
- replace the trait with attribute-only created_at/updated_at columns (same schema, Gedmo still populates them) so resource validation succeeds

### How to review/test
- login as "Mandanten-Admin"
- navigate to customer settings -> support section
- edit or create a support contact - there should be no error, and after reloading the page, the changes should still be there

### Linked PRs
- [ ] minor vue3 refactoring: https://github.com/demos-europe/demosplan-core/pull/6584
- [ ] ui cleanup: https://github.com/demos-europe/demosplan-core/pull/6589

