### PR TITLE
fix(refs DPLAN-18200): confirm unconfirmed segments on 'save and finish'

### DIFF
--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -776,6 +776,46 @@ export default {
       this.ignoreProsemirrorUpdates = false
     },
 
+    /**
+     * Confirms every segment that is still an unconfirmed proposal.
+     *
+     * Clicking the 'save and finish' button implicitly accepts all remaining proposals. For each one the
+     * segmentMark is set to confirmed, which assigns the pmId that the drafts-list ProseMirror logic
+     * later relies on, and its store status is updated to 'confirmed'. Confirming a mark does not
+     * change document positions, so the ranges read once up front stay valid across the loop
+     */
+    confirmAllUnconfirmedSegments () {
+      const ranges = this.prosemirror.keyAccess.rangeTrackerKey.getState(this.prosemirror.view.state)
+      const confirmedSegments = []
+
+      this.ignoreProsemirrorUpdates = true
+
+      this.segments.forEach(segment => {
+        if (segment.status === 'confirmed') {
+          return
+        }
+
+        const range = ranges[segment.id]
+
+        /**
+         * A proposal without a mark in the document (e.g. a broken draft) cannot be confirmed in
+         * ProseMirror, so it is skipped rather than throwing on the missing range
+         */
+        if (!range) {
+          return
+        }
+
+        setRange(this.prosemirror.view)(range.from, range.to, { segmentId: segment.id, isConfirmed: true })
+        confirmedSegments.push({ ...segment, status: 'confirmed' })
+      })
+
+      this.ignoreProsemirrorUpdates = false
+
+      if (confirmedSegments.length) {
+        this.locallyUpdateSegments(confirmedSegments)
+      }
+    },
+
     handleSegmentCreation (segmentToCreate) {
       const segment = {
         id: uuid(),
@@ -907,6 +947,8 @@ export default {
         if (window.dpconfirm(Translator.trans('statement.split.complete.confirm'))) {
           this.setProperty({ prop: 'isBusy', val: true })
           try {
+            // Confirming completes any remaining proposals so they are saved in a valid, confirmed state
+            this.confirmAllUnconfirmedSegments()
             const currentStatementText = this.prosemirror.getContent(this.prosemirror.view.state)
 
             this.setProperty({ prop: 'statementText', val: currentStatementText })

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -187,6 +187,7 @@ import {
   setRange,
   setRangeEditingState,
 } from '@DpJs/lib/prosemirror/commands'
+import { DOMParser, DOMSerializer } from 'prosemirror-model'
 import {
   dpApi,
   DpButton,
@@ -197,17 +198,16 @@ import {
   hasOwnProp,
 } from '@demos-europe/demosplan-ui'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
-import { DOMParser, DOMSerializer } from 'prosemirror-model'
 import AddonWrapper from '@DpJs/components/addon/AddonWrapper'
 import CardPane from './CardPane'
 import dayjs from 'dayjs'
 import { EditorState } from 'prosemirror-state'
 import { generateRangeChangeMap } from '@DpJs/lib/prosemirror/utilities'
-import { v4 as uuid } from 'uuid'
 import SegmentationEditor from './SegmentationEditor'
 import SideBar from './SideBar'
 import StatementMeta from '@DpJs/components/procedure/StatementSegmentsList/StatementMeta/StatementMeta'
 import StatementMetaTooltip from '../StatementMetaTooltip'
+import { v4 as uuid } from 'uuid'
 
 /**
  * Merges ProseMirror segmentMark data with segment metadata from the store.

--- a/client/js/components/statement/splitStatement/SplitStatementView.vue
+++ b/client/js/components/statement/splitStatement/SplitStatementView.vue
@@ -790,26 +790,28 @@ export default {
 
       this.ignoreProsemirrorUpdates = true
 
-      this.segments.forEach(segment => {
-        if (segment.status === 'confirmed') {
-          return
-        }
+      try {
+        this.segments.forEach(segment => {
+          if (segment.status === 'confirmed') {
+            return
+          }
 
-        const range = ranges[segment.id]
+          const range = ranges[segment.id]
 
-        /**
-         * A proposal without a mark in the document (e.g. a broken draft) cannot be confirmed in
-         * ProseMirror, so it is skipped rather than throwing on the missing range
-         */
-        if (!range) {
-          return
-        }
+          /**
+           * A proposal without a mark in the document (e.g. a broken draft) cannot be confirmed in
+           * ProseMirror, so it is skipped rather than throwing on the missing range
+           */
+          if (!range) {
+            return
+          }
 
-        setRange(this.prosemirror.view)(range.from, range.to, { segmentId: segment.id, isConfirmed: true })
-        confirmedSegments.push({ ...segment, status: 'confirmed' })
-      })
-
-      this.ignoreProsemirrorUpdates = false
+          setRange(this.prosemirror.view)(range.from, range.to, { segmentId: segment.id, isConfirmed: true })
+          confirmedSegments.push({ ...segment, status: 'confirmed' })
+        })
+      } finally {
+        this.ignoreProsemirrorUpdates = false
+      }
 
       if (confirmedSegments.length) {
         this.locallyUpdateSegments(confirmedSegments)

--- a/tests/frontend/unit/SplitStatementView.confirmOnFinish.spec.js
+++ b/tests/frontend/unit/SplitStatementView.confirmOnFinish.spec.js
@@ -1,0 +1,221 @@
+/**
+ * Tests for auto-confirming unconfirmed proposals when finishing a split.
+ * Clicking "Aufteilen abschließen" must confirm every remaining proposal so it is persisted in a
+ * valid, confirmed state (segmentMark gets a pmId, store status becomes 'confirmed') instead of
+ * being saved as a broken, never-confirmed segment.
+ */
+
+/*
+ * Mock the prosemirror commands so we can assert whether/how the range machinery is invoked.
+ * `setRange` is curried: setRange(view)(from, to, attrs).
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const mockSetRangeInner = jest.fn()
+
+jest.mock('@DpJs/lib/prosemirror/commands', () => ({
+  activateRangeEdit: jest.fn(),
+  applySelectionChange: jest.fn(),
+  removeRange: jest.fn(),
+  setRange: jest.fn(() => mockSetRangeInner),
+  setRangeEditingState: jest.fn(() => jest.fn()),
+}))
+
+import { setRange } from '@DpJs/lib/prosemirror/commands'
+import SplitStatementView from '@DpJs/components/statement/splitStatement/SplitStatementView'
+
+const { confirmAllUnconfirmedSegments, saveAndFinish, clickTrackerSaveButton } = SplitStatementView.methods
+
+/**
+ * Builds a mock component context. `segments` is the store segment list; `ranges` maps
+ * segmentId → range object (a segment absent from it has no mark in the document).
+ */
+const buildContext = (segments, ranges) => ({
+  segments,
+  ignoreProsemirrorUpdates: false,
+  prosemirror: {
+    view: { state: {} },
+    keyAccess: {
+      rangeTrackerKey: { getState: () => ranges },
+    },
+  },
+  locallyUpdateSegments: jest.fn(),
+})
+
+describe('SplitStatementView.confirmAllUnconfirmedSegments', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('confirms only the unconfirmed segments and marks them confirmed in the store', () => {
+    const segments = [
+      { id: 'a', status: 'confirmed', tags: [] },
+      { id: 'b', status: false, tags: [] },
+      { id: 'c', status: false, tags: [] },
+    ]
+    const ranges = {
+      a: { from: 1, to: 10, isConfirmed: true },
+      b: { from: 11, to: 20, isConfirmed: false },
+      c: { from: 21, to: 30, isConfirmed: false },
+    }
+    const context = buildContext(segments, ranges)
+
+    confirmAllUnconfirmedSegments.call(context)
+
+    // The already-confirmed segment is left untouched; only the two proposals are confirmed.
+    expect(mockSetRangeInner).toHaveBeenCalledTimes(2)
+    expect(mockSetRangeInner).toHaveBeenCalledWith(11, 20, { segmentId: 'b', isConfirmed: true })
+    expect(mockSetRangeInner).toHaveBeenCalledWith(21, 30, { segmentId: 'c', isConfirmed: true })
+
+    // The store is updated with the newly confirmed segments.
+    expect(context.locallyUpdateSegments).toHaveBeenCalledWith([
+      { id: 'b', status: 'confirmed', tags: [] },
+      { id: 'c', status: 'confirmed', tags: [] },
+    ])
+  })
+
+  it('does nothing when every segment is already confirmed', () => {
+    const segments = [
+      { id: 'a', status: 'confirmed', tags: [] },
+      { id: 'b', status: 'confirmed', tags: [] },
+    ]
+    const ranges = {
+      a: { from: 1, to: 10, isConfirmed: true },
+      b: { from: 11, to: 20, isConfirmed: true },
+    }
+    const context = buildContext(segments, ranges)
+
+    confirmAllUnconfirmedSegments.call(context)
+
+    expect(setRange).not.toHaveBeenCalled()
+    expect(context.locallyUpdateSegments).not.toHaveBeenCalled()
+  })
+
+  it('skips an unconfirmed segment that has no range without throwing', () => {
+    const segments = [
+      { id: 'a', status: false, tags: [] },
+      { id: 'b', status: false, tags: [] },
+    ]
+    // Segment 'a' has no mark in the document.
+    const ranges = {
+      b: { from: 11, to: 20, isConfirmed: false },
+    }
+    const context = buildContext(segments, ranges)
+
+    expect(() => confirmAllUnconfirmedSegments.call(context)).not.toThrow()
+
+    // Only the segment with a range is confirmed.
+    expect(mockSetRangeInner).toHaveBeenCalledTimes(1)
+    expect(mockSetRangeInner).toHaveBeenCalledWith(11, 20, { segmentId: 'b', isConfirmed: true })
+    expect(context.locallyUpdateSegments).toHaveBeenCalledWith([
+      { id: 'b', status: 'confirmed', tags: [] },
+    ])
+  })
+})
+
+/**
+ * Builds a saveAndFinish context wired to a backing store state so the send step sees the effects of
+ * confirmAllUnconfirmedSegments. `getPostedSegments` returns a snapshot of exactly what saveSegmentsFinal
+ * would have sent to the backend, captured at the moment it is invoked.
+ */
+const buildFinishContext = (initialSegments, ranges) => {
+  // Backing store state; `segments` reads from it so store mutations are visible to the send step.
+  const state = { segments: initialSegments.map(segment => ({ ...segment })) }
+  let postedSegments = null
+
+  const context = {
+    get segments () {
+      return state.segments
+    },
+    ignoreProsemirrorUpdates: false,
+    prosemirror: {
+      view: { state: {} },
+      getContent: jest.fn(() => '<p>statement</p>'),
+      keyAccess: {
+        rangeTrackerKey: { getState: () => ranges },
+      },
+    },
+    setProperty: jest.fn(),
+    clickTrackerSaveButton,
+    confirmAllUnconfirmedSegments,
+    // Mirrors the SplitStatementStore locallyUpdateSegments mutation: merge updates into state by id.
+    locallyUpdateSegments: jest.fn(updatedSegments => {
+      state.segments = state.segments.map(segment => {
+        const updated = updatedSegments.find(candidate => candidate.id === segment.id)
+
+        return updated ? { ...segment, ...updated } : segment
+      })
+    }),
+    // Stands in for the store action that POSTs to the backend; captures what would be sent.
+    saveSegmentsFinal: jest.fn(function () {
+      postedSegments = this.segments.map(segment => ({ ...segment }))
+
+      return Promise.resolve(true)
+    }),
+  }
+
+  return { context, getPostedSegments: () => postedSegments }
+}
+
+describe('SplitStatementView.saveAndFinish — backend payload', () => {
+  let originalDpconfirm
+
+  beforeAll(() => {
+    originalDpconfirm = window.dpconfirm
+    global.Translator = { trans: key => key }
+    global.dplan = { notify: { error: jest.fn() } }
+  })
+
+  afterAll(() => {
+    window.dpconfirm = originalDpconfirm
+    delete global.Translator
+    delete global.dplan
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.dpconfirm = jest.fn(() => true)
+  })
+
+  it('confirms every proposal before the segments are sent to the backend', async () => {
+    /*
+     * Mirrors the ticket bug: an AI/pipeline proposal that was created (so it has a segmentMark, and
+     * therefore a range keyed by segmentId) but never confirmed — its statementText spans still lack a
+     * pmId. Finishing must confirm it so it is never persisted in that broken state.
+     */
+    const segments = [
+      { id: 'a', status: 'confirmed', tags: [] },
+      { id: 'b', status: false, tags: [] },
+      { id: 'c', status: false, tags: [] },
+    ]
+    const ranges = {
+      a: { from: 1, to: 10, isConfirmed: true },
+      b: { from: 11, to: 20, isConfirmed: false },
+      c: { from: 21, to: 30, isConfirmed: false },
+    }
+    const { context, getPostedSegments } = buildFinishContext(segments, ranges)
+
+    await saveAndFinish.call(context)
+
+    // Each proposal is confirmed in the document (setRange assigns the pmId) before sending.
+    expect(mockSetRangeInner).toHaveBeenCalledWith(11, 20, { segmentId: 'b', isConfirmed: true })
+    expect(mockSetRangeInner).toHaveBeenCalledWith(21, 30, { segmentId: 'c', isConfirmed: true })
+
+    // The payload handed to the backend never contains an unconfirmed segment.
+    expect(context.saveSegmentsFinal).toHaveBeenCalledTimes(1)
+    const posted = getPostedSegments()
+
+    expect(posted).toHaveLength(3)
+    expect(posted.every(segment => segment.status === 'confirmed')).toBe(true)
+  })
+
+  it('does not send anything to the backend when the user cancels the confirm dialog', async () => {
+    window.dpconfirm.mockReturnValueOnce(false)
+    const { context } = buildFinishContext(
+      [{ id: 'a', status: false, tags: [] }],
+      { a: { from: 1, to: 10, isConfirmed: false } },
+    )
+
+    await saveAndFinish.call(context)
+
+    expect(context.saveSegmentsFinal).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION


### Ticket
DPLAN-18200

- when the user clicks the 'finish segmentation' button, all segment proposals that have not been confirmed by the user are now auto-confirmed on save, meaning that they are sent with `status: 'confirmed'` to the BE
- previously, segments that were unconfirmed when saving didn't get a `pmId`, which lead to the error `TypeError: Cannot read properties of undefined (reading 'marks')`


### PR Checklist

- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
