### PR TITLE
refactor: log scalars via Monolog context instead of varExport

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/AssessmentTable/DemosPlanAssessmentTableController.php
@@ -46,7 +46,6 @@ use demosplan\DemosPlanCoreBundle\Services\Breadcrumb\Breadcrumb;
 use demosplan\DemosPlanCoreBundle\Services\HTMLFragmentSlicer;
 use demosplan\DemosPlanCoreBundle\StoredQuery\AssessmentTableQuery;
 use demosplan\DemosPlanCoreBundle\Traits\DI\RefreshElasticsearchIndexTrait;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanCoreBundle\ValueObject\AssessmentTable\StatementBulkEditVO;
 use Doctrine\Common\Collections\Collection;
 use Exception;
@@ -920,7 +919,7 @@ class DemosPlanAssessmentTableController extends BaseController
 
             $departmentId = $currentUser->getUser()->getDepartment()->getId();
 
-            $this->getLogger()->debug('Get Fragment Consideration Versions as Reviewer: '.DemosPlanTools::varExport($isReviewer, true));
+            $this->getLogger()->debug('Get Fragment Consideration Versions as Reviewer: {isReviewer}', ['isReviewer' => $isReviewer]);
 
             $fragmentVersions = $this->statementHandler->getStatementFragmentVersions($fragmentId, $departmentId, $isReviewer);
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -51,7 +51,6 @@ use demosplan\DemosPlanCoreBundle\Services\Breadcrumb\Breadcrumb;
 use demosplan\DemosPlanCoreBundle\Tools\ServiceImporter;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPaginator;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use DirectoryIterator;
 use Exception;
 use League\Flysystem\FilesystemOperator;
@@ -816,20 +815,26 @@ class DemosPlanDocumentController extends BaseController
                 $destination = $extractDir.'/'.$dirname;
                 // if path contains any relative path immediately skip file
                 if (0 !== mb_substr_count($destination, '../')) {
-                    $this->getLogger()->error('Possible Zip-slip-Attack. File not extracted. Destination:'.DemosPlanTools::varExport($destination, true));
+                    $this->getLogger()->error('Possible Zip-slip-Attack. File not extracted. Destination: {destination}', ['destination' => $destination]);
                     continue;
                 }
 
                 // Falls gar kein valider Filename ermittelt werden konnte, lieber einen Hash als nix
                 if ('' === $filename) {
                     $filename = md5(random_int(0, 9999));
-                    $this->getLogger()->warning('Es konnte via kein gültiger Name gefunden werden. RandomHash: '.DemosPlanTools::varExport($filename, true));
+                    $this->getLogger()->warning('Es konnte via kein gültiger Name gefunden werden. RandomHash: {filename}', ['filename' => $filename]);
                 } else {
                     ++$successFiles;
                 }
 
-                $this->getLogger()->info('DocumentImport set Filename '.DemosPlanTools::varExport($filename, true).' Dirname: '.DemosPlanTools::varExport($dirname, true).
-                    ' Orig base64encoded: '.DemosPlanTools::varExport(base64_encode($filenameOrig), true));
+                $this->getLogger()->info(
+                    'DocumentImport set Filename {filename} Dirname: {dirname} Orig base64encoded: {filenameOrigBase64}',
+                    [
+                        'filename'           => $filename,
+                        'dirname'            => $dirname,
+                        'filenameOrigBase64' => base64_encode($filenameOrig),
+                    ]
+                );
                 $zip->renameIndex($indexInZipFile, $dirname.'/'.$filename);
                 $zip->extractTo($extractDir, $zip->getNameIndex($indexInZipFile));
             }

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -39,7 +39,6 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use demosplan\DemosPlanCoreBundle\Types\UserFlagKey;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanCoreBundle\ValueObject\SettingsFilter;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\AddressBookEntryVO;
 use Exception;
@@ -85,9 +84,10 @@ class DemosPlanUserController extends BaseController
         }
         $roles = $this->currentUser->getUser()->getRoles();
         $this->getLogger()->info(
-            'Welcomepage for Orga '.DemosPlanTools::varExport($orga->getName(), true).' '.DemosPlanTools::varExport($orga->getId(), true)
+            'Welcomepage for Orga {orgaName} {orgaId}',
+            ['orgaName' => $orga->getName(), 'orgaId' => $orga->getId()]
         );
-        $this->getLogger()->info('Welcomepage Roles '.DemosPlanTools::varExport($roles, true));
+        $this->getLogger()->info('Welcomepage Roles {roles}', ['roles' => $roles]);
 
         $templateVars = $this->checkProfileCompleted();
 
@@ -282,8 +282,13 @@ class DemosPlanUserController extends BaseController
         }
         $templateVars['profileCompleted'] = filter_var($this->currentUser->getUser()->isProfileCompleted(), FILTER_VALIDATE_BOOLEAN);
         $templateVars['newUser'] = filter_var($this->currentUser->getUser()->isNewUser(), FILTER_VALIDATE_BOOLEAN);
-        $this->getLogger()->info('Check Profile completed: '.DemosPlanTools::varExport($templateVars['profileCompleted'], true)
-            .' NewUser: '.DemosPlanTools::varExport($templateVars['newUser'], true));
+        $this->getLogger()->info(
+            'Check Profile completed: {profileCompleted} NewUser: {newUser}',
+            [
+                'profileCompleted' => $templateVars['profileCompleted'],
+                'newUser'          => $templateVars['newUser'],
+            ]
+        );
 
         return $templateVars;
     }

--- a/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Document/ElementsService.php
@@ -36,7 +36,6 @@ use demosplan\DemosPlanCoreBundle\Repository\ElementsRepository;
 use demosplan\DemosPlanCoreBundle\Repository\ParagraphRepository;
 use demosplan\DemosPlanCoreBundle\Repository\SingleDocumentRepository;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\PlanningDocumentCategoryResourceType;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -631,7 +630,7 @@ class ElementsService implements ElementsServiceInterface
             $em->persist($elementEntity);
             $em->flush();
 
-            $this->logger->info('Organisationen '.DemosPlanTools::varExport($orgaIds, true).' wurden für die Kategorie '.$elementId.' berechtigt');
+            $this->logger->info('Organisationen {orgaIds} wurden für die Kategorie {elementId} berechtigt', ['orgaIds' => $orgaIds, 'elementId' => $elementId]);
 
             return true;
         } catch (Exception $e) {
@@ -667,7 +666,7 @@ class ElementsService implements ElementsServiceInterface
             $em->persist($elementEntity);
             $em->flush();
 
-            $this->logger->info('Berechtigungen der Organisationen '.DemosPlanTools::varExport($orgaIds, true).' wurden von der Kategorie '.$elementId.' entfernt');
+            $this->logger->info('Berechtigungen der Organisationen {orgaIds} wurden von der Kategorie {elementId} entfernt', ['orgaIds' => $orgaIds, 'elementId' => $elementId]);
 
             return true;
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -702,7 +702,7 @@ class DraftStatementService
             );
 
             if (false === $submitResult) {
-                $this->logger->warning('DraftStatement could not be submitted: '.DemosPlanTools::varExport($submitResult, true));
+                $this->logger->warning('DraftStatement could not be submitted', ['submitResult' => $submitResult]);
                 continue;
             }
 
@@ -1205,7 +1205,7 @@ class DraftStatementService
                 $draftStatement['paragraph'] = $this->entityHelper->toArray($parentParagraph);
             } catch (Exception) {
                 // Einige alte Einträge verweisen möcglicherweise noch nicht auf eine ParagraphVersion
-                $this->logger->error('No ParagraphVersion found for Id '.DemosPlanTools::varExport($draftStatement['paragraph']->getId(), true));
+                $this->logger->error('No ParagraphVersion found for Id {paragraphId}', ['paragraphId' => $draftStatement['paragraph']->getId()]);
                 unset($draftStatement['paragraph']);
                 $draftStatement['paragraphId'] = null;
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementDeleter.php
@@ -31,7 +31,6 @@ use demosplan\DemosPlanCoreBundle\Logic\StatementAttachmentService;
 use demosplan\DemosPlanCoreBundle\Repository\EntitySyncLinkRepository;
 use demosplan\DemosPlanCoreBundle\Repository\StatementRepository;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\OptimisticLockException;
@@ -168,7 +167,7 @@ class StatementDeleter
                 try {
                     // Prohibit deletion if a consultation token exists for this statement
                     if ($this->consultationTokenService->getTokenForStatement($statement) instanceof ConsultationToken) {
-                        throw new DemosException('error.delete.statement.consultation.token', 'Statement '.DemosPlanTools::varExport($statementId, true).' has an associated consultation token.');
+                        throw new DemosException('error.delete.statement.consultation.token', sprintf('Statement %s has an associated consultation token.', $statementId));
                     }
                     if ($canTransaction) {
                         $doctrineConnection->beginTransaction();

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -176,7 +176,7 @@ class StatementFragmentService
         try {
             return $this->statementFragmentRepository->get($fragmentId);
         } catch (Exception $e) {
-            $this->logger->error('Could not find StatementFragment with id '.DemosPlanTools::varExport($fragmentId, true).': ', [$e]);
+            $this->logger->error('Could not find StatementFragment with id {fragmentId}', ['fragmentId' => $fragmentId, 'exception' => $e]);
 
             return null;
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementService.php
@@ -2609,7 +2609,7 @@ class StatementService implements StatementServiceInterface
                 }
             }
         } catch (Exception $e) {
-            $this->logger->error('Get HeadStatement IDs of statements : '.DemosPlanTools::varExport($statementIds, true).' failed: ', [$e]);
+            $this->logger->error('Get HeadStatement IDs of statements failed', ['statementIds' => $statementIds, 'exception' => $e]);
         }
 
         return $result;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementToLegacyConverter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementToLegacyConverter.php
@@ -23,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Logic\DateHelper;
 use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
 use demosplan\DemosPlanCoreBundle\Repository\SingleDocumentVersionRepository;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Doctrine\Common\Collections\Collection;
 use Exception;
 use Psr\Log\LoggerInterface;
@@ -110,8 +109,8 @@ class StatementToLegacyConverter
             } catch (Exception) {
                 // Some old entries may not yet refer to a ParagraphVersion
                 $this->logger->error(
-                    'No ParagraphVersion found for Id '
-                    .DemosPlanTools::varExport($statementArray['paragraph']->getId(), true)
+                    'No ParagraphVersion found for Id {paragraphId}',
+                    ['paragraphId' => $statementArray['paragraph']->getId()]
                 );
                 unset($statementArray['paragraph']);
                 $statementArray['paragraphId'] = null;
@@ -188,10 +187,8 @@ class StatementToLegacyConverter
                 $statementArray['procedure']['publicParticipationPhaseDefinitionName'] = $publicParticipationPhaseDefinitionName;
             } catch (Exception $e) {
                 $this->logger->warning(
-                    'Could not convert  Statement Procedure to Legacy. Statement: '.DemosPlanTools::varExport(
-                        $statementArray['id'],
-                        true
-                    ).$e
+                    'Could not convert Statement Procedure to Legacy. Statement: {statementId}',
+                    ['statementId' => $statementArray['id'], 'exception' => $e]
                 );
             }
         }
@@ -213,10 +210,8 @@ class StatementToLegacyConverter
                 $statementArray['organisation'] = $this->entityHelper->toArray($statementArray['organisation']);
             } catch (Exception $e) {
                 $this->logger->warning(
-                    'Could not convert Statement Organisation to Legacy. Statement: '.DemosPlanTools::varExport(
-                        $statementArray['id'],
-                        true
-                    ).$e
+                    'Could not convert Statement Organisation to Legacy. Statement: {statementId}',
+                    ['statementId' => $statementArray['id'], 'exception' => $e]
                 );
             }
         }
@@ -231,9 +226,8 @@ class StatementToLegacyConverter
                 $statementArray['meta'] = $this->entityHelper->toArray($statementArray['meta']);
             } catch (Exception $e) {
                 $this->logger->warning(
-                    'Could not convert Statement Meta to Legacy. Statement: '
-                    .DemosPlanTools::varExport($statementArray['id'], true)
-                    .$e
+                    'Could not convert Statement Meta to Legacy. Statement: {statementId}',
+                    ['statementId' => $statementArray['id'], 'exception' => $e]
                 );
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
@@ -35,7 +35,6 @@ use demosplan\DemosPlanCoreBundle\Repository\OrgaRepository;
 use demosplan\DemosPlanCoreBundle\Repository\OrgaTypeRepository;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\InvitablePublicAgencyResourceType;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\OrgaResourceType;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanCoreBundle\ValueObject\OrgaSignatureValueObject;
 use demosplan\DemosPlanCoreBundle\ValueObject\SettingsFilter;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\DataProtectionOrganisation;
@@ -494,7 +493,7 @@ class OrgaService implements OrgaServiceInterface
                 $notifications['emailNotificationEndingPhase'] = $settingEndingPhase[0];
             }
         }
-        $this->logger->debug('loadOrgaNotifications Loaded: '.DemosPlanTools::varExport($notifications, true));
+        $this->logger->debug('loadOrgaNotifications Loaded', ['notifications' => $notifications]);
         $orga->setNotifications($notifications);
     }
 
@@ -514,7 +513,7 @@ class OrgaService implements OrgaServiceInterface
         );
         if (is_array($settingSubmissionType) && 1 === count($settingSubmissionType)) {
             $orga->setSubmissionType($settingSubmissionType[0]->getContent());
-            $this->logger->debug('loadOrgaSubmissionType Loaded: '.DemosPlanTools::varExport($settingSubmissionType[0]->getContent(), true));
+            $this->logger->debug('loadOrgaSubmissionType Loaded: {submissionType}', ['submissionType' => $settingSubmissionType[0]->getContent()]);
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
@@ -47,7 +47,6 @@ use demosplan\DemosPlanCoreBundle\Repository\UserPasswordHistoryRepository;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
 use demosplan\DemosPlanCoreBundle\Repository\UserRoleInCustomerRepository;
 use demosplan\DemosPlanCoreBundle\Types\UserFlagKey;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use demosplan\DemosPlanCoreBundle\ValueObject\TestUserValueObject;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\CustomerResourceInterface;
 use demosplan\DemosPlanCoreBundle\ValueObject\User\OrgaUsersPair;
@@ -150,8 +149,10 @@ class UserService implements UserServiceInterface
             $user = $this->findDistinctUserByEmailOrLogin($login);
 
             if (false === $user) {
-                $this->logger->warning('Could not find one distinct user by login or email. Maybe given email is not unique',
-                    [DemosPlanTools::varExport($login, true)]);
+                $this->logger->warning(
+                    'Could not find one distinct user by login or email. Maybe given email is not unique',
+                    ['login' => $login]
+                );
 
                 return null;
             }
@@ -814,7 +815,7 @@ class UserService implements UserServiceInterface
         try {
             $orga = $this->orgaService->getOrga($organisationId);
             if (null === $orga) {
-                $this->logger->warning('No orga found for orgaId: '.DemosPlanTools::varExport($organisationId, true));
+                $this->logger->warning('No orga found for orgaId: {orgaId}', ['orgaId' => $organisationId]);
 
                 return [];
             }

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
@@ -18,7 +18,6 @@ use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Exception\DemosException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Psr\Log\LoggerInterface;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
@@ -143,8 +142,8 @@ class ZipImportService
                 // if path contains any relative path immediately skip file
                 if (0 !== mb_substr_count($destination, '../')) {
                     $this->logger->error(
-                        'Possible Zip-slip-Attack. File not extracted. Destination:'
-                        .DemosPlanTools::varExport($destination, true)
+                        'Possible Zip-slip-Attack. File not extracted. Destination: {destination}',
+                        ['destination' => $destination]
                     );
                     continue;
                 }
@@ -153,18 +152,18 @@ class ZipImportService
                 if ('' === $filename) {
                     $filename = md5((string) random_int(0, 9999));
                     $this->logger->warning(
-                        'No valid name could be found. RandomHash: '
-                        .DemosPlanTools::varExport($filename, true)
+                        'No valid name could be found. RandomHash: {filename}',
+                        ['filename' => $filename]
                     );
                 }
 
                 $this->logger->info(
-                    'DocumentImport set Filename '
-                    .DemosPlanTools::varExport($filename, true)
-                    .' Dirname: '
-                    .DemosPlanTools::varExport($dirname, true)
-                    .' FileNameOrig: '
-                    .DemosPlanTools::varExport($filenameOrig, true)
+                    'DocumentImport set Filename {filename} Dirname: {dirname} FileNameOrig: {filenameOrig}',
+                    [
+                        'filename'     => $filename,
+                        'dirname'      => $dirname,
+                        'filenameOrig' => $filenameOrig,
+                    ]
                 );
                 $zip->renameIndex($indexInZipFile, $dirname.'/'.$filename);
                 $zip->extractTo($extractDir, $zip->getNameIndex($indexInZipFile));

--- a/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/Permissions.php
@@ -877,7 +877,7 @@ class Permissions implements PermissionsInterface, PermissionEvaluatorInterface
 
         $this->logger->debug('Permissionset scope: '.$scope);
         $hasPermissionSet = $this->getPermissionset($scope) === $permissionset;
-        $this->logger->debug('Has Permissionset: '.DemosPlanTools::varExport($hasPermissionSet, true));
+        $this->logger->debug('Has Permissionset: {hasPermissionSet}', ['hasPermissionSet' => $hasPermissionSet]);
 
         return $hasPermissionSet;
     }

--- a/demosplan/DemosPlanCoreBundle/Repository/ParagraphRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/ParagraphRepository.php
@@ -22,7 +22,6 @@ use demosplan\DemosPlanCoreBundle\Exception\ProcedureNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\StatementElementNotFoundException;
 use demosplan\DemosPlanCoreBundle\Repository\IRepository\ArrayInterface;
 use demosplan\DemosPlanCoreBundle\Repository\IRepository\ObjectInterface;
-use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\ORMException;
@@ -120,7 +119,7 @@ class ParagraphRepository extends FluentRepository implements ArrayInterface, Ob
             if (is_array($result) && array_key_exists(0, $result)) {
                 $maxOrder = $result[0]['order'];
             } else {
-                $this->getLogger()->warning('could not get max paragraph order. Result '.DemosPlanTools::varExport($result, true));
+                $this->getLogger()->warning('could not get max paragraph order', ['result' => $result]);
             }
 
             return $maxOrder;


### PR DESCRIPTION
### Ticket
Maintenance, no ticket.

First step of removing `DemosPlanTools::varExport()`. This PR covers only the mechanical
part: the 31 log calls that passed a **scalar**, where `var_export` did nothing but add
quotes around the value. Message becomes a constant string with `{placeholder}`s, the value
moves into the Monolog context array.

Monolog already covers this: `NormalizerFormatter` (base of `monolog.formatter.line`, which
`logging_formatter` resolves to in `config/parameters_default.yml`) normalizes and
JSON-encodes context with a depth cap, and `process_psr_3_messages` is enabled for all
handlers except `console`, so the placeholders are interpolated. Benefits over the old form:
no dump built when the level is filtered out, single-line records instead of `var_export`'s
multi-line output, and a stable Sentry fingerprint because the payload is no longer part of
the message.

Two changes beyond the plain swap:

- Numerically-keyed exception context (`[$e]`) and message-concatenated exceptions (`.$e`)
  become `['exception' => $e]`, which is why exceptions were previously unreadable in these
  records. Affects `StatementFragmentService`, `StatementService` and the three sites in
  `StatementToLegacyConverter`.
- `StatementDeleter` is not a log call but a `DemosException` message, so it uses `sprintf`
  rather than context.

The `DemosPlanTools` import is dropped from the 10 files that no longer reference it; it
stays in the 4 files that still have call sites left for the follow-ups below.

Deliberately **not** in this PR, because each needs a judgement call rather than a review
scan — the remaining ~80 call sites are grouped into follow-ups by theme: Elasticsearch query
dumps, PDF/RabbitMQ payload dumps, `StatementGeoService`, mail logging, the Dataport user/role
mapping, entity dumps, WMS responses, and exception messages. The helper itself is deleted at
the end of that sequence.

### How to review/test
Every hunk is the same transformation, so it should read quickly. Worth a second look:

- `UserService.php:154` — kept as `['login' => $login]`. Dropping information isn't a
  mechanical change, but this is a login/email and is a candidate for removal in the
  mail/user follow-up.
- `DraftStatementService.php:705` — `submitResult` is always `false` inside
  `if (false === $submitResult)`, so the context is dead weight. Converted faithfully rather
  than fixed here.

Verification: `php -l` clean on all 14 files. PHPStan level 5 on the changed files reports 204
errors, all pre-existing and none on a changed line. No test run: the changes are log calls
only and no test covers `DemosPlanTools`.

Unrelated finding while touching the file: `DemosPlanDocumentController.php:824` has
`md5(random_int(0, 9999))` without a `(string)` cast (PHPStan level 5 flags it); the duplicated
block in `ZipImportService.php:152` already has the cast.

### PR Checklist

- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
