### PR TITLE
chore: dedupe transitive dompurify to patched 3.4.12

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8213,19 +8213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.2, dompurify@npm:^3.4.5":
-  version: 3.4.11
-  resolution: "dompurify@npm:3.4.11"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.4.12":
+"dompurify@npm:^3.0.2, dompurify@npm:^3.4.12, dompurify@npm:^3.4.5":
   version: 3.4.12
   resolution: "dompurify@npm:3.4.12"
   dependencies:


### PR DESCRIPTION
this fixes a low security alert:
DOMPurify: `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements

Replaces https://github.com/demos-europe/demosplan-core/pull/6627
