### PR TITLE
chore: bump demosplan-ui from 0.27.0 to 0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-vue": "10.99.1",
     "@carbon/vue": "^3.0.27",
     "@cesium/engine": "^20.0.1",
-    "@demos-europe/demosplan-ui": "0.27.0",
+    "@demos-europe/demosplan-ui": "0.28.0",
     "@demos-europe/dp-consent": "^1.3",
     "@efrane/vuex-json-api": "^0.1.3",
     "@masterportal/masterportalapi": "2.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,9 +2899,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@demos-europe/demosplan-ui@npm:0.27.0":
-  version: 0.27.0
-  resolution: "@demos-europe/demosplan-ui@npm:0.27.0"
+"@demos-europe/demosplan-ui@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@demos-europe/demosplan-ui@npm:0.28.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.0.0"
     "@floating-ui/dom": "npm:^1.6.0"
@@ -2954,7 +2954,7 @@ __metadata:
     vue-click-outside: "npm:^1.1.0"
     vue-multiselect: "npm:^3.1.0"
     vue-sliding-pagination: "npm:^v2.0.0-alpha-1"
-  checksum: 10c0/efe2432dd20568489d7571c8c3ecee043efb2eac2696b8ea0b2494771f4ee8a7b86763070a98ebaa633ecd50086e521b3282116c23b27aa1a3ff7e91c6a8f006
+  checksum: 10c0/dd48c8a39f0724d4fb417e2233d972ac514f459b77d95588a741052382629b3622107444cb210896577e4997a6365f08a14caffd12a7ed259f10a15a9580f96b
   languageName: node
   linkType: hard
 
@@ -7981,7 +7981,7 @@ __metadata:
     "@carbon/icons-vue": "npm:10.99.1"
     "@carbon/vue": "npm:^3.0.27"
     "@cesium/engine": "npm:^20.0.1"
-    "@demos-europe/demosplan-ui": "npm:0.27.0"
+    "@demos-europe/demosplan-ui": "npm:0.28.0"
     "@demos-europe/dp-consent": "npm:^1.3"
     "@efrane/vuex-json-api": "npm:^0.1.3"
     "@eslint/js": "npm:^9.39.1"


### PR DESCRIPTION
From the changelog:

### Added
- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpBulkEditHeader: add `buttonRowStart` slot to render buttons before the deselect button ([@huellnerdemos](https://github.com/huellnerdemos))
- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpButton: add `transparent` variant ([@huellnerdemos](https://github.com/huellnerdemos))
- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpDataTable: emit `columns-reordered` when the user drags a column into a new position ([@huellnerdemos](https://github.com/huellnerdemos))
- ([#1552](https://github.com/demos-europe/demosplan-ui/pull/1552)) DpDataTable, DpTableRow:
  - add props to exclude individual rows from dragging
  - keep row dragging inside its own table ([@rafelddemos](https://github.com/rafelddemos))
- ([#1543](https://github.com/demos-europe/demosplan-ui/pull/1543)) DpAccordion: add `padded` prop to apply inset spacing to the toggle trigger and `highlightToggledTrigger` prop to give it a background color while its section is expanded ([@riechedemos](https://github.com/riechedemos))

### Changed
- ([#1549](https://github.com/demos-europe/demosplan-ui/pull/1549)) DpBulkEditHeader: restyle to a light surface with rounded corners and a left accent border, and render the deselect button in the `outline` variant ([@huellnerdemos](https://github.com/huellnerdemos))

### Fixed
- ([#1552](https://github.com/demos-europe/demosplan-ui/pull/1552)) DpDataTable: pass `handle` through to SortableJS so rows are dragged by the drag handle only instead of from anywhere in the row ([@rafelddemos](https://github.com/rafelddemos))
- Dependencies: Fix several security alerts by updating dependencies
  - brace-expansion from 5.0.5 to 5.0.8
  - postcss from 8.5.15 to 8.5.25
  - ip-address from 10.2.0 to 10.4.0
  - undici from 7.28.0 to 7.29.0