### PR TITLE
chore: bump demosplan-ui from v0.25.0 to 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.25.0",
+    "@demos-europe/demosplan-ui": "0.26.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,9 +2899,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.25.0"
+"@demos-europe/demosplan-ui@npm:0.26.0":
+  version: 0.26.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.26.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2954,7 +2954,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/9b201eb76aa1b932380deb23dfa23c58edff9adeb57ae47c27fa8ff57bb37f56bac6603f376645285286901fc3e96559b966e41a8e60f9d8e01be5e412c4c966
+  checksum: 10c0/b740e269ae5b2bb44cba9db4319953b68f4c3ccf8a44b1902e17eb52ab1d6d03f0019458117c1d96885707eb50282615b23ebe941aed42fd58418e3b46da63b3
   languageName: node
   linkType: hard
 
@@ -8017,7 +8017,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.25.0"
+    "@demos-europe/demosplan-ui": "npm:0.26.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
- new version adds optional title to DpInlineNotification and fixes conditional validation in DpEditor, DpTextarea, and DpUploadFiles