### PR TITLE
fix(refs HDDP-27): add extension to async export fallback filenames

### DIFF
--- a/demosplan/DemosPlanCoreBundle/MessageHandler/ExportAssessmentTableMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/ExportAssessmentTableMessageHandler.php
@@ -88,7 +88,9 @@ class ExportAssessmentTableMessageHandler
                 $response,
                 $message->getUserId(),
                 $message->getProcedureId(),
-                'Abwaegungstabelle'
+                // The export format doubles as extension so the download stays openable even if the
+                // response declares no name.
+                'Abwaegungstabelle.'.$message->getExportFormat()
             );
             $job->setFileHash($storedFile->getFileHash());
             $job->setFileName($storedFile->getFileName());

--- a/demosplan/DemosPlanCoreBundle/MessageHandler/ExportProcedureMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/ExportProcedureMessageHandler.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
 
 /**
@@ -50,6 +51,7 @@ class ExportProcedureMessageHandler
         private readonly ExportService $exportService,
         private readonly LoggerInterface $logger,
         private readonly RequestStack $requestStack,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -87,7 +89,9 @@ class ExportProcedureMessageHandler
                 $response,
                 $message->getUserId(),
                 null,
-                'Verfahrensexport.zip'
+                // Same key ExportService names the archive after, so the fallback cannot diverge
+                // from it per project or locale.
+                $this->translator->trans('procedure.export_filename').'.zip'
             );
             $job->setFileHash($storedFile->getFileHash());
             $job->setFileName($storedFile->getFileName());

--- a/tests/backend/core/MessageHandler/ExportAssessmentTableMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/ExportAssessmentTableMessageHandlerTest.php
@@ -142,7 +142,8 @@ class ExportAssessmentTableMessageHandlerTest extends UnitTestCase
     public function testInvokeFallsBackToDefaultNameWhenResponseCarriesNoDisposition(): void
     {
         // Arrange - a ZIP built by ZipStream inside the stream callback may reach the worker without
-        // a Content-Disposition on the response object; the stored name must still be usable
+        // a Content-Disposition on the response object; the stored name must still carry the
+        // extension, or the browser hands the user a file it cannot open
         $job = new AssessmentTableExportJob();
         $this->mockFindReturning($job);
         $this->responseGeneratorMock->method('__invoke')->willReturn(new StreamedResponse(static function (): void {
@@ -150,14 +151,31 @@ class ExportAssessmentTableMessageHandlerTest extends UnitTestCase
         }));
         $this->fileServiceMock->expects($this->once())
             ->method('saveTemporaryFile')
-            ->with($this->isType('string'), 'Abwaegungstabelle', 'u1', 'proc-1', FileService::VIRUSCHECK_NONE)
+            ->with($this->isType('string'), 'Abwaegungstabelle.zip', 'u1', 'proc-1', FileService::VIRUSCHECK_NONE)
             ->willReturn($this->fileWithHash('hash-1'));
 
         // Act
         ($this->sut)(new ExportAssessmentTableMessage('job-1', 'zip', [], 'u1', 'proc-1', 'c1'));
 
         // Assert
-        self::assertSame('Abwaegungstabelle', $job->getFileName());
+        self::assertSame('Abwaegungstabelle.zip', $job->getFileName());
+    }
+
+    public function testInvokeFallbackNameUsesRequestedExportFormatAsExtension(): void
+    {
+        // Arrange - the fallback extension must follow the requested format, not a fixed guess
+        $job = new AssessmentTableExportJob();
+        $this->mockFindReturning($job);
+        $this->responseGeneratorMock->method('__invoke')->willReturn(new StreamedResponse(static function (): void {
+            echo 'docx-bytes';
+        }));
+        $this->fileServiceMock->method('saveTemporaryFile')->willReturn($this->fileWithHash('hash-1'));
+
+        // Act
+        ($this->sut)(new ExportAssessmentTableMessage('job-1', 'docx', [], 'u1', 'proc-1', 'c1'));
+
+        // Assert
+        self::assertSame('Abwaegungstabelle.docx', $job->getFileName());
     }
 
     public function testInvokeWritesJobStatusThroughStatusWriterEvenWhenExportFails(): void

--- a/tests/backend/core/MessageHandler/ExportProcedureMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/ExportProcedureMessageHandlerTest.php
@@ -66,7 +66,8 @@ class ExportProcedureMessageHandlerTest extends UnitTestCase
             new ExportResponseFileStore($this->fileServiceMock),
             $this->exportServiceMock,
             $this->loggerMock,
-            $this->createMock(RequestStack::class)
+            $this->createMock(RequestStack::class),
+            $translator
         );
     }
 
@@ -175,6 +176,36 @@ class ExportProcedureMessageHandlerTest extends UnitTestCase
         self::assertSame(ProcedureExportJob::STATUS_COMPLETED, $job->getStatus());
         self::assertSame('hash-1', $job->getFileHash());
         self::assertSame('Verfahrensexport.zip', $job->getFileName());
+    }
+
+    public function testInvokeNamesFileFromTranslationWhenResponseDeclaresNoFilename(): void
+    {
+        // Arrange - a ZIP response without Content-Disposition must still yield the translated
+        // archive name, not a hardcoded literal that diverges per project or locale.
+        $job = new ProcedureExportJob();
+        $this->mockFindReturning($job);
+        $this->exportServiceMock->method('generateProcedureExportZip')->willReturn(
+            new StreamedResponse(static function (): void {
+                echo 'zip-bytes';
+            })
+        );
+
+        $this->fileServiceMock->expects($this->once())
+            ->method('saveTemporaryFile')
+            ->with(
+                $this->isType('string'),
+                'translated:procedure.export_filename.zip',
+                'u1',
+                null,
+                FileService::VIRUSCHECK_NONE
+            )
+            ->willReturn($this->fileWithHash('hash-1'));
+
+        // Act
+        ($this->sut)(new ExportProcedureMessage('job-1', ['p1'], 'u1', 'c1'));
+
+        // Assert
+        self::assertSame('translated:procedure.export_filename.zip', $job->getFileName());
     }
 
     private function mockFindReturning(ProcedureExportJob $job): void


### PR DESCRIPTION
### Ticket
HDDP-27

The async export stores its result as a file and serves it to a later download request. The name for
that file comes from the response's `Content-Disposition`, with a fallback for responses that declare
none. Both fallbacks were wrong:

- The assessment table passed `Abwaegungstabelle` — no file extension, so the browser handed the user
  a file it could not open.
- The procedure export passed a hardcoded `Verfahrensexport.zip`, duplicating the German value of
  `procedure.export_filename`. It matches today by coincidence and silently diverges as soon as a
  project overrides that key or a different locale is used.

The assessment table fallback now appends the requested export format as extension, and the procedure
fallback resolves the same translation key `ExportService` names the archive after.

A ZIP response can reach the worker without a `Content-Disposition`, because `ZipStream` emits its
headers through PHP's `header()` from inside the stream callback rather than on the response object —
and `header()` is a no-op in a worker process. That is why the fallback is load-bearing here and not
just a defensive default.

### How to review/test
`vendor/bin/phpunit tests/backend/core/MessageHandler/ExportProcedureMessageHandlerTest.php tests/backend/core/MessageHandler/ExportAssessmentTableMessageHandlerTest.php`

Three tests cover the fallback path; each fails without the change. The existing
`testInvokeFallsBackToDefaultNameWhenResponseCarriesNoDisposition` was asserting the extensionless
name and is updated.

Note this is forward-only: export jobs already completed keep their stored name until re-exported.

### PR Checklist

- [x] Create/Update tests
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
