### PR TITLE
fix(DPLAN-18254): align profile page heading with content width

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_user.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/portal_user.html.twig
@@ -7,7 +7,8 @@
     {% embed '@DemosPlanCore/DemosPlanCore/includes/participation_area_skeleton.html.twig' with {
         content_heading: 'profile'|trans,
         content_subheading: 'text.profile.edit'|trans,
-        full_width: true
+        full_width: true,
+        full_width_pageheader: true
     }%}
 
         {% block content %}


### PR DESCRIPTION
### Ticket
DPLAN-18254

The heading "Meine Daten" and its subheading in the profile page header were indented by 25% while the content below rendered full width.

`portal_user.html.twig` only passed `full_width: true`, which affects the content section. The pageheader has its own flag, `full_width_pageheader`, which defaulted to `false` — so the header rendered an empty `u-1-of-4` spacer column and pushed the heading into `u-3-of-4`. Passing `full_width_pageheader: true` drops the spacer and makes the heading column full width.

### How to review/test
Open `/portal/user` (Meine Daten). The heading and subheading should now be left-aligned with the form fields below.

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly