### PR TITLE
refactor(refs DPLAN-15761, #AB27466): replace inline-template with slot [vue 3 migration]

### DIFF
--- a/client/js/bundles/statement/fragmentStatement.js
+++ b/client/js/bundles/statement/fragmentStatement.js
@@ -11,17 +11,23 @@
  * This is the entrypoint for fragment_statement.html.twig
  */
 
+import { DpButton, DpEditor, DpMultiselect, dpValidate, VPopover } from '@demos-europe/demosplan-ui'
 import AssessmentTableStore from '@DpJs/store/statement/AssessmentTable'
 import DeleteFragmentButton from '@DpJs/lib/statement/DeleteFragmentButton'
 import DpCreateStatementFragment from '@DpJs/components/statement/statement/DpCreateStatementFragment'
-import { dpValidate } from '@demos-europe/demosplan-ui'
+import DpSelectDocument from '@DpJs/components/statement/fragment/SelectDocument'
 import { initialize } from '@DpJs/InitVue'
 
 const stores = {
   assessmentTable: AssessmentTableStore,
 }
 const components = {
+  DpButton,
   DpCreateStatementFragment,
+  DpEditor,
+  DpMultiselect,
+  DpSelectDocument,
+  VPopover,
 }
 
 initialize(components, stores).then(() => {

--- a/client/js/components/statement/statement/DpCreateStatementFragment.vue
+++ b/client/js/components/statement/statement/DpCreateStatementFragment.vue
@@ -7,22 +7,28 @@
   All rights reserved
 </license>
 
+<template>
+  <div>
+    <slot
+      :counties="counties"
+      :department="department"
+      :fragment-text="fragmentText"
+      :municipalities="municipalities"
+      :priority-areas="priorityAreas"
+      :reset-select-menu="resetSelectMenu"
+      :set-fragment-text="setFragmentText"
+      :tags="tags"
+      :update-field="updateField"
+    />
+  </div>
+</template>
+
 <script>
-import { DpButton, DpEditor, DpMultiselect, VPopover } from '@demos-europe/demosplan-ui'
 import { mapActions, mapGetters } from 'vuex'
-import DpSelectDocument from './../fragment/SelectDocument'
 
 export default {
 
   name: 'DpCreateStatementFragment',
-
-  components: {
-    DpButton,
-    DpEditor,
-    DpMultiselect,
-    DpSelectDocument,
-    VPopover,
-  },
 
   props: {
     initTags: {
@@ -91,6 +97,10 @@ export default {
 
     setFragmentText () {
       this.fragmentText = this.statementText
+    },
+
+    updateField (field, value) {
+      this[field] = value
     },
   },
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/fragment_statement.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/fragment_statement.html.twig
@@ -52,8 +52,18 @@
                 :init-priority-areas="JSON.parse('{{ selectedPriorityAreas|default([])|json_encode|e('js', 'utf-8') }}')"
                 init-fragment-text="{{ fragment.text|default|wysiwyg }}"
                 procedure-id="{{ procedure }}"
-                statement-text="{{ templateVars.statement.text|default|escape|wysiwyg(hasPermission('feature_obscure_text') ? 'dp-obscure' : []) }}"
-                inline-template>
+                statement-text="{{ templateVars.statement.text|default|escape|wysiwyg(hasPermission('feature_obscure_text') ? 'dp-obscure' : []) }}">
+                <template #default="{
+                    counties,
+                    department,
+                    fragmentText,
+                    municipalities,
+                    priorityAreas,
+                    resetSelectMenu,
+                    setFragmentText,
+                    tags,
+                    updateField
+                }">
                 <div>
                     <p class="u-mt-0_5">{{ "text.statement.fragment"|trans|wysiwyg }}</p>
 
@@ -277,6 +287,7 @@
 
                 {% endif %}
             </div>
+            </template>
         </dp-create-statement-fragment>
     {%- endapply %}
 

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanStatement/includes/fragment_statement_form.html.twig
@@ -19,7 +19,8 @@
             mark: true,
             obscure: hasPermission('feature_obscure_text')
          }"
-        v-model="fragmentText">
+        :value="fragmentText"
+        @input="value => updateField('fragmentText', value)">
     </dp-editor>
 
     {# meta #}
@@ -53,7 +54,8 @@
                 {% endfor %}
                 <dp-multiselect
                     id="r_tags[]"
-                    v-model="tags"
+                    :value="tags"
+                    @input="value => updateField('tags', value)"
                     class="u-mt-0_25 weight--normal"
                     data-cy="fragmentTopicsTags"
                     group-label="groupName"
@@ -115,7 +117,8 @@
                     {% endfor %}
                     <dp-multiselect
                         id="r_counties[]"
-                        v-model="counties"
+                        :value="counties"
+                        @input="value => updateField('counties', value)"
                         class="u-mt-0_25 weight--normal"
                         data-cy="fragmentCounties"
                         label="name"
@@ -157,7 +160,8 @@
                     {% endfor %}
                     <dp-multiselect
                         id="r_municipalities[]"
-                        v-model="municipalities"
+                        :value="municipalities"
+                        @input="value => updateField('municipalities', value)"
                         class="u-mt-0_25 weight--normal"
                         data-cy="fragmentMunicipalities"
                         label="name"
@@ -200,7 +204,8 @@
                     {% endfor %}
                     <dp-multiselect
                         id="r_priorityAreas[]"
-                        v-model="priorityAreas"
+                        :value="priorityAreas"
+                        @input="value => updateField('priorityAreas', value)"
                         class="u-mt-0_25 weight--normal"
                         data-cy="fragmentPriorityAreas"
                         label="name"
@@ -260,7 +265,8 @@
                     {% set agencies = agencies|merge([{ id: departmentId, name: department.orga.name ~ ', ' ~ department.name }]) %}
                 {% endfor %}
                 <dp-multiselect
-                    v-model="department"
+                    :value="department"
+                    @input="value => updateField('department', value)"
                     :allow-empty="false"
                     class="inline-block"
                     label="name"


### PR DESCRIPTION
### Ticket
DPLAN-15761

Removes the inline-template in `fragment_statement.html.twig` since it's no longer supported in vue 3.

### How to review/test
- Open a project in which statements can be split into fragments
- Login as FPA, navigate to the assessment table, claim a statement and select "In Datensätze aufteilen"
- Make sure that tags, municipalities, etc. from the statement are applied to the multiselects, test that the multiselects still work properly
- Create a fragment and check that all the data is correctly saved


### PR Checklist

- [x] Run `yarn lint`
- [x] Link all relevant tickets
