### PR TITLE
fix(refs: DPLAN-17637): fix AdminProcedure relationship resolution in cross-procedure search

### DIFF
--- a/client/js/components/procedure/DpSearchSubmitters.vue
+++ b/client/js/components/procedure/DpSearchSubmitters.vue
@@ -216,6 +216,7 @@ const search = term => {
     },
     include: 'procedure',
     fields: {
+      AdminProcedure: 'name',
       AdminStatementCrossProcedureSearch: [
         'authoredDate',
         'authorName',

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -205,7 +205,17 @@ class OwnsProcedureConditionFactory
     public function isEitherTemplateOrProcedure(bool $template): ClauseFunctionInterface
     {
         if ($this->userOrProcedure instanceof User) {
-            return $this->conditionFactory->propertyHasValue($template, ['master']);
+            /*
+             * Procedure::$master is persisted as an integer column but semantically boolean
+             * (see ProcedureResourceType::getResourceTypeConditions()). SQL-executed conditions
+             * work with either representation because MySQL loosely casts bool to int, but
+             * conditions evaluated in PHP (e.g. EDT relationship resolution) use strict
+             * comparison and require the int representation to match.
+             */
+            return $this->conditionFactory->anyConditionApplies(
+                $this->conditionFactory->propertyHasValue($template, ['master']),
+                $this->conditionFactory->propertyHasValue((int) $template, ['master']),
+            );
         }
 
         $procedure = $this->userOrProcedure;

--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -70,7 +70,20 @@ class OwnsProcedureConditionFactory
             $user = $this->userOrProcedure;
             $organisationId = $user->getOrganisationId();
 
-            return $this->conditionFactory->propertyHasStringAsMember($organisationId, ['planningOffices']);
+            if (null === $organisationId) {
+                return $this->conditionFactory->false();
+            }
+
+            /*
+             * `propertyHasStringAsMember()` (DQL `MEMBER OF`) reads the `planningOffices`
+             * to-many property with DIRECT access, which works when the condition is executed
+             * as SQL but returns the raw, unresolved `PersistentCollection` when the condition
+             * is evaluated in PHP against an already-fetched entity (e.g. EDT relationship
+             * resolution), breaking the `in_array()` call in `OneOf::reduce()`.
+             * `propertyHasAnyOfValues()` uses UNPACK access instead, which is resolved correctly
+             * in both cases.
+             */
+            return $this->conditionFactory->propertyHasAnyOfValues([$organisationId], ['planningOffices', 'id']);
         }
 
         $procedure = $this->userOrProcedure;
@@ -235,7 +248,9 @@ class OwnsProcedureConditionFactory
         if ($this->userOrProcedure instanceof User) {
             $user = $this->userOrProcedure;
 
-            return $this->conditionFactory->propertyHasStringAsMember($user->getId(), ['authorizedUsers']);
+            // see isAuthorizedViaPlanningAgency() for why UNPACK access via
+            // propertyHasAnyOfValues() is used instead of propertyHasStringAsMember()
+            return $this->conditionFactory->propertyHasAnyOfValues([$user->getId()], ['authorizedUsers', 'id']);
         }
 
         $procedure = $this->userOrProcedure;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminStatementCrossProcedureSearchResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdminStatementCrossProcedureSearchResourceType.php
@@ -206,7 +206,7 @@ final class AdminStatementCrossProcedureSearchResourceType extends AbstractState
          * {@see ProcedureService::getAdminProcedureConditions()} — the same rule that builds the
          * allowed procedure IDs in {@see self::getAccessConditions()}. */
         $configBuilder->procedure
-            ->setRelationshipType($this->resourceTypeStore->getProcedureResourceType())
+            ->setRelationshipType($this->resourceTypeStore->getAdminProcedureResourceType())
             ->readable()
             ->filterable();
 

--- a/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
+++ b/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
@@ -201,6 +201,59 @@ class OwnsProcedureConditionFactoryTest extends FunctionalTestCase
         // The condition should NOT match procedures where user is not authorized
     }
 
+    /**
+     * `authorizedUsers` is a `ManyToMany` collection. Once Doctrine hydrates a {@link Procedure}
+     * from the database, reading that property via reflection (as EDT does for conditions
+     * evaluated in PHP, e.g. when resolving an already-fetched to-one relationship) yields the
+     * lazy, un-fetched {@link \Doctrine\ORM\PersistentCollection} rather than a resolved array.
+     * The condition must still be able to check membership in that case.
+     */
+    public function testUserIsExplicitlyAuthorizedMatchesHydratedProcedureInPhp(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+        $procedure = ProcedureFactory::createOne();
+        $procedure->_real()->getAuthorizedUsers()->add($user->_real());
+        $this->getEntityManager()->flush();
+        $procedureId = $procedure->_real()->getId();
+        $this->getEntityManager()->clear();
+
+        // Re-fetch so `authorizedUsers` is hydrated as a lazy Doctrine collection instead of
+        // the `ArrayCollection` set up above.
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $factory = $this->createFactory($user->_real());
+        $condition = $factory->userIsExplicitlyAuthorized();
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertTrue(
+            $reindexer->isMatchingEntity($hydratedProcedure, [$condition]),
+            'A procedure whose authorizedUsers contains the user must match when evaluated in PHP.'
+        );
+    }
+
+    public function testUserIsExplicitlyAuthorizedDoesNotMatchHydratedProcedureInPhpWhenNotAuthorized(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+        $procedure = ProcedureFactory::createOne();
+        $this->getEntityManager()->flush();
+        $procedureId = $procedure->_real()->getId();
+        $this->getEntityManager()->clear();
+
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $factory = $this->createFactory($user->_real());
+        $condition = $factory->userIsExplicitlyAuthorized();
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertFalse($reindexer->isMatchingEntity($hydratedProcedure, [$condition]));
+    }
+
     // ========================================================================
     // Tests for isAuthorizedViaOrgaOrManually() - THE BUG WE FIXED
     // ========================================================================
@@ -347,6 +400,62 @@ class OwnsProcedureConditionFactoryTest extends FunctionalTestCase
         // Assert
         $this->assertNotNull($condition);
         // The condition should NOT match since user's org is not a planning office
+    }
+
+    /**
+     * `planningOffices` is a `ManyToMany` collection, subject to the same PHP-evaluation
+     * limitation as {@link self::testUserIsExplicitlyAuthorizedMatchesHydratedProcedureInPhp()}.
+     */
+    public function testIsAuthorizedViaPlanningAgencyMatchesHydratedProcedureInPhp(): void
+    {
+        // Arrange
+        $planningOfficeOrga = OrgaFactory::createOne();
+        $user = UserFactory::createOne();
+        $this->linkUserToOrga($user->_real(), $planningOfficeOrga->_real());
+        $procedure = ProcedureFactory::createOne();
+        $procedure->_real()->addPlanningOffice($planningOfficeOrga->_real());
+        $this->getEntityManager()->flush();
+        $procedureId = $procedure->_real()->getId();
+        $this->getEntityManager()->clear();
+
+        // Re-fetch so `planningOffices` is hydrated as a lazy Doctrine collection instead of
+        // the `ArrayCollection` set up above.
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $factory = $this->createFactory($user->_real());
+        $condition = $factory->isAuthorizedViaPlanningAgency();
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertTrue(
+            $reindexer->isMatchingEntity($hydratedProcedure, [$condition]),
+            "A procedure whose planningOffices contains the user's orga must match when evaluated in PHP."
+        );
+    }
+
+    public function testIsAuthorizedViaPlanningAgencyDoesNotMatchHydratedProcedureInPhpWhenOrgNotInPlanningOffices(): void
+    {
+        // Arrange
+        $userOrga = OrgaFactory::createOne();
+        $planningOfficeOrga = OrgaFactory::createOne();
+        $user = UserFactory::createOne();
+        $this->linkUserToOrga($user->_real(), $userOrga->_real());
+        $procedure = ProcedureFactory::createOne();
+        $procedure->_real()->addPlanningOffice($planningOfficeOrga->_real());
+        $this->getEntityManager()->flush();
+        $procedureId = $procedure->_real()->getId();
+        $this->getEntityManager()->clear();
+
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $factory = $this->createFactory($user->_real());
+        $condition = $factory->isAuthorizedViaPlanningAgency();
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertFalse($reindexer->isMatchingEntity($hydratedProcedure, [$condition]));
     }
 
     // ========================================================================

--- a/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
+++ b/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
@@ -23,6 +23,7 @@ use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\OwnsProcedureConditionFactory;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
+use EDT\Querying\Utilities\Reindexer;
 use Psr\Log\LoggerInterface;
 use Tests\Base\FunctionalTestCase;
 
@@ -412,6 +413,65 @@ class OwnsProcedureConditionFactoryTest extends FunctionalTestCase
         // Assert
         $this->assertNotNull($condition);
         // Should create condition checking procedure.deleted = false
+    }
+
+    // ========================================================================
+    // Tests for isEitherTemplateOrProcedure()
+    // ========================================================================
+
+    /**
+     * {@link \demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure::$master} is persisted as
+     * an `integer` column. Once Doctrine hydrates a {@link Procedure} from the database, reading
+     * the property via reflection (as EDT does for conditions evaluated in PHP, e.g. when
+     * resolving an already-fetched to-one relationship) yields an `int`, not a `bool`. The
+     * condition must match regardless of which representation is stored.
+     */
+    public function testIsEitherTemplateOrProcedureMatchesHydratedNonTemplateProcedureInPhp(): void
+    {
+        // Arrange
+        $procedure = ProcedureFactory::createOne(['master' => false])->_real();
+        $procedureId = $procedure->getId();
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        // Re-fetch so `master` is hydrated from the database as its persisted `int`
+        // representation instead of the `bool` set via the entity's setter.
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $testUser = $this->getUserReference(self::TEST_USER_REFERENCE);
+        $factory = $this->createFactory($testUser);
+        $condition = $factory->isEitherTemplateOrProcedure(false);
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertTrue(
+            $reindexer->isMatchingEntity($hydratedProcedure, [$condition]),
+            'A non-template procedure hydrated by Doctrine must match the "not a template" condition when evaluated in PHP.'
+        );
+    }
+
+    public function testIsEitherTemplateOrProcedureDoesNotMatchHydratedTemplateProcedureInPhp(): void
+    {
+        // Arrange
+        $procedure = ProcedureFactory::createOne(['master' => true])->_real();
+        $procedureId = $procedure->getId();
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        $hydratedProcedure = $this->getEntityManager()->find(Procedure::class, $procedureId);
+
+        $testUser = $this->getUserReference(self::TEST_USER_REFERENCE);
+        $factory = $this->createFactory($testUser);
+        $condition = $factory->isEitherTemplateOrProcedure(false);
+
+        $reindexer = $this->getContainer()->get(Reindexer::class);
+
+        // Act & Assert
+        self::assertFalse(
+            $reindexer->isMatchingEntity($hydratedProcedure, [$condition]),
+            'A template procedure must not match the "not a template" condition.'
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
- `OwnsProcedureConditionFactory::isEitherTemplateOrProcedure()` compared `Procedure::master` with `!==`, which fails once Doctrine hydrates the property as `int` instead of the `bool` the condition was built with — dropping every real procedure when the relationship is resolved in PHP.
- `isAuthorizedViaPlanningAgency()` and `userIsExplicitlyAuthorized()` checked to-many collection membership via `propertyHasStringAsMember()`, which reads the property with DIRECT access; when evaluated in PHP against an already-loaded entity this returns the raw `PersistentCollection` instead of an array, crashing `in_array()`.
- The `procedure` relationship on `AdminStatementCrossProcedureSearchResourceType` pointed at `ProcedureResourceType`, contradicting its own docblock, which requires `AdminProcedureResourceType` for consistent access conditions.
- The frontend never requested a sparse fieldset for the sideloaded `AdminProcedure` resource, so grouping headings fell back to a generic label instead of the real procedure name.

## Related PR
https://github.com/demos-europe/demosplan-core/pull/6632

## Test plan
- [x] `OwnsProcedureConditionFactoryTest` (21 tests) — new regression tests hydrate real `Procedure` entities via Doctrine and evaluate the conditions in PHP, reproducing both crashes before the fix and passing after
- [x] `AdminStatementCrossProcedureSearchResourceTypeTest` (8 tests) — green
- [x] PHPStan level 5 on changed files — no new findings