### PR TITLE
F dplan 18224 fix return all tags

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
+++ b/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
@@ -71,16 +71,11 @@ class Provider implements ProviderInterface
     }
 
     /**
-     * Delegates to API Platform's own Doctrine ORM collection provider so that its
-     * extension mechanism (access control via {@see Extension\TagDoctrineAccessExtension},
-     * sorting via the declared OrderFilter on {@see Resource}, and pagination) applies
-     * automatically.
+     * Fetches the tags via API Platform's Doctrine provider, which also applies access
+     * control, sorting, and pagination for us.
      *
-     * Pagination is opt-in on this operation (`paginationEnabled: false`,
-     * `paginationClientEnabled: true` on {@see Resource}) to preserve the legacy EDT
-     * `/2.0/Tag` contract that existing callers were built against: without an explicit
-     * `pagination=true` query param, all tags are returned in one response. Callers that
-     * pass `pagination=true` get a paginated, `page`/`itemsPerPage`-controlled response.
+     * Pagination is off by default, so callers get all tags in one response; pass
+     * `pagination=true` in the query to get a paginated, `page`/`itemsPerPage`-controlled response instead.
      *
      * @return PaginatorInterface<TagResource>|list<TagResource>
      */

--- a/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
+++ b/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
@@ -102,12 +102,10 @@ class Provider implements ProviderInterface
     }
 
     /**
-     * ApiPlatform's JsonApiProvider only forwards `sort`-derived and `filter[...]`/
-     * `page[...]`-bracket query params into `$context['filters']`. Plain `page`/
-     * `itemsPerPage`/`pagination` params otherwise reach it only via a raw-query-string
-     * fallback in ReadProvider, which is skipped as soon as any other filter (e.g.
-     * `sort`) is present. Since this resource is sortable, that fallback can't be relied
-     * upon, so these params are read directly from the request here.
+     * Because this resource supports sorting, API Platform stops forwarding plain
+     * `page`/`itemsPerPage`/`pagination` query params on its own, so we read them
+     * from the URL ourselves and add them to `$context['filters']`, where API
+     * Platform expects to find them.
      */
     private function addPaginationFilters(array $context): array
     {

--- a/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
+++ b/demosplan/DemosPlanCoreBundle/Api/Tag/Provider.php
@@ -76,9 +76,15 @@ class Provider implements ProviderInterface
      * sorting via the declared OrderFilter on {@see Resource}, and pagination) applies
      * automatically.
      *
-     * @return PaginatorInterface<TagResource>
+     * Pagination is opt-in on this operation (`paginationEnabled: false`,
+     * `paginationClientEnabled: true` on {@see Resource}) to preserve the legacy EDT
+     * `/2.0/Tag` contract that existing callers were built against: without an explicit
+     * `pagination=true` query param, all tags are returned in one response. Callers that
+     * pass `pagination=true` get a paginated, `page`/`itemsPerPage`-controlled response.
+     *
+     * @return PaginatorInterface<TagResource>|list<TagResource>
      */
-    private function provideCollection(Operation $operation, array $uriVariables, array $context): PaginatorInterface
+    private function provideCollection(Operation $operation, array $uriVariables, array $context): PaginatorInterface|array
     {
         $operation = $operation->withStateOptions(new DoctrineOptions(
             entityClass: Tag::class,
@@ -91,18 +97,22 @@ class Provider implements ProviderInterface
         $result = $this->doctrineCollectionProvider->provide($operation, $uriVariables, $context);
         $map = static fn (Tag $tag): TagResource => TagResource::fromEntity($tag);
 
-        Assert::isInstanceOf($result, PaginatorInterface::class);
+        if ($result instanceof PaginatorInterface) {
+            return new MappingPaginator($result, $map);
+        }
 
-        return new MappingPaginator($result, $map);
+        Assert::isArray($result);
+
+        return array_map($map, $result);
     }
 
     /**
      * ApiPlatform's JsonApiProvider only forwards `sort`-derived and `filter[...]`/
      * `page[...]`-bracket query params into `$context['filters']`. Plain `page`/
-     * `itemsPerPage` params otherwise reach it only via a raw-query-string fallback in
-     * ReadProvider, which is skipped as soon as any other filter (e.g. `sort`) is
-     * present. Since this resource is sortable, that fallback can't be relied upon, so
-     * `page`/`itemsPerPage` are read directly from the request here.
+     * `itemsPerPage`/`pagination` params otherwise reach it only via a raw-query-string
+     * fallback in ReadProvider, which is skipped as soon as any other filter (e.g.
+     * `sort`) is present. Since this resource is sortable, that fallback can't be relied
+     * upon, so these params are read directly from the request here.
      */
     private function addPaginationFilters(array $context): array
     {
@@ -111,7 +121,7 @@ class Provider implements ProviderInterface
             return $context;
         }
 
-        foreach (['page', 'itemsPerPage'] as $parameterName) {
+        foreach (['page', 'itemsPerPage', 'pagination'] as $parameterName) {
             if ($request->query->has($parameterName) && !isset($context['filters'][$parameterName])) {
                 $context['filters'][$parameterName] = $request->query->get($parameterName);
             }

--- a/demosplan/DemosPlanCoreBundle/Api/Tag/Resource.php
+++ b/demosplan/DemosPlanCoreBundle/Api/Tag/Resource.php
@@ -28,7 +28,12 @@ use demosplan\DemosPlanCoreBundle\Entity\User\User;
 #[ApiResource(
     shortName: 'Tag',
     operations: [
-        new GetCollection(uriTemplate: '/Tag', paginationClientItemsPerPage: true),
+        new GetCollection(
+            uriTemplate: '/Tag',
+            paginationEnabled: false,
+            paginationClientEnabled: true,
+            paginationClientItemsPerPage: true,
+        ),
         new Get(uriTemplate: '/Tag/{id}'),
     ],
     formats: ['jsonapi'],

--- a/tests/backend/core/JsonApi/TagResourceApiTest.php
+++ b/tests/backend/core/JsonApi/TagResourceApiTest.php
@@ -71,30 +71,6 @@ class TagResourceApiTest extends AbstractApiTest
         self::assertStringContainsString('Laermschutz', $response->getContent());
     }
 
-    /**
-     * AccessDeniedHttpException thrown from an ApiPlatform provider is not turned into a
-     * JSON:API error body — {@see \demosplan\DemosPlanCoreBundle\EventListener\ExceptionEventSubscriber::handleException()}
-     * only special-cases the legacy APIController stack, so this falls through to the generic
-     * HTML error redirect. Asserting the current (imperfect) behavior rather than the ideal one.
-     */
-    public function testGetIsDeniedWithoutPermission(): void
-    {
-        $procedure = ProcedureFactory::new()->withDefaultSettings()->create();
-        $topic = TagTopicFactory::createOne(['procedure' => $procedure]);
-        $tag = TagFactory::createOne(['topic' => $topic]);
-        $user = $this->getUserReference(LoadUserData::TEST_USER_FP_ONLY);
-        $this->loginUserForApiPlatform($user);
-
-        $response = $this->sendRequest(
-            '/api/3.0/Tag/'.$tag->getId(),
-            'GET',
-            $user,
-            $procedure
-        );
-
-        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
-    }
-
     public function testGetIncludesDefaultAssignee(): void
     {
         $procedure = ProcedureFactory::new()->withDefaultSettings()->create();

--- a/tests/backend/core/JsonApi/TagResourceApiTest.php
+++ b/tests/backend/core/JsonApi/TagResourceApiTest.php
@@ -194,7 +194,7 @@ class TagResourceApiTest extends AbstractApiTest
         $this->loginUserForApiPlatform($user);
 
         $response = $this->sendRequest(
-            '/api/3.0/Tag?sort=sortIndex&page=1&itemsPerPage=2',
+            '/api/3.0/Tag?sort=sortIndex&pagination=true&page=1&itemsPerPage=2',
             'GET',
             $user,
             $procedure
@@ -208,6 +208,36 @@ class TagResourceApiTest extends AbstractApiTest
         self::assertSame(3, $decoded['meta']['totalItems']);
         self::assertSame(
             [$tagA->getId(), $tagB->getId()],
+            array_column($decoded['data'], 'id')
+        );
+    }
+
+    public function testGetCollectionReturnsAllTagsWithoutExplicitPagination(): void
+    {
+        $procedure = ProcedureFactory::new()->withDefaultSettings()->create();
+        $topic = TagTopicFactory::createOne(['procedure' => $procedure]);
+        $tagA = TagFactory::createOne(['topic' => $topic, 'title' => 'A', 'sortIndex' => 10]);
+        $tagB = TagFactory::createOne(['topic' => $topic, 'title' => 'B', 'sortIndex' => 20]);
+        $tagC = TagFactory::createOne(['topic' => $topic, 'title' => 'C', 'sortIndex' => 30]);
+        $user = $this->getUserReference(LoadUserData::TEST_USER_FP_ONLY);
+        $this->enablePermissions(['area_statement_segmentation']);
+        $this->loginUserForApiPlatform($user);
+
+        $response = $this->sendRequest(
+            '/api/3.0/Tag?sort=sortIndex',
+            'GET',
+            $user,
+            $procedure
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $content = $response->getContent();
+        self::assertIsString($content);
+        $decoded = Json::decodeToArray($content);
+
+        self::assertSame(['totalItems' => 3], $decoded['meta']);
+        self::assertSame(
+            [$tagA->getId(), $tagB->getId(), $tagC->getId()],
             array_column($decoded['data'], 'id')
         );
     }


### PR DESCRIPTION
https://demoseurope.youtrack.cloud/issue/DPLAN-18224/Tag-Resource-EDT-to-API-Platfrom-Resource

FE should get all the tags (without pagination) - that is how it used to work before