### PR TITLE
feat(refs DPLAN-18248, #AB50749): Set zip upload file for planning docs to max. 2GB

### DIFF
--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanDocument/elements_admin_list.html.twig
@@ -83,7 +83,8 @@
                     "r_zipImport",
                     "hide",
                     "zip",
-                    "form.button.upload.zip"
+                    "form.button.upload.zip",
+                    maxFileSize: 2147483648
                 )
             }}
 


### PR DESCRIPTION
### Ticket
[DPLAN-18248](https://demoseurope.youtrack.cloud/issue/DPLAN-18248/Neu-ADO-issue-50749-Planungsdokument-zip-upload-analog-Planfest)

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->
This PR is connected to the main PR for the DPLAN-18248. It limits the zip file upload to 2 GB for this one upload case.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
As admin - go to zip upload in planning documents section.
Max. 2 GB should be allowed.

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

