### PR TITLE
fix(ref: DPLAN-18104): reset to page 1 before reload when deleting the last statement

### DIFF
--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -1198,6 +1198,14 @@ export default {
 
         this.deleteStatement(id)
           .then(() => {
+            /*
+             * If this was the only item on the current page, that page no longer exists after
+             * deletion — go back to page 1 directly instead of requesting an out-of-range page.
+             */
+            if (this.pagination.count <= 1 && this.pagination.currentPage > 1) {
+              this.pagination.currentPage = 1
+            }
+
             this.getItemsByPage(this.pagination.currentPage)
             // Reset the custom success callback to the default one
             this.$store.api.successCallbacks[0] = this.$store.api.handleResponse

--- a/client/js/components/statement/listStatements/ListStatements.vue
+++ b/client/js/components/statement/listStatements/ListStatements.vue
@@ -1200,10 +1200,11 @@ export default {
           .then(() => {
             /*
              * If this was the only item on the current page, that page no longer exists after
-             * deletion — go back to page 1 directly instead of requesting an out-of-range page.
+             * deletion — go back to the previous page directly
+             * instead of requesting an out-of-range page.
              */
             if (this.pagination.count <= 1 && this.pagination.currentPage > 1) {
-              this.pagination.currentPage = 1
+              this.pagination.currentPage -= 1
             }
 
             this.getItemsByPage(this.pagination.currentPage)


### PR DESCRIPTION
### Ticket
[DPLAN-18104](https://demoseurope.youtrack.cloud/issue/DPLAN-18104)


Deleting the only remaining statement on a page beyond page 1 previously triggered a reload of that now out-of-range page, causing a failed request and an error toast before the existing fallback recovered.

### How to review/test
Take a look a the statmentslist win min 2 pages, delete the last on on page 2. You should be redirected without error to page 1 of statmentslist.

### PR Checklist

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
