### PR TITLE
chore: dedupe dompurify to patched version (3.4.13)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7656,19 +7656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.2, dompurify@npm:^3.4.5":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.4.13":
+"dompurify@npm:^3.0.2, dompurify@npm:^3.4.13, dompurify@npm:^3.4.5":
   version: 3.4.13
   resolution: "dompurify@npm:3.4.13"
   dependencies:


### PR DESCRIPTION
fixes a moderate security alert:
IN_PLACE hook removal leaves a detached subtree executable, causing XSS