### PR TITLE
refactor(refs DPLAN-15761, #AB-27466): remove inline-template in public detail

### DIFF
--- a/client/js/bundles/core/listDraft.js
+++ b/client/js/bundles/core/listDraft.js
@@ -10,7 +10,7 @@
 /**
  * This is the entrypoint for list_draft.html.twig
  */
-import { DpButton, DpModal, DpUploadFiles, prefixClass } from '@demos-europe/demosplan-ui'
+import { DpButton, DpModal, DpSelect, DpUploadFiles, prefixClass } from '@demos-europe/demosplan-ui'
 import DpMapModal from '@DpJs/components/statement/assessmentTable/DpMapModal'
 import DpPublicDetailNoMap from '@DpJs/components/statement/DpPublicDetailNoMap'
 import DpPublicStatementList from '@DpJs/components/statement/publicStatementLists/DpPublicStatementList'
@@ -19,12 +19,17 @@ import publicStatement from '@DpJs/store/statement/PublicStatement'
 import StatementForm from '@DpJs/lib/statement/StatementForm'
 import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 
+/*
+ * DpPublicDetailNoMap renders the Twig markup as scoped slot content, which is compiled in the
+ * scope of this app - so everything the template uses has to be registered here, not on the component
+ */
 const components = {
   DpButton,
   DpMapModal,
   DpModal,
   DpPublicDetailNoMap,
   DpPublicStatementList,
+  DpSelect,
   DpUploadFiles,
   StatementModal,
 }

--- a/client/js/bundles/core/publicDetail.js
+++ b/client/js/bundles/core/publicDetail.js
@@ -13,17 +13,26 @@
  */
 
 import { DpUploadFiles, DpVideoPlayer, TableWrapper } from '@demos-europe/demosplan-ui'
+import { defineAsyncComponent } from 'vue'
 import DpPublicDetailNoMap from '@DpJs/components/statement/DpPublicDetailNoMap'
 import { initialize } from '@DpJs/InitVue'
 import publicStatement from '@DpJs/store/statement/PublicStatement'
 import RegisterFlyout from '@DpJs/components/user/RegisterFlyout'
 import StatementForm from '@DpJs/lib/statement/StatementForm'
+import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 
+/*
+ * DpPublicDetailNoMap renders the Twig markup as scoped slot content, which is compiled in the
+ * scope of this app - so everything the template uses has to be registered here, not on the component
+ */
 const components = {
   DpPublicDetailNoMap,
   DpUploadFiles,
   DpVideoPlayer,
+  // Only rendered by the projects that override public_elements_list.html.twig
+  ElementsList: defineAsyncComponent(() => import('@DpJs/components/document/ElementsList')),
   RegisterFlyout,
+  StatementModal,
 }
 
 const stores = {

--- a/client/js/bundles/core/publicParagraphDocument.js
+++ b/client/js/bundles/core/publicParagraphDocument.js
@@ -15,11 +15,17 @@ import { DpUploadFiles, prefixClass, TableWrapper } from '@demos-europe/demospla
 import DpPublicDetailNoMap from '@DpJs/components/statement/DpPublicDetailNoMap'
 import { initialize } from '@DpJs/InitVue'
 import publicStatement from '@DpJs/store/statement/PublicStatement'
+import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 import TocStateMemorizer from '@DpJs/lib/statement/TocStateMemorizer'
 
+/*
+ * DpPublicDetailNoMap renders the Twig markup as scoped slot content, which is compiled in the
+ * scope of this app - so everything the template uses has to be registered here, not on the component
+ */
 const components = {
   DpPublicDetailNoMap,
   DpUploadFiles,
+  StatementModal,
 }
 
 const stores = {

--- a/client/js/bundles/map/publicDetail.js
+++ b/client/js/bundles/map/publicDetail.js
@@ -13,6 +13,7 @@
  */
 import { DpUploadFiles, DpVideoPlayer, TableWrapper } from '@demos-europe/demosplan-ui'
 import CustomLayer from '@DpJs/components/map/publicdetail/controls/CustomLayer'
+import { defineAsyncComponent } from 'vue'
 import DpLayerLegend from '@DpJs/components/map/publicdetail/controls/legendList/DpLayerLegend'
 import DpPublicDetail from '@DpJs/components/map/publicdetail/DpPublicDetail'
 import DpPublicLayerListWrapper from '@DpJs/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper'
@@ -24,6 +25,7 @@ import MapTools from '@DpJs/components/map/publicdetail/controls/MapTools'
 import publicStatement from '@DpJs/store/statement/PublicStatement'
 import RegisterFlyout from '@DpJs/components/user/RegisterFlyout'
 import StatementForm from '@DpJs/lib/statement/StatementForm'
+import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 
 //  Vuex store modules (to be registered on core bundle vuex store)
 const stores = {
@@ -31,7 +33,10 @@ const stores = {
   publicStatement,
 }
 
-//  (Unmounted) vue parent components
+/*
+ * DpPublicDetail renders the Twig markup as scoped slot content, which is compiled in the scope
+ * of this app - so everything the template uses has to be registered here, not on the component
+ */
 const components = {
   'dp-custom-layer': CustomLayer,
   DpLayerLegend,
@@ -42,7 +47,10 @@ const components = {
   DpUnfoldToolbarControl,
   DpUploadFiles,
   DpVideoPlayer,
+  // Only rendered by the projects that override public_elements_list.html.twig
+  ElementsList: defineAsyncComponent(() => import('@DpJs/components/document/ElementsList')),
   RegisterFlyout,
+  StatementModal,
 }
 
 initialize(components, stores).then(() => {

--- a/client/js/bundles/statement/listReleasedGroup.js
+++ b/client/js/bundles/statement/listReleasedGroup.js
@@ -11,18 +11,28 @@
  * This is the entrypoint for list_released_group.html.twig
  */
 
-import { DpModal, DpUploadFiles } from '@demos-europe/demosplan-ui'
+import { DpButton, DpModal, DpSelect, DpUploadFiles } from '@demos-europe/demosplan-ui'
 import DpMapModal from '@DpJs/components/statement/assessmentTable/DpMapModal'
 import DpPublicDetailNoMap from '@DpJs/components/statement/DpPublicDetailNoMap'
+import DpPublicStatementList from '@DpJs/components/statement/publicStatementLists/DpPublicStatementList'
 import { initialize } from '@DpJs/InitVue'
 import publicStatement from '@DpJs/store/statement/PublicStatement'
 import StatementForm from '@DpJs/lib/statement/StatementForm'
+import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
 
+/*
+ * DpPublicDetailNoMap renders the Twig markup as scoped slot content, which is compiled in the
+ * scope of this app - so everything the template uses has to be registered here, not on the component
+ */
 const components = {
+  DpButton,
   DpMapModal,
   DpModal,
   DpPublicDetailNoMap,
+  DpPublicStatementList,
+  DpSelect,
   DpUploadFiles,
+  StatementModal,
 }
 
 const stores = {

--- a/client/js/components/map/publicdetail/DpPublicDetail.vue
+++ b/client/js/components/map/publicdetail/DpPublicDetail.vue
@@ -18,7 +18,6 @@
       :handle-fullscreen-focus="handleFullscreenFocus"
       :prefix-class="prefixClass"
       :set-ref="setRef"
-      :toggle-map-hint="toggleMapHint"
       :toggle-statement-modal="toggleStatementModal"
       :toggle-tabs="toggleTabs"
       :update="update"

--- a/client/js/components/map/publicdetail/DpPublicDetail.vue
+++ b/client/js/components/map/publicdetail/DpPublicDetail.vue
@@ -7,36 +7,37 @@
   All rights reserved
 </license>
 
-<script>
-import { DpContextualHelp, prefixClassMixin } from '@demos-europe/demosplan-ui'
-import { mapMutations, mapState } from 'vuex'
-import CustomLayer from '@DpJs/components/map/publicdetail/controls/CustomLayer'
-import { defineAsyncComponent } from 'vue'
-import DpLayerLegend from '@DpJs/components/map/publicdetail/controls/legendList/DpLayerLegend'
-import DpPublicLayerListWrapper from '@DpJs/components/map/publicdetail/controls/layerlist/DpPublicLayerListWrapper'
-import DpUnfoldToolbarControl from '@DpJs/components/map/publicdetail/controls/DpUnfoldToolbarControl'
-import Map from '@DpJs/components/map/publicdetail/Map'
-import MapTools from '@DpJs/components/map/publicdetail/controls/MapTools'
-import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
+<template>
+  <div>
+    <slot
+      :active-action-box-tab="activeActionBoxTab"
+      :active-statement="activeStatement"
+      :active-tab="activeTab"
+      :check-key-event="checkKeyEvent"
+      :fold-open-toolbar-items="foldOpenToolbarItems"
+      :handle-fullscreen-focus="handleFullscreenFocus"
+      :prefix-class="prefixClass"
+      :set-ref="setRef"
+      :toggle-map-hint="toggleMapHint"
+      :toggle-statement-modal="toggleStatementModal"
+      :toggle-tabs="toggleTabs"
+      :update="update"
+      :update-statement-and-open-modal="updateStatementAndOpenModal"
+    />
+  </div>
+</template>
 
+<script>
+import { mapMutations, mapState } from 'vuex'
+import { prefixClassMixin } from '@demos-europe/demosplan-ui'
+import { useSlotRefs } from '@DpJs/composables/useSlotRefs'
+
+/*
+ * The components the Twig markup uses are registered on the app by the bundle entrypoints, not here:
+ * as scoped slot content it's compiled in the app's scope, not in this component's
+ */
 export default {
   name: 'DpPublicDetail',
-
-  components: {
-    DpContextualHelp,
-    'dp-custom-layer': CustomLayer,
-    DpLayerLegend,
-    'dp-map': Map,
-    'dp-map-tools': MapTools,
-    DpPublicLayerListWrapper,
-    DpUnfoldToolbarControl,
-    DpVideoPlayer: defineAsyncComponent(async () => {
-      const { DpVideoPlayer } = await import('@demos-europe/demosplan-ui')
-
-      return DpVideoPlayer
-    }),
-    StatementModal,
-  },
 
   mixins: [prefixClassMixin],
 
@@ -58,10 +59,15 @@ export default {
     },
   },
 
+  setup () {
+    const { setRef, slotRefs } = useSlotRefs()
+
+    return { setRef, slotRefs }
+  },
+
   data () {
     return {
       activeTab: this.isMapEnabled ? '#procedureDetailsMap' : '#procedureDetailsDocumentlist',
-      consultationTokenInputField: '',
       focusableElements: [],
       lastFocusedElement: '',
     }
@@ -113,8 +119,8 @@ export default {
 
     foldOpenToolbarItems (items) {
       items.forEach(item => {
-        if (this.$refs[item] && typeof this.$refs[item].toggle === 'function') {
-          this.$refs[item].fold()
+        if (this.slotRefs[item] && typeof this.slotRefs[item].toggle === 'function') {
+          this.slotRefs[item].fold()
         }
       })
     },
@@ -146,7 +152,7 @@ export default {
     },
 
     toggleStatementModal (updateStatementPayload) {
-      this.$refs.statementModal.toggleModal(true, updateStatementPayload)
+      this.slotRefs.statementModal.toggleModal(true, updateStatementPayload)
     },
 
     toggleTabs (tabId) {

--- a/client/js/components/map/publicdetail/DpPublicDetail.vue
+++ b/client/js/components/map/publicdetail/DpPublicDetail.vue
@@ -75,10 +75,8 @@ export default {
   computed: {
     ...mapState('PublicStatement', [
       'activeActionBoxTab',
-      'showMapHint',
       'initForm',
       'statement',
-      'localStorageName',
     ]),
 
     activeStatement () {
@@ -87,7 +85,7 @@ export default {
   },
 
   methods: {
-    ...mapMutations('PublicStatement', ['initialiseStore', 'update', 'updateHighlighted', 'updateStatement']),
+    ...mapMutations('PublicStatement', ['initialiseStore', 'update', 'updateHighlighted']),
 
     checkKeyEvent (event) {
       if (this.isFullscreen) {
@@ -157,10 +155,6 @@ export default {
     toggleTabs (tabId) {
       this.activeTab = tabId
       history.pushState(null, null, this.activeTab)
-    },
-
-    toggleMapHint (state = false) {
-      this.update({ key: 'showMapHint', val: state })
     },
 
     updateStatementAndOpenModal (updateStatementPayload) {

--- a/client/js/components/map/publicdetail/DpPublicDetail.vue
+++ b/client/js/components/map/publicdetail/DpPublicDetail.vue
@@ -118,7 +118,7 @@ export default {
 
     foldOpenToolbarItems (items) {
       items.forEach(item => {
-        if (this.slotRefs[item] && typeof this.slotRefs[item].toggle === 'function') {
+        if (this.slotRefs[item] && typeof this.slotRefs[item].fold === 'function') {
           this.slotRefs[item].fold()
         }
       })

--- a/client/js/components/statement/DpPublicDetailNoMap.vue
+++ b/client/js/components/statement/DpPublicDetailNoMap.vue
@@ -10,10 +10,8 @@
 <template>
   <div>
     <slot
-      :active-action-box-tab="activeActionBoxTab"
       :active-statement="activeStatement"
       :active-tab="activeTab"
-      :dp-validate="dpValidate"
       :dp-validate-action="dpValidateAction"
       :is-submitting="isSubmitting"
       :open-statement-modal-from-list="openStatementModalFromList"

--- a/client/js/components/statement/DpPublicDetailNoMap.vue
+++ b/client/js/components/statement/DpPublicDetailNoMap.vue
@@ -74,10 +74,8 @@ export default {
 
   computed: {
     ...mapState('PublicStatement', [
-      'activeActionBoxTab',
       'initForm',
       'statement',
-      'unsavedDrafts',
     ]),
 
     activeStatement () {
@@ -86,7 +84,7 @@ export default {
   },
 
   methods: {
-    ...mapMutations('PublicStatement', ['initialiseStore', 'updateHighlighted', 'updateStatement', 'localStorageName']),
+    ...mapMutations('PublicStatement', ['initialiseStore', 'updateHighlighted']),
 
     submitForm (formId, hiddenFieldName) {
       const form = this.$el.querySelector(`[data-dp-validate="${formId}"]`)

--- a/client/js/components/statement/DpPublicDetailNoMap.vue
+++ b/client/js/components/statement/DpPublicDetailNoMap.vue
@@ -7,36 +7,39 @@
   All rights reserved
 </license>
 
+<template>
+  <div>
+    <slot
+      :active-action-box-tab="activeActionBoxTab"
+      :active-statement="activeStatement"
+      :active-tab="activeTab"
+      :dp-validate="dpValidate"
+      :dp-validate-action="dpValidateAction"
+      :is-submitting="isSubmitting"
+      :open-statement-modal-from-list="openStatementModalFromList"
+      :prefix-class="prefixClass"
+      :set-ref="setRef"
+      :submit-form="submitForm"
+      :toggle-confirm-modal="toggleConfirmModal"
+      :toggle-statement-modal="toggleStatementModal"
+      :toggle-tabs="toggleTabs"
+      :update-statement-and-open-modal="updateStatementAndOpenModal"
+    />
+  </div>
+</template>
+
 <script>
 import { addFormHiddenField, removeFormHiddenField } from '../../lib/core/libs/FormActions'
-import { DpButton, DpContextualHelp, DpModal, dpValidateMixin, prefixClassMixin } from '@demos-europe/demosplan-ui'
+import { dpValidateMixin, prefixClassMixin } from '@demos-europe/demosplan-ui'
 import { mapMutations, mapState } from 'vuex'
-import { defineAsyncComponent } from 'vue'
-import DpPublicStatementList from '@DpJs/components/statement/publicStatementLists/DpPublicStatementList'
-import StatementModal from '@DpJs/components/statement/publicStatementModal/StatementModal'
+import { useSlotRefs } from '@DpJs/composables/useSlotRefs'
 
+/*
+ * The components the Twig markup uses are registered on the app by the bundle entrypoints, not here:
+ * as scoped slot content it's compiled in the app's scope, not in this component's
+ */
 export default {
   name: 'DpPublicDetailNoMap',
-
-  components: {
-    StatementModal,
-    DpButton,
-    DpContextualHelp,
-    DpModal,
-    DpPublicStatementList,
-    DpMapModal: defineAsyncComponent(() => import('@DpJs/components/statement/assessmentTable/DpMapModal')),
-    DpSelect: defineAsyncComponent(async () => {
-      const { DpSelect } = await import('@demos-europe/demosplan-ui')
-
-      return DpSelect
-    }),
-    DpVideoPlayer: defineAsyncComponent(async () => {
-      const { DpVideoPlayer } = await import('@demos-europe/demosplan-ui')
-
-      return DpVideoPlayer
-    }),
-    ElementsList: defineAsyncComponent(() => import('@DpJs/components/document/ElementsList')),
-  },
 
   mixins: [dpValidateMixin, prefixClassMixin],
 
@@ -58,10 +61,15 @@ export default {
     },
   },
 
+  setup () {
+    const { setRef, slotRefs } = useSlotRefs()
+
+    return { setRef, slotRefs }
+  },
+
   data () {
     return {
       activeTab: '#procedureDetailsDocumentlist',
-      consultationTokenInputField: '',
       isSubmitting: false,
     }
   },
@@ -98,11 +106,11 @@ export default {
     },
 
     toggleConfirmModal () {
-      this.$refs.confirmModal.toggle()
+      this.slotRefs.confirmModal.toggle()
     },
 
     toggleStatementModal (updateStatementPayload) {
-      this.$refs.statementModal.toggleModal(true, updateStatementPayload)
+      this.slotRefs.statementModal.toggleModal(true, updateStatementPayload)
     },
 
     toggleTabs (tabId) {
@@ -114,13 +122,13 @@ export default {
        * Only set custom fields from list if there are NO unsaved changes
        * If there are unsaved changes, localStorage will restore them
        */
-      const hasUnsavedChanges = this.$refs.statementModal.unsavedDrafts.includes(id)
+      const hasUnsavedChanges = this.slotRefs.statementModal.unsavedDrafts.includes(id)
 
       if (!hasUnsavedChanges && customFields?.length > 0) {
-        this.$refs.statementModal.setCustomFieldsForEditing(customFields)
+        this.slotRefs.statementModal.setCustomFieldsForEditing(customFields)
       }
 
-      this.$refs.statementModal.getDraftStatement(id, true, true)
+      this.slotRefs.statementModal.getDraftStatement(id, true, true)
     },
 
     updateStatementAndOpenModal (updateStatementPayload) {

--- a/client/js/composables/useSlotRefs.ts
+++ b/client/js/composables/useSlotRefs.ts
@@ -1,0 +1,49 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+import type { ComponentPublicInstance } from 'vue'
+
+type SlotRefTarget = Element | ComponentPublicInstance | null
+
+/**
+ * Lets a component reach children that live in its default slot.
+ *
+ * A `ref` inside slot content registers on the slot owner - for Twig-rendered slots that is the
+ * root app instance, not the component providing the slot. So components that reached their
+ * markup via `$refs` under `inline-template` have the children hand themselves over instead:
+ *
+ *   <slot :set-ref="setRef" />                          // component template
+ *   <statement-modal :ref="setRef('statementModal')">   // slot content in Twig
+ *   this.slotRefs.statementModal                        // component
+ *
+ * @returns {Object} {
+ *   setRef,     // (name) => ref setter to bind via :ref in the slot content
+ *   slotRefs,   // registered children, keyed by the name passed to setRef
+ * }
+ */
+export function useSlotRefs () {
+  // Deliberately plain objects - component instances must not be made reactive.
+  const slotRefs: Record<string, SlotRefTarget> = {}
+  const setters: Record<string, (el: SlotRefTarget) => void> = {}
+
+  /**
+   * Cached per name, so that re-rendering the slot does not re-register the ref.
+   */
+  function setRef (name: string) {
+    if (!setters[name]) {
+      setters[name] = (el: SlotRefTarget) => {
+        slotRefs[name] = el
+      }
+    }
+
+    return setters[name]
+  }
+
+  return { setRef, slotRefs }
+}

--- a/client/js/store/statement/PublicStatement.js
+++ b/client/js/store/statement/PublicStatement.js
@@ -72,7 +72,6 @@ const PublicStatementStore = {
     localStorageName: '',
     userId: '',
     procedureId: '',
-    showMapHint: false,
     statement: statementStructure,
     draftStatements: {},
     unsavedDrafts: [],
@@ -107,7 +106,6 @@ const PublicStatementStore = {
 
       const localStorageForUser = `user:${state.userId}:${state.procedureId}`
 
-      state.showMapHint = true
       const userItem = localStorage.getItem(localStorageForUser)
 
       if (userItem) {

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/includes/actionbox.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/includes/actionbox.html.twig
@@ -52,7 +52,7 @@
             {{ uiComponent('form.element', {
                 control: {
                     name: 'token',
-                    attributes: [ 'v-model=consultationTokenInputField', 'aria-describedby=consultationHint' ~ context|capitalize ],
+                    attributes: [ 'aria-describedby=consultationHint' ~ context|capitalize ],
                     class: 'c-actionbox__form-input color--white'
                 },
                 elementClass: 'font-size-medium u-mt-0_5',

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
@@ -45,7 +45,7 @@
 
     {# content #}
     <dp-public-detail-no-map procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
-        <template #default="{ setRef, updateStatementAndOpenModal }">
+        <template #default="{ activeStatement, prefixClass, setRef, toggleStatementModal, updateStatementAndOpenModal }">
         <div id="scParagraph" class="{{ 'o-page__padded'|prefixClass }}">
 
             {% if templateVars.list.documentlistToc|default([])|length > 0 %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/public_paragraph_document.html.twig
@@ -44,7 +44,8 @@
     {% endblock page_header %}
 
     {# content #}
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
+    <dp-public-detail-no-map procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
+        <template #default="{ setRef, updateStatementAndOpenModal }">
         <div id="scParagraph" class="{{ 'o-page__padded'|prefixClass }}">
 
             {% if templateVars.list.documentlistToc|default([])|length > 0 %}
@@ -238,7 +239,7 @@
                     extra-personal-hint="{% block extra_personal_hint %}{% endblock %}"
                     ext-id="{{ templateVars.number|default }}"
                     :form-fields="JSON.parse('{{ statementFields|json_encode|e('js', 'utf-8') }}')"
-                    ref="statementModal"
+                    :ref="setRef('statementModal')"
                     :logged-in="Boolean({{ currentUser.loggedIn }})"
                     :is-map-enabled="Boolean({{ proceduresettings.isMapEnabled }})"
                     :statement-form-fields="JSON.parse('{{ statementFields|json_encode|e('js', 'utf-8') }}')"
@@ -260,6 +261,7 @@
             {% endif %}
 
         </div>
+        </template>
     </dp-public-detail-no-map>
 
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanMap/map_public_participation_detail.html.twig
@@ -343,14 +343,14 @@
 
                     {# Layers #}
                     <dp-public-layer-list-wrapper
-                        ref="layerList"
+                        :ref="setRef('layerList')"
                         :layer-groups-alternate-visibility="Boolean({{ procedureSettings.layerGroupsAlternateVisibility }})"
                         @layer-list:unfolded="foldOpenToolbarItems(['layerLegend', 'mapTools', 'customLayer'])">
                     </dp-public-layer-list-wrapper>
 
                     {# Legends #}
                     <dp-layer-legend
-                        ref="layerLegend"
+                        :ref="setRef('layerLegend')"
                         v-show="Boolean({{ display_legend_box }})"
                         :layers-with-legend-files="JSON.parse('{{ layers_with_legend_files|json_encode|e('js', 'utf-8') }}')"
                         :plan-pdf="JSON.parse('{{ planPdf|json_encode|e('js', 'utf-8') }}')"
@@ -360,13 +360,13 @@
 
                     {# Zoom to extend, measure length + area #}
                     <dp-map-tools
-                        ref="mapTools"
+                        :ref="setRef('mapTools')"
                         @map-tools:unfolded="foldOpenToolbarItems(['layerList', 'layerLegend', 'customLayer'])">
                     </dp-map-tools>
 
                     {# Add custom layer on the fly #}
                     <dp-custom-layer
-                        ref="customLayer"
+                        :ref="setRef('customLayer')"
                         :init-available-projections="JSON.parse('{{ templateVars.availableProjections|json_encode|e('js', 'utf-8') }}')"
                         @custom-layer:unfolded="foldOpenToolbarItems(['layerList', 'layerLegend', 'mapTools'])">
                     </dp-custom-layer>

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_detail.html.twig
@@ -92,17 +92,40 @@
         } %}
     {% endblock pageheader %}
 
+    {# The scoped slot props are consumed throughout this template, by the blocks projects override,
+       and by the includes rendered below - keep the two destructurings in sync with those usages #}
     {% if isMapEnabled %}
         <dp-public-detail
             :is-map-enabled="{{ isMapEnabled ? 'true' : 'false' }}"
             user-id="{{ currentUser.id|default }}"
-            procedure-id="{{ procedure }}"
-            inline-template>
+            procedure-id="{{ procedure }}">
+            <template #default="{
+                activeActionBoxTab,
+                activeStatement,
+                activeTab,
+                checkKeyEvent,
+                foldOpenToolbarItems,
+                handleFullscreenFocus,
+                prefixClass,
+                setRef,
+                toggleStatementModal,
+                toggleTabs,
+                update,
+                updateStatementAndOpenModal
+            }">
     {% else %}
         <dp-public-detail-no-map
             user-id="{{ currentUser.id|default }}"
-            procedure-id="{{ procedure }}"
-            inline-template>
+            procedure-id="{{ procedure }}">
+            <template #default="{
+                activeStatement,
+                activeTab,
+                prefixClass,
+                setRef,
+                toggleStatementModal,
+                toggleTabs,
+                updateStatementAndOpenModal
+            }">
     {% endif %}
     <div>
 
@@ -485,7 +508,7 @@
                         ext-id="{{ templateVars.number|default }}"
                         orga-id="{{ branding.orgaId|default }}"
                         procedure-id="{{ procedure }}"
-                        ref="statementModal"
+                        :ref="setRef('statementModal')"
                         :allow-anonymous-statements="Boolean({{ proceduresettings.allowAnonymousStatements }})"
                         :counties="JSON.parse('{{ counties|json_encode|e('js', 'utf-8') }}')"
                         :draft-statement="JSON.parse('{{ templateVars.draftStatement|default([])|json_encode|e('js', 'utf-8') }}')"
@@ -509,6 +532,7 @@
                 {% endif %}
             </div>
         </div>
+            </template>
     {% if isMapEnabled == false %}
         </dp-public-detail-no-map>
     {% else %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_draft.html.twig
@@ -49,7 +49,8 @@
         {% endif %}
     {%  endfor %}
 
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}"><div>
+    <dp-public-detail-no-map procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
+    <template #default="{ dpValidateAction, isSubmitting, openStatementModalFromList, setRef, submitForm, toggleConfirmModal }"><div>
     <div class="{{ 'o-page__padded--spaced u-pv'|prefixClass }}">
         <form class="{{ 'layout flow-root'|prefixClass }}" name="sortform" action="{{ path('DemosPlan_statement_list_draft',{'procedure':procedure}) }}" method="post">
             {{ include('@DemosPlanCore/DemosPlanCore/includes/csrf.html.twig') }}
@@ -84,7 +85,7 @@
                         {% if templateVars.orga.submissionType|default == constant('demosplan\\DemosPlanCoreBundle\\Entity\\User\\Orga::STATEMENT_SUBMISSION_TYPE_DEFAULT') %}
                             <dp-modal
                                 content-classes="u-2-of-3"
-                                ref="confirmModal"
+                                :ref="setRef('confirmModal')"
                                 aria-label="{{ 'statements.marked.release'|trans }}"
                                 aria-modal='true'
                             >
@@ -119,7 +120,7 @@
                         {% elseif templateVars.orga.submissionType|default == constant('demosplan\\DemosPlanCoreBundle\\Entity\\User\\Orga::STATEMENT_SUBMISSION_TYPE_SHORT')  %}
                             <dp-modal
                                 content-classes="u-2-of-3"
-                                ref="confirmModal"
+                                :ref="setRef('confirmModal')"
                                 aria-label="{{ 'statements.marked.submit'|trans }}"
                                 aria-modal='true'
                             >
@@ -176,14 +177,14 @@
         </form>
     </div>
     <dp-map-modal
-        ref="mapModal"
+        :ref="setRef('mapModal')"
         procedure-id="{{ procedure }}"
         map-options-route="dplan_api_map_options_public"
     >
     </dp-map-modal>
 
     <statement-modal
-        ref="statementModal"
+        :ref="setRef('statementModal')"
         current-page="draftList"
         :counties="JSON.parse('{{ counties|json_encode|e('js', 'utf-8') }}')"
         :draft-statement="JSON.parse('{{ templateVars.draftStatement|default([])|json_encode|e('js', 'utf-8') }}')"
@@ -205,7 +206,8 @@
         statement-form-hint-recheck="{{ templateVars.procedureUiDefinition.statementFormHintRecheck|default }}"
         statement-form-hint-statement="{{ templateVars.procedureUiDefinition.statementFormHintStatement|default }}">
     </statement-modal>
-    </div></dp-public-detail-no-map>
+    </div></template>
+    </dp-public-detail-no-map>
 {% endblock demosplanbundlecontent %}
 
 {% block javascripts %}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_released_group.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_released_group.html.twig
@@ -20,7 +20,8 @@
         %}
     {% endblock %}
 
-    <dp-public-detail-no-map inline-template procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
+    <dp-public-detail-no-map procedure-id="{{ procedure }}" user-id="{{ currentUser.id|default }}">
+    <template #default="{ dpValidateAction, isSubmitting, openStatementModalFromList, setRef, submitForm, toggleConfirmModal }">
 
     <div class="o-page__padded--spaced u-pv">
 
@@ -54,7 +55,7 @@
 
                     <dp-modal
                         content-classes="u-2-of-3"
-                        ref="confirmModal"
+                        :ref="setRef('confirmModal')"
                         aria-label="{{ "statements.marked.submit"|trans }}"
                         aria-modal='true'
                     >
@@ -105,7 +106,7 @@
         </form>
 
         <dp-map-modal
-            ref="mapModal"
+            :ref="setRef('mapModal')"
             procedure-id="{{ procedure }}"
         ></dp-map-modal>
 
@@ -132,7 +133,7 @@
         {%  endfor %}
 
         <statement-modal
-            ref="statementModal"
+            :ref="setRef('statementModal')"
             current-page="draftList"
             ext-id="{{ templateVars.number|default }}"
             :logged-in="Boolean({{ currentUser.loggedIn }})"
@@ -154,7 +155,8 @@
             :form-options="JSON.parse('{{ templateVars.formOptions|default({})|json_encode|e('js', 'utf-8') }}')"
             :draft-statement="JSON.parse('{{ templateVars.draftStatement|default([])|json_encode|e('js', 'utf-8') }}')">
         </statement-modal>
-    </div></dp-public-detail-no-map>
+    </div></template>
+    </dp-public-detail-no-map>
 
 {% endblock %}
 

--- a/tests/frontend/unit/useSlotRefs.spec.ts
+++ b/tests/frontend/unit/useSlotRefs.spec.ts
@@ -1,3 +1,12 @@
+/**
+ * (c) 2010-present DEMOS plan GmbH.
+ *
+ * This file is part of the package demosplan,
+ * for more information see the license file.
+ *
+ * All rights reserved
+ */
+
 import { useSlotRefs } from '@DpJs/composables/useSlotRefs'
 
 describe('useSlotRefs', () => {

--- a/tests/frontend/unit/useSlotRefs.spec.ts
+++ b/tests/frontend/unit/useSlotRefs.spec.ts
@@ -1,0 +1,48 @@
+import { useSlotRefs } from '@DpJs/composables/useSlotRefs'
+
+describe('useSlotRefs', () => {
+  it('registers a child under the name it was set up with', () => {
+    const { setRef, slotRefs } = useSlotRefs()
+    const child = { toggleModal: jest.fn() }
+
+    setRef('statementModal')(child)
+
+    expect(slotRefs.statementModal).toBe(child)
+  })
+
+  it('returns the same setter for a name, so re-rendering the slot does not re-register the ref', () => {
+    const { setRef } = useSlotRefs()
+
+    expect(setRef('statementModal')).toBe(setRef('statementModal'))
+  })
+
+  it('keeps refs of different names apart', () => {
+    const { setRef, slotRefs } = useSlotRefs()
+    const modal = {}
+    const layerList = {}
+
+    setRef('confirmModal')(modal)
+    setRef('layerList')(layerList)
+
+    expect(slotRefs.confirmModal).toBe(modal)
+    expect(slotRefs.layerList).toBe(layerList)
+  })
+
+  it('clears the ref when the child unmounts', () => {
+    const { setRef, slotRefs } = useSlotRefs()
+
+    setRef('confirmModal')({})
+    setRef('confirmModal')(null)
+
+    expect(slotRefs.confirmModal).toBeNull()
+  })
+
+  it('does not share state between instances', () => {
+    const first = useSlotRefs()
+    const second = useSlotRefs()
+
+    first.setRef('statementModal')({})
+
+    expect(second.slotRefs.statementModal).toBeUndefined()
+  })
+})


### PR DESCRIPTION
In vue 3, inline-templates are no longer supported.

- instead of `inline-template`, we now use slots
- component registration is moved to bundle files
- children inside the slot hand their refs over via a `setRef` callback (`useSlotRefs`), because a `ref` in slot content registers on the slot owner, not on the component providing the slot
- drop the `consultationTokenInputField` `v-model` which wasn't used anywhere; the token is submitted natively through the input name

### Ticket
DPLAN-18257 (DPLAN-15761)

### How to review/test
These changes should be thoroughly tested by QA, but for review probably just check public detail, drafts list (Entwürfe) and "Freigaben der Institution" in one project

### PR Checklist

- [x] Create/Update tests
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
