### PR TITLE
fix DS-589: strip read-only relationships from segment update payload

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -989,27 +989,6 @@ export default {
       }
     },
 
-    /**
-     * Remove non-updatable comments from segments relationships for update request
-     * @param relations {Object}
-     */
-    excludeComments (relations) {
-      if (relations.comments) {
-        this.setProperty({ prop: 'isLoading', val: true })
-        delete relations.comments
-      }
-    },
-
-    /**
-     * Remove non-updatable recommendationVersions from segments relationships for update request
-     * @param relations {Object}
-     */
-    excludeRecommendationVersion (relations) {
-      if (relations.recommendationVersions) {
-        delete relations.recommendationVersions
-      }
-    },
-
     restoreComments (comments) {
       if (comments) {
         const segmentWithComments = {
@@ -1058,15 +1037,10 @@ export default {
         { ...this.segment.relationships.comments } :
         null
 
-      // Update relationships (assignee/place)
-      const relations = this.updateRelationships()
-
-      /**
-       *  Comments and recommendationVersions need to be removed from the PATCH payload
-       *  as updating them is technically not supported
-       */
-      this.excludeComments(relations)
-      this.excludeRecommendationVersion(relations)
+      // Update relationships (assignee/place). Read-only relationships (comments,
+      // recommendationVersions) are stripped inside updateRelationships so they never
+      // reach the PATCH payload.
+      this.updateRelationships()
 
       this.lockedBeforeSave = this.isLocked
       this.isSaving = true
@@ -1261,6 +1235,17 @@ export default {
 
     updateRelationships () {
       let relations = { ...this.segment.relationships }
+
+      /*
+       * `comments` and `recommendationVersions` are read-only on the StatementSegment resource
+       * (they are managed through their own resources/endpoints, never via a segment update).
+       * They must not end up in the update payload. They have to be removed here, before the item
+       * is written to the store, because the vuex-json-api `save` diff reads the *stored* item —
+       * stripping them from the returned object alone has no effect. `finalizeSave()` /
+       * `restoreComments()` put the comments back into the store afterwards so the UI keeps them.
+       */
+      delete relations.comments
+      delete relations.recommendationVersions
 
       if (this.showWorkflowActions) {
         let assignee = { assignee: { data: null } }

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -1037,9 +1037,11 @@ export default {
         { ...this.segment.relationships.comments } :
         null
 
-      // Update relationships (assignee/place). Read-only relationships (comments,
-      // recommendationVersions) are stripped inside updateRelationships so they never
-      // reach the PATCH payload.
+      /*
+       * Update relationships (assignee/place). Read-only relationships (comments,
+       * recommendationVersions) are stripped inside updateRelationships so they never
+       * reach the PATCH payload.
+       */
       this.updateRelationships()
 
       this.lockedBeforeSave = this.isLocked

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -601,6 +601,10 @@ export default {
       'slidebar',
     ]),
 
+    ...mapState('StatementSegment', {
+      segmentItems: 'items',
+    }),
+
     assignableUsers () {
       const assigneeOptions = Object.values({ ...this.assignableUserItems })
         .map(assignableUser => {
@@ -732,10 +736,6 @@ export default {
   methods: {
     ...mapActions('SegmentSlidebar', [
       'toggleSlidebarContent',
-    ]),
-
-    ...mapMutations('SegmentSlidebar', [
-      'setProperty',
     ]),
 
     ...mapActions('StatementSegment', {
@@ -893,12 +893,6 @@ export default {
       })
     },
 
-    finalizeSave (comments) {
-      this.restoreComments(comments)
-      this.setProperty({ prop: 'isLoading', val: false })
-      this.isEditing = false
-    },
-
     hasPolygonFeatures () {
       const raw = this.segment.attributes.polygon
 
@@ -989,18 +983,38 @@ export default {
       }
     },
 
-    restoreComments (comments) {
-      if (comments) {
-        const segmentWithComments = {
-          ...this.segment,
-          relationships: {
-            ...this.segment.relationships,
-            comments,
-          },
-        }
+    /**
+     * Re-add read-only relationships stripped by updateRelationships() to the store
+     * Comments and recommendationVersions are only added as relationship if they don't exist already
+     *
+     * @param comments {Object|null}
+     * @param recommendationVersions {Object|null}
+     */
+    restoreReadOnlyRelationships ({ comments, recommendationVersions }) {
+      const storedSegment = this.segmentItems[this.segment.id]
 
-        this.setSegment({ ...segmentWithComments, id: this.segment.id })
+      if (!storedSegment) {
+        return
       }
+
+      const restoreComments = comments && !storedSegment.relationships.comments
+      const restoreRecommendationVersions = recommendationVersions && !storedSegment.relationships.recommendationVersions
+
+      if (!restoreComments && !restoreRecommendationVersions) {
+        return
+      }
+
+      const relationships = { ...storedSegment.relationships }
+
+      if (restoreComments) {
+        relationships.comments = comments
+      }
+
+      if (restoreRecommendationVersions) {
+        relationships.recommendationVersions = recommendationVersions
+      }
+
+      this.setSegment({ ...storedSegment, relationships, id: storedSegment.id })
     },
 
     saveCustomFields () {
@@ -1033,9 +1047,14 @@ export default {
     },
 
     save () {
-      const comments = this.segment.relationships.comments ?
-        { ...this.segment.relationships.comments } :
-        null
+      const readOnlyRelationships = {
+        comments: this.segment.relationships.comments ?
+          { ...this.segment.relationships.comments } :
+          null,
+        recommendationVersions: this.segment.relationships.recommendationVersions ?
+          { ...this.segment.relationships.recommendationVersions } :
+          null,
+      }
 
       /*
        * Update relationships (assignee/place). Read-only relationships (comments,
@@ -1047,8 +1066,18 @@ export default {
       this.lockedBeforeSave = this.isLocked
       this.isSaving = true
 
-      return this.saveSegmentAction({ id: this.segment.id })
+      const savePromise = this.saveSegmentAction({ id: this.segment.id })
+
+      this.restoreReadOnlyRelationships(readOnlyRelationships)
+
+      return savePromise
         .then(() => {
+          /*
+           * The saveAction overwrites segment data in the store without the readonly relationships, so we need to restore
+           * them again here to ensure comments don't vanish from the interface while saving
+           */
+          this.restoreReadOnlyRelationships(readOnlyRelationships)
+
           /*
            * Clearing the assignee ("nicht zugewiesen") is sent as a separate explicit PATCH because the
            * vuex-json-api diff drops a to-one relationship set to `{ data: null }` (it diffs against a
@@ -1080,6 +1109,7 @@ export default {
         .then(() => {
           dplan.notify.notify('confirm', Translator.trans('confirm.saved'))
 
+          this.isEditing = false
           this.isFullscreen = false
 
           this.toggleAssignableUsersSelect()
@@ -1092,16 +1122,14 @@ export default {
             }
           })
         })
-        .catch((err) => {
+        .catch(err => {
           console.error('Save failed:', err)
           dplan.notify.notify('error', Translator.trans('error.changes.not.saved'))
-        })
-        .catch(() => {
           this.restoreSegmentAction(this.segment.id)
         })
         .finally(() => {
           this.isSaving = false
-          this.finalizeSave(comments)
+          this.restoreReadOnlyRelationships(readOnlyRelationships)
         })
     },
 
@@ -1239,12 +1267,9 @@ export default {
       let relations = { ...this.segment.relationships }
 
       /*
-       * `comments` and `recommendationVersions` are read-only on the StatementSegment resource
-       * (they are managed through their own resources/endpoints, never via a segment update).
-       * They must not end up in the update payload. They have to be removed here, before the item
-       * is written to the store, because the vuex-json-api `save` diff reads the *stored* item —
-       * stripping them from the returned object alone has no effect. `finalizeSave()` /
-       * `restoreComments()` put the comments back into the store afterwards so the UI keeps them.
+       * `comments` and `recommendationVersions` are read-only on the StatementSegment resource (they are managed through
+       * their own resources/endpoints), so we need to remove them from the payload to prevent them from being written
+       * to the store and sent to the BE on save
        */
       delete relations.comments
       delete relations.recommendationVersions
@@ -1290,7 +1315,13 @@ export default {
     },
 
     updateSegment (key, val) {
-      const updated = { ...this.segment, ...{ attributes: { ...this.segment.attributes, ...{ [key]: val } } } }
+      const updated = {
+        ...this.segment,
+        attributes: {
+          ...this.segment.attributes,
+          [key]: val,
+        },
+      }
 
       this.setSegment({ ...updated, id: this.segment.id })
     },


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/tickets/DS-589

Description
Changing a segment's assignee (for example when forwarding a segment for technical review) could fail with a JSON:API validation error and the change was rejected:

[data][relationships][comments]: Unexpected field(s) in the context of the list of relationships, allowed fields are: parentStatement,assignee, place, tags

On the StatementSegment resource, `comments` and `recommendationVersions` are read-only relationships — they are managed through their own resources and can never be written through a segment update. The backend rejects any
relationship in an update payload that is not updatable, so as soon as one of them reached the PATCH request the whole update failed and the assignee could not be changed.

The component already tried to drop these fields (`excludeComments()` / `excludeRecommendationVersion()`), but it deleted
them from a detached copy of the relationships object. The `save` action of vuex-json-api builds the request body by diffing the *stored* item, so the stripping had no effect. Whether the fields ended up in the payload depended entirely on the store state (the diff baseline vs. the current item's comments), which is why the problem was intermittent and only showed up in some environments.

This PR removes the read-only relationships in `updateRelationships()`, before the item is written to the store, so they can never enter the diff or the request body. Comments are still restored to the store after saving, so the UI keeps displaying them.

### How to review/test
1. Open a segment that has comments in the segment view.
2. Change its assignee (e.g. forward it for technical review) and save.
3. The assignee change is persisted without a validation error, and the comments remain visible on the segment.

The reliable trigger for the old behaviour is a diverging store state:
the segment's `comments` in the store differing from the diff baseline (e.g. after the comments are (re)loaded into the item but not the baseline). The fix makes the update robust regardless of that state.

- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly
