### PR TITLE
fix(refs DPLAN-18299): import all statement copies from assessment table exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## UNRELEASED
 
+### Fixed
+- Copies of a statement are no longer silently dropped when an assessment table export is imported. The export carries a reference to the statement each row originates from, so every copy arrives, and re-importing the same export adds only what is not there yet.
+- The reminder mail about ending segment deadlines lists every segment, also when several of them share an ID.
+
 ## v4.55.0 (2026-08-12)
 
 ### Changed

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260814070913.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260814070913.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20260814070913 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add source_statement_id to reference the statement an imported statement originates from';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _statement ADD source_statement_id CHAR(36) DEFAULT NULL');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _statement DROP source_statement_id');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Statement/Statement.php
@@ -209,6 +209,17 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     protected $internId;
 
     /**
+     * Identifies the statement this one was imported from, when it originates from an assessment
+     * table export of a procedure on another instance.
+     *
+     * Unlike {@link StatementInterface::$externId} this is unambiguous: statement copies share
+     * their externId within a procedure, so only this reference can pair an imported statement
+     * with the statement it came from.
+     */
+    #[ORM\Column(name: 'source_statement_id', type: 'string', length: 36, nullable: true, options: ['fixed' => true])]
+    protected ?string $sourceStatementId = null;
+
+    /**
      * @var User
      */
     #[ORM\JoinColumn(name: '_u_id', referencedColumnName: '_u_id', nullable: true, onDelete: 'RESTRICT')]
@@ -1304,6 +1315,18 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
         return $this->externId;
     }
 
+    public function setSourceStatementId(?string $sourceStatementId): Statement
+    {
+        $this->sourceStatementId = $sourceStatementId;
+
+        return $this;
+    }
+
+    public function getSourceStatementId(): ?string
+    {
+        return $this->sourceStatementId;
+    }
+
     /**
      * The usual statement pair (original + non original), makes it tricky to ensure
      * a unique internId per procedure, because these pair is a kind of a copy.
@@ -1324,7 +1347,7 @@ class Statement extends CoreEntity implements UuidEntityInterface, StatementInte
     }
 
     /**
-     * @param string $internId
+     * @param string|null $internId
      */
     public function setInternId($internId): Statement
     {

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/AbstractStatementFromRowBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/AbstractStatementFromRowBuilder.php
@@ -60,6 +60,12 @@ abstract class AbstractStatementFromRowBuilder
 
     abstract public function getExternId(): string;
 
+    abstract public function setSourceStatementId(Cell $cell): ?ConstraintViolationListInterface;
+
+    abstract public function getSourceStatementId(): ?string;
+
+    abstract public function resetInternId(): void;
+
     abstract public function setMemo(Cell $cell): ?ConstraintViolationListInterface;
 
     abstract public function setFeedback(Cell $cell): ?ConstraintViolationListInterface;

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilder.php
@@ -30,9 +30,11 @@ use PhpOffice\PhpSpreadsheet\Shared\Date;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Webmozart\Assert\Assert;
 
 use function is_string;
 
@@ -258,6 +260,35 @@ class StatementFromRowBuilder extends AbstractStatementFromRowBuilder
         return $this->statement->getExternId();
     }
 
+    public function setSourceStatementId(Cell $cell): ?ConstraintViolationListInterface
+    {
+        $sourceStatementId = trim((string) $cell->getValue());
+        if ('' === $sourceStatementId) {
+            $this->getConcreteStatement()->setSourceStatementId(null);
+
+            return null;
+        }
+
+        $violations = $this->validator->validate($sourceStatementId, new Uuid());
+        if (0 !== $violations->count()) {
+            return $violations;
+        }
+
+        $this->getConcreteStatement()->setSourceStatementId($sourceStatementId);
+
+        return null;
+    }
+
+    public function getSourceStatementId(): ?string
+    {
+        return $this->getConcreteStatement()->getSourceStatementId();
+    }
+
+    public function resetInternId(): void
+    {
+        $this->getConcreteStatement()->setInternId(null);
+    }
+
     public function setNumberOfAnonymVotes(Cell $cell): ?ConstraintViolationListInterface
     {
         $this->statement->setNumberOfAnonymVotes($cell->getValue() ?? 0);
@@ -329,6 +360,17 @@ class StatementFromRowBuilder extends AbstractStatementFromRowBuilder
     public function resetStatement(): void
     {
         $this->statement = new Statement();
+    }
+
+    /**
+     * The source statement reference only exists on the concrete entity, not on
+     * {@link StatementInterface}.
+     */
+    private function getConcreteStatement(): Statement
+    {
+        Assert::isInstanceOf($this->statement, Statement::class);
+
+        return $this->statement;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementFromRowBuilderWithZipSupport.php
@@ -258,6 +258,21 @@ class StatementFromRowBuilderWithZipSupport extends AbstractStatementFromRowBuil
         return $this->baseStatementFromRowBuilder->getExternId();
     }
 
+    public function setSourceStatementId(Cell $cell): ?ConstraintViolationListInterface
+    {
+        return $this->baseStatementFromRowBuilder->setSourceStatementId($cell);
+    }
+
+    public function getSourceStatementId(): ?string
+    {
+        return $this->baseStatementFromRowBuilder->getSourceStatementId();
+    }
+
+    public function resetInternId(): void
+    {
+        $this->baseStatementFromRowBuilder->resetInternId();
+    }
+
     public function setMemo(Cell $cell): ?ConstraintViolationListInterface
     {
         return $this->baseStatementFromRowBuilder->setMemo($cell);

--- a/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Import/Statement/StatementSpreadsheetImporter.php
@@ -35,6 +35,12 @@ use function array_key_exists;
 
 class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
 {
+    /**
+     * Column carrying the id of the statement a row originates from. Absent from exports created
+     * before it existed, and empty wherever the value was lost on the way.
+     */
+    protected const COLUMN_SOURCE_REFERENCE = 'Referenz';
+
     public function __construct(CurrentProcedureService $currentProcedureService, CurrentUserService $currentUser, ElementsService $elementsService, OrgaService $orgaService, StatementCopier $statementCopier, StatementService $statementService, TranslatorInterface $translator, ValidatorInterface $validator, private readonly EntityManagerInterface $entityManager)
     {
         parent::__construct($currentProcedureService, $currentUser, $elementsService, $orgaService, $statementCopier, $statementService, $translator, $validator);
@@ -109,9 +115,16 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
             'Mitzeichnende'                 => $builder->setNumberOfAnonymVotes(...),
             'Verfahrensschritt'             => null,
             'Art der Einreichung'           => null,
+            self::COLUMN_SOURCE_REFERENCE   => $builder->setSourceStatementId(...),
         ];
 
         return [$callBackMap, $builder];
+    }
+
+    private function skipStatement(AbstractStatementFromRowBuilder $builder, string $skippedIdentifier): void
+    {
+        $this->skippedStatements[$skippedIdentifier] = ($this->skippedStatements[$skippedIdentifier] ?? 0) + 1;
+        $builder->resetStatement();
     }
 
     private function getStatementFromRowBuilder(ProcedureInterface $procedure): StatementFromRowBuilder
@@ -150,6 +163,7 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
 
         $usedExternIds = $this->statementService->getExternIdsInUse($currentProcedure->getId());
         $usedInternIds = $this->statementService->getInternIdsInUse($currentProcedure->getId());
+        $usedSourceStatementIds = $this->statementService->getSourceStatementIdsInUse($currentProcedure->getId());
 
         // loop through all rows and (if valid) create corresponding original statements and statement copies
         [$columnCallbacks, $builder] = $this->getColumnCallbacks($headIterator);
@@ -177,22 +191,42 @@ class StatementSpreadsheetImporter extends AbstractStatementSpreadsheetImporter
 
             $internId = $builder->getInternId();
             $externId = $builder->getExternId();
+            // Null unless the export carried a reference column. Statement copies share extern
+            // and intern id with the statement they were copied from, so where a reference is
+            // available it is the only reliable identity.
+            $sourceStatementId = $builder->getSourceStatementId();
 
-            if (null !== $internId && array_key_exists($internId, $usedInternIds)) {
-                // skip statements with existing intern IDs
-                $this->skippedStatements[$internId] = ($this->skippedStatements[$internId] ?? 0) + 1;
-                $builder->resetStatement();
-                continue;
-            }
-            if (array_key_exists($externId, $usedExternIds)) {
-                // skip statements with existing extern IDs
-                $this->skippedStatements[$externId] = ($this->skippedStatements[$externId] ?? 0) + 1;
-                $builder->resetStatement();
-                continue;
+            if (null !== $sourceStatementId) {
+                if (array_key_exists($sourceStatementId, $usedSourceStatementIds)) {
+                    // skip statements already imported from the same source statement
+                    $this->skipStatement($builder, $externId);
+                    continue;
+                }
+                $usedSourceStatementIds[$sourceStatementId] = $sourceStatementId;
+                // The intern id has to stay unique per procedure, so only the first statement
+                // imported for a given one keeps it. That mirrors the source, where a copy has no
+                // intern id of its own and reports the one of the statement it was copied from.
+                if (null !== $internId && array_key_exists($internId, $usedInternIds)) {
+                    $builder->resetInternId();
+                    $internId = null;
+                }
+            } else {
+                if (null !== $internId && array_key_exists($internId, $usedInternIds)) {
+                    // skip statements with existing intern IDs
+                    $this->skipStatement($builder, $internId);
+                    continue;
+                }
+                if (array_key_exists($externId, $usedExternIds)) {
+                    // skip statements with existing extern IDs
+                    $this->skipStatement($builder, $externId);
+                    continue;
+                }
             }
 
             $usedExternIds[$externId] = $externId;
-            $usedInternIds[$internId] = $internId;
+            if (null !== $internId) {
+                $usedInternIds[$internId] = $internId;
+            }
 
             // create the original statement and its copy if valid
             $originalStatementOrViolations = $builder->buildStatementAndReset();

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentDeadlineReminderService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/SegmentDeadlineReminderService.php
@@ -137,9 +137,12 @@ class SegmentDeadlineReminderService
      * Builds the nested procedure -> workflow place -> segment structure the
      * template renders, carrying the direct link for each segment.
      *
+     * Segments of statements imported from another instance can share their extern id, so the
+     * entries are collected as a list instead of being keyed by it.
+     *
      * @param list<Segment> $segments
      *
-     * @return array<string, array<string, array<string, string>>>
+     * @return array<string, array<string, list<array{externId: string, link: string}>>>
      */
     private function buildSegmentEntries(array $segments): array
     {
@@ -147,7 +150,10 @@ class SegmentDeadlineReminderService
         foreach ($segments as $segment) {
             $procedureName = $segment->getProcedure()->getName();
             $workflowPlace = $segment->getPlace()->getName();
-            $entries[$procedureName][$workflowPlace][$segment->getExternId()] = $this->generateSegmentLink($segment);
+            $entries[$procedureName][$workflowPlace][] = [
+                'externId' => $segment->getExternId(),
+                'link'     => $this->generateSegmentLink($segment),
+            ];
         }
 
         return $entries;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -446,6 +446,11 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
             30
         );
 
+        // Carries the statement id so an instance importing this export can pair its statements
+        // with the ones they originate from. The extern id cannot serve that purpose: statement
+        // copies share it within a procedure.
+        $columnsDefinition[] = $this->createColumnDefinition('id', 'statement.source.reference', 40);
+
         return $columnsDefinition;
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -733,6 +733,16 @@ class StatementService implements StatementServiceInterface
     }
 
     /**
+     * @param non-empty-string $procedureId
+     *
+     * @return array<non-empty-string, non-empty-string>
+     */
+    public function getSourceStatementIdsInUse(string $procedureId): array
+    {
+        return $this->statementRepository->getSourceStatementIdsInUse($procedureId);
+    }
+
+    /**
      * Takes an array of statement IDs and retrieves the corresponding statement entities from doctrine.
      *
      * @param string                    $procedureId   all statements must be in this procedure

--- a/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/StatementRepository.php
@@ -544,6 +544,26 @@ class StatementRepository extends CoreRepository implements ArrayInterface, Obje
     }
 
     /**
+     * @param non-empty-string $procedureId
+     *
+     * @return array<non-empty-string, non-empty-string>
+     */
+    public function getSourceStatementIdsInUse(string $procedureId): array
+    {
+        $query = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('statement.sourceStatementId')
+            ->from(Statement::class, 'statement')
+            ->where('statement.procedure = :procedureId')
+            ->andWhere('statement.sourceStatementId IS NOT NULL')
+            ->setParameter('procedureId', $procedureId)
+            ->getQuery();
+        $sourceStatementIds = array_column($query->getScalarResult(), 'sourceStatementId');
+
+        return array_combine($sourceStatementIds, $sourceStatementIds);
+    }
+
+    /**
      * Some Statements does not have any StatementMeta. Whysoever.
      */
     protected function ensureHasMeta(Statement $statement): Statement

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_segment_deadline_reminder.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanUser/email_segment_deadline_reminder.html.twig
@@ -12,8 +12,8 @@ Bitte schließen Sie die Bearbeitung bis dahin ab.
         {% for place, segments in places %}
 
             Schritt "{{ place }}"
-                {% for segmentExternId, link in segments %}
-                  - Abschnitt <a href="{{ link }}">{{ segmentExternId }}</a>
+                {% for segment in segments %}
+                  - Abschnitt <a href="{{ segment.link }}">{{ segment.externId }}</a>
                 {% endfor %}
         {% endfor %}
 {% endfor %}

--- a/tests/backend/core/Statement/Functional/SegmentDeadlineReminderServiceTest.php
+++ b/tests/backend/core/Statement/Functional/SegmentDeadlineReminderServiceTest.php
@@ -15,8 +15,10 @@ namespace Tests\Core\Statement\Functional;
 use DateInterval;
 use DateTime;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\MailTemplateFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Statement\SegmentFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Workflow\PlaceFactory;
 use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use demosplan\DemosPlanCoreBundle\Logic\Segment\SegmentDeadlineReminderService;
 use Tests\Base\FunctionalTestCase;
@@ -89,6 +91,43 @@ class SegmentDeadlineReminderServiceTest extends FunctionalTestCase
         $this->sut->sendSegmentDeadlineReminderMails();
 
         self::assertSame(0, $this->countQueuedMailsTo($assignee->getEmail()));
+    }
+
+    public function testListsSegmentsSharingAnExternIdSeparately(): void
+    {
+        // Statements imported from another instance can share their extern id, and so can their
+        // segments. Each segment still needs its own line and link in the reminder.
+        $assignee = $this->createAssignee('reminder-duplicate-externid@test.example');
+        $deadline = $this->todayPlus('P7D');
+        $procedure = ProcedureFactory::createOne();
+        $place = PlaceFactory::createOne(['procedure' => $procedure]);
+        $segmentAttributes = [
+            'assignee'  => $assignee,
+            'deadline'  => $deadline,
+            'externId'  => 'M1-1',
+            'place'     => $place,
+            'procedure' => $procedure,
+        ];
+        $firstSegment = SegmentFactory::createOne($segmentAttributes);
+        $secondSegment = SegmentFactory::createOne($segmentAttributes);
+
+        $this->sut->sendSegmentDeadlineReminderMails();
+
+        $mailBody = $this->getQueuedMailBodyTo($assignee->getEmail());
+        self::assertSame(2, substr_count($mailBody, 'M1-1'));
+        self::assertStringContainsString('segment='.$firstSegment->getId(), $mailBody);
+        self::assertStringContainsString('segment='.$secondSegment->getId(), $mailBody);
+    }
+
+    private function getQueuedMailBodyTo(string $email): string
+    {
+        foreach ($this->mailService->getMailsToSend() as $mail) {
+            if ($email === $mail->getTo()) {
+                return $mail->getContent();
+            }
+        }
+
+        self::fail('No mail queued to '.$email);
     }
 
     private function createAssignee(string $email): object

--- a/tests/backend/core/Statement/Functional/StatementSourceReferenceImportTest.php
+++ b/tests/backend/core/Statement/Functional/StatementSourceReferenceImportTest.php
@@ -40,6 +40,11 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
     private const SOURCE_ID_1 = 'ae2f4c1e-3b7d-4a10-9c62-0f1b8d5e7a31';
     private const SOURCE_ID_2 = 'b1c9d0e2-5f43-4c88-a7d1-2e6f9b0c4a55';
     private const SOURCE_ID_3 = 'c7e5a3b1-9d02-4f76-8b34-1a5c8e2d6f90';
+    private const FIRST_CHUNK = 'first chunk';
+    private const SECOND_CHUNK = 'second chunk';
+    private const HEADER = ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'];
+    private const HEADER_WITHOUT_REFERENCE = ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz'];
+    private const HEADER_WITH_INTERN_ID = ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Eingangsnummer', 'Referenz'];
 
     /** @var list<string>|null */
     private ?array $temporaryFiles = [];
@@ -71,10 +76,10 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
         // Three assessment table copies of the same statement: same extern id, distinct source
         // references, distinct text chunks.
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            self::HEADER,
             [
-                ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
-                ['M1', 'second chunk', self::CATEGORY, null, null, self::SOURCE_ID_2],
+                ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null, self::SOURCE_ID_1],
+                ['M1', self::SECOND_CHUNK, self::CATEGORY, null, null, self::SOURCE_ID_2],
                 ['M1', 'third chunk', self::CATEGORY, null, null, self::SOURCE_ID_3],
             ]
         );
@@ -97,7 +102,7 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
     public function testStoresSourceReferenceOnOriginalStatementAsWell(): void
     {
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            self::HEADER,
             [['M1', 'some text', self::CATEGORY, null, null, self::SOURCE_ID_1]]
         );
 
@@ -113,17 +118,16 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
 
     public function testSkipsStatementsWhoseSourceReferenceWasAlreadyImported(): void
     {
-        $header = ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'];
         $firstImport = $this->createImporter();
-        $firstImport->process($this->createWorkbook($header, [
-            ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
+        $firstImport->process($this->createWorkbook(self::HEADER, [
+            ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null, self::SOURCE_ID_1],
         ]));
         self::assertCount(1, $firstImport->getGeneratedStatements());
 
         // Re-importing a newer export adds only statements not imported before.
         $secondImport = $this->createImporter();
-        $secondImport->process($this->createWorkbook($header, [
-            ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
+        $secondImport->process($this->createWorkbook(self::HEADER, [
+            ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null, self::SOURCE_ID_1],
             ['M2', 'another statement', self::CATEGORY, null, null, self::SOURCE_ID_2],
         ]));
 
@@ -141,10 +145,10 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
         // Copies report the intern id of the statement they were copied from, but it has to stay
         // unique per procedure.
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Eingangsnummer', 'Referenz'],
+            self::HEADER_WITH_INTERN_ID,
             [
-                ['M1', 'first chunk', self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_1],
-                ['M1', 'second chunk', self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_2],
+                ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_1],
+                ['M1', self::SECOND_CHUNK, self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_2],
             ]
         );
 
@@ -166,10 +170,10 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
     {
         // Legacy exports carry no reference column - the extern id stays the only identity there.
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz'],
+            self::HEADER_WITHOUT_REFERENCE,
             [
-                ['M1', 'first chunk', self::CATEGORY, null, null],
-                ['M1', 'second chunk', self::CATEGORY, null, null],
+                ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null],
+                ['M1', self::SECOND_CHUNK, self::CATEGORY, null, null],
             ]
         );
 
@@ -185,10 +189,10 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
     {
         // An empty reference column falls back to the extern id, same as a legacy export.
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            self::HEADER,
             [
-                ['M1', 'first chunk', self::CATEGORY, null, null, null],
-                ['M1', 'second chunk', self::CATEGORY, null, null, null],
+                ['M1', self::FIRST_CHUNK, self::CATEGORY, null, null, null],
+                ['M1', self::SECOND_CHUNK, self::CATEGORY, null, null, null],
             ]
         );
 
@@ -203,7 +207,7 @@ class StatementSourceReferenceImportTest extends FunctionalTestCase
     public function testReportsViolationForMalformedSourceReference(): void
     {
         $workbook = $this->createWorkbook(
-            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            self::HEADER,
             [['M1', 'some text', self::CATEGORY, null, null, 'not-a-uuid']]
         );
 

--- a/tests/backend/core/Statement/Functional/StatementSourceReferenceImportTest.php
+++ b/tests/backend/core/Statement/Functional/StatementSourceReferenceImportTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Functional;
+
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadProcedureData;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
+use demosplan\DemosPlanCoreBundle\Logic\Import\Statement\StatementSpreadsheetImporter;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementCopier;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CurrentUserService;
+use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\Base\FunctionalTestCase;
+
+/**
+ * Covers the source reference an assessment table export carries so an importing instance can pair
+ * its statements with the ones they originate from.
+ */
+class StatementSourceReferenceImportTest extends FunctionalTestCase
+{
+    private const CATEGORY = 'Gesamtstellungnahme';
+    private const SOURCE_ID_1 = 'ae2f4c1e-3b7d-4a10-9c62-0f1b8d5e7a31';
+    private const SOURCE_ID_2 = 'b1c9d0e2-5f43-4c88-a7d1-2e6f9b0c4a55';
+    private const SOURCE_ID_3 = 'c7e5a3b1-9d02-4f76-8b34-1a5c8e2d6f90';
+
+    /** @var list<string>|null */
+    private ?array $temporaryFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var CurrentProcedureService $currentProcedureService */
+        $currentProcedureService = self::getContainer()->get(CurrentProcedureService::class);
+        $currentProcedureService->setProcedure($this->getProcedureReference(LoadProcedureData::TESTPROCEDURE));
+        $this->logIn($this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles ?? [] as $temporaryFile) {
+            if (is_file($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
+        $this->temporaryFiles = [];
+
+        parent::tearDown();
+    }
+
+    public function testImportsEveryCopyWhenSourceReferencesDiffer(): void
+    {
+        // Three assessment table copies of the same statement: same extern id, distinct source
+        // references, distinct text chunks.
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            [
+                ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
+                ['M1', 'second chunk', self::CATEGORY, null, null, self::SOURCE_ID_2],
+                ['M1', 'third chunk', self::CATEGORY, null, null, self::SOURCE_ID_3],
+            ]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        self::assertFalse($sut->hasErrors(), var_export($sut->getErrorsAsArray(), true));
+        self::assertCount(3, $sut->getGeneratedStatements());
+        self::assertSame([], $sut->getSkippedStatements());
+
+        $importedSourceIds = array_map(
+            static fn (Statement $statement): ?string => $statement->getSourceStatementId(),
+            $sut->getGeneratedStatements()
+        );
+        sort($importedSourceIds);
+        self::assertSame([self::SOURCE_ID_1, self::SOURCE_ID_2, self::SOURCE_ID_3], $importedSourceIds);
+    }
+
+    public function testStoresSourceReferenceOnOriginalStatementAsWell(): void
+    {
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            [['M1', 'some text', self::CATEGORY, null, null, self::SOURCE_ID_1]]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        $generatedStatements = $sut->getGeneratedStatements();
+        self::assertCount(1, $generatedStatements);
+        $original = $generatedStatements[0]->getOriginal();
+        self::assertInstanceOf(Statement::class, $original);
+        self::assertSame(self::SOURCE_ID_1, $original->getSourceStatementId());
+    }
+
+    public function testSkipsStatementsWhoseSourceReferenceWasAlreadyImported(): void
+    {
+        $header = ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'];
+        $firstImport = $this->createImporter();
+        $firstImport->process($this->createWorkbook($header, [
+            ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
+        ]));
+        self::assertCount(1, $firstImport->getGeneratedStatements());
+
+        // Re-importing a newer export adds only statements not imported before.
+        $secondImport = $this->createImporter();
+        $secondImport->process($this->createWorkbook($header, [
+            ['M1', 'first chunk', self::CATEGORY, null, null, self::SOURCE_ID_1],
+            ['M2', 'another statement', self::CATEGORY, null, null, self::SOURCE_ID_2],
+        ]));
+
+        self::assertFalse($secondImport->hasErrors(), var_export($secondImport->getErrorsAsArray(), true));
+        self::assertCount(1, $secondImport->getGeneratedStatements());
+        self::assertSame(
+            self::SOURCE_ID_2,
+            $secondImport->getGeneratedStatements()[0]->getSourceStatementId()
+        );
+        self::assertSame(['M1' => 1], $secondImport->getSkippedStatements());
+    }
+
+    public function testKeepsInternIdOnFirstStatementOnlyWhenCopiesShareIt(): void
+    {
+        // Copies report the intern id of the statement they were copied from, but it has to stay
+        // unique per procedure.
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Eingangsnummer', 'Referenz'],
+            [
+                ['M1', 'first chunk', self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_1],
+                ['M1', 'second chunk', self::CATEGORY, null, null, 'E-123', self::SOURCE_ID_2],
+            ]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        self::assertFalse($sut->hasErrors(), var_export($sut->getErrorsAsArray(), true));
+        self::assertCount(2, $sut->getGeneratedStatements());
+
+        $internIds = array_map(
+            static fn (Statement $statement): ?string => $statement->getOriginal()?->getInternId(false),
+            $sut->getGeneratedStatements()
+        );
+        sort($internIds);
+        self::assertSame([null, 'E-123'], $internIds);
+    }
+
+    public function testSkipsDuplicateExternIdsWhenReferenceColumnIsAbsent(): void
+    {
+        // Legacy exports carry no reference column - the extern id stays the only identity there.
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz'],
+            [
+                ['M1', 'first chunk', self::CATEGORY, null, null],
+                ['M1', 'second chunk', self::CATEGORY, null, null],
+            ]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        self::assertCount(1, $sut->getGeneratedStatements());
+        self::assertSame(['M1' => 1], $sut->getSkippedStatements());
+        self::assertNull($sut->getGeneratedStatements()[0]->getSourceStatementId());
+    }
+
+    public function testSkipsDuplicateExternIdsWhenReferenceColumnIsEmpty(): void
+    {
+        // An empty reference column falls back to the extern id, same as a legacy export.
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            [
+                ['M1', 'first chunk', self::CATEGORY, null, null, null],
+                ['M1', 'second chunk', self::CATEGORY, null, null, null],
+            ]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        self::assertCount(1, $sut->getGeneratedStatements());
+        self::assertSame(['M1' => 1], $sut->getSkippedStatements());
+        self::assertNull($sut->getGeneratedStatements()[0]->getSourceStatementId());
+    }
+
+    public function testReportsViolationForMalformedSourceReference(): void
+    {
+        $workbook = $this->createWorkbook(
+            ['ID', 'Text', 'Dokumentenkategorie', 'Dokument', 'Absatz', 'Referenz'],
+            [['M1', 'some text', self::CATEGORY, null, null, 'not-a-uuid']]
+        );
+
+        $sut = $this->createImporter();
+        $sut->process($workbook);
+
+        self::assertTrue($sut->hasErrors());
+    }
+
+    private function createImporter(): StatementSpreadsheetImporter
+    {
+        return new StatementSpreadsheetImporter(
+            self::getContainer()->get(CurrentProcedureService::class),
+            self::getContainer()->get(CurrentUserService::class),
+            self::getContainer()->get(ElementsService::class),
+            self::getContainer()->get(OrgaService::class),
+            self::getContainer()->get(StatementCopier::class),
+            self::getContainer()->get(StatementService::class),
+            self::getContainer()->get(TranslatorInterface::class),
+            self::getContainer()->get(ValidatorInterface::class),
+            self::getContainer()->get(EntityManagerInterface::class)
+        );
+    }
+
+    /**
+     * @param list<string>            $header
+     * @param list<list<string|null>> $rows
+     */
+    private function createWorkbook(array $header, array $rows): SplFileInfo
+    {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet->fromArray([$header, ...$rows], null, 'A1', true);
+
+        $path = tempnam(sys_get_temp_dir(), 'source_reference_import_').'.xlsx';
+        $this->temporaryFiles[] = $path;
+        (new Xlsx($spreadsheet))->save($path);
+        $spreadsheet->disconnectWorksheets();
+
+        return new SplFileInfo($path, '', basename($path));
+    }
+}

--- a/tests/backend/core/Statement/Unit/AssessmentTableXlsExporterSourceReferenceTest.php
+++ b/tests/backend/core/Statement/Unit/AssessmentTableXlsExporterSourceReferenceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Statement\Unit;
+
+use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use demosplan\DemosPlanCoreBundle\Logic\AssessmentTable\AssessmentTableServiceOutput;
+use demosplan\DemosPlanCoreBundle\Logic\EditorService;
+use demosplan\DemosPlanCoreBundle\Logic\Export\DocumentWriterSelector;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\CurrentProcedureService;
+use demosplan\DemosPlanCoreBundle\Logic\SimpleSpreadsheetService;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentHandler;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\AssessmentTableExporter\AssessmentTableXlsExporter;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\Formatter\StatementFormatter;
+use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
+use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+/**
+ * The reference column carries the statement id so an instance importing the export can pair its
+ * statements with the ones they originate from.
+ */
+class AssessmentTableXlsExporterSourceReferenceTest extends TestCase
+{
+    protected ?AssessmentTableXlsExporter $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // No permission is enabled, so only the ungated columns are part of the format.
+        $permissions = $this->createMock(PermissionsInterface::class);
+        $permissions->method('hasPermission')->willReturn(false);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $this->sut = new AssessmentTableXlsExporter(
+            $this->createMock(AssessmentHandler::class),
+            $this->createMock(AssessmentTableServiceOutput::class),
+            $this->createMock(CurrentProcedureService::class),
+            $this->createMock(CurrentUserInterface::class),
+            $this->createMock(DocumentWriterSelector::class),
+            $this->createMock(EditorService::class),
+            $this->createMock(Environment::class),
+            $this->createMock(LoggerInterface::class),
+            $permissions,
+            $this->createMock(RequestStack::class),
+            $this->createMock(ServiceImporter::class),
+            $this->createMock(SimpleSpreadsheetService::class),
+            $this->createMock(StatementHandler::class),
+            $this->createMock(StatementFormatter::class),
+            $translator
+        );
+    }
+
+    public function testStatementFormatCarriesTheStatementId(): void
+    {
+        $columnKeys = array_column($this->sut->selectFormat('statements'), 'key');
+
+        self::assertContains('id', $columnKeys);
+    }
+
+    public function testSegmentFormatCarriesTheStatementId(): void
+    {
+        $columnKeys = array_column($this->sut->selectFormat('segments'), 'key');
+
+        self::assertContains('id', $columnKeys);
+    }
+
+    public function testStatementAttachmentsFormatCarriesTheStatementId(): void
+    {
+        $columnKeys = array_column($this->sut->selectFormat('statementsWithAttachments'), 'key');
+
+        self::assertContains('id', $columnKeys);
+    }
+}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -3798,6 +3798,7 @@ statement.similarStatementSubmitters.delete: |
 statement.similarStatementSubmitters.hint: "Falls von weiteren Einreichenden inhaltlich identische Stellungnahmen eingegangen sind, können diese Personen hier angegeben werden."
 statement.solved.description: "Wenn sich alle Abschnitte einer Stellungnahme in einem solchen Bearbeitungsschritt befinden, bekommt die Stellungnahme den Status \"Abgeschlossen\"."
 statement.solved.hint: "Wenn sich alle Abschnitte einer Stellungnahme in Bearbeitungsschritten befinden, bei denen diese Checkbox aktiviert ist, bekommt die Stellungnahme den Status \"Abgeschlossen\"."
+statement.source.reference: "Referenz"
 statement.specification: "Angaben zur Stellungnahme"
 statement.split.complete: "Aufteilen abschließen"
 statement.split.complete.confirm: "Sind Sie sicher, dass Sie die Stellungnahme vollständig aufgeteilt haben? Sie können die gleiche Stellungnahme zu einem späteren Zeitpunkt nicht erneut bearbeiten."


### PR DESCRIPTION
### Ticket
DPLAN-18299

An assessment table export writes one row per statement, and copies share their extern id. The import used the extern id as identity, so every copy after the first was skipped — silently, because the skipped-rows list is only logged when the import aborts for other reasons. The copy-and-shorten workflow used to split large statements therefore lost data without any message.

The export now carries the statement id in a "Referenz" column. Where the import finds that column, it stores the value on the imported statement and deduplicates on it: all copies arrive, each with its own reference, and re-importing a newer export adds only what is not there yet. Older exports without the column, and rows where the value is empty, keep the previous extern-id behaviour unchanged.

Note that the column is not gated by a permission, so it appears in the XLSX assessment table exports of every project.

Two details worth knowing while reviewing:

- Exported copies report the intern id of the statement they were copied from, and that has to stay unique per procedure — so only the first statement imported for a given intern id keeps it, mirroring what `StatementCopier` does within a procedure.
- The reminder mail for ending segment deadlines keyed its entries by segment extern id and collapsed segments sharing one, losing a link. Fixed in the second commit, since duplicate extern ids become legitimate with this change.

### How to review/test

- Export an assessment table from a procedure that contains copies of a statement, then import it into another procedure: every copy arrives, each with its own reference.
- Import the same file again: nothing is duplicated.
- Import an export created before this change: behaviour unchanged, copies still skipped.
- `SYMFONY_DEPRECATIONS_HELPER=disabled ./vendor/bin/phpunit tests/backend/core/Statement/Functional/StatementSourceReferenceImportTest.php tests/backend/core/Statement/Unit/AssessmentTableXlsExporterSourceReferenceTest.php tests/backend/core/Statement/Functional/SegmentDeadlineReminderServiceTest.php`

### PR Checklist

- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Update changelog
