### PR TITLE
feat(refs DPLAN-18326): reset two-factor authentication from the user administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Requires `demos-europe/demosplan-addon` ^0.79, and every release from this one on does. The saved filter combinations of the assessment table were renamed `UserFilterSet` → `Bookmark`: entity, database table, repository, service and resource type, and in the contract layer `BookmarkInterface`, `BookmarkPath`, `Paths::bookmark()` and `BaseBookmarkResourceConfigBuilder`. Addons referring to any of the old names have to be updated. The table is renamed by an included migration, so no manual step is needed.
 ### Added
+- Organisation administrators and support can reset the two-factor authentication of a user in the user administration, for cases where access to the second factor was lost. The reset only removes the second factor and can never activate it for someone else. Every reset is recorded in the report so it stays traceable who reset it for whom.
 - Statements can now be imported from a CSV file, in addition to the existing Excel import. The import runs as a background job; files with more than 3,000 rows, a duplicate Eingangsnummer, or an oversized statement text are rejected with a clear error instead of importing only part of the file. (DPLAN-18247)
 
 ### Fixed

--- a/client/js/components/user/DpUserList/DpUserListItem.vue
+++ b/client/js/components/user/DpUserList/DpUserListItem.vue
@@ -207,7 +207,7 @@ export default {
     },
 
     canResetTwoFactor () {
-      return hasPermission('feature_2fa') && true === this.user.attributes.twoFactorEnabled
+      return hasPermission('feature_2fa') && this.user.attributes.twoFactorEnabled
     },
 
     hasDepartment () {

--- a/client/js/components/user/DpUserList/DpUserListItem.vue
+++ b/client/js/components/user/DpUserList/DpUserListItem.vue
@@ -118,6 +118,22 @@
         @user:update="updateUser"
       />
 
+      <div
+        v-if="canResetTwoFactor"
+        class="mb-2"
+      >
+        <p class="lbl__hint mb-1">
+          {{ Translator.trans('2fa.reset.hint') }}
+        </p>
+        <dp-button
+          :busy="isResettingTwoFactor"
+          data-cy="resetTwoFactor"
+          :text="Translator.trans('2fa.reset')"
+          variant="outline"
+          @click="resetTwoFactor"
+        />
+      </div>
+
       <dp-button-row
         form-name="userForm"
         primary
@@ -130,7 +146,7 @@
 </template>
 
 <script>
-import { DpButtonRow, DpIcon, dpValidateMixin } from '@demos-europe/demosplan-ui'
+import { dpApi, DpButton, DpButtonRow, DpIcon, dpValidateMixin } from '@demos-europe/demosplan-ui'
 import { mapActions, mapMutations, mapState } from 'vuex'
 import DpTableCard from '@DpJs/components/user/DpTableCardList/DpTableCard'
 import DpUserFormFields from './DpUserFormFields'
@@ -139,6 +155,7 @@ export default {
   name: 'DpUserListItem',
 
   components: {
+    DpButton,
     DpButtonRow,
     DpIcon,
     DpTableCard,
@@ -176,6 +193,7 @@ export default {
       isOpen: false,
       editMode: false,
       isLoading: true,
+      isResettingTwoFactor: false,
     }
   },
 
@@ -186,6 +204,10 @@ export default {
 
     ariaLabel () {
       return Translator.trans(this.isOpen ? 'aria.collapse' : 'aria.expand')
+    },
+
+    canResetTwoFactor () {
+      return hasPermission('feature_2fa') && true === this.user.attributes.twoFactorEnabled
     },
 
     hasDepartment () {
@@ -265,6 +287,44 @@ export default {
     save () {
       this.isOpen = !this.isOpen
       this.saveUserAction(this.user.id)
+    },
+
+    async resetTwoFactor () {
+      const userName = `${this.user.attributes.firstname} ${this.user.attributes.lastname}`
+
+      if (!await window.dpconfirm(Translator.trans('2fa.reset.confirm', { name: userName }))) {
+        return
+      }
+
+      this.isResettingTwoFactor = true
+
+      const payload = {
+        data: {
+          id: this.user.id,
+          type: 'AdministratableUser',
+          attributes: {
+            twoFactorEnabled: false,
+          },
+        },
+      }
+
+      try {
+        await dpApi.patch(
+          Routing.generate('api_resource_update', { resourceType: 'AdministratableUser', resourceId: this.user.id }),
+          {},
+          payload,
+        )
+        this.setItem({
+          ...this.user,
+          attributes: { ...this.user.attributes, twoFactorEnabled: false },
+        })
+        dplan.notify.notify('confirm', Translator.trans('2fa.reset.success'))
+      } catch (error) {
+        console.error(error)
+        dplan.notify.notify('error', Translator.trans('error.api.generic'))
+      } finally {
+        this.isResettingTwoFactor = false
+      }
     },
 
     updateUser (payload) {

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -591,6 +591,7 @@ area_use_mastertoeblist:
     label: 'use Mastertöbliste'
     loginRequired: true
 feature_2fa:
+    expose: true
     label: 'Allow two-factor authentication'
     loginRequired: true
 feature_admin_assessmenttable_export_docx:

--- a/config/services.yml
+++ b/config/services.yml
@@ -911,6 +911,8 @@ services:
 
     demosplan\DemosPlanCoreBundle\Logic\Report\StatementReportEntryFactory: ~
 
+    demosplan\DemosPlanCoreBundle\Logic\Report\UserReportEntryFactory: ~
+
     demosplan\DemosPlanCoreBundle\Logic\Report\ExportReportService:
         lazy: true
 

--- a/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Report/ReportEntry.php
@@ -44,6 +44,7 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface, ReportEntry
     final public const GROUP_STATEMENT = 'statement';
     final public const GROUP_MASTER_PUBLIC_AGENCY = 'mastertoeb';
     final public const GROUP_ORGA = 'orga';
+    final public const GROUP_USER = 'user';
 
     final public const CATEGORY_ADD = 'add';
     final public const CATEGORY_ANONYMIZE_META = 'anonymizeMeta';
@@ -60,6 +61,7 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface, ReportEntry
     final public const CATEGORY_MOVE = 'move';
     final public const CATEGORY_ORGA_SHOWLIST_CHANGE = 'orgaShowlistChange';
     final public const CATEGORY_REGISTER_INVITATION = 'register_invitation';
+    final public const CATEGORY_RESET_TWO_FACTOR = 'resetTwoFactor';
     final public const CATEGORY_STATEMENT_SYNC_INSOURCE = 'syncStatementSourceCategory';
     final public const CATEGORY_STATEMENT_SYNC_INTARGET = 'syncStatementTargetCategory';
     final public const CATEGORY_UPDATE = 'update';
@@ -73,6 +75,7 @@ class ReportEntry extends CoreEntity implements UuidEntityInterface, ReportEntry
     final public const IDENTIFIER_TYPE_FINAL_MAIL = 'finalMail';
     final public const IDENTIFIER_TYPE_MASTER_PUBLIC_AGENCY = 'masterToeb';
     final public const IDENTIFIER_TYPE_ORGANISATION = 'orga';
+    final public const IDENTIFIER_TYPE_USER = 'user';
 
     /**
      * @var string|null

--- a/demosplan/DemosPlanCoreBundle/Logic/Report/UserReportEntryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Report/UserReportEntryFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Logic\Report;
+
+use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
+use DemosEurope\DemosplanAddon\Utilities\Json;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+
+class UserReportEntryFactory extends AbstractReportEntryFactory
+{
+    /**
+     * Documents that an administrator removed the second factors of another user,
+     * so it stays traceable who restored whose access.
+     */
+    public function createTwoFactorResetEntry(UserInterface $affectedUser): ReportEntry
+    {
+        $entry = $this->createReportEntry();
+        $entry->setCategory(ReportEntry::CATEGORY_RESET_TWO_FACTOR);
+        $entry->setUser($this->currentUserProvider->getUser());
+        $entry->setIdentifier($affectedUser->getId());
+        $entry->setIdentifierType(ReportEntry::IDENTIFIER_TYPE_USER);
+        $entry->setMessage(Json::encode([
+            'userId'    => $affectedUser->getId(),
+            'userName'  => $affectedUser->getFullname(),
+            'userEmail' => $affectedUser->getEmail(),
+        ], JSON_UNESCAPED_UNICODE));
+
+        return $entry;
+    }
+
+    protected function createReportEntry(): ReportEntry
+    {
+        $entry = parent::createReportEntry();
+        $entry->setGroup(ReportEntry::GROUP_USER);
+
+        return $entry;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserSecurityHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserSecurityHandler.php
@@ -14,6 +14,8 @@ namespace demosplan\DemosPlanCoreBundle\Logic\User;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
+use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
+use demosplan\DemosPlanCoreBundle\Logic\Report\UserReportEntryFactory;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticator;
 
 class UserSecurityHandler
@@ -22,6 +24,8 @@ class UserSecurityHandler
         private readonly TotpAuthenticator $totpAuthenticator,
         private readonly MessageBagInterface $messageBag,
         private readonly UserService $userService,
+        private readonly UserReportEntryFactory $userReportEntryFactory,
+        private readonly ReportService $reportService,
     ) {
     }
 
@@ -30,6 +34,25 @@ class UserSecurityHandler
         $user = $this->handeTotp($updateUserData, $user);
 
         return $this->handeEmailAuth($updateUserData, $user);
+    }
+
+    /**
+     * Removes every second factor from the given user so they can log in with their
+     * credentials alone. Used by administrators when a user lost access to their
+     * second factor.
+     */
+    public function resetTwoFactorAuthentication(UserInterface $user): void
+    {
+        $user->setTotpEnabled(false);
+        $user->setTotpSecret(null);
+        $user->setAuthCodeEmailEnabled(false);
+        $user->setEmailAuthCode('');
+
+        $this->userService->updateUserObject($user);
+
+        $this->reportService->persistAndFlushReportEntry(
+            $this->userReportEntryFactory->createTwoFactorResetEntry($user)
+        );
     }
 
     private function handeTotp(array $updateUserData, UserInterface $user): UserInterface

--- a/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceConfigBuilder/UserResourceConfigBuilder.php
@@ -29,6 +29,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $invited
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $newsletter
  * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $noPiwik
+ * @property-read AttributeConfigBuilderInterface<ClauseFunctionInterface<bool>, UserInterface> $twoFactorEnabled
  * @property-read ToManyRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,RoleInterface> $roles
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,UserInterface,DepartmentInterface> $department
  * @property-read ToOneRelationshipConfigBuilderInterface<ClauseFunctionInterface<bool>,OrderBySortMethodInterface,\DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface,OrgaInterface> $orga

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/AdministratableUserResourceType.php
@@ -25,6 +25,7 @@ use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\JsonApiEsService;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\ReadableEsResourceTypeInterface;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserHandler;
+use demosplan\DemosPlanCoreBundle\Logic\User\UserSecurityHandler;
 use demosplan\DemosPlanCoreBundle\Repository\UserRepository;
 use demosplan\DemosPlanCoreBundle\ResourceConfigBuilder\UserResourceConfigBuilder;
 use demosplan\DemosPlanCoreBundle\Services\Elasticsearch\AbstractQuery;
@@ -35,6 +36,7 @@ use EDT\JsonApi\RequestHandling\ModifiedEntity;
 use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
 use EDT\Wrapping\EntityDataInterface;
+use EDT\Wrapping\PropertyBehavior\Attribute\Factory\CallbackAttributeSetBehaviorFactory;
 use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
 use EDT\Wrapping\PropertyBehavior\Relationship\ToMany\CallbackToManyRelationshipSetBehavior;
 use EDT\Wrapping\PropertyBehavior\Relationship\ToOne\CallbackToOneRelationshipSetBehavior;
@@ -62,7 +64,8 @@ final class AdministratableUserResourceType extends DplanResourceType implements
     public function __construct(private readonly QueryUser $esQuery,
         private readonly JsonApiEsService $jsonApiEsService,
         private readonly UserRepository $userRepository,
-        private readonly UserHandler $userHandler)
+        private readonly UserHandler $userHandler,
+        private readonly UserSecurityHandler $userSecurityHandler)
     {
     }
 
@@ -201,6 +204,28 @@ final class AdministratableUserResourceType extends DplanResourceType implements
         $configBuilder->noPiwik
             ->setReadableByCallable(static fn (User $user): bool => $user->getNoPiwik(), DefaultField::YES)
             ->setSortable();
+
+        if ($this->currentUser->hasPermission('feature_2fa')) {
+            $configBuilder->twoFactorEnabled
+                ->setReadableByCallable(
+                    static fn (UserInterface $user): bool => $user->isTotpEnabled() || $user->isEmailAuthEnabled(),
+                    DefaultField::YES
+                )
+                ->addUpdateBehavior(
+                    new CallbackAttributeSetBehaviorFactory(
+                        [],
+                        function (UserInterface $user, bool $twoFactorEnabled): array {
+                            if ($twoFactorEnabled) {
+                                throw new BadRequestException('Two factor authentication can only be reset, not enabled, by an administrator.');
+                            }
+                            $this->userSecurityHandler->resetTwoFactorAuthentication($user);
+
+                            return [];
+                        },
+                        OptionalField::YES,
+                    )
+                );
+        }
 
         $configBuilder->roles
             ->addUpdateBehavior(

--- a/tests/backend/core/User/Functional/UserSecurityHandlerTest.php
+++ b/tests/backend/core/User/Functional/UserSecurityHandlerTest.php
@@ -12,6 +12,9 @@ namespace Tests\Core\User\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
+use demosplan\DemosPlanCoreBundle\Logic\Report\UserReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserSecurityHandler;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticator;
@@ -22,6 +25,8 @@ class UserSecurityHandlerTest extends FunctionalTestCase
     private $totpAuthenticator;
     private $messageBag;
     private $userService;
+    private $userReportEntryFactory;
+    private $reportService;
     private $userSecurityHandler;
     private $user;
 
@@ -31,10 +36,14 @@ class UserSecurityHandlerTest extends FunctionalTestCase
         $this->messageBag = $this->createMock(MessageBagInterface::class);
         $this->userService = $this->createMock(UserService::class);
         $this->user = $this->createMock(User::class);
+        $this->userReportEntryFactory = $this->createMock(UserReportEntryFactory::class);
+        $this->reportService = $this->createMock(ReportService::class);
         $this->userSecurityHandler = new UserSecurityHandler(
             $this->totpAuthenticator,
             $this->messageBag,
-            $this->userService
+            $this->userService,
+            $this->userReportEntryFactory,
+            $this->reportService
         );
     }
 
@@ -81,6 +90,28 @@ class UserSecurityHandlerTest extends FunctionalTestCase
         $this->messageBag->expects($this->once())->method('add')->with('error', 'error.2fa.code.invalid');
 
         $this->userSecurityHandler->handleUserSecurityPropertiesUpdate($this->user, $updateUserData);
+    }
+
+    public function testResetTwoFactorAuthenticationClearsBothSecondFactors(): void
+    {
+        $user = new User();
+        $user->setTotpEnabled(true);
+        $user->setTotpSecret('someSecret');
+        $user->setAuthCodeEmailEnabled(true);
+        $user->setEmailAuthCode('123456');
+        $this->userService->expects($this->once())->method('updateUserObject')->with($user);
+        $reportEntry = new ReportEntry();
+        $this->userReportEntryFactory->expects($this->once())
+            ->method('createTwoFactorResetEntry')->with($user)->willReturn($reportEntry);
+        $this->reportService->expects($this->once())
+            ->method('persistAndFlushReportEntry')->with($reportEntry);
+
+        $this->userSecurityHandler->resetTwoFactorAuthentication($user);
+
+        self::assertFalse($user->isTotpEnabled());
+        self::assertNull($user->getTotpSecret());
+        self::assertFalse($user->isEmailAuthEnabled());
+        self::assertSame('', $user->getEmailAuthCode());
     }
 
     public function testDisablesEmailAuthWhenDisableEmailCodeProvided()

--- a/tests/backend/core/User/Functional/UserSecurityHandlerTest.php
+++ b/tests/backend/core/User/Functional/UserSecurityHandlerTest.php
@@ -11,8 +11,8 @@
 namespace Tests\Core\User\Functional;
 
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
-use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
+use demosplan\DemosPlanCoreBundle\Entity\User\User;
 use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
 use demosplan\DemosPlanCoreBundle\Logic\Report\UserReportEntryFactory;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserSecurityHandler;

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -15,6 +15,10 @@
 2fa.totp.enable: "Zwei-Faktor-Authentifizierung per App aktivieren"
 2fa.code: "Zwei-Faktor-Authentifizierungscode"
 2fa.email.subject: 'Zwei-Faktor-Authentifizierung für Ihr {projectName} Konto'
+2fa.reset: "Zwei-Faktor-Authentifizierung zurücksetzen"
+2fa.reset.confirm: "Soll die Zwei-Faktor-Authentifizierung für {name} wirklich zurückgesetzt werden? Der Nutzer kann sich danach allein mit Passwort anmelden und die Zwei-Faktor-Authentifizierung neu einrichten."
+2fa.reset.hint: "Für dieses Konto ist die Zwei-Faktor-Authentifizierung aktiviert. Setzen Sie sie zurück, falls der Zugriff auf den zweiten Faktor verloren gegangen ist."
+2fa.reset.success: "Die Zwei-Faktor-Authentifizierung wurde zurückgesetzt."
 2fa.email.login.explanation: '<p class="weight--normal">Sollten Sie nach kurzer Zeit keine Email bekommen haben, brechen Sie den Vorgang bitte ab und melden sich erneut an. Bei der Anmeldung wird automatisch eine Email an die im System hinterlegte Adresse verschickt.</p>'
 abort: "Abbrechen"
 abort.and.back: "Abbrechen und zurück"


### PR DESCRIPTION
### Ticket
DPLAN-18326

Organisation administrators and support had no way to reset the two-factor
authentication of a user who lost access to their second factor (device gone,
technical problem). The only remedy so far was a manual database change.

The expanded entry in the user administration now offers a
"Zwei-Faktor-Authentifizierung zurücksetzen" button. It clears both second
factors (TOTP app and email code), so the user can log in with their password
alone and set 2FA up again.

Implemented as a `twoFactorEnabled` attribute on `AdministratableUser` rather
than a new endpoint, so the existing authorization applies unchanged:

- the attribute only exists when `feature_2fa` is granted, and writing needs
  `feature_user_edit` — the same permission the user administration already
  requires
- `getAccessConditions()` is merged into the entity lookup on the update path
  (`AbstractResourceType::updateEntity`), so an organisation administrator can
  only reset users of their own organisation and support only within the
  customer — a foreign id simply does not resolve
- the write behaviour accepts `false` only; sending `true` throws, so 2FA can
  never be activated for somebody else through this route

Every reset is written as a report entry (group `user`, category
`resetTwoFactor`) recording who reset it for whom.

`feature_2fa` was missing `expose: true`, so it was not available to
JavaScript-based permission checks at all. That is fixed here as well.

### How to review/test
1. Give a test user a second factor (TOTP or email) in their profile.
2. Log in as support or as an organisation administrator of that user's
   organisation and open the user administration.
3. Expand the user — the reset button appears above the save/cancel row. It
   stays hidden for users without an active second factor.
4. Confirm the dialog; the user can afterwards log in without a second factor.
5. Check the report entries for a `resetTwoFactor` record.

Also worth checking: as an organisation administrator, a `PATCH` on a user of
another organisation must fail rather than reset anything.

### Linked PRs
The `UserInterface` extension this builds on:

- demos-europe/demosplan-addon#186

### PR Checklist

- [x] Create/Update tests
- [x] Add/Update data-cy attributes
- [x] Run `yarn lint`
- [x] Link all relevant tickets
- [x] Update changelog
