### PR TITLE
feat: audit file storage consistency during nightly maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Requires `demos-europe/demosplan-addon` ^0.79, and every release from this one on does. The saved filter combinations of the assessment table were renamed `UserFilterSet` → `Bookmark`: entity, database table, repository, service and resource type, and in the contract layer `BookmarkInterface`, `BookmarkPath`, `Paths::bookmark()` and `BaseBookmarkResourceConfigBuilder`. Addons referring to any of the old names have to be updated. The table is renamed by an included migration, so no manual step is needed.
 ### Added
 - Statements can now be imported from a CSV file, in addition to the existing Excel import. The import runs as a background job; files with more than 3,000 rows, a duplicate Eingangsnummer, or an oversized statement text are rejected with a clear error instead of importing only part of the file. (DPLAN-18247)
+- The nightly maintenance now checks the stored files against the file entries in the database and writes the result to the log: entries whose file is missing from the storage, stored files no entry refers to, files kept at an unexpected path, and files that survived their deletion. The check only reads; `dplan:file:audit-consistency` runs it on demand.
 
 ### Fixed
 - Downloading the result of a background export works for large archives. The file is sent to the browser piece by piece instead of being held in memory as a whole, which could abort the download.

--- a/demosplan/DemosPlanCoreBundle/Command/FileConsistencyAuditCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/FileConsistencyAuditCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Command;
+
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyAuditor;
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyReport;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * Runs the audit that {@link AuditFileConsistencyMessageHandler} performs nightly, on demand.
+ *
+ * Reads only; use `--samples` to list the findings the log entry samples.
+ */
+#[AsCommand(
+    name: 'dplan:file:audit-consistency',
+    description: 'Report files that exist in the database but not in the storage, and vice versa.'
+)]
+class FileConsistencyAuditCommand extends CoreCommand
+{
+    public function __construct(
+        ParameterBagInterface $parameterBag,
+        private readonly FileConsistencyAuditor $fileConsistencyAuditor,
+        ?string $name = null,
+    ) {
+        parent::__construct($parameterBag, $name);
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('samples', null, InputOption::VALUE_NONE, 'List the sampled findings, not only the counts');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('File consistency audit');
+
+        $report = $this->fileConsistencyAuditor->audit();
+
+        $io->table(
+            ['Check', 'Count'],
+            [
+                ['Database rows', $report->databaseRowCount],
+                ['Soft deleted rows', $report->softDeletedRowCount],
+                ['Storage objects', $report->storageObjectCount],
+                ['Missing in storage', $report->missingInStorageCount],
+                ['Orphaned in storage', $report->orphanedInStorageCount],
+                ['Stored at unexpected path', $report->misplacedCount],
+                ['Soft deleted but still stored', $report->softDeletedStillInStorageCount],
+                ['Rows without hash', $report->rowsWithoutHashCount],
+            ]
+        );
+
+        if ($input->getOption('samples')) {
+            $this->writeSamples($io, $report);
+        }
+
+        if ($report->inventoryTruncated) {
+            $io->warning('The storage listing hit its limit; the findings above are incomplete.');
+        }
+
+        if ($report->hasFindings()) {
+            $io->warning(sprintf('Audit finished in %.1fs with findings.', $report->durationSeconds));
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Audit finished in %.1fs, database and storage agree.', $report->durationSeconds));
+
+        return Command::SUCCESS;
+    }
+
+    private function writeSamples(SymfonyStyle $io, FileConsistencyReport $report): void
+    {
+        $sampleSets = [
+            'Missing in storage'            => $report->missingInStorageSamples,
+            'Orphaned in storage'           => $report->orphanedInStorageSamples,
+            'Stored at unexpected path'     => $report->misplacedSamples,
+            'Soft deleted but still stored' => $report->softDeletedStillInStorageSamples,
+            'Rows without hash'             => $report->rowsWithoutHashSamples,
+        ];
+
+        foreach ($sampleSets as $title => $samples) {
+            if ([] === $samples) {
+                continue;
+            }
+            $io->section($title);
+            $io->table(array_keys($samples[0]), array_map('array_values', $samples));
+        }
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/File/AuditFindings.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/File/AuditFindings.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\File;
+
+/**
+ * Counts findings of one kind while keeping at most a fixed number of examples.
+ */
+class AuditFindings
+{
+    private int $count = 0;
+
+    /** @var list<array<string, string>> */
+    private array $samples = [];
+
+    public function __construct(private readonly int $sampleLimit)
+    {
+    }
+
+    /**
+     * @param array<string, string> $finding
+     */
+    public function add(array $finding): void
+    {
+        ++$this->count;
+        if (count($this->samples) < $this->sampleLimit) {
+            $this->samples[] = $finding;
+        }
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    public function getSamples(): array
+    {
+        return $this->samples;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyAuditor.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyAuditor.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\File;
+
+use demosplan\DemosPlanCoreBundle\Repository\FileRepository;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\StorageAttributes;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Compares the `_files` table against the objects in the default storage.
+ *
+ * Files are referenced from other entities by filestring only, so a reference can outlive both the
+ * row and the object. The audit answers the two questions that follow from that: which rows point
+ * at an object that is not there, and which objects are not claimed by any row.
+ *
+ * A row is matched by its hash, not by its full path: the same physical object is shared between
+ * rows when a file is copied into another procedure, and legacy rows store an absolute path from
+ * the time before flysystem. A row whose hash is found somewhere else than where the row says is
+ * therefore reported as misplaced rather than as missing.
+ *
+ * The audit only reads.
+ */
+class FileConsistencyAuditor
+{
+    /**
+     * Findings are counted in full but only this many of each kind end up in the report, so that a
+     * badly broken instance still produces a log entry that can be written and read.
+     */
+    private const SAMPLE_LIMIT = 50;
+
+    /**
+     * The storage inventory is held in memory to diff it against the database in a single pass.
+     * Beyond this many objects the audit gives up instead of running the maintenance worker out of
+     * memory, which would take the rest of the nightly tasks down with it.
+     */
+    private const MAX_TRACKED_OBJECTS = 3_000_000;
+
+    public function __construct(
+        private readonly FilesystemOperator $defaultStorage,
+        private readonly FileRepository $fileRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    public function audit(): FileConsistencyReport
+    {
+        $startedAt = microtime(true);
+
+        [$objectPathsByHash, $storageObjectCount, $truncated] = $this->buildStorageInventory();
+
+        $databaseRowCount = 0;
+        $softDeletedRowCount = 0;
+        /** @var array<string, true> $claimedHashes */
+        $claimedHashes = [];
+        $missingInStorage = new AuditFindings(self::SAMPLE_LIMIT);
+        $misplaced = new AuditFindings(self::SAMPLE_LIMIT);
+        $softDeletedStillInStorage = new AuditFindings(self::SAMPLE_LIMIT);
+        $rowsWithoutHash = new AuditFindings(self::SAMPLE_LIMIT);
+
+        foreach ($this->fileRepository->getFileLocationRows() as $row) {
+            ++$databaseRowCount;
+            $hash = $row['hash'];
+
+            if (null === $hash || '' === $hash) {
+                $rowsWithoutHash->add(['ident' => $row['ident']]);
+                continue;
+            }
+
+            if ($row['deleted']) {
+                ++$softDeletedRowCount;
+            }
+
+            $foundAt = $objectPathsByHash[$hash] ?? null;
+            // Claim the hash even when the object is gone. Several rows may share one object, and
+            // the orphan pass must not report an object that a row - misplaced or not - refers to.
+            $claimedHashes[$hash] = true;
+
+            if (null === $foundAt) {
+                if (!$row['deleted']) {
+                    $missingInStorage->add([
+                        'ident'        => $row['ident'],
+                        'hash'         => $hash,
+                        'expectedPath' => $this->getExpectedPath($row['path'], $hash),
+                    ]);
+                }
+                continue;
+            }
+
+            if ($row['deleted']) {
+                // Soft deleted rows are removed by CleanupFilesMessageHandler; an object that
+                // survives several audits points at a delete that keeps failing.
+                $softDeletedStillInStorage->add(['ident' => $row['ident'], 'path' => $foundAt[0]]);
+                continue;
+            }
+
+            $expectedPath = $this->getExpectedPath($row['path'], $hash);
+            if (!$this->isStoredWhereExpected($expectedPath, $foundAt)) {
+                $misplaced->add([
+                    'ident'        => $row['ident'],
+                    'expectedPath' => $expectedPath,
+                    'foundAt'      => $foundAt[0],
+                ]);
+            }
+        }
+
+        $orphaned = new AuditFindings(self::SAMPLE_LIMIT);
+        foreach ($objectPathsByHash as $hash => $paths) {
+            if (isset($claimedHashes[$hash])) {
+                continue;
+            }
+            foreach ($paths as $path) {
+                $orphaned->add(['path' => $path]);
+            }
+        }
+
+        return new FileConsistencyReport(
+            $databaseRowCount,
+            $softDeletedRowCount,
+            $storageObjectCount,
+            $missingInStorage->getCount(),
+            $missingInStorage->getSamples(),
+            $orphaned->getCount(),
+            $orphaned->getSamples(),
+            $misplaced->getCount(),
+            $misplaced->getSamples(),
+            $softDeletedStillInStorage->getCount(),
+            $softDeletedStillInStorage->getSamples(),
+            $rowsWithoutHash->getCount(),
+            $rowsWithoutHash->getSamples(),
+            microtime(true) - $startedAt,
+            $truncated,
+        );
+    }
+
+    /**
+     * Indexes the storage by filename, which is the hash a `_files` row stores.
+     *
+     * @return array{0: array<string, list<string>>, 1: int, 2: bool}
+     *
+     * @throws FilesystemException
+     */
+    private function buildStorageInventory(): array
+    {
+        $objectPathsByHash = [];
+        $objectCount = 0;
+        $truncated = false;
+
+        /** @var StorageAttributes $attributes */
+        foreach ($this->defaultStorage->listContents('/', true) as $attributes) {
+            if (!$attributes->isFile()) {
+                continue;
+            }
+
+            if (self::MAX_TRACKED_OBJECTS <= $objectCount) {
+                $this->logger->error(
+                    'File consistency audit aborted the storage listing',
+                    ['limit' => self::MAX_TRACKED_OBJECTS]
+                );
+                $truncated = true;
+                break;
+            }
+
+            $path = $this->normalizePath($attributes->path());
+            $objectPathsByHash[basename($path)][] = $path;
+            ++$objectCount;
+        }
+
+        return [$objectPathsByHash, $objectCount, $truncated];
+    }
+
+    /**
+     * The path a row claims its object lives under.
+     */
+    private function getExpectedPath(?string $path, string $hash): string
+    {
+        $path = $this->normalizePath($path ?? '');
+
+        return '' === $path ? $hash : $path.'/'.$hash;
+    }
+
+    /**
+     * Whether one of the places the object was found is the place the row means.
+     *
+     * Paths are compared by suffix, not for equality, because the two sides carry different roots.
+     * Most rows predate flysystem and store an absolute path from the machine they were uploaded
+     * on ('/srv/www/<instance>/files/2021/10'), while the storage knows that same object as
+     * '2021/10/<hash>'; a bucket prefix produces the mirrored case. Matching the shared tail keeps
+     * those rows out of the findings without having to know either root.
+     *
+     * @param list<string> $foundAt
+     */
+    private function isStoredWhereExpected(string $expectedPath, array $foundAt): bool
+    {
+        foreach ($foundAt as $actualPath) {
+            if ($expectedPath === $actualPath
+                || str_ends_with($expectedPath, '/'.$actualPath)
+                || str_ends_with($actualPath, '/'.$expectedPath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+        // Legacy rows store paths relative to the instance directory, e.g. './files/2019/07'.
+        $path = preg_replace('#^\./#', '', $path) ?? $path;
+
+        return trim($path, '/');
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyAuditor.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyAuditor.php
@@ -81,34 +81,32 @@ class FileConsistencyAuditor
                 continue;
             }
 
-            if ($row['deleted']) {
-                ++$softDeletedRowCount;
-            }
-
-            $foundAt = $objectPathsByHash[$hash] ?? null;
             // Claim the hash even when the object is gone. Several rows may share one object, and
             // the orphan pass must not report an object that a row - misplaced or not - refers to.
             $claimedHashes[$hash] = true;
+            $foundAt = $objectPathsByHash[$hash] ?? [];
 
-            if (null === $foundAt) {
-                if (!$row['deleted']) {
-                    $missingInStorage->add([
-                        'ident'        => $row['ident'],
-                        'hash'         => $hash,
-                        'expectedPath' => $this->getExpectedPath($row['path'], $hash),
-                    ]);
+            if ($row['deleted']) {
+                ++$softDeletedRowCount;
+                if ([] !== $foundAt) {
+                    // Soft deleted rows are removed by CleanupFilesMessageHandler; an object that
+                    // survives several audits points at a delete that keeps failing.
+                    $softDeletedStillInStorage->add(['ident' => $row['ident'], 'path' => $foundAt[0]]);
                 }
                 continue;
             }
 
-            if ($row['deleted']) {
-                // Soft deleted rows are removed by CleanupFilesMessageHandler; an object that
-                // survives several audits points at a delete that keeps failing.
-                $softDeletedStillInStorage->add(['ident' => $row['ident'], 'path' => $foundAt[0]]);
+            $expectedPath = $this->getExpectedPath($row['path'], $hash);
+
+            if ([] === $foundAt) {
+                $missingInStorage->add([
+                    'ident'        => $row['ident'],
+                    'hash'         => $hash,
+                    'expectedPath' => $expectedPath,
+                ]);
                 continue;
             }
 
-            $expectedPath = $this->getExpectedPath($row['path'], $hash);
             if (!$this->isStoredWhereExpected($expectedPath, $foundAt)) {
                 $misplaced->add([
                     'ident'        => $row['ident'],
@@ -118,15 +116,7 @@ class FileConsistencyAuditor
             }
         }
 
-        $orphaned = new AuditFindings(self::SAMPLE_LIMIT);
-        foreach ($objectPathsByHash as $hash => $paths) {
-            if (isset($claimedHashes[$hash])) {
-                continue;
-            }
-            foreach ($paths as $path) {
-                $orphaned->add(['path' => $path]);
-            }
-        }
+        $orphaned = $this->collectOrphanedObjects($objectPathsByHash, $claimedHashes);
 
         return new FileConsistencyReport(
             $databaseRowCount,
@@ -145,6 +135,29 @@ class FileConsistencyAuditor
             microtime(true) - $startedAt,
             $truncated,
         );
+    }
+
+    /**
+     * Objects whose filename no row claims - unreachable from the application, still stored.
+     *
+     * @param array<string, list<string>> $objectPathsByHash
+     * @param array<string, true>         $claimedHashes
+     */
+    private function collectOrphanedObjects(array $objectPathsByHash, array $claimedHashes): AuditFindings
+    {
+        $orphaned = new AuditFindings(self::SAMPLE_LIMIT);
+
+        foreach ($objectPathsByHash as $hash => $paths) {
+            if (isset($claimedHashes[$hash])) {
+                continue;
+            }
+
+            foreach ($paths as $path) {
+                $orphaned->add(['path' => $path]);
+            }
+        }
+
+        return $orphaned;
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyReport.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/File/FileConsistencyReport.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\File;
+
+/**
+ * Result of a {@link FileConsistencyAuditor} run.
+ *
+ * Counts are complete, sample lists are capped: a broken instance can produce hundreds of
+ * thousands of findings, and a log entry has to stay readable and writable.
+ */
+final readonly class FileConsistencyReport
+{
+    /**
+     * @param list<array{ident: string, hash: string, expectedPath: string}>    $missingInStorageSamples
+     * @param list<array{path: string}>                                         $orphanedInStorageSamples
+     * @param list<array{ident: string, expectedPath: string, foundAt: string}> $misplacedSamples
+     * @param list<array{ident: string, path: string}>                          $softDeletedStillInStorageSamples
+     * @param list<array{ident: string}>                                        $rowsWithoutHashSamples
+     */
+    public function __construct(
+        public int $databaseRowCount,
+        public int $softDeletedRowCount,
+        public int $storageObjectCount,
+        public int $missingInStorageCount,
+        public array $missingInStorageSamples,
+        public int $orphanedInStorageCount,
+        public array $orphanedInStorageSamples,
+        public int $misplacedCount,
+        public array $misplacedSamples,
+        public int $softDeletedStillInStorageCount,
+        public array $softDeletedStillInStorageSamples,
+        public int $rowsWithoutHashCount,
+        public array $rowsWithoutHashSamples,
+        public float $durationSeconds,
+        public bool $inventoryTruncated,
+    ) {
+    }
+
+    public function hasFindings(): bool
+    {
+        return 0 < $this->missingInStorageCount
+            || 0 < $this->orphanedInStorageCount
+            || 0 < $this->misplacedCount
+            || 0 < $this->softDeletedStillInStorageCount
+            || 0 < $this->rowsWithoutHashCount;
+    }
+
+    /**
+     * Counts first, samples last.
+     *
+     * A log entry can be cut off by whatever writes or ships it, and the counts are what the entry
+     * exists for; the samples are a starting point for digging and can afford to be the part that
+     * is lost.
+     *
+     * @return array<string, mixed>
+     */
+    public function toLogContext(): array
+    {
+        return [
+            'databaseRows'                     => $this->databaseRowCount,
+            'softDeletedRows'                  => $this->softDeletedRowCount,
+            'storageObjects'                   => $this->storageObjectCount,
+            'missingInStorage'                 => $this->missingInStorageCount,
+            'orphanedInStorage'                => $this->orphanedInStorageCount,
+            'misplaced'                        => $this->misplacedCount,
+            'softDeletedStillInStorage'        => $this->softDeletedStillInStorageCount,
+            'rowsWithoutHash'                  => $this->rowsWithoutHashCount,
+            'durationSeconds'                  => round($this->durationSeconds, 2),
+            'inventoryTruncated'               => $this->inventoryTruncated,
+            'missingInStorageSamples'          => $this->missingInStorageSamples,
+            'orphanedInStorageSamples'         => $this->orphanedInStorageSamples,
+            'misplacedSamples'                 => $this->misplacedSamples,
+            'softDeletedStillInStorageSamples' => $this->softDeletedStillInStorageSamples,
+            'rowsWithoutHashSamples'           => $this->rowsWithoutHashSamples,
+        ];
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Message/AuditFileConsistencyMessage.php
+++ b/demosplan/DemosPlanCoreBundle/Message/AuditFileConsistencyMessage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Message;
+
+final class AuditFileConsistencyMessage
+{
+}

--- a/demosplan/DemosPlanCoreBundle/MessageHandler/AuditFileConsistencyMessageHandler.php
+++ b/demosplan/DemosPlanCoreBundle/MessageHandler/AuditFileConsistencyMessageHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\MessageHandler;
+
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyAuditor;
+use demosplan\DemosPlanCoreBundle\Message\AuditFileConsistencyMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Throwable;
+
+/**
+ * Writes one log entry per night stating whether database and storage still agree.
+ *
+ * Scheduled ahead of {@link CleanupFilesMessageHandler} so the entry describes the state the day
+ * left behind, before the cleanup deletes orphaned objects and soft deleted rows.
+ */
+#[AsMessageHandler]
+final class AuditFileConsistencyMessageHandler
+{
+    public function __construct(
+        private readonly FileConsistencyAuditor $fileConsistencyAuditor,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(AuditFileConsistencyMessage $message): void
+    {
+        try {
+            $report = $this->fileConsistencyAuditor->audit();
+        } catch (Throwable $e) {
+            $this->logger->error('Daily maintenance task failed for: file consistency audit.', [$e]);
+
+            return;
+        }
+
+        if ($report->hasFindings()) {
+            $this->logger->warning('File consistency audit found inconsistencies', $report->toLogContext());
+
+            return;
+        }
+
+        $this->logger->info('File consistency audit found no inconsistencies', $report->toLogContext());
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileRepository.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Exception\NotYetImplementedException;
 use demosplan\DemosPlanCoreBundle\Repository\IRepository\ArrayInterface;
 use demosplan\DemosPlanCoreBundle\Repository\IRepository\ObjectInterface;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
@@ -61,6 +62,32 @@ class FileRepository extends FluentRepository implements ArrayInterface, ObjectI
         }
 
         return reset($fileInfos);
+    }
+
+    /**
+     * Streams the columns the storage consistency audit needs, for every row including soft deleted ones.
+     *
+     * Entities are deliberately not hydrated: the audit walks the complete table, and four scalar
+     * columns per row keep that affordable.
+     *
+     * @return iterable<array{ident: string, hash: string|null, path: string|null, deleted: bool}>
+     *
+     * @throws DBALException
+     */
+    public function getFileLocationRows(): iterable
+    {
+        $result = $this->getEntityManager()->getConnection()->executeQuery(
+            'SELECT _f_ident AS ident, _f_hash AS hash, _f_path AS path, _f_deleted AS deleted FROM _files'
+        );
+
+        while (false !== ($row = $result->fetchAssociative())) {
+            yield [
+                'ident'   => (string) $row['ident'],
+                'hash'    => null === $row['hash'] ? null : (string) $row['hash'],
+                'path'    => null === $row['path'] ? null : (string) $row['path'],
+                'deleted' => (bool) $row['deleted'],
+            ];
+        }
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/Scheduler/DailyMaintenanceScheduler.php
+++ b/demosplan/DemosPlanCoreBundle/Scheduler/DailyMaintenanceScheduler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace demosplan\DemosPlanCoreBundle\Scheduler;
 
 use demosplan\DemosPlanCoreBundle\Message\AccountDeletionRunMessage;
+use demosplan\DemosPlanCoreBundle\Message\AuditFileConsistencyMessage;
 use demosplan\DemosPlanCoreBundle\Message\AutoSwitchProcedurePhasesMessage;
 use demosplan\DemosPlanCoreBundle\Message\CleanupFilesMessage;
 use demosplan\DemosPlanCoreBundle\Message\CreateUnsubmittedDraftEmailsMessage;
@@ -45,6 +46,7 @@ use Symfony\Component\Scheduler\ScheduleProviderInterface;
  * @see SendSegmentDeadlineReminderEmailsMessageHandler
  * @see DeleteOrphanEmailAddressesMessageHandler
  * @see PurgeSentEmailsMessageHandler
+ * @see AuditFileConsistencyMessageHandler
  * @see CleanupFilesMessageHandler
  */
 #[AsSchedule('daily_maintenance')]
@@ -67,6 +69,9 @@ class DailyMaintenanceScheduler implements ScheduleProviderInterface
             ->add(RecurringMessage::cron('25 0 * * *', new SendAssignedTaskNotificationEmailsMessage()))
             ->add(RecurringMessage::cron('30 0 * * *', new DeleteOrphanEmailAddressesMessage()))
             ->add(RecurringMessage::cron('35 0 * * *', new PurgeSentEmailsMessage()))
+            // Runs before the cleanup so the audit reports the state the day left behind,
+            // instead of the state the cleanup just produced.
+            ->add(RecurringMessage::cron('38 0 * * *', new AuditFileConsistencyMessage()))
             ->add(RecurringMessage::cron('40 0 * * *', new CleanupFilesMessage()))
             ->add(RecurringMessage::cron('45 0 * * *', new LoginAuditCleanupMessage()))
             ->add(RecurringMessage::cron('50 0 * * *', new AccountDeletionRunMessage()))

--- a/tests/backend/core/Core/Unit/File/Unit/FileConsistencyAuditorTest.php
+++ b/tests/backend/core/Core/Unit/File/Unit/FileConsistencyAuditorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Unit\File\Unit;
+
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyAuditor;
+use demosplan\DemosPlanCoreBundle\Repository\FileRepository;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Drives {@link FileConsistencyAuditor} against an in-memory storage and a stubbed row stream, so
+ * the classification of each finding is asserted without touching S3 or the database.
+ */
+class FileConsistencyAuditorTest extends TestCase
+{
+    private ?FilesystemOperator $storage = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storage = new Filesystem(new InMemoryFilesystemAdapter());
+    }
+
+    public function testReportsNoFindingsWhenStorageMatchesDatabase(): void
+    {
+        $this->storage->write('2026/07/hash-a', 'content');
+        $this->storage->write('2026/08/hash-b', 'content');
+
+        $report = $this->createAuditor([
+            $this->row('ident-a', 'hash-a', '2026/07'),
+            $this->row('ident-b', 'hash-b', '2026/08'),
+        ])->audit();
+
+        self::assertFalse($report->hasFindings());
+        self::assertSame(2, $report->databaseRowCount);
+        self::assertSame(2, $report->storageObjectCount);
+    }
+
+    public function testReportsRowWithoutStorageObject(): void
+    {
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2026/07')])->audit();
+
+        self::assertSame(1, $report->missingInStorageCount);
+        self::assertSame(
+            [['ident' => 'ident-a', 'hash' => 'hash-a', 'expectedPath' => '2026/07/hash-a']],
+            $report->missingInStorageSamples
+        );
+    }
+
+    public function testReportsStorageObjectWithoutRow(): void
+    {
+        $this->storage->write('2026/07/hash-a', 'content');
+        $this->storage->write('2026/07/orphan', 'content');
+
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2026/07')])->audit();
+
+        self::assertSame(0, $report->missingInStorageCount);
+        self::assertSame(1, $report->orphanedInStorageCount);
+        self::assertSame([['path' => '2026/07/orphan']], $report->orphanedInStorageSamples);
+    }
+
+    public function testReportsObjectStoredAtUnexpectedPath(): void
+    {
+        $this->storage->write('2019/01/hash-a', 'content');
+
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2026/07')])->audit();
+
+        self::assertSame(0, $report->missingInStorageCount);
+        self::assertSame(0, $report->orphanedInStorageCount);
+        self::assertSame(
+            [['ident' => 'ident-a', 'expectedPath' => '2026/07/hash-a', 'foundAt' => '2019/01/hash-a']],
+            $report->misplacedSamples
+        );
+    }
+
+    /**
+     * Rows written before flysystem store an absolute path from the machine the upload happened on.
+     * The storage root is not part of that path, so the shared tail decides.
+     */
+    public function testAcceptsLegacyAbsolutePathOfAnyRoot(): void
+    {
+        $this->storage->write('2019/01/hash-a', 'content');
+
+        $report = $this->createAuditor([
+            $this->row('ident-a', 'hash-a', '/srv/www/demos/some.instance.de/files/2019/01'),
+        ])->audit();
+
+        self::assertFalse($report->hasFindings());
+    }
+
+    /**
+     * The mirrored case: the storage prepends a bucket prefix the row never knew about.
+     */
+    public function testAcceptsStoragePrefixMissingFromTheRow(): void
+    {
+        $this->storage->write('bucket-prefix/2019/01/hash-a', 'content');
+
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2019/01')])->audit();
+
+        self::assertFalse($report->hasFindings());
+    }
+
+    public function testAcceptsObjectInStorageRootForRowWithoutPath(): void
+    {
+        $this->storage->write('hash-a', 'content');
+
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '')])->audit();
+
+        self::assertFalse($report->hasFindings());
+    }
+
+    /**
+     * Copying a file into another procedure creates a second row for the same object.
+     */
+    public function testSharedHashIsClaimedByEveryRow(): void
+    {
+        $this->storage->write('2026/07/hash-a', 'content');
+
+        $report = $this->createAuditor([
+            $this->row('ident-a', 'hash-a', '2026/07'),
+            $this->row('ident-b', 'hash-a', '2026/07'),
+        ])->audit();
+
+        self::assertFalse($report->hasFindings());
+        self::assertSame(2, $report->databaseRowCount);
+    }
+
+    public function testSoftDeletedRowKeepsItsObjectOutOfTheOrphanCount(): void
+    {
+        $this->storage->write('2026/07/hash-a', 'content');
+
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2026/07', true)])->audit();
+
+        self::assertSame(0, $report->orphanedInStorageCount);
+        self::assertSame(0, $report->missingInStorageCount);
+        self::assertSame(1, $report->softDeletedRowCount);
+        self::assertSame(1, $report->softDeletedStillInStorageCount);
+    }
+
+    public function testSoftDeletedRowWithoutObjectIsNotAFinding(): void
+    {
+        $report = $this->createAuditor([$this->row('ident-a', 'hash-a', '2026/07', true)])->audit();
+
+        self::assertFalse($report->hasFindings());
+    }
+
+    public function testReportsRowWithoutHash(): void
+    {
+        $report = $this->createAuditor([$this->row('ident-a', null, '2026/07')])->audit();
+
+        self::assertSame(1, $report->rowsWithoutHashCount);
+        self::assertSame([['ident' => 'ident-a']], $report->rowsWithoutHashSamples);
+    }
+
+    /**
+     * @return array{ident: string, hash: string|null, path: string|null, deleted: bool}
+     */
+    private function row(string $ident, ?string $hash, ?string $path, bool $deleted = false): array
+    {
+        return ['ident' => $ident, 'hash' => $hash, 'path' => $path, 'deleted' => $deleted];
+    }
+
+    /**
+     * @param list<array{ident: string, hash: string|null, path: string|null, deleted: bool}> $rows
+     */
+    private function createAuditor(array $rows): FileConsistencyAuditor
+    {
+        $fileRepository = $this->createMock(FileRepository::class);
+        $fileRepository->method('getFileLocationRows')->willReturn($rows);
+
+        return new FileConsistencyAuditor($this->storage, $fileRepository, new NullLogger());
+    }
+}

--- a/tests/backend/core/MessageHandler/AuditFileConsistencyMessageHandlerTest.php
+++ b/tests/backend/core/MessageHandler/AuditFileConsistencyMessageHandlerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\MessageHandler;
+
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyAuditor;
+use demosplan\DemosPlanCoreBundle\Logic\File\FileConsistencyReport;
+use demosplan\DemosPlanCoreBundle\Message\AuditFileConsistencyMessage;
+use demosplan\DemosPlanCoreBundle\MessageHandler\AuditFileConsistencyMessageHandler;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class AuditFileConsistencyMessageHandlerTest extends TestCase
+{
+    private ?FileConsistencyAuditor $auditor = null;
+    private ?LoggerInterface $logger = null;
+    private ?AuditFileConsistencyMessageHandler $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auditor = $this->createMock(FileConsistencyAuditor::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->sut = new AuditFileConsistencyMessageHandler($this->auditor, $this->logger);
+    }
+
+    public function testLogsInfoEntryWhenStorageAndDatabaseAgree(): void
+    {
+        $this->auditor->method('audit')->willReturn($this->createReport(0));
+
+        $this->logger->expects(self::once())->method('info')
+            ->with('File consistency audit found no inconsistencies', self::isType('array'));
+        $this->logger->expects(self::never())->method('warning');
+
+        ($this->sut)(new AuditFileConsistencyMessage());
+    }
+
+    public function testLogsWarningEntryWithCountsWhenFilesAreMissing(): void
+    {
+        $this->auditor->method('audit')->willReturn($this->createReport(3));
+
+        $this->logger->expects(self::once())->method('warning')
+            ->with(
+                'File consistency audit found inconsistencies',
+                self::callback(static fn (array $context): bool => 3 === $context['missingInStorage'])
+            );
+
+        ($this->sut)(new AuditFileConsistencyMessage());
+    }
+
+    /**
+     * A log entry can be cut off by whatever writes or ships it, so every count has to appear
+     * before the first sample list.
+     */
+    public function testLogContextListsAllCountsBeforeAnySamples(): void
+    {
+        $this->auditor->method('audit')->willReturn($this->createReport(3));
+
+        $this->logger->expects(self::once())->method('warning')
+            ->with(self::anything(), self::callback(static function (array $context): bool {
+                $keys = array_keys($context);
+                $firstSample = min(array_map(
+                    static fn (string $key): int => array_search($key, $keys, true),
+                    array_filter($keys, static fn (string $key): bool => str_ends_with($key, 'Samples'))
+                ));
+                $counts = array_filter($keys, static fn (string $key): bool => !str_ends_with($key, 'Samples'));
+
+                return max(array_map(
+                    static fn (string $key): int => array_search($key, $keys, true),
+                    $counts
+                )) < $firstSample;
+            }));
+
+        ($this->sut)(new AuditFileConsistencyMessage());
+    }
+
+    /**
+     * A failing audit must not take the remaining nightly maintenance tasks down with it.
+     */
+    public function testLogsErrorWhenAuditFails(): void
+    {
+        $this->auditor->method('audit')->willThrowException(new Exception('storage unreachable'));
+
+        $this->logger->expects(self::once())->method('error');
+
+        ($this->sut)(new AuditFileConsistencyMessage());
+    }
+
+    private function createReport(int $missingInStorageCount): FileConsistencyReport
+    {
+        return new FileConsistencyReport(
+            10,
+            0,
+            10,
+            $missingInStorageCount,
+            [],
+            0,
+            [],
+            0,
+            [],
+            0,
+            [],
+            0,
+            [],
+            1.5,
+            false
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only audit that runs nightly at 00:38 — deliberately just before the existing file cleanup, so it reports the state the day left behind rather than the state the cleanup just produced. It writes one structured log entry: how many rows point at an object that is not in the storage, how many objects no row claims, plus rows whose object sits at an unexpected path, soft deleted rows whose object survived, and rows without a hash. Counts come first in the log context and samples last, so an entry that gets cut off still carries the verdict.

Rows are matched by hash rather than by full path: one object is shared by several rows once a file is copied into another procedure, and most rows predate flysystem and store an absolute path from the machine the upload happened on. Paths are therefore compared on their shared tail, which keeps those rows out of the findings without needing to know either root.

`dplan:file:audit-consistency` runs the same audit on demand.

### How to review/test

- on demand: `docker compose exec -T development bin/<project> dplan:file:audit-consistency --samples`
- through the bus, as it runs nightly: `docker compose exec -T development bin/<project> dplan:scheduler:trigger audit-file-consistency` — the entry lands in `var/log/<env>/<project>/dplan.log`
- `docker compose exec development su -l $USER -s /usr/bin/zsh -c 'cd /srv/www && ./vendor/bin/phpunit tests/backend/core/Core/Unit/File/Unit/FileConsistencyAuditorTest.php tests/backend/core/MessageHandler/AuditFileConsistencyMessageHandlerTest.php'`

### PR Checklist

- [x] Create/Update tests
- [x] Update changelog
