### PR TITLE
fix(refs DS-565): update initial segment state after (un)claim request

### DIFF
--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -807,7 +807,17 @@ export default {
 
       return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
         .then(() => {
+          /*
+           * `set` updates `initial` (which is what we need here) but overwrites `items` too, with a
+           * snapshot taken before the request. Restore `items` afterward to keep edits the user made
+           * while the request was in flight - the edit controls are already live at this point, because
+           * `isAssignedToMe` reacts to the optimistic update above
+           */
+          const currentSegment = { ...this.segment }
+
           this.setSegmentAndInitial({ ...dataToUpdate, id: this.segment.id })
+          this.setSegment({ ...currentSegment, id: this.segment.id })
+
           this.claimLoading = false
           this.isCollapsed = false
           this.selectedAssignee = {

--- a/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
+++ b/client/js/components/procedure/StatementSegmentsList/StatementSegment.vue
@@ -747,6 +747,11 @@ export default {
     ...mapMutations('StatementSegment', {
       updateSegment: 'update',
       setSegment: 'setItem',
+      /*
+       * `setItem` writes only `items`; `set` writes `items` and `initial`, which save() diffs against.
+       * Use `set` after a direct PATCH so `initial` keeps matching what the BE holds.
+       */
+      setSegmentAndInitial: 'set',
     }),
 
     abort () {
@@ -802,6 +807,7 @@ export default {
 
       return dpApi.patch(Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }), {}, payload)
         .then(() => {
+          this.setSegmentAndInitial({ ...dataToUpdate, id: this.segment.id })
           this.claimLoading = false
           this.isCollapsed = false
           this.selectedAssignee = {
@@ -1078,25 +1084,6 @@ export default {
            */
           this.restoreReadOnlyRelationships(readOnlyRelationships)
 
-          /*
-           * Clearing the assignee ("nicht zugewiesen") is sent as a separate explicit PATCH because the
-           * vuex-json-api diff drops a to-one relationship set to `{ data: null }` (it diffs against a
-           * stale `initial` baseline that setSegment never updates), so an unassign would be silently
-           * omitted from saveSegmentAction's request body. Mirrors the explicit payload already used by
-           * claimSegment()/unclaimSegment(). It must complete before fetchUpdatedSegment, which would
-           * otherwise re-store the stale assignee.
-           */
-          const isUnassigning = !this.selectedAssignee?.id || this.selectedAssignee.id === 'noAssigneeId'
-
-          return isUnassigning ?
-            dpApi.patch(
-              Routing.generate('api_resource_update', { resourceType: 'StatementSegment', resourceId: this.segment.id }),
-              {},
-              { data: { type: 'StatementSegment', id: this.segment.id, relationships: { assignee: { data: null } } } },
-            ) :
-            Promise.resolve()
-        })
-        .then(() => {
           return Promise.all([
             this.fetchUpdatedSegment().catch((err) => {
               console.error('Failed to fetch updated segment:', err)
@@ -1252,8 +1239,8 @@ export default {
           delete dataToUpdate.relationships.assignee
           // Reset recommendation text in store (segment might have been in edit mode with some changes)
           dataToUpdate.attributes.recommendation = this.$store.state.StatementSegment.initial[this.segment.id].attributes.recommendation
-          // Set segment in store, without the assignee and with resetted recommendation
-          this.setSegment({ ...dataToUpdate, id: this.segment.id })
+          // Set segment in store, without the assignee and with reset recommendation
+          this.setSegmentAndInitial({ ...dataToUpdate, id: this.segment.id })
           this.claimLoading = false
           this.selectedAssignee = { id: '', name: '' }
         })


### PR DESCRIPTION
### Ticket
[DS-565](https://demoseurope.youtrack.cloud/tickets/DS-565)

**Bug:**
If a user with role Sachbearbeitung (not Fachplanung-Admin) wants to set assignee to "not assigned" and place to "Abgeschlossen", several error messages appear after saving.

**Previous fix and new fix:**
- originally, unassigning a segment did not work on the first request if the user had claimed the segment without then reloading the page, because vuex-json-api stores the initial (i.e. persisted) segment state as a baseline to diff against, but when claiming or unassigning, the initial assignee was not updated
- because of this, https://github.com/demos-europe/demosplan-core/pull/6403 introduced a second patch request to ensure the assignee was set to null
- if the user just navigated to the page and unassigned the segment, this now led to errors: the first request already applied both changes and locked the segment, so the second patch request was rejected
- to fix this and still keep the fix from https://github.com/demos-europe/demosplan-core/pull/6403, we now use the 'set' mutation after a claim/unclaim request to also update the initial segment state, so that the assignee is also updated there, and no second request is needed anymore


### How to review/test
- Log in as Sachbearbeitung
- Navigate to "Erwiderungen verfassen"
- For a segment that is assigned to you, change assignee to "unassigned" and change the place to a locked place
- When you save, there should only be a green success message, no error messages
- To be sure the previous fix was not broken, log in as Fachplanung-Admin
- Navigate to "Erwiderungen verfassen"
- claim a segment
- then without reloading the page, set the assignee to "unassigned", change the place to a locked place
- When you save, there should be no errors, and when you reload the page, your changes should be saved


### PR Checklist

- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
