### PR TITLE
fix(orga): make showlist a per-customer setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "cebe/php-openapi": "^1.5",
     "cocur/slugify": "^4.0",
     "composer/composer": "^2.8",
-    "demos-europe/demosplan-addon": "^0.79",
+    "demos-europe/demosplan-addon": "^0.80",
     "doctrine/annotations": "^2.0",
     "doctrine/common": "^3.2",
     "doctrine/data-fixtures": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c971b5e4da32520bbb2ba2205b637630",
+    "content-hash": "9b09138ba4b2b2f818e6107ab7f927ee",
     "packages": [
         {
             "name": "ankitpokhrel/tus-php",
@@ -1710,16 +1710,16 @@
         },
         {
             "name": "demos-europe/demosplan-addon",
-            "version": "v0.79",
+            "version": "v0.80",
             "source": {
                 "type": "git",
                 "url": "https://github.com/demos-europe/demosplan-addon.git",
-                "reference": "df61226df6bd38e3c819aeb67362a9bd51fb8179"
+                "reference": "d56f369b719be470bec3122d353baa5ea85597d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/df61226df6bd38e3c819aeb67362a9bd51fb8179",
-                "reference": "df61226df6bd38e3c819aeb67362a9bd51fb8179",
+                "url": "https://api.github.com/repos/demos-europe/demosplan-addon/zipball/d56f369b719be470bec3122d353baa5ea85597d0",
+                "reference": "d56f369b719be470bec3122d353baa5ea85597d0",
                 "shasum": ""
             },
             "require": {
@@ -1786,9 +1786,9 @@
             ],
             "description": "This is the base package for all demosplan addons",
             "support": {
-                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.79"
+                "source": "https://github.com/demos-europe/demosplan-addon/tree/v0.80"
             },
-            "time": "2026-08-20T16:01:17+00:00"
+            "time": "2026-08-26T09:20:26+00:00"
         },
         {
             "name": "demos-europe/edt-access-definitions",

--- a/demosplan/DemosPlanCoreBundle/Command/Data/GenerateOrganisationCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Data/GenerateOrganisationCommand.php
@@ -158,6 +158,7 @@ class GenerateOrganisationCommand extends DataProviderCommand
         $orgaStatusInCustomer->setCustomer($this->customerHandler->getCurrentCustomer());
         $orgaStatusInCustomer->setOrgaType($this->orgaType);
         $orgaStatusInCustomer->setStatus(OrgaStatusInCustomer::STATUS_ACCEPTED);
+        $orgaStatusInCustomer->setShowlist(true);
 
         $orga->addStatusInCustomer($orgaStatusInCustomer);
 

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/OrgaStatusInCustomerFactory.php
@@ -75,6 +75,7 @@ final class OrgaStatusInCustomerFactory extends PersistentProxyObjectFactory
             'orga'     => OrgaFactory::new(),
             'orgaType' => OrgaTypeFactory::new(),
             'status'   => OrgaStatusInCustomerInterface::STATUS_ACCEPTED,
+            'showlist' => true,
         ];
     }
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260821170633.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260821170633.php
@@ -1,4 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
 
 namespace Application\Migrations;
 

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260821170633.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/08/Version20260821170633.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the per-customer {@see \demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer::$showlist}
+ * column and backfills it from the orga-level {@see \demosplan\DemosPlanCoreBundle\Entity\User\Orga::$showlist}
+ * column, so the public-agency visibility flag becomes per customer/orgaType instead of a single
+ * value shared across all customers.
+ */
+final class Version20260821170633 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add per-customer showlist column to relation_customer_orga_orga_type and backfill from _orga._o_showlist';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE relation_customer_orga_orga_type ADD showlist TINYINT(1) DEFAULT 1 NOT NULL');
+
+        // Copy the orga-level showlist value into every per-customer status row of that orga.
+        // Runs exactly once via this migration; never re-run manually (would overwrite diverged values).
+        $this->addSql(<<<'SQL'
+            UPDATE relation_customer_orga_orga_type osc
+            JOIN _orga o ON osc._o_id = o._o_id
+            SET osc.showlist = o._o_showlist
+        SQL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE relation_customer_orga_orga_type DROP showlist');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -122,6 +122,10 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     /**
      * @var bool
      *           Is this orga listed in public toeb list
+     *
+     * @deprecated moved per-customer to {@link OrgaStatusInCustomer::$showlist}; use
+     *             {@link getShowlistForCustomer()} for the current-customer value. Retained for the
+     *             transition dual-write until the column is dropped.
      */
     #[ORM\Column(name: '_o_showlist', type: 'boolean', nullable: false, options: ['default' => false])]
     protected $showlist = true;
@@ -493,6 +497,58 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     public function isShowlist(): bool
     {
         return $this->getShowlist();
+    }
+
+    /**
+     * Returns the per-customer {@link OrgaStatusInCustomer::$showlist} value for the given customer.
+     *
+     * An orga may hold one status row per orgaType within a customer, but `showlist` is a single
+     * per-customer decision: {@link OrgaRepository::updateShowlistForCustomer()} writes every row of
+     * the customer, and {@link Orga::addCustomerAndOrgaType()} makes new rows inherit the value, so
+     * the rows do not diverge. The PUBLIC_AGENCY row is preferred as the canonical one because it is
+     * the grain {@link InvitablePublicAgencyResourceType} filters on; any other row of the customer
+     * is used for orgas that hold no PUBLIC_AGENCY row.
+     *
+     * Defaults to `false` when the orga has no status row in that customer at all, matching the
+     * query paths which inner-join `statusInCustomers` and exclude such orgas entirely. Used as the
+     * backing value of the {@link OrgaResourceType::$showlist} attribute, read per current customer.
+     */
+    public function getShowlistForCustomer(CustomerInterface $customer): bool
+    {
+        $statusesInCustomer = $this->getStatusesInCustomer($customer);
+        if ([] === $statusesInCustomer) {
+            return false;
+        }
+
+        foreach ($statusesInCustomer as $statusInCustomer) {
+            if (OrgaTypeInterface::PUBLIC_AGENCY === $statusInCustomer->getOrgaType()->getName()) {
+                return $statusInCustomer->getShowlist();
+            }
+        }
+
+        return reset($statusesInCustomer)->getShowlist();
+    }
+
+    /**
+     * Returns all status rows the orga holds in the given customer — one per orgaType.
+     *
+     * Compares by id rather than identity to stay correct for detached or session-deserialized
+     * customers (the Doctrine identity map is only reliable within a request).
+     *
+     * @return list<OrgaStatusInCustomer>
+     */
+    public function getStatusesInCustomer(CustomerInterface $customer): array
+    {
+        $customerId = $customer->getId();
+        $statusesInCustomer = [];
+        /** @var OrgaStatusInCustomer $statusInCustomer */
+        foreach ($this->getStatusInCustomers() as $statusInCustomer) {
+            if ($customerId === $statusInCustomer->getCustomer()->getId()) {
+                $statusesInCustomer[] = $statusInCustomer;
+            }
+        }
+
+        return $statusesInCustomer;
     }
 
     public function setGwId(?string $gwId): self
@@ -1153,6 +1209,13 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
         $relation->setOrgaType($orgaType);
         $relation->setOrga($this);
         $relation->setStatus($status);
+        // showlist is a per-customer decision, so a new orgaType row adopts the value already set
+        // for this customer. Without this an orga hidden by an admin would silently become visible
+        // again as soon as it gains another orgaType.
+        $existingStatuses = $this->getStatusesInCustomer($customer);
+        if ([] !== $existingStatuses) {
+            $relation->setShowlist($this->getShowlistForCustomer($customer));
+        }
 
         // add to list if not yet exists
         // Collection->contains does not find relation

--- a/demosplan/DemosPlanCoreBundle/Entity/User/OrgaStatusInCustomer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/OrgaStatusInCustomer.php
@@ -71,6 +71,15 @@ class OrgaStatusInCustomer extends CoreEntity implements UuidEntityInterface, Or
     #[ORM\Column(type: 'string', length: 255, nullable: false)]
     protected $status;
 
+    /**
+     * Whether this orga may be listed in the public-agency invitation list for the
+     * customer/orgaType this row represents.
+     *
+     * @var bool
+     */
+    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => true])]
+    protected $showlist = true;
+
     public function getId(): ?string
     {
         return $this->id;
@@ -122,5 +131,17 @@ class OrgaStatusInCustomer extends CoreEntity implements UuidEntityInterface, Or
             OrgaStatusInCustomerInterface::STATUS_ACCEPTED, OrgaStatusInCustomerInterface::STATUS_REJECTED, OrgaStatusInCustomerInterface::STATUS_PENDING => $status,
             default                                                                                                                                       => throw new InvalidArgumentException("Invalid status {$status}"),
         };
+    }
+
+    public function getShowlist(): bool
+    {
+        return $this->showlist;
+    }
+
+    public function setShowlist(bool $showlist): self
+    {
+        $this->showlist = $showlist;
+
+        return $this;
     }
 }

--- a/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Permission/AccessControlService.php
@@ -23,9 +23,7 @@ use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Permissions\Permission;
 use demosplan\DemosPlanCoreBundle\Repository\AccessControlRepository;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use InvalidArgumentException;
-use Psr\Log\LoggerInterface;
 
 /**
  * This file is part of the package demosplan.
@@ -43,7 +41,6 @@ class AccessControlService
         private readonly AccessControlRepository $accessControlPermissionRepository,
         private readonly RoleHandler $roleHandler,
         private readonly OrgaService $orgaService,
-        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -56,26 +53,25 @@ class AccessControlService
 
     public function createPermission(string $permissionName, OrgaInterface $orga, CustomerInterface $customer, RoleInterface $role): ?AccessControl
     {
-        try {
-            $permission = new AccessControl();
-            $permission->setPermissionName($permissionName);
-            $permission->setOrga($orga);
-            $permission->setCustomer($customer);
-            $permission->setRole($role);
-            $this->accessControlPermissionRepository->add($permission);
+        $existingPermission = $this->accessControlPermissionRepository->findOneBy([
+            'permission'   => $permissionName,
+            'organisation' => $orga,
+            'customer'     => $customer,
+            'role'         => $role,
+        ]);
 
-            return $permission;
-        } catch (UniqueConstraintViolationException $exception) {
-            $this->logger->warning('Unique constraint violation occurred while trying to create a permission.', [
-                'exception'      => $exception->getMessage(),
-                'permissionName' => $permissionName,
-                'orga'           => $orga->getId(),
-                'customer'       => $customer->getId(),
-                'role'           => $role->getId(),
-            ]);
+        if ($existingPermission instanceof AccessControl) {
+            return $existingPermission;
         }
 
-        return null;
+        $permission = new AccessControl();
+        $permission->setPermissionName($permissionName);
+        $permission->setOrga($orga);
+        $permission->setCustomer($customer);
+        $permission->setRole($role);
+        $this->accessControlPermissionRepository->add($permission);
+
+        return $permission;
     }
 
     public function getPermissions(?OrgaInterface $orga, ?CustomerInterface $customer, array $roles): array

--- a/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/OrgaService.php
@@ -338,7 +338,7 @@ class OrgaService implements OrgaServiceInterface
     {
         return $this->getOrganisations([
             $this->conditionFactory->propertyHasValue(1, $this->orgaResourceType->showname),
-            $this->conditionFactory->propertyHasValue(true, $this->orgaResourceType->showlist),
+            $this->conditionFactory->propertyHasValue(true, $this->orgaResourceType->statusInCustomers->showlist),
         ]);
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -1754,9 +1754,12 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
     {
         $mandatoryErrors = 0;
 
-        // if support changes visibility of toeb in toeblist, a reason must be given
+        // if support changes visibility of toeb in toeblist, a reason must be given.
+        // Compare against the per-customer value so the gate agrees with the write path
+        // (UserService::updateOrga) and the report entry, both of which operate per-customer.
         $showList = array_key_exists('showlist', $data) ? filter_var($data['showlist'], FILTER_VALIDATE_BOOLEAN) : false;
-        if ($this->canUpdateShowList() && $showList !== $currentOrga->getShowlist() && (!array_key_exists('showlistChangeReason', $data)
+        $currentShowList = $currentOrga->getShowlistForCustomer($this->customerService->getCurrentCustomer());
+        if ($this->canUpdateShowList() && $showList !== $currentShowList && (!array_key_exists('showlistChangeReason', $data)
             || '' === trim((string) $data['showlistChangeReason']))) {
             $this->getMessageBag()->add('error', 'reason.change');
             ++$mandatoryErrors;

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserService.php
@@ -518,7 +518,8 @@ class UserService implements UserServiceInterface
         try {
             /** @var Orga $orgaBefore */
             $orgaBefore = $this->orgaRepository->find($orgaId);
-            $showListBefore = $orgaBefore->getShowlist();
+            $currentCustomer = $this->customerService->getCurrentCustomer();
+            $showListBefore = $orgaBefore->getShowlistForCustomer($currentCustomer);
             $emailBefore = $orgaBefore->getEmail2();
             $emailCCBefore = $orgaBefore->getCcEmail2();
 
@@ -545,6 +546,13 @@ class UserService implements UserServiceInterface
             }
 
             $orga = $this->orgaRepository->update($orgaId, $data);
+            // Mirror the showlist write onto the per-customer status row, matching the
+            // orga-level write performed by OrgaRepository::generateObjectValues() under the
+            // `updateShowlist` guard. Dual-write during transition until the orga-level column
+            // is dropped.
+            if (array_key_exists('updateShowlist', $data)) {
+                $this->orgaRepository->updateShowlistForCustomer($orga, $currentCustomer, (bool) ($data['showlist'] ?? false));
+            }
             // update ggf. Notifications
             $orga = $this->orgaService->updateOrgaNotifications($orga, $data);
             $orga = $this->orgaService->updateOrgaSubmissionType($orga, $data);

--- a/demosplan/DemosPlanCoreBundle/Repository/OrgaRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/OrgaRepository.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
 use Cocur\Slugify\Slugify;
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Slug;
 use demosplan\DemosPlanCoreBundle\Entity\User\Address;
@@ -208,6 +209,34 @@ class OrgaRepository extends SluggedRepository implements ArrayInterface
     }
 
     /**
+     * Updates the per-customer {@link OrgaStatusInCustomer::$showlist} value for the given orga.
+     *
+     * Writes every status row the orga holds in that customer, not just the PUBLIC_AGENCY one:
+     * `showlist` is a single per-customer decision, while {@link OrgaService::getParticipants()}
+     * matches *any* orgaType row of the customer. Writing one row only would leave an orga that
+     * holds several orgaTypes listed after being hidden.
+     *
+     * Mirrors the orga-level write performed in {@link generateObjectValues()} under the
+     * `updateShowlist` guard, so the per-customer rows stay in sync during the transition until
+     * the orga-level column is dropped. No-op when no status row exists for the given customer.
+     * Flushes at the write site so the change survives even if the later report path is skipped.
+     */
+    public function updateShowlistForCustomer(Orga $orga, CustomerInterface $customer, bool $showlist): void
+    {
+        $statusesInCustomer = $orga->getStatusesInCustomer($customer);
+        if ([] === $statusesInCustomer) {
+            return;
+        }
+
+        $em = $this->getEntityManager();
+        foreach ($statusesInCustomer as $statusInCustomer) {
+            $statusInCustomer->setShowlist($showlist);
+            $em->persist($statusInCustomer);
+        }
+        $em->flush();
+    }
+
+    /**
      * Adds a User to an Organisation.
      *
      * @param string $orgaId
@@ -382,7 +411,10 @@ class OrgaRepository extends SluggedRepository implements ArrayInterface
         // Therefore we need to take extra care and measures to ensure that
         // this flag is not accidentally set to false.
         // Due to this updateShowlist needs to be explicitly set directly or
-        // via UserHandler->setCanUpdateShowList() in backend
+        // via UserHandler->setCanUpdateShowList() in backend.
+        // This writes the legacy orga-level column; the per-customer mirror is written by
+        // OrgaRepository::updateShowlistForCustomer(), called from UserService::updateOrga()
+        // under the same `updateShowlist` guard. Dual-write, intentional during transition.
         if (array_key_exists('updateShowlist', $data)) {
             $entity->setShowlist((bool) $data['showlist']);
         }
@@ -626,6 +658,11 @@ class OrgaRepository extends SluggedRepository implements ArrayInterface
             $organisation->setDeleted(true);
             $organisation->setShowname(false);
             $organisation->setShowlist(false);
+            // Hide the orga in every customer's status row (GDPR wipe).
+            foreach ($organisation->getStatusInCustomers() as $statusInCustomer) {
+                $statusInCustomer->setShowlist(false);
+                $em->persist($statusInCustomer);
+            }
 
             $em->persist($organisation);
             $em->flush();

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitablePublicAgencyResourceType.php
@@ -66,7 +66,7 @@ class InvitablePublicAgencyResourceType extends DplanResourceType
 
         $conditions = [
             $this->conditionFactory->propertyHasValue(false, Paths::orga()->deleted),
-            $this->conditionFactory->propertyHasValue(true, Paths::orga()->showlist),
+            $this->conditionFactory->propertyHasValue(true, Paths::orga()->statusInCustomers->showlist),
             $this->conditionFactory->propertyHasValue(
                 RoleInterface::GPSORG,
                 Paths::orga()->users->roleInCustomers->role->groupCode

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
@@ -177,7 +177,7 @@ final class OrgaResourceType extends DplanResourceType implements OrgaResourceTy
             $this->createAttribute($this->emailNotificationNewStatement)->readable(true, $this->getEmailNotificationNewStatement(...)),
             $this->createAttribute($this->postalcode)->readable(true, static fn (Orga $orga): string => $orga->getPostalcode()),
             $this->createAttribute($this->reviewerEmail)->aliasedPath($this->emailReviewerAdmin)->readable(true),
-            $this->createAttribute($this->showlist)->readable(true),
+            $this->createAttribute($this->showlist)->readable(true, fn (Orga $orga): bool => $orga->getShowlistForCustomer($this->currentCustomerService->getCurrentCustomer())),
             $this->createAttribute($this->showname)->readable(true),
             $this->createAttribute($this->state)->readable(true, static fn (Orga $orga): string => $orga->getState()),
             $this->createAttribute($this->street)->readable(true, static fn (Orga $orga): string => $orga->getStreet()),

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaStatusInCustomerResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaStatusInCustomerResourceType.php
@@ -22,6 +22,7 @@ use EDT\PathBuilding\End;
  * @property-read CustomerResourceType $customer
  * @property-read OrgaResourceType $orga
  * @property-read OrgaTypeResourceType $orgaType
+ * @property-read End $showlist
  * @property-read End $status
  */
 final class OrgaStatusInCustomerResourceType extends DplanResourceType
@@ -63,6 +64,7 @@ final class OrgaStatusInCustomerResourceType extends DplanResourceType
             $this->createToOneRelationship($this->orgaType)->readable()->sortable()->filterable(),
             $this->createToOneRelationship($this->orga)->readable()->sortable()->filterable(),
             $this->createAttribute($this->status)->readable(true)->filterable()->sortable(),
+            $this->createAttribute($this->showlist)->readable(true)->filterable()->sortable(),
         ];
 
         if ($this->resourceTypeStore->getCustomerResourceType()->isReferencable()) {

--- a/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
+++ b/tests/backend/core/AccessControlPermission/AccessControlServiceTest.php
@@ -103,12 +103,14 @@ class AccessControlServiceTest extends UnitTestCase
         self::assertSame($permissionToCheck, $accessControlPermission->getPermissionName());
     }
 
-    public function testDuplicatePermissionCreationThrowsException(): void
+    public function testDuplicatePermissionCreationReturnsExistingPermission(): void
     {
         $permissionToCheck = 'my_permission';
-        $this->sut->createPermission($permissionToCheck, $this->testOrga->_real(), $this->testCustomer->_real(), $this->testRole);
-        $createdPermission = $this->sut->createPermission($permissionToCheck, $this->testOrga->_real(), $this->testCustomer->_real(), $this->testRole);
-        $this->assertNull($createdPermission);
+        $firstPermission = $this->sut->createPermission($permissionToCheck, $this->testOrga->_real(), $this->testCustomer->_real(), $this->testRole);
+        $secondPermission = $this->sut->createPermission($permissionToCheck, $this->testOrga->_real(), $this->testCustomer->_real(), $this->testRole);
+
+        self::assertInstanceOf(AccessControl::class, $secondPermission);
+        self::assertSame($firstPermission->getId(), $secondPermission->getId());
     }
 
     public function testGetPermissions(): void

--- a/tests/backend/core/User/Functional/UserServiceTest.php
+++ b/tests/backend/core/User/Functional/UserServiceTest.php
@@ -277,7 +277,7 @@ class UserServiceTest extends FunctionalTestCase
 
     public function testFindDistinctUserByEmailOrLoginReturnsFalseForNonExistentUser(): void
     {
-        $result = $this->sut->findDistinctUserByEmailOrLogin('nonexistent-user-' . uniqid() . '@example.de');
+        $result = $this->sut->findDistinctUserByEmailOrLogin('nonexistent-user-'.uniqid().'@example.de');
         static::assertFalse($result);
     }
 

--- a/tests/backend/core/User/Functional/UserServiceTest.php
+++ b/tests/backend/core/User/Functional/UserServiceTest.php
@@ -10,11 +10,13 @@
 
 namespace Tests\Core\User\Functional;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\OrgaTypeInterface;
 use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
 use demosplan\DemosPlanCoreBundle\Entity\User\Address;
 use demosplan\DemosPlanCoreBundle\Entity\User\AddressBookEntry;
 use demosplan\DemosPlanCoreBundle\Entity\User\Department;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Entity\User\OrgaStatusInCustomer;
 use demosplan\DemosPlanCoreBundle\Entity\User\OrgaType;
 use demosplan\DemosPlanCoreBundle\Entity\User\Role;
 use demosplan\DemosPlanCoreBundle\Entity\User\User;
@@ -22,6 +24,7 @@ use demosplan\DemosPlanCoreBundle\Exception\UserAlreadyExistsException;
 use demosplan\DemosPlanCoreBundle\Logic\ContentService;
 use demosplan\DemosPlanCoreBundle\Logic\User\OrgaService;
 use demosplan\DemosPlanCoreBundle\Logic\User\UserService;
+use demosplan\DemosPlanCoreBundle\Repository\OrgaRepository;
 use demosplan\DemosPlanCoreBundle\Types\UserFlagKey;
 use demosplan\DemosPlanCoreBundle\ValueObject\SettingsFilter;
 use Exception;
@@ -946,7 +949,9 @@ class UserServiceTest extends FunctionalTestCase
         $orgaService = self::getContainer()->get(OrgaService::class);
         $publicAgencyTestId = $this->getOrgaReference('testOrgaInvitableInstitution')->getId();
 
-        $countOrgas = $this->countEntries(Orga::class, ['showname' => true, 'showlist' => true, 'deleted' => false]);
+        // Baseline from the per-customer source of truth (statusInCustomers.showlist), not the
+        // legacy orga-level column, matching what getParticipants() now filters on.
+        $countOrgas = $this->countVisibleParticipants();
         $listOfOrgas = $orgaService->getParticipants();
         static::assertCount($countOrgas, $listOfOrgas);
 
@@ -980,6 +985,150 @@ class UserServiceTest extends FunctionalTestCase
 
         $listOfOrgas4 = $orgaService->getParticipants();
         static::assertCount($countOrgas, $listOfOrgas4);
+    }
+
+    /**
+     * The showlist flag is per customer: an orga registered in two customers may be hidden in one
+     * and visible in the other. Exercises the query path (getParticipants runs an EDT condition over
+     * statusInCustomers->showlist) and the write path (updateShowlistForCustomer), not just the
+     * getter, so the join-alias dedup the design relies on is actually covered.
+     */
+    public function testShowlistIsPerCustomer()
+    {
+        /** @var OrgaService $orgaService */
+        $orgaService = self::getContainer()->get(OrgaService::class);
+        /** @var Orga $orga */
+        $orga = $this->getOrgaReference('testOrgaInvitableInstitution');
+        $orgaId = $orga->getId();
+        $customerHindsight = $this->getCustomerReference('testCustomer');
+        $customerBrandenburg = $this->getCustomerReference('testCustomerBrandenburg');
+        // testOrgaInvitableInstitution is OPSORG in the default customer; add an OPSORG row in the
+        // second customer so the per-customer split is observable.
+        $opsorgType = $this->getEntityManager()->getRepository(OrgaType::class)->findOneBy(['name' => OrgaTypeInterface::PUBLIC_AGENCY]);
+        $orga->addCustomerAndOrgaType($customerBrandenburg, $opsorgType);
+        $this->getEntityManager()->persist($orga);
+        $this->getEntityManager()->flush();
+
+        // Baseline: visible in both customers.
+        static::assertTrue($orga->getShowlistForCustomer($customerHindsight));
+        static::assertTrue($orga->getShowlistForCustomer($customerBrandenburg));
+
+        // Hide in the current (testCustomer) customer via the real write path.
+        $orgaRepository = self::getContainer()->get(OrgaRepository::class);
+        $orgaRepository->updateShowlistForCustomer($orga, $customerHindsight, false);
+        $this->getEntityManager()->refresh($orga);
+
+        static::assertFalse($orga->getShowlistForCustomer($customerHindsight));
+        // Second customer is unaffected — the per-customer split holds.
+        static::assertTrue($orga->getShowlistForCustomer($customerBrandenburg));
+
+        // Query-level proof: the orga is absent from getParticipants() (current customer) while
+        // hidden there, even though its orga-level _o_showlist is still true (dual-write only
+        // mirrors on the update path, and the default fixture value is true).
+        $participantsHidden = $orgaService->getParticipants();
+        static::assertNotContains($orgaId, array_map(static fn (Orga $o): string => $o->getId(), $participantsHidden));
+
+        // Re-enable and confirm it reappears — the change is reversible and not stuck on the
+        // orga-level column.
+        $orgaRepository->updateShowlistForCustomer($orga, $customerHindsight, true);
+        $this->getEntityManager()->refresh($orga);
+        $participantsVisible = $orgaService->getParticipants();
+        static::assertContains($orgaId, array_map(static fn (Orga $o): string => $o->getId(), $participantsVisible));
+    }
+
+    /**
+     * showlist is one decision per customer, spanning every orgaType row the orga holds there.
+     *
+     * getParticipants() matches *any* orgaType row of the current customer, so hiding an orga that
+     * holds several orgaTypes must write all of them — otherwise it stays listed via the untouched
+     * row.
+     */
+    public function testShowlistWriteCoversEveryOrgaTypeOfTheCustomer()
+    {
+        /** @var OrgaService $orgaService */
+        $orgaService = self::getContainer()->get(OrgaService::class);
+        /** @var Orga $orga */
+        $orga = $this->getOrgaReference('testOrgaInvitableInstitution');
+        $orgaId = $orga->getId();
+        $customer = $this->getCustomerReference('testCustomer');
+
+        // Give the orga a second orgaType in the same customer, next to its PUBLIC_AGENCY row.
+        $municipalityType = $this->getEntityManager()->getRepository(OrgaType::class)
+            ->findOneBy(['name' => OrgaTypeInterface::MUNICIPALITY]);
+        $orga->addCustomerAndOrgaType($customer, $municipalityType);
+        $this->getEntityManager()->persist($orga);
+        $this->getEntityManager()->flush();
+        static::assertCount(2, $orga->getStatusesInCustomer($customer));
+
+        $orgaRepository = self::getContainer()->get(OrgaRepository::class);
+        $orgaRepository->updateShowlistForCustomer($orga, $customer, false);
+        $this->getEntityManager()->refresh($orga);
+
+        // Every row of the customer is hidden, not just the PUBLIC_AGENCY one.
+        foreach ($orga->getStatusesInCustomer($customer) as $statusInCustomer) {
+            static::assertFalse($statusInCustomer->getShowlist());
+        }
+        $participants = $orgaService->getParticipants();
+        static::assertNotContains($orgaId, array_map(static fn (Orga $o): string => $o->getId(), $participants));
+    }
+
+    /**
+     * An orga holding no PUBLIC_AGENCY row in the customer still has a readable and writable
+     * showlist — roughly half the orgas in a real customer are not public agencies, and their
+     * flag must not be stuck at false.
+     */
+    public function testShowlistIsReadableAndWritableWithoutPublicAgencyRow()
+    {
+        /** @var Orga $orga */
+        $orga = $this->getOrgaReference('testOrgaInvitableInstitution');
+        $customerBrandenburg = $this->getCustomerReference('testCustomerBrandenburg');
+
+        // Only a MUNICIPALITY row in this customer — no PUBLIC_AGENCY row at all.
+        $municipalityType = $this->getEntityManager()->getRepository(OrgaType::class)
+            ->findOneBy(['name' => OrgaTypeInterface::MUNICIPALITY]);
+        $orga->addCustomerAndOrgaType($customerBrandenburg, $municipalityType);
+        $this->getEntityManager()->persist($orga);
+        $this->getEntityManager()->flush();
+
+        $orgaTypeNames = array_map(
+            static fn (OrgaStatusInCustomer $s): string => $s->getOrgaType()->getName(),
+            $orga->getStatusesInCustomer($customerBrandenburg)
+        );
+        static::assertNotContains(OrgaTypeInterface::PUBLIC_AGENCY, $orgaTypeNames);
+
+        static::assertTrue($orga->getShowlistForCustomer($customerBrandenburg));
+
+        $orgaRepository = self::getContainer()->get(OrgaRepository::class);
+        $orgaRepository->updateShowlistForCustomer($orga, $customerBrandenburg, false);
+        $this->getEntityManager()->refresh($orga);
+
+        static::assertFalse($orga->getShowlistForCustomer($customerBrandenburg));
+    }
+
+    /**
+     * A new orgaType row adopts the customer's current showlist value, so gaining an orgaType
+     * never silently makes a hidden orga visible again.
+     */
+    public function testNewOrgaTypeRowInheritsShowlistOfTheCustomer()
+    {
+        /** @var Orga $orga */
+        $orga = $this->getOrgaReference('testOrgaInvitableInstitution');
+        $customer = $this->getCustomerReference('testCustomer');
+
+        $orgaRepository = self::getContainer()->get(OrgaRepository::class);
+        $orgaRepository->updateShowlistForCustomer($orga, $customer, false);
+        $this->getEntityManager()->refresh($orga);
+
+        $municipalityType = $this->getEntityManager()->getRepository(OrgaType::class)
+            ->findOneBy(['name' => OrgaTypeInterface::MUNICIPALITY]);
+        $orga->addCustomerAndOrgaType($customer, $municipalityType);
+        $this->getEntityManager()->persist($orga);
+        $this->getEntityManager()->flush();
+
+        static::assertFalse($orga->getShowlistForCustomer($customer));
+        foreach ($orga->getStatusesInCustomer($customer) as $statusInCustomer) {
+            static::assertFalse($statusInCustomer->getShowlist());
+        }
     }
 
     public function testWipeUser()
@@ -1053,5 +1202,28 @@ class UserServiceTest extends FunctionalTestCase
         /** @var AddressBookEntry $addressBookEntry */
         $addressBookEntry = $this->testUser = $this->fixtures->getReference('testAddressBookEntry1');
         static::assertEquals($organisation->getId(), $addressBookEntry->getOrganisation()->getId());
+    }
+
+    /**
+     * Counts orgas visible in the current customer's participant list, mirroring the
+     * getParticipants() filter (non-deleted, showname, per-customer showlist, not the anonymous
+     * orga) directly on OrgaStatusInCustomer rather than the legacy orga-level column.
+     */
+    private function countVisibleParticipants(): int
+    {
+        $customerId = $this->getCustomerReference('testCustomer')->getId();
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('count(distinct o.id)')
+            ->from(Orga::class, 'o')
+            ->join('o.statusInCustomers', 's')
+            ->where('o.deleted = false')
+            ->andWhere('o.showname = true')
+            ->andWhere('o.id != :anonymousId')
+            ->andWhere('s.customer = :customerId')
+            ->andWhere('s.showlist = true')
+            ->setParameter('anonymousId', User::ANONYMOUS_USER_ORGA_ID)
+            ->setParameter('customerId', $customerId);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 }


### PR DESCRIPTION
`showlist` gates whether an organisation appears in the invitation lists, but it lived on
`Orga` as a single value shared across every customer — unlike `status`, `orgaType` and
customer membership, which are all per customer on `OrgaStatusInCustomer`. Disabling it in
one customer therefore hid the organisation everywhere, and an organisation could not be
visible in one customer while hidden in another.

The flag moves to `OrgaStatusInCustomer` and is resolved for the current customer in the
backend, so the flat `showlist` API attribute keeps its contract and the frontend is
untouched.

**Grain:** `showlist` is one decision per customer, spanning every orgaType row the
organisation holds there — reads prefer the public-agency row (the grain
`InvitablePublicAgencyResourceType` filters on) and fall back to any other row of the
customer; writes cover all rows; a newly added orgaType row inherits the customer's current
value. This keeps it aligned with `getParticipants()`, which matches any orgaType row, and
keeps the flag settable for organisations that are not public agencies (roughly half of them
in a real customer).

`Orga._o_showlist` is retained and dual-written during the transition; a follow-up drops the
column together with the `canUpdateShowList` plumbing.

### How to review/test
- The migration adds the column and backfills it from `_o_showlist`, so existing settings
  carry over. It must run exactly once — re-running the `UPDATE … JOIN` would overwrite
  deliberately diverged per-customer values.
- `UserServiceTest` covers the query path end to end: per-customer split via
  `getParticipants()`, multi-orgaType writes, organisations without a public-agency row, and
  orgaType inheritance.

### PR Checklist
- [x] Create/Update tests