### PR TITLE
feat(refs DPLAN-18219): update assignee on tag change

### DIFF
--- a/client/js/components/statement/splitStatement/SideBar.vue
+++ b/client/js/components/statement/splitStatement/SideBar.vue
@@ -335,10 +335,6 @@ export default {
       return this.deadline !== this.initialDeadline
     },
 
-    hasSelectedAssignee () {
-      return Boolean(this.selectedAssignee?.id) && this.selectedAssignee.id !== 'noAssigneeId'
-    },
-
     initialAssignee () {
       if (this.currentSegment && hasOwnProp(this.currentSegment, 'assigneeId')) {
         return this.getAssignableUserById(this.currentSegment.assigneeId)
@@ -396,28 +392,19 @@ export default {
 
   watch: {
     /*
-     * When a tag with a default assignee is added to an unassigned segment, preselect
-     * that user as assignee (first added tag with a default assignee wins). The
-     * selection is persisted with the regular save flow via updateSegment().
+     * Keep the assignee field in sync with the segment's tags: the first selected tag
+     * that has a default assignee wins and is applied even if an assignee is already set.
+     * If no selected tag provides one, the field is reset to "not assigned". The selection
+     * is persisted with the regular save flow via updateSegment().
      */
-    'editingSegment.tags': function (newTags, oldTags) {
-      if (!hasPermission('feature_tag_default_assignee') || !newTags || this.hasSelectedAssignee) {
+    'editingSegment.tags': function (newTags) {
+      if (!hasPermission('feature_tag_default_assignee') || !newTags) {
         return
       }
 
-      const addedTags = oldTags ? newTags.filter(tag => !oldTags.some(el => el.id === tag.id)) : newTags
+      const defaultAssignee = this.getFirstTagAssignee(newTags)
 
-      for (const addedTag of addedTags) {
-        const availableTag = this.availableTags.find(tag => tag.id === addedTag.id)
-        const defaultAssigneeId = availableTag?.relationships?.defaultAssignee?.data?.id
-        const defaultAssignee = defaultAssigneeId ? this.getAssignableUserById(defaultAssigneeId) : null
-
-        if (defaultAssignee) {
-          this.selectedAssignee = defaultAssignee
-
-          return
-        }
-      }
+      this.selectedAssignee = defaultAssignee || this.getAssignableUserById('noAssigneeId') || null
     },
   },
 
@@ -436,6 +423,20 @@ export default {
 
     getAssignableUserById (id) {
       return this.assignableUsers.find(user => user.id === id)
+    },
+
+    getFirstTagAssignee (tags) {
+      for (const tag of tags) {
+        const availableTag = this.availableTags.find(el => el.id === tag.id)
+        const defaultAssigneeId = availableTag?.relationships?.defaultAssignee?.data?.id
+        const defaultAssignee = defaultAssigneeId ? this.getAssignableUserById(defaultAssigneeId) : null
+
+        if (defaultAssignee) {
+          return defaultAssignee
+        }
+      }
+
+      return null
     },
 
     getPlaceById (placeId) {

--- a/client/js/components/statement/splitStatement/SideBar.vue
+++ b/client/js/components/statement/splitStatement/SideBar.vue
@@ -402,9 +402,15 @@ export default {
         return
       }
 
-      const defaultAssignee = this.getFirstTagAssignee(newTags)
+      const assignee = this.getFirstTagAssignee(newTags) || this.getAssignableUserById('noAssigneeId')
 
-      this.selectedAssignee = defaultAssignee || this.getAssignableUserById('noAssigneeId') || null
+      /*
+       * Only update once a valid option exists; avoid setting null while the assignable
+       * users are still loading, which would break dp-multiselect and the save logic.
+       */
+      if (assignee) {
+        this.selectedAssignee = assignee
+      }
     },
   },
 

--- a/tests/frontend/unit/SplitStatementSideBar.spec.js
+++ b/tests/frontend/unit/SplitStatementSideBar.spec.js
@@ -33,6 +33,15 @@ const tagWithoutDefaultAssignee = {
   },
 }
 
+const tagWithOtherDefaultAssignee = {
+  id: 'tag3',
+  attributes: { title: 'Tag with other assignee' },
+  relationships: {
+    defaultAssignee: { data: { id: 'user2', type: 'AssignableUser' } },
+    topic: { data: { id: 'topic1', type: 'TagTopic' } },
+  },
+}
+
 describe('SplitStatement SideBar', () => {
   let store
   let wrapper
@@ -45,7 +54,7 @@ describe('SplitStatement SideBar', () => {
           state: {
             assignableUsers: [noAssignee, assignableUser, otherUser],
             availablePlaces: [{ id: 'place1', name: 'Place 1' }],
-            availableTags: [tagWithDefaultAssignee, tagWithoutDefaultAssignee],
+            availableTags: [tagWithDefaultAssignee, tagWithoutDefaultAssignee, tagWithOtherDefaultAssignee],
             editingSegment: { id: 'segment1', tags: [] },
             editModeActive: true,
             initialSegments: [],
@@ -111,7 +120,7 @@ describe('SplitStatement SideBar', () => {
     expect(wrapper.vm.selectedAssignee.id).toBe('noAssigneeId')
   })
 
-  it('does not overwrite an already selected assignee', async () => {
+  it('overwrites an already selected assignee when a tag with a default assignee is added', async () => {
     wrapper.vm.selectedAssignee = otherUser
     await nextTick()
 
@@ -121,10 +130,10 @@ describe('SplitStatement SideBar', () => {
     }
     await nextTick()
 
-    expect(wrapper.vm.selectedAssignee.id).toBe('user2')
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
   })
 
-  it('uses the first added tag that has a default assignee', async () => {
+  it('uses the first selected tag that has a default assignee, skipping tags without one', async () => {
     store.state.SplitStatement.editingSegment = {
       id: 'segment1',
       tags: [{ id: 'tag2', tagName: 'Tag without assignee' }],
@@ -139,6 +148,94 @@ describe('SplitStatement SideBar', () => {
         { id: 'tag2', tagName: 'Tag without assignee' },
         { id: 'tag1', tagName: 'Tag with assignee' },
       ],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+  })
+
+  it('keeps the first selected tag assignee when a later tag with a different assignee is added', async () => {
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag1', tagName: 'Tag with assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+
+    // Adding a second tag (kept after the first) must not change the assignee: the first wins.
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [
+        { id: 'tag1', tagName: 'Tag with assignee' },
+        { id: 'tag3', tagName: 'Tag with other assignee' },
+      ],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+  })
+
+  it('updates the assignee when the segment is retagged with a tag that has a different default assignee', async () => {
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag1', tagName: 'Tag with assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag3', tagName: 'Tag with other assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user2')
+  })
+
+  it('resets the assignee to not assigned when retagged with a tag that has no default assignee', async () => {
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag1', tagName: 'Tag with assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag2', tagName: 'Tag without assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('noAssigneeId')
+  })
+
+  it('resets the assignee to not assigned when all tags are removed', async () => {
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag1', tagName: 'Tag with assignee' }],
+    }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('user1')
+
+    store.state.SplitStatement.editingSegment = { id: 'segment1', tags: [] }
+    await nextTick()
+
+    expect(wrapper.vm.selectedAssignee.id).toBe('noAssigneeId')
+  })
+
+  it('overrules a manually selected assignee when the tags change afterwards', async () => {
+    // The user picks an assignee by hand.
+    wrapper.vm.selectedAssignee = otherUser
+    await nextTick()
+
+    // A subsequent tag change applies the first tag's default assignee.
+    store.state.SplitStatement.editingSegment = {
+      id: 'segment1',
+      tags: [{ id: 'tag1', tagName: 'Tag with assignee' }],
     }
     await nextTick()
 


### PR DESCRIPTION
### Ticket
DPLAN-18219

When splitting a statement, changing a segment's tag did not update the Bearbeiter*in field: once an assignee was set from a tag, it stayed on the old value even after the tag was removed or replaced.

Now, on every tag change the assignee field is recomputed from the currently selected tags: the first selected tag that has a default assignee wins, and the field resets to "Nicht zugewiesen" when no selected tag provides one. The value is applied even if an assignee was already set, and is persisted through the regular save flow.

How to review/test

1. Start splitting a statement and edit a segment proposal.
2. Assign a tag that has a default assignee -> the Bearbeiter*in field is filled with that user
3. Remove that tag and assign a different tag that has another default assignee -> the field updates to the new user
4. Assign a tag without a default assignee (or remove all tags) -> the assignee field resets to "Nicht zugewiesen"
5. With two tags that both have a default assignee, the first selected one wins

### PR Checklist

- [x] Create/Update tests
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
