### PR TITLE
fix(DPLAN-18159): render SegmentImportJobList only when permission is enabled

### DIFF
--- a/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
+++ b/client/js/components/procedure/AdministrationImport/ExcelImport/ExcelImport.vue
@@ -67,7 +67,10 @@
     </form>
 
     <!-- Import Jobs List -->
-    <div class="u-mt-2">
+    <div
+      v-if="hasPermission('area_statement_segmentation')"
+      class="u-mt-2"
+    >
       <h2>{{ Translator.trans('import.jobs.list') }}</h2>
       <segment-import-job-list
         :init-url="importJobsUrl"


### PR DESCRIPTION
### Ticket
[DPLAN-18159](https://demoseurope.youtrack.cloud/issue/DPLAN-18159) Fehlermeldung beim Zurückkehren auf Importseite

**Description:**  Users with `feature_statements_import_excel` permission but without `area_statement_segmentation` receive console errors when opening the import page:

ExcelImport.vue unconditionally renders <segment-import-job-list> whenever the import tab is shown. The component immediately polls `dplan_import_jobs_api`, which requires `area_statement_segmentation` permission. Users with only statement import permissions fail this check and receive an `AccessDeniedException`.

- add a permission check to avoid unnecessary API calls to forbidden endpoints

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
