### PR TITLE
feat(DPLAN-18206): When orgas are not invited by the allowUninvitedOr…

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -214,6 +214,7 @@ fos_elastica:
                 coordinate: {type: text, index: true}
                 legalNotice: {type: text, index: false}
                 participationGuestOnly: { type: boolean }
+                allowUninvitedInstitutions: { type: boolean }
             # define callback to check whether entity should be indexed
             indexable_callback: 'shouldBeIndexed'
             persistence:

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -1403,6 +1403,15 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     }
 
     /**
+     * Delegates to {@link ProcedureSettings::isAllowUninvitedInstitutions()} so the flag
+     * is reachable by FOSElastica's property accessor when indexing this entity.
+     */
+    public function isAllowUninvitedInstitutions(): bool
+    {
+        return $this->getSettings()->isAllowUninvitedInstitutions();
+    }
+
+    /**
      * Is procedure added to Organisation.
      *
      * @param string $orgaId

--- a/demosplan/DemosPlanCoreBundle/Repository/ProcedureElasticsearchRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ProcedureElasticsearchRepository.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryProcedure;
 use demosplan\DemosPlanCoreBundle\Traits\DI\ElasticsearchQueryTrait;
 use Elastica\Index;
 use Elastica\Query\BoolQuery;
+use Elastica\Query\Term;
 use Elastica\Query\Terms;
 use Psr\Log\LoggerInterface;
 
@@ -71,7 +72,10 @@ class ProcedureElasticsearchRepository
             $boolInternalQuery->addMustNot(new Terms('phasePermissionset', ['hidden']));
 
             if (!$this->permissions->hasPermission('feature_procedure_all_orgas_invited')) {
-                $boolInternalQuery->addMust(new Terms('organisationIds', [$esQuery->getOrgaId()]));
+                $invitedOrAllowedQuery = new BoolQuery();
+                $invitedOrAllowedQuery->addShould(new Terms('organisationIds', [$esQuery->getOrgaId()]));
+                $invitedOrAllowedQuery->addShould(new Term(['allowUninvitedInstitutions' => true]));
+                $boolInternalQuery->addMust($this->setMinimumShouldMatch($invitedOrAllowedQuery, 1));
             }
             $boolQuery->addShould($boolInternalQuery);
             $boolQuery = $this->setMinimumShouldMatch($boolQuery, 1);


### PR DESCRIPTION
**Ticket**

https://demoseurope.youtrack.cloud/issue/DPLAN-18206/Neu-ADO-issue-50004-Institution-verwalten-in-ROG-aktivieren

**Bug:** institution users whose organisation was not invited to a **particular project (see ticket)** procedure could still see it in their procedure overview, but got an access-denied error when opening it.

Root cause: **particular project (see ticket)** had a project-wide permission (`feature_procedure_all_orgas_invited`) that told the procedure list to show every procedure to every institution, regardless of invitation. The detail page, however, always checked the real invitation list. So the list and the detail page disagreed — visible in the list, blocked on click.

**Fix:**
- Removed the `feature_procedure_all_orgas_invited` permission from **particular project (see ticket)**, so the list now respects real invitations like the detail page does.
- Since procedures can also explicitly allow uninvited institutions to participate (the "Registrierte, nicht eingeladene Institutionen dürfen sich beteiligen" checkbox from DPLAN-18206), the list query and the Elasticsearch index were updated to also honor that per-procedure flag — otherwise procedures using that checkbox would have disappeared from the list too.
- Added a one-off data migration for **particular project (see ticket)** so existing procedures keep working as before (they get allowUninvitedInstitutions = true by default, since they were previously visible to everyone). New procedures created after this change use the normal default (false) unless a planner opts in.

**How to review/test**

1. As an institution user whose org is not invited to a **particular project (see ticket)** procedure, confirm the procedure no longer appears in the overview list.
2. Check the "nicht eingeladene Institutionen" checkbox on a procedure, confirm an uninvited institution can now see and access that specific procedure.
3. Run the affected test suites (ProcedureElasticsearchRepository, diplanrog PermissionsTest).
4. After deploy, run the included migration on **particular project (see ticket)**'s database — do not run it on any other project.