### PR TITLE
fix HDDP-27: stream export download in chunks to avoid memory exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## UNRELEASED
 
 ### Fixed
+- Downloading the result of a background export works for large archives. The file is sent to the browser piece by piece instead of being held in memory as a whole, which could abort the download.
 - Copies of a statement are no longer silently dropped when an assessment table export is imported. The export carries a reference to the statement each row originates from, so every copy arrives, and re-importing the same export adds only what is not there yet.
 - The reminder mail about ending segment deadlines lists every segment, also when several of them share an ID.
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/ExportJobDownloadResponseFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/ExportJobDownloadResponseFactory.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class ExportJobDownloadResponseFactory
 {
+    private const CHUNK_SIZE = 1024 * 1024;
+
     public function __construct(
         private readonly FileService $fileService,
         private readonly FilesystemOperator $defaultStorage,
@@ -53,11 +55,24 @@ class ExportJobDownloadResponseFactory
         }
 
         $stream = $storage->readStream($fileInfo->getAbsolutePath());
+        // Write in chunks and hand each one to the client right away. Without the flush an active
+        // output buffer keeps the complete archive in memory and exhausts the memory limit.
         $response = new StreamedResponse(static function () use ($stream): void {
-            fpassthru($stream);
+            while (!feof($stream)) {
+                $chunk = fread($stream, self::CHUNK_SIZE);
+                if (false === $chunk) {
+                    break;
+                }
+                echo $chunk;
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
+                flush();
+            }
             fclose($stream);
         });
         $response->headers->set('Content-Type', 'application/octet-stream');
+        $response->headers->set('Content-Length', (string) $storage->fileSize($fileInfo->getAbsolutePath()));
         $response->headers->set(
             'Content-Disposition',
             'attachment; filename="'.($job->getFileName() ?? $fileInfo->getFileName()).'"'

--- a/tests/backend/core/Export/Unit/ExportJobDownloadResponseFactoryTest.php
+++ b/tests/backend/core/Export/Unit/ExportJobDownloadResponseFactoryTest.php
@@ -59,6 +59,7 @@ class ExportJobDownloadResponseFactoryTest extends UnitTestCase
     {
         // Arrange
         $this->defaultStorageMock->method('fileExists')->willReturn(true);
+        $this->defaultStorageMock->method('fileSize')->willReturn(9);
         $this->defaultStorageMock->expects($this->once())
             ->method('readStream')
             ->with(self::ABSOLUTE_PATH)
@@ -74,6 +75,7 @@ class ExportJobDownloadResponseFactoryTest extends UnitTestCase
             'attachment; filename="Verfahrensexport.zip"',
             $response->headers->get('Content-Disposition')
         );
+        self::assertSame('9', $response->headers->get('Content-Length'));
         self::assertSame('zip-bytes', $this->sendAndCapture($response));
     }
 
@@ -150,11 +152,20 @@ class ExportJobDownloadResponseFactoryTest extends UnitTestCase
         return $stream;
     }
 
+    /**
+     * Collects via an output handler, because the response flushes its buffer per chunk.
+     */
     private function sendAndCapture(StreamedResponse $response): string
     {
-        ob_start();
-        $response->sendContent();
+        $captured = '';
+        ob_start(static function (string $chunk) use (&$captured): string {
+            $captured .= $chunk;
 
-        return (string) ob_get_clean();
+            return '';
+        });
+        $response->sendContent();
+        ob_end_clean();
+
+        return $captured;
     }
 }


### PR DESCRIPTION
### Ticket
HDDP-27

Downloading the result of an asynchronous export could exhaust the memory limit and abort the
transfer mid-stream:

```
app.ERROR: OutOfMemoryError: Allowed memory size of 2147483648 bytes exhausted
(tried to allocate 2147483648 bytes) in ExportJobDownloadResponseFactory
```

`fpassthru()` handed the archive to the output layer without ever flushing it, so an active output
buffer accumulated the complete file in memory. The reported allocation is that buffer doubling from
1 GB to 2 GB — for a multi-gigabyte archive the download therefore died where the export had been
moved into the background to begin with.

The response now reads the archive in 1 MiB chunks and flushes each one to the client, and it sends a
`Content-Length`. Measured with a 200 MB file at `memory_limit=64M`: `fpassthru()` and a chunked copy
without flushing both die, the flushing loop peaks at 6 MB. Both `readStream()` and `fileSize()` go
through the `FilesystemOperator`, so local, S3 and the lazy default storage take the same path.

### How to review/test
Trigger an assessment table or procedure export large enough to matter, then download the finished
job and watch the memory of the serving process — it stays flat instead of growing with the file.
The unit test covers the chunked output and the new header; it captures through an output handler
because the response now flushes its own buffer.

### PR Checklist

- [x] Create/Update tests
- [x] Link all relevant tickets
- [x] Update changelog
- [ ] Move the tickets on the board accordingly

