### PR TITLE
feat (DPLAN-18198): Segment proposals whose tags are delivered by demospipes now preselect the tag's default assignee (Bearbeiter*in) automatically

### DIFF
--- a/client/js/store/statement/SplitStatementStore.js
+++ b/client/js/store/statement/SplitStatementStore.js
@@ -146,6 +146,40 @@ const SplitStatementStore = {
       }
     },
 
+    /**
+     * Preselects a segment's assignee from the default assignee of its first tag that has one.
+     * This mirrors the manual behaviour in SideBar.vue (the tag-add watcher) for tags that arrive
+     * pre-attached to segments (e.g. proposed by demospipes), which never trigger that watcher.
+     * Only users assignable in the procedure are applied, and an existing assignee is never overwritten.
+     */
+    applyTagDefaultAssignees ({ state, commit }) {
+      if (!hasPermission('feature_tag_default_assignee')) {
+        return
+      }
+
+      const segmentsWithDefaultAssignee = structuredClone(state.segments).map(segment => {
+        if (segment.assigneeId) {
+          return segment
+        }
+
+        for (const segmentTag of segment.tags) {
+          const availableTag = state.availableTags.find(tag => tag.id === segmentTag.id)
+          const defaultAssigneeId = availableTag?.relationships?.defaultAssignee?.data?.id
+          const isAssignableUser = Boolean(defaultAssigneeId) && state.assignableUsers.some(user => user.id === defaultAssigneeId)
+
+          if (isAssignableUser) {
+            segment.assigneeId = defaultAssigneeId
+
+            return segment
+          }
+        }
+
+        return segment
+      })
+
+      commit('setProperty', { prop: 'segments', val: segmentsWithDefaultAssignee })
+    },
+
     closeEditMode ({ commit }) {
       commit('setProperty', { prop: 'editModeActive', val: false })
       commit('setProperty', { prop: 'editingSegment', val: null })
@@ -307,6 +341,8 @@ const SplitStatementStore = {
 
         commit('setProperty', { prop: 'uncategorizedTags', val: mergedTags })
         commit('setProperty', { prop: 'availableTags', val: availableTags })
+
+        dispatch('applyTagDefaultAssignees')
       })
     },
 

--- a/tests/frontend/unit/SplitStatementStore.spec.js
+++ b/tests/frontend/unit/SplitStatementStore.spec.js
@@ -1,0 +1,108 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+import SplitStatementStore from '@DpJs/store/statement/SplitStatementStore'
+
+describe('SplitStatement store', () => {
+  describe('applyTagDefaultAssignees', () => {
+    const buildTag = (id, defaultAssigneeId = null) => ({
+      id,
+      relationships: defaultAssigneeId ?
+        { defaultAssignee: { data: { id: defaultAssigneeId } } } :
+        {},
+    })
+
+    const runAction = ({ segments, availableTags = [], assignableUsers = [] }) => {
+      const state = { segments, availableTags, assignableUsers }
+      const commit = jest.fn()
+
+      SplitStatementStore.actions.applyTagDefaultAssignees({ state, commit })
+
+      return commit
+    }
+
+    beforeEach(() => {
+      globalThis.hasPermission = jest.fn(() => true)
+      globalThis.structuredClone = globalThis.structuredClone || (value => JSON.parse(JSON.stringify(value)))
+    })
+
+    it('does nothing when the feature permission is disabled', () => {
+      globalThis.hasPermission = jest.fn(() => false)
+
+      const commit = runAction({
+        segments: [{ id: 'seg1', tags: [{ id: 'tag1' }] }],
+        availableTags: [buildTag('tag1', 'user1')],
+        assignableUsers: [{ id: 'user1' }],
+      })
+
+      expect(commit).not.toHaveBeenCalled()
+    })
+
+    it('assigns the default assignee of the first tag that has an assignable one', () => {
+      const commit = runAction({
+        segments: [{ id: 'seg1', tags: [{ id: 'tag1' }] }],
+        availableTags: [buildTag('tag1', 'user1')],
+        assignableUsers: [{ id: 'user1' }],
+      })
+
+      expect(commit).toHaveBeenCalledWith('setProperty', {
+        prop: 'segments',
+        val: [expect.objectContaining({ id: 'seg1', assigneeId: 'user1' })],
+      })
+    })
+
+    it('lets the first tag with a default assignee win', () => {
+      const commit = runAction({
+        segments: [{ id: 'seg1', tags: [{ id: 'tag1' }, { id: 'tag2' }] }],
+        availableTags: [buildTag('tag1', 'user1'), buildTag('tag2', 'user2')],
+        assignableUsers: [{ id: 'user1' }, { id: 'user2' }],
+      })
+
+      const committedSegments = commit.mock.calls[0][1].val
+
+      expect(committedSegments[0].assigneeId).toBe('user1')
+    })
+
+    it('does not overwrite an existing assignee', () => {
+      const commit = runAction({
+        segments: [{ id: 'seg1', assigneeId: 'manual', tags: [{ id: 'tag1' }] }],
+        availableTags: [buildTag('tag1', 'user1')],
+        assignableUsers: [{ id: 'user1' }],
+      })
+
+      const committedSegments = commit.mock.calls[0][1].val
+
+      expect(committedSegments[0].assigneeId).toBe('manual')
+    })
+
+    it('skips a default assignee that is not assignable in the procedure', () => {
+      const commit = runAction({
+        segments: [{ id: 'seg1', tags: [{ id: 'tag1' }] }],
+        availableTags: [buildTag('tag1', 'user1')],
+        assignableUsers: [{ id: 'someoneElse' }],
+      })
+
+      const committedSegments = commit.mock.calls[0][1].val
+
+      expect(committedSegments[0].assigneeId).toBeUndefined()
+    })
+
+    it('leaves a segment unassigned when no tag has a default assignee', () => {
+      const commit = runAction({
+        segments: [{ id: 'seg1', tags: [{ id: 'tag1' }] }],
+        availableTags: [buildTag('tag1')],
+        assignableUsers: [{ id: 'user1' }],
+      })
+
+      const committedSegments = commit.mock.calls[0][1].val
+
+      expect(committedSegments[0].assigneeId).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Ticket:
https://demoseurope.youtrack.cloud/issue/DPLAN-18218

Description:
Segment proposals whose tags are delivered by demospipes now preselect the tag's default assignee (Bearbeiter*in) automatically — both in the drafts-list view and when the proposals are confirmed into real segments.

### How to review/test
start splitting a new statement -> edit a segment proposal with no assignee -> assign a tag that has not default assignee yet -> save.
Go to Tag edit page and assign that used tag from the earlier segment proposal an assignee.
Go back to the splitting statement view - the prev assigned Tag should now cause the segment to get that assignee


- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
