### PR TITLE
fix(refs DPLAN-18292): grant master blueprint ownership to owning org…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/OwnsProcedureConditionFactory.php
@@ -87,7 +87,8 @@ class OwnsProcedureConditionFactory
      *
      * If {@link GlobalConfigInterface::hasProcedureUserRestrictedAccess} is set to `true`,
      * then the user must be authorized manually for the procedure AND must be in the
-     * procedure's owning organization.
+     * procedure's owning organization. The platform master blueprint is exempt from the
+     * manual authorization part, see {@link self::isMasterTemplate()}.
      *
      * The returned condition will not apply role checks by itself. Use in conjunction with
      * {@link self::hasProcedureAccessingRole}.
@@ -96,16 +97,59 @@ class OwnsProcedureConditionFactory
      */
     public function isAuthorizedViaOrgaOrManually(): FunctionInterface
     {
-        // When explicit authorization is enabled, require BOTH explicit authorization
-        // AND owning organization match to prevent access by users who changed organizations
-        if ($this->globalConfig->hasProcedureUserRestrictedAccess()) {
-            return $this->conditionFactory->allConditionsApply(
-                $this->userIsExplicitlyAuthorized(),
-                $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure()
-            );
+        if (!$this->globalConfig->hasProcedureUserRestrictedAccess()) {
+            return $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure();
         }
 
-        return $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure();
+        // When explicit authorization is enabled, require BOTH explicit authorization
+        // AND owning organization match to prevent access by users who changed organizations.
+        // The owning organization match is never waived, so no exemption below can grant
+        // access across organizations.
+        return $this->conditionFactory->allConditionsApply(
+            $this->userOwnsProcedureViaOrgaOfUserThatCreatedTheProcedure(),
+            $this->conditionFactory->anyConditionApplies(
+                $this->isMasterTemplate(),
+                $this->userIsExplicitlyAuthorized()
+            )
+        );
+    }
+
+    /**
+     * Whether the procedure is the platform master blueprint ("Plattform-Blaupause"), the
+     * per-installation singleton that all new procedures are copied from.
+     *
+     * This exists to exempt that blueprint from {@link self::userIsExplicitlyAuthorized()}
+     * while explicit authorization is enabled. The master blueprint is seeded by migration
+     * rather than created through the UI, so it never receives the creator row that
+     * ProcedureService::setAuthorizedUsersToProcedure() writes for every other
+     * procedure. Its authorized user list is therefore permanently empty, and
+     * {@link self::userIsExplicitlyAuthorized()} resolves an empty list to a hard `false()` —
+     * which would make the blueprint owned by nobody and its settings page unopenable, even
+     * for the organisation that owns it. Note also that inheriting authorized users from a
+     * master blueprint is explicitly refused when copying it (T15644 / T23583), which is
+     * further evidence it was never meant to carry a per-user authorization list.
+     *
+     * Combined with the never-waived organisation match in
+     * {@link self::isAuthorizedViaOrgaOrManually()} and the role check in
+     * {@link self::hasProcedureAccessingRole()}, this grants the master blueprint to
+     * FP-role users of the owning organisation — matching the intent of ADO #44507, which
+     * made it visible to exactly that group but left it unopenable.
+     *
+     * @return ClauseFunctionInterface<bool>
+     *
+     * @throws PathException
+     */
+    public function isMasterTemplate(): ClauseFunctionInterface
+    {
+        if ($this->userOrProcedure instanceof User) {
+            return $this->conditionFactory->propertyHasValue(true, ['masterTemplate']);
+        }
+
+        $procedure = $this->userOrProcedure;
+
+        return $procedure->isMasterTemplate()
+            ? $this->conditionFactory->true()
+            : $this->conditionFactory->false();
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureService.php
@@ -640,7 +640,10 @@ class ProcedureService implements ProcedureServiceInterface
 
             $procedureList = $this->procedureRepository->getEntities($conditions, $sortMethods);
 
-            // Add master templates for the user's organization when fetching templates
+            // Add master templates for the user's organization when fetching templates.
+            // This cannot be expressed as a condition on the query above: the platform master
+            // blueprint has customer = NULL, while the query is limited to the current customer
+            // whenever a 'customer' filter key is present. See getMasterTemplatesForUser().
             if ($template && null !== $user->getOrganisationId()) {
                 $masterTemplates = $this->getMasterTemplatesForUser($user);
                 // Merge and deduplicate procedures by their ID to prevent duplicates
@@ -667,6 +670,17 @@ class ProcedureService implements ProcedureServiceInterface
     /**
      * Get master templates that belong to the user's organization.
      * Master templates have masterTemplate = true and are accessible to all users in the same organization.
+     *
+     * This deliberately bypasses the condition-based query in
+     * {@link self::getProcedureAdminList()} rather than contributing a condition to it. The
+     * platform master blueprint is a per-installation singleton that sits outside customer
+     * scope — its customer column is NULL — whereas that query is restricted to the current
+     * customer whenever a 'customer' filter key is present, which the blueprint list handler
+     * always sets. A condition could therefore never match it.
+     *
+     * Ownership is a separate concern and is not bypassed here: whether the blueprint can
+     * actually be opened is decided by
+     * {@link OwnsProcedureConditionFactory::isMasterTemplate()}.
      *
      * @return array<int, Procedure>
      */

--- a/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
+++ b/tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php
@@ -21,6 +21,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\EntityFetcher;
 use demosplan\DemosPlanCoreBundle\Logic\OwnsProcedureConditionFactory;
 use EDT\DqlQuerying\ConditionFactories\DqlConditionFactory;
 use Psr\Log\LoggerInterface;
@@ -466,5 +467,139 @@ class OwnsProcedureConditionFactoryTest extends FunctionalTestCase
         $this->assertNotNull($condition1);
         $this->assertNotNull($condition2);
         // Both users should be able to access the procedure via their shared org
+    }
+
+    // ========================================================================
+    // Tests for isMasterTemplate() - the platform master blueprint exemption
+    //
+    // The platform master blueprint is seeded by migration rather than created
+    // through the UI, so it never receives the creator row that every other
+    // procedure gets. While explicit authorization is enabled that empty list made
+    // userIsExplicitlyAuthorized() resolve to a hard false(), leaving the blueprint
+    // owned by nobody and its settings page unopenable even for its owning orga.
+    //
+    // Unlike the tests above these evaluate the produced conditions rather than only
+    // asserting they are non-null, so they fail if the exemption regresses.
+    // ========================================================================
+
+    private function getEntityFetcher(): EntityFetcher
+    {
+        return $this->getContainer()->get(EntityFetcher::class);
+    }
+
+    /**
+     * Only the config is mocked here - it is a collaborator, not the system under test.
+     */
+    private function createRestrictedAccessConfig(): GlobalConfigInterface
+    {
+        $config = $this->createMock(GlobalConfigInterface::class);
+        $config->method('hasProcedureUserRestrictedAccess')->willReturn(true);
+
+        return $config;
+    }
+
+    /**
+     * Evaluates a procedure's ownership condition against a user, the way
+     * {@link ProcedureAccessEvaluator::isOwningProcedure()} does when a permission is checked.
+     */
+    private function ownsProcedureUnderRestrictedAccess(User $user, Procedure $procedure): bool
+    {
+        $condition = $this->createFactory($procedure, $this->createRestrictedAccessConfig())
+            ->isAuthorizedViaOrgaOrManually();
+
+        return $this->getEntityFetcher()->objectMatches($user, $condition);
+    }
+
+    public function testMasterTemplateIsOwnedByOrgaMemberWithoutExplicitAuthorization(): void
+    {
+        // Arrange
+        $orga = OrgaFactory::createOne();
+        $user = UserFactory::createOne();
+        $masterTemplate = ProcedureFactory::createOne(['master' => true, 'masterTemplate' => true]);
+
+        $this->linkUserToOrga($user->_real(), $orga->_real());
+        $this->linkProcedureToOrga($masterTemplate->_real(), $orga->_real());
+        $this->getEntityManager()->flush();
+
+        $this->assertCount(0, $masterTemplate->_real()->getAuthorizedUsers());
+
+        // Act
+        $owns = $this->ownsProcedureUnderRestrictedAccess($user->_real(), $masterTemplate->_real());
+
+        // Assert
+        $this->assertTrue($owns);
+    }
+
+    public function testOrdinaryBlueprintIsNotOwnedWithoutExplicitAuthorization(): void
+    {
+        // Arrange - identical to the master template case except for the flag under test,
+        // so that the exemption cannot be mistaken for a general waiver
+        $orga = OrgaFactory::createOne();
+        $user = UserFactory::createOne();
+        $blueprint = ProcedureFactory::createOne(['master' => true, 'masterTemplate' => false]);
+
+        $this->linkUserToOrga($user->_real(), $orga->_real());
+        $this->linkProcedureToOrga($blueprint->_real(), $orga->_real());
+        $this->getEntityManager()->flush();
+
+        $this->assertCount(0, $blueprint->_real()->getAuthorizedUsers());
+
+        // Act
+        $owns = $this->ownsProcedureUnderRestrictedAccess($user->_real(), $blueprint->_real());
+
+        // Assert
+        $this->assertFalse($owns);
+    }
+
+    public function testMasterTemplateIsNotOwnedByUserFromAnotherOrga(): void
+    {
+        // Arrange - the owning organisation match is never waived by the exemption
+        $procedureOrga = OrgaFactory::createOne(['name' => self::TEST_ORGA_NAME_DEMOS]);
+        $userOrga = OrgaFactory::createOne(['name' => self::TEST_ORGA_NAME_EXAMPLE]);
+        $user = UserFactory::createOne();
+        $masterTemplate = ProcedureFactory::createOne(['master' => true, 'masterTemplate' => true]);
+
+        $this->linkUserToOrga($user->_real(), $userOrga->_real());
+        $this->linkProcedureToOrga($masterTemplate->_real(), $procedureOrga->_real());
+        $this->getEntityManager()->flush();
+
+        // Act
+        $owns = $this->ownsProcedureUnderRestrictedAccess($user->_real(), $masterTemplate->_real());
+
+        // Assert
+        $this->assertFalse($owns);
+    }
+
+    /**
+     * The same exemption has to hold in the opposite shape of the factory, where conditions
+     * are built from a user and evaluated against procedures. Both shapes share
+     * isAuthorizedViaOrgaOrManually(), so this pins down the "keep in sync" contract
+     * between ProcedureAccessEvaluator::isOwningProcedure() and getOwnsProcedureConditions().
+     */
+    public function testMasterTemplateMatchesConditionsBuiltFromUserWithoutExplicitAuthorization(): void
+    {
+        // Arrange
+        $orga = OrgaFactory::createOne();
+        $user = UserFactory::createOne();
+        $masterTemplate = ProcedureFactory::createOne(['master' => true, 'masterTemplate' => true]);
+        $blueprint = ProcedureFactory::createOne(['master' => true, 'masterTemplate' => false]);
+
+        $this->linkUserToOrga($user->_real(), $orga->_real());
+        $this->linkProcedureToOrga($masterTemplate->_real(), $orga->_real());
+        $this->linkProcedureToOrga($blueprint->_real(), $orga->_real());
+        $this->getEntityManager()->flush();
+
+        $condition = $this->createFactory($user->_real(), $this->createRestrictedAccessConfig())
+            ->isAuthorizedViaOrgaOrManually();
+
+        // Act
+        $matchedIds = array_map(
+            static fn (Procedure $procedure): string => $procedure->getId(),
+            $this->getEntityFetcher()->listEntitiesUnrestricted(Procedure::class, [$condition])
+        );
+
+        // Assert
+        $this->assertContains($masterTemplate->_real()->getId(), $matchedIds);
+        $this->assertNotContains($blueprint->_real()->getId(), $matchedIds);
     }
 }


### PR DESCRIPTION
Ticket
  DPLAN-18292

  The platform master blueprint ("Plattform-Blaupause") shows up in the procedure template list but cannot be opened: clicking it redirects back with `?status=accessdenied`, logging `AccessDeniedException` on  `area_admin_preferences` for users holding an FP role.

  `area_admin_preferences` is only ever enabled inside the `ownsProcedure()` branch, so "may open the settings page" is equivalent to "owns the procedure". With `procedure_user_restricted_access` enabled, ownership additionally requires an explicit `procedure_user` row, and `userIsExplicitlyAuthorized()` resolves an empty list to a hard `false()` — an empty list therefore means *nobody* owns the procedure rather than *everybody*.

  The master blueprint is seeded by migration rather than created through the UI, so it never receives the creator row that
  `ProcedureService::setAuthorizedUsersToProcedure()` writes for every other procedure. Its list stays permanently empty and the blueprint stays permanently unowned. Consistent with that, inheriting authorized users from a master blueprint is deliberately refused when copying it (T15644 / T23583).

  Commit 3a9895205 (ADO #44507) added the master blueprint to the list, described as *"visible and accessible to all users in that organization"*, but changed only `ProcedureService` and not the ownership layer. Visibility became org-scoped while ownership stayed user-scoped — the two diverge wherever `procedure_user_restricted_access` is on. Visibility shipped, accessibility did not; this PR is the missing half.

  **Change:** exempt the master blueprint from the explicit-authorization requirement in `OwnsProcedureConditionFactory::isAuthorizedViaOrgaOrManually()`, which now reads *owning-organisation match AND (master blueprint OR explicitly authorized)*. The organisation match and the role check are untouched, so the grant is exactly "users with an FP role in the owning organisation" — the group ADO #44507 made it visible to.


Two review notes:

- The exemption is expressed as a **condition**, not as an early `return` inside one of the factory's two shapes. `isAuthorizedViaOrgaOrManually()` is shared by `ProcedureAccessEvaluator::isOwningProcedure()` (permission checks) and
  `getOwnsProcedureConditions()` (list queries), which carry a documented "keep in sync" contract. Expressing it as a condition satisfies that contract by construction instead of relying on both branches being edited together.

- `getMasterTemplatesForUser()` and its merge block in `ProcedureService` are  **intentionally kept** and only gain a comment. The master blueprint has `customer = NULL` while the list query is restricted to the current customer
  whenever a `customer` filter key is present — which the blueprint list handler always sets. It can therefore never come from the regular query, independently of ownership, so removing the merge would drop it from the list again. The comment exists so this isn't deleted later as apparent dead weight.

**Scope of the behaviour change:** only projects with `procedure_user_restricted_access: true` are affected — the core default is `false`, where ownership is already organisation-only and nothing changes.

### How to review/test

Requires a project with `procedure_user_restricted_access: true`.

1. Pick a user with an FP role whose organisation owns the master blueprint (`master_template = 1`) and who has **no** `procedure_user` row for it:

       SELECT p._p_id, p._p_name, p.master_template, p.customer, p._o_id,
              (SELECT COUNT(*) FROM procedure_user pu
                WHERE pu.procedure_id = p._p_id) AS authorized_total
       FROM   `_procedure` p
       WHERE  p.master_template = 1;

2. Before: open *Verfahrensvorlagen* → click the master blueprint → redirect with `?status=accessdenied`.
3. After: the settings page opens. No `procedure_user` row was added.
4. Regression check: an ordinary blueprint with zero authorized users must still **not** be openable, and the master blueprint must not be openable for a user from a different organisation.

Unit tests:

    docker compose exec development su -l $USER -s /usr/bin/zsh -c 'cd /srv/www && SYMFONY_DEPRECATIONS_HELPER=disabled php -d xdebug.mode=off ./vendor/bin/phpunit tests/backend/core/Logic/OwnsProcedureConditionFactoryTest.php'

Four cases added: master blueprint without authorized users (owned), ordinary blueprint otherwise identical (not owned), master blueprint with a different organisation (not owned), plus the same check in the factory's other shape (conditions built from a `User`, evaluated against procedures).

Heads-up for reviewers: the 20 pre-existing tests in that file only assert `assertNotNull($condition)` on methods that cannot return null, so they pass with the reported behaviour fully present. The new cases evaluate the produced
conditions via `EntityFetcher`. Rewriting the existing ones is left out of scope here.

PHPStan level 5 on the touched files: 37 errors before and after — none introduced. The one hit inside `OwnsProcedureConditionFactory` (`identical.alwaysFalse`, in `hasProcedureAccessingRole()`) is pre-existing.

### PR Checklist

- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly


