### PR TITLE
chore(refs DPLAN-18229): bump demosplan-ui from 0.26.0 to 0.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.26.0",
+    "@demos-europe/demosplan-ui": "0.27.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,9 +2899,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.26.0":
-  version: 0.26.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.26.0"
+"@demos-europe/demosplan-ui@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.27.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2954,7 +2954,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/b740e269ae5b2bb44cba9db4319953b68f4c3ccf8a44b1902e17eb52ab1d6d03f0019458117c1d96885707eb50282615b23ebe941aed42fd58418e3b46da63b3
+  checksum: 10c0/efe2432dd20568489d7571c8c3ecee043efb2eac2696b8ea0b2494771f4ee8a7b86763070a98ebaa633ecd50086e521b3282116c23b27aa1a3ff7e91c6a8f006
   languageName: node
   linkType: hard
 
@@ -8017,7 +8017,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.26.0"
+    "@demos-europe/demosplan-ui": "npm:0.27.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
The new version replaces the robot ai icon with the sparkle icon (used in RecommendationModal)