### PR TITLE
fix DPLAN-18286 : only print the feedback row when a channel was chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Patch Version**: Incremented for bug fixes.
 
 ## UNRELEASED
+### Fixed
+- The statement PDF attached to the submission confirmation no longer states that the submitter declined feedback when no feedback preference was recorded at all.
 ## v4.16.5 (2026-06-26)
 ### Fixed
 - Sorting the assessment table by submitter no longer produces an empty table.

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/list_export_entry_public_citizen.tex.twig
@@ -18,10 +18,21 @@
                 {{ "email.address"|trans|latex|raw }}: & {{ statement.uEmail|latex|raw }}\\
             {% endif %}
 
-            {# feedback #}{% if hasPermission('field_statement_feedback')
+            {#
+                feedback
+                Render this row only when the submitter actually chose a feedback channel.
+                An empty statement.feedback means the question was never answered: either the
+                procedure does not display the "Ich möchte eine Rückmeldung erhalten" checkbox
+                (ProcedureSettings::publicParticipationFeedbackEnabled, false by default and
+                not editable without feature_feedback_on_statement_controllable), or the
+                submitter left it unchecked. Falling back to "nicht erwünscht" stated a
+                decision the submitter never made.
+            #}
+            {% if hasPermission('field_statement_feedback')
+                and statement.feedback|default('') in ['email', 'snailmail']
                 and (statement.procedure.statementFormDefinition.getFieldDefinitionByName('getEvaluationMailViaEmail').isEnabled == true
                 or statement.procedure.statementFormDefinition.getFieldDefinitionByName('getEvaluationMailViaSnailMailOrEmail').isEnabled == true)
-            %} {{ "feedback"|trans|latex|raw }}: & {% if statement.feedback is defined and statement.feedback == 'email' %}{{ "via.mail"|trans|latex|raw }}{% elseif statement.feedback is defined and statement.feedback == 'snailmail' %} {{ "via.post"|trans|latex|raw }} {% else %} {{ "notrequired"|trans|latex|raw }} {% endif %}\\{% endif %}
+            %} {{ "feedback"|trans|latex|raw }}: & {% if 'email' == statement.feedback %}{{ "via.mail"|trans|latex|raw }}{% else %} {{ "via.post"|trans|latex|raw }} {% endif %}\\{% endif %}
 
             {# feedback address #}
             {% block address %}


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-18286/Eingangsbestatigung-PDF-gibt-Ruckmeldung-nicht-erwunscht-aus-obwohl-nichts-ausgewahlt-wurde

Description:
The statement PDF attached to the submission confirmation stated `Rückmeldung: nicht erwünscht` for statements submitted by non-logged-in users, even though those users had never been asked about a feedback preference. A submitter noticed
this and objected, since they do want a reply.

The row rendered the stored feedback value and fell back to the `notrequired` text for any value other than `email` or `snailmail`. An empty value does not mean the submitter declined — it also occurs when:

- the procedure does not display the feedback checkbox at all (`ProcedureSettings::publicParticipationFeedbackEnabled` defaults to `false` and `ServiceStorage` only writes it when `feature_feedback_on_statement_controllable` is
  granted, which is the case in a minority of projects), or the submitter simply left the checkbox unchecked.

The condition guarding the row never checked that setting — it only checked `field_statement_feedback` (enabled platform-wide) and whether one of the `getEvaluationMailViaEmail` / `getEvaluationMailViaSnailMailOrEmail` form fields is enabled
for the procedure type. That is why the text appeared in some procedures and could not be reproduced in others.

The row is now rendered only when a channel was explicitly chosen, and the fallback text is gone. This mirrors the assessment table, which already gates the same field on a non-empty value in `assessment_statement_detail_statement_data.html.twig`.

Deliberately **not** gated on `publicParticipationFeedbackEnabled`: the chosen approach is correct regardless of whether the checkbox is offered in a given procedure, and it avoids threading the procedure setting into the PDF export, where `Procedure::getSettings()` has a non-nullable return type.

### How to review/test

No frontend build needed — this is a Twig template. Clear the cache, then use the route that renders the same PDF that gets attached to the confirmation mail:

/verfahren/{procedureId}/stellungnahmen/single/pdf?sId={draftStatementId}

Pick a procedure whose procedure type has `getEvaluationMailViaEmail` or
`getEvaluationMailViaSnailMailOrEmail` enabled, then check three statements:

| `_draft_statement._ds_feedback` | Expected |
| --- | --- |
| `''` | no `Rückmeldung` row at all (previously `nicht erwünscht`) |
| `'email'` | `Rückmeldung: per E-Mail` |
| `'snailmail'` | `Rückmeldung: per Post`, address row below unchanged |

The full end-to-end path via the confirmation mail and its PDF attachment produces the same document, so testing through MailHog is possible but not necessary.




- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly