### PR TITLE
fix: make fragment list load again

### DIFF
--- a/client/js/components/statement/fragmentList/DpFragmentList.vue
+++ b/client/js/components/statement/fragmentList/DpFragmentList.vue
@@ -109,7 +109,7 @@ export default {
 
     /*
      * We have to do such weird stuff because the data-structure is not the same as in the a-table.
-     * we can wait for the JSON-API-Magic or think about refactoring the fragment-store, that we don't have the statement-Layer in between
+     * We can wait for the JSON-API-Magic or think about refactoring the fragment-store, that we don't have the statement-Layer in between
      */
     while (i--) {
       this.$store.commit('Fragment/addFragment', {

--- a/client/js/components/statement/fragmentList/DpFragmentList.vue
+++ b/client/js/components/statement/fragmentList/DpFragmentList.vue
@@ -108,11 +108,11 @@ export default {
     let i = fragments ? fragments.length : 0
 
     /*
-     * We have to do such weird stuff because the data-structure is not the same as n the a-table.
-     * we can what for the JSON-API-Magic or think about refactoring the fragment-store, that we don't have the statement-Layer in between
+     * We have to do such weird stuff because the data-structure is not the same as in the a-table.
+     * we can wait for the JSON-API-Magic or think about refactoring the fragment-store, that we don't have the statement-Layer in between
      */
     while (i--) {
-      this.$store.commit('fragment/addFragment', {
+      this.$store.commit('Fragment/addFragment', {
         statementId: this.fragments[i].statement.id,
         fragment: this.fragments[i],
       })

--- a/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
@@ -158,7 +158,11 @@ class FragmentElasticsearchRepository extends CoreRepository
     private function findQueryDepartmentId(QueryFragment $esQuery): ?string
     {
         foreach ($esQuery->getFiltersMust() as $filter) {
-            if (in_array($filter->getField(), ['departmentId', 'versions.modifiedByDepartmentId'], true)) {
+            // Must filters on these fields may also carry an array (a multi-value filter, or the
+            // [''] of a FilterMissing), which cannot scope the nested sort to a single department
+            if (in_array($filter->getField(), ['departmentId', 'versions.modifiedByDepartmentId'], true)
+                && is_string($filter->getValue())
+            ) {
                 return $filter->getValue();
             }
         }

--- a/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
@@ -14,6 +14,7 @@ use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use demosplan\DemosPlanCoreBundle\Logic\Document\ElementsService;
 use demosplan\DemosPlanCoreBundle\Logic\Document\ParagraphService;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\QueryFragment;
+use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\SortField;
 use demosplan\DemosPlanCoreBundle\Traits\DI\ElasticsearchQueryTrait;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
 use Doctrine\Persistence\ManagerRegistry;
@@ -127,37 +128,8 @@ class FragmentElasticsearchRepository extends CoreRepository
 
             // Sorting
             // default
-            $esSortFields = [];
-
-            // A fragment's versions can belong to different departments; scope the nested sort to the
-            // department already being queried so we don't sort by another department's edit timestamp
-            $departmentId = null;
-            foreach ($esQuery->getFiltersMust() as $filter) {
-                if (in_array($filter->getField(), ['departmentId', 'versions.modifiedByDepartmentId'], true)) {
-                    $departmentId = $filter->getValue();
-                    break;
-                }
-            }
-
             $esQuery->setSort($esQuery->getAvailableSorts());
-            foreach ($esQuery->getSort() as $esQuerySort) {
-                foreach ($esQuerySort->getFields() as $sortField) {
-                    // Sorting on a field inside the nested 'versions' mapping requires an explicit nested context
-                    if (str_starts_with($sortField->getName(), 'versions.')) {
-                        $nested = ['path' => 'versions'];
-                        if (null !== $departmentId) {
-                            $nested['filter'] = ['term' => ['versions.modifiedByDepartmentId' => $departmentId]];
-                        }
-                        $esSortFields[$sortField->getName()] = [
-                            'order'  => $sortField->getDirection(),
-                            'nested' => $nested,
-                        ];
-                    } else {
-                        $esSortFields[$sortField->getName()] = $sortField->getDirection();
-                    }
-                }
-            }
-            $query->addSort($esSortFields);
+            $query->addSort($this->buildSortFields($esQuery, $this->findQueryDepartmentId($esQuery)));
 
             $this->logger->debug('Elasticsearch Fragment Query: '.DemosPlanTools::varExport($query->getQuery(), true));
 
@@ -176,6 +148,58 @@ class FragmentElasticsearchRepository extends CoreRepository
         }
 
         return $result;
+    }
+
+    /**
+     * A fragment's versions can belong to different departments; the sort on a nested version field
+     * needs to be scoped to the department already being queried, to avoid sorting by another
+     * department's edit timestamp.
+     */
+    private function findQueryDepartmentId(QueryFragment $esQuery): ?string
+    {
+        foreach ($esQuery->getFiltersMust() as $filter) {
+            if (in_array($filter->getField(), ['departmentId', 'versions.modifiedByDepartmentId'], true)) {
+                return $filter->getValue();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string|array{order: string, nested: array}>
+     */
+    private function buildSortFields(QueryFragment $esQuery, ?string $departmentId): array
+    {
+        $esSortFields = [];
+        foreach ($esQuery->getSort() as $esQuerySort) {
+            foreach ($esQuerySort->getFields() as $sortField) {
+                $esSortFields[$sortField->getName()] = $this->buildSortFieldValue($sortField, $departmentId);
+            }
+        }
+
+        return $esSortFields;
+    }
+
+    /**
+     * @return string|array{order: string, nested: array}
+     */
+    private function buildSortFieldValue(SortField $sortField, ?string $departmentId): array|string
+    {
+        // Sorting on a field inside the nested 'versions' mapping requires an explicit nested context
+        if (!str_starts_with($sortField->getName(), 'versions.')) {
+            return $sortField->getDirection();
+        }
+
+        $nested = ['path' => 'versions'];
+        if (null !== $departmentId) {
+            $nested['filter'] = ['term' => ['versions.modifiedByDepartmentId' => $departmentId]];
+        }
+
+        return [
+            'order'  => $sortField->getDirection(),
+            'nested' => $nested,
+        ];
     }
 
     public function getGlobalConfig(): GlobalConfigInterface

--- a/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
@@ -129,14 +129,28 @@ class FragmentElasticsearchRepository extends CoreRepository
             // default
             $esSortFields = [];
 
+            // A fragment's versions can belong to different departments; scope the nested sort to the
+            // department already being queried so we don't sort by another department's edit timestamp
+            $departmentId = null;
+            foreach ($esQuery->getFiltersMust() as $filter) {
+                if (in_array($filter->getField(), ['departmentId', 'versions.modifiedByDepartmentId'], true)) {
+                    $departmentId = $filter->getValue();
+                    break;
+                }
+            }
+
             $esQuery->setSort($esQuery->getAvailableSorts());
             foreach ($esQuery->getSort() as $esQuerySort) {
                 foreach ($esQuerySort->getFields() as $sortField) {
                     // Sorting on a field inside the nested 'versions' mapping requires an explicit nested context
                     if (str_starts_with($sortField->getName(), 'versions.')) {
+                        $nested = ['path' => 'versions'];
+                        if (null !== $departmentId) {
+                            $nested['filter'] = ['term' => ['versions.modifiedByDepartmentId' => $departmentId]];
+                        }
                         $esSortFields[$sortField->getName()] = [
                             'order'  => $sortField->getDirection(),
-                            'nested' => ['path' => 'versions'],
+                            'nested' => $nested,
                         ];
                     } else {
                         $esSortFields[$sortField->getName()] = $sortField->getDirection();

--- a/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FragmentElasticsearchRepository.php
@@ -132,7 +132,15 @@ class FragmentElasticsearchRepository extends CoreRepository
             $esQuery->setSort($esQuery->getAvailableSorts());
             foreach ($esQuery->getSort() as $esQuerySort) {
                 foreach ($esQuerySort->getFields() as $sortField) {
-                    $esSortFields[$sortField->getName()] = $sortField->getDirection();
+                    // Sorting on a field inside the nested 'versions' mapping requires an explicit nested context
+                    if (str_starts_with($sortField->getName(), 'versions.')) {
+                        $esSortFields[$sortField->getName()] = [
+                            'order'  => $sortField->getDirection(),
+                            'nested' => ['path' => 'versions'],
+                        ];
+                    } else {
+                        $esSortFields[$sortField->getName()] = $sortField->getDirection();
+                    }
                 }
             }
             $query->addSort($esSortFields);

--- a/demosplan/DemosPlanCoreBundle/Services/Elasticsearch/FilterDisplay.php
+++ b/demosplan/DemosPlanCoreBundle/Services/Elasticsearch/FilterDisplay.php
@@ -19,7 +19,7 @@ class FilterDisplay
     /** @var string */
     protected $titleKey;
     /** @var FilterValue[] */
-    protected $values;
+    protected $values = [];
     /** @var string|null */
     protected $aggregationNullValue;
     /** @var bool */


### PR DESCRIPTION
There were a few issues in the fragment list (`Datensatznavigation > Datensätze`) that prevented the list from loading and are fixed in this PR:
- `null` was returned instead of an empty array for `FilterDisplay` `values`, breaking the `map` filter in twig
- wrong name was used for a vuex module (`'fragment'` instead of `'Fragment'`)
- compatibility issue with ES8 (doesn't happen with ES7)

### How to review/test
- Log in as Fachplanung-Fachbehörde
- Navigate to Datensatnavigation > Datensätze
- No error should be displayed and if fragments are assigned to the department, they should be displayed in the list
(to assign fragments to a department, go to the assessment table, split a statement into fragments and assign the fragments to the department)
