### PR TITLE
DPLAN-16770: use vitest mock in inline image anchors test

### DIFF
--- a/tests/frontend/unit/inlineImageAnchors.test.js
+++ b/tests/frontend/unit/inlineImageAnchors.test.js
@@ -7,9 +7,10 @@
  * All rights reserved
  */
 
-global.Translator = { trans: jest.fn(key => key === 'image.open' ? 'Bild öffnen' : key) }
-
 import { inlineImageAnchors, inlineImageAnchorsForEditing, stripInlineImageAnchors } from '@DpJs/lib/shared/inlineImageAnchors'
+import { vi } from 'vitest'
+
+global.Translator = { trans: vi.fn(key => key === 'image.open' ? 'Bild öffnen' : key) }
 
 describe('inlineImageAnchors', () => {
   it('replaces a pdf_importer_image anchor with an img and a visible link', () => {


### PR DESCRIPTION
### Ticket
DPLAN-16770

The frontend test runner was migrated from jest to vitest (#6279), but
`tests/frontend/unit/inlineImageAnchors.test.js` still calls `jest.fn()`. Vitest does not
provide a `jest` global, so the call throws a `ReferenceError` while the module is being
evaluated. That kills the whole file as a failed suite (`0 test`) and turns the FE test job
red on `release_kanban` and on every branch based on it.

The fix uses `vi.fn()` with an explicit `import { vi } from 'vitest'` and moves the
`global.Translator` assignment below the imports. The file is now byte-identical to the
version on `main`, where this was already corrected in #6665 — so no conflict is introduced
when `release_kanban` and `main` are reconciled later.

### How to review/test
Check that the FE test job passes on this PR. `tests/frontend/unit/inlineImageAnchors.test.js`
should be reported as a passing suite instead of a failed one.

No further `jest` references remain in `tests/frontend/`.

### PR Checklist

- [x] Run `yarn test`
- [x] Link all relevant tickets