### PR TITLE
fix: scope institution tags to the current customer

### DIFF
--- a/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
+++ b/client/js/components/procedure/admin/InstitutionTagManagement/InstitutionList.vue
@@ -95,7 +95,7 @@
             <div
               v-else
               :key="`tags:${idx}`"
-              v-text="separateByCommas(institution.tags.filter(tag => tag.category.id === category.id))"
+              v-text="separateByCommas(institution.tags.filter(tag => tag.category?.id === category.id))"
             />
           </template>
           <template
@@ -323,16 +323,20 @@ export default {
           edit: this.editingInstitutionId === id,
           id,
           name: attributes.name,
-          tags: relationships.assignedTags.data.map(tag => {
-            const tagDetails = this.getTagById(tag.id)
+          tags: relationships.assignedTags.data
+            .map(tag => {
+              const tagDetails = this.getTagById(tag.id)
 
-            return {
-              id: tag.id,
-              type: tag.type,
-              name: tagDetails.name,
-              category: tagDetails.category,
-            }
-          }),
+              return tagDetails ?
+                {
+                  id: tag.id,
+                  type: tag.type,
+                  name: tagDetails.name,
+                  category: tagDetails.category,
+                } :
+                null
+            })
+            .filter(Boolean),
         }
       })
     },
@@ -422,8 +426,14 @@ export default {
       })
       this.editingInstitution.relationships.assignedTags.data.forEach(el => {
         const tag = this.getTagById(el.id)
+        const categoryId = tag?.category?.id
 
-        this.editingInstitutionTags[tag.category.id].push(tag)
+        // Tags of a category the current customer cannot see have no column to be edited in
+        if (!categoryId || !this.editingInstitutionTags[categoryId]) {
+          return
+        }
+
+        this.editingInstitutionTags[categoryId].push(tag)
       })
 
       // Initialize editingInstitutionCustomFields from the component-local value cache

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/InstitutionTagCategoryFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/InstitutionTagCategoryFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
+use demosplan\DemosPlanCoreBundle\Repository\InstitutionTagCategoryRepository;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;
+
+/**
+ * @extends PersistentProxyObjectFactory<InstitutionTagCategory>
+ *
+ * @method        InstitutionTagCategory|Proxy                              create(array|callable $attributes = [])
+ * @method static InstitutionTagCategory|Proxy                              createOne(array $attributes = [])
+ * @method static InstitutionTagCategory|Proxy                              find(object|array|mixed $criteria)
+ * @method static InstitutionTagCategory|Proxy                              findOrCreate(array $attributes)
+ * @method static InstitutionTagCategory|Proxy                              first(string $sortedField = 'id')
+ * @method static InstitutionTagCategory|Proxy                              last(string $sortedField = 'id')
+ * @method static InstitutionTagCategory|Proxy                              random(array $attributes = [])
+ * @method static InstitutionTagCategory|Proxy                              randomOrCreate(array $attributes = [])
+ * @method static InstitutionTagCategoryRepository|ProxyRepositoryDecorator repository()
+ * @method static InstitutionTagCategory[]|Proxy[]                          all()
+ * @method static InstitutionTagCategory[]|Proxy[]                          createMany(int $number, array|callable $attributes = [])
+ * @method static InstitutionTagCategory[]|Proxy[]                          createSequence(iterable|callable $sequence)
+ * @method static InstitutionTagCategory[]|Proxy[]                          findBy(array $attributes)
+ * @method static InstitutionTagCategory[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
+ * @method static InstitutionTagCategory[]|Proxy[]                          randomSet(int $number, array $attributes = [])
+ */
+final class InstitutionTagCategoryFactory extends PersistentProxyObjectFactory
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     */
+    protected function defaults(): array
+    {
+        return [
+            'name'     => self::faker()->unique()->words(3, true),
+            'customer' => CustomerFactory::new(),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    public static function class(): string
+    {
+        return InstitutionTagCategory::class;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/InstitutionTagFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/Factory/User/InstitutionTagFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User;
+
+use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
+use demosplan\DemosPlanCoreBundle\Repository\InstitutionTagRepository;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;
+
+/**
+ * @extends PersistentProxyObjectFactory<InstitutionTag>
+ *
+ * @method        InstitutionTag|Proxy                              create(array|callable $attributes = [])
+ * @method static InstitutionTag|Proxy                              createOne(array $attributes = [])
+ * @method static InstitutionTag|Proxy                              find(object|array|mixed $criteria)
+ * @method static InstitutionTag|Proxy                              findOrCreate(array $attributes)
+ * @method static InstitutionTag|Proxy                              first(string $sortedField = 'id')
+ * @method static InstitutionTag|Proxy                              last(string $sortedField = 'id')
+ * @method static InstitutionTag|Proxy                              random(array $attributes = [])
+ * @method static InstitutionTag|Proxy                              randomOrCreate(array $attributes = [])
+ * @method static InstitutionTagRepository|ProxyRepositoryDecorator repository()
+ * @method static InstitutionTag[]|Proxy[]                          all()
+ * @method static InstitutionTag[]|Proxy[]                          createMany(int $number, array|callable $attributes = [])
+ * @method static InstitutionTag[]|Proxy[]                          createSequence(iterable|callable $sequence)
+ * @method static InstitutionTag[]|Proxy[]                          findBy(array $attributes)
+ * @method static InstitutionTag[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
+ * @method static InstitutionTag[]|Proxy[]                          randomSet(int $number, array $attributes = [])
+ */
+final class InstitutionTagFactory extends PersistentProxyObjectFactory
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     */
+    protected function defaults(): array
+    {
+        return [
+            'label'    => self::faker()->unique()->words(2, true),
+            'category' => InstitutionTagCategoryFactory::new(),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    public static function class(): string
+    {
+        return InstitutionTag::class;
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTag.php
@@ -134,6 +134,11 @@ class InstitutionTag extends CoreEntity implements UuidEntityInterface, Institut
         $this->label = $label;
     }
 
+    public function getCategory(): InstitutionTagCategory
+    {
+        return $this->category;
+    }
+
     public function setCategory(InstitutionTagCategoryInterface $category): void
     {
         $this->category = $category;

--- a/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTagCategory.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/InstitutionTagCategory.php
@@ -86,6 +86,11 @@ class InstitutionTagCategory extends CoreEntity implements UuidEntityInterface, 
         $this->name = $name;
     }
 
+    public function getCustomer(): Customer
+    {
+        return $this->customer;
+    }
+
     public function setCustomer(CustomerInterface $customer): void
     {
         $this->customer = $customer;

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagCategoryResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagCategoryResourceType.php
@@ -22,6 +22,9 @@ use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\Querying\Contracts\PathException;
 use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
 
+/**
+ * @property-read CustomerResourceType $customer
+ */
 class InstitutionTagCategoryResourceType extends DplanResourceType
 {
     public function __construct(private readonly InstitutionTagRepository $institutionTagRepository)

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InstitutionTagResourceType.php
@@ -16,6 +16,7 @@ use DemosEurope\DemosplanAddon\EntityPath\Paths;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
 use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTagCategory;
 use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\ViolationsException;
 use demosplan\DemosPlanCoreBundle\Logic\ApiRequest\ResourceType\DplanResourceType;
 use demosplan\DemosPlanCoreBundle\Repository\InstitutionTagRepository;
@@ -25,6 +26,7 @@ use Doctrine\Common\Collections\Collection;
 use EDT\JsonApi\ApiDocumentation\OptionalField;
 use EDT\JsonApi\ResourceConfig\Builder\ResourceConfigBuilderInterface;
 use EDT\PathBuilding\End;
+use EDT\Querying\Contracts\PathException;
 use EDT\Wrapping\PropertyBehavior\FixedSetBehavior;
 use EDT\Wrapping\PropertyBehavior\Relationship\ToOne\CallbackToOneRelationshipSetBehavior;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -34,8 +36,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @template-extends DplanResourceType<InstitutionTag>
  *
- * @property-read End                     $label
- * @property-read OrgaResourceType        $taggedInstitutions
+ * @property-read End                              $label
+ * @property-read OrgaResourceType                 $taggedInstitutions
+ * @property-read InstitutionTagCategoryResourceType $category
  */
 class InstitutionTagResourceType extends DplanResourceType
 {
@@ -142,12 +145,21 @@ class InstitutionTagResourceType extends DplanResourceType
         return $this->currentUser->hasPermission('feature_institution_tag_update');
     }
 
+    /**
+     * @throws CustomerNotFoundException
+     * @throws PathException
+     */
     protected function getAccessConditions(): array
     {
         if ($this->currentUser->hasPermission(
             'feature_institution_tag_read',
         )) {
-            return [$this->conditionFactory->true()];
+            $currentCustomerId = $this->currentCustomerService->getCurrentCustomer()->getId();
+
+            return [$this->conditionFactory->propertyHasValue(
+                $currentCustomerId,
+                $this->category->customer->id
+            )];
         }
 
         return [$this->conditionFactory->false()];

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitableInstitutionResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/InvitableInstitutionResourceType.php
@@ -126,10 +126,13 @@ final class InvitableInstitutionResourceType extends DplanResourceType
                     function (Orga $institution, array $newAssignedTags): array {
                         $newAssignedTags = new ArrayCollection($newAssignedTags);
                         $currentlyAssignedTags = $institution->getAssignedTags();
+                        $currentCustomerId = $this->currentCustomerService->getCurrentCustomer()->getId();
 
-                        // removed tags
+                        // The payload covers the current customer only, so a tag of another
+                        // customer is absent from it without having been removed.
                         $removedTags = $currentlyAssignedTags->filter(
                             static fn (InstitutionTag $currentTag): bool => !$newAssignedTags->contains($currentTag)
+                                && $currentCustomerId === $currentTag->getCategory()->getCustomer()->getId()
                         );
 
                         // new tags

--- a/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
+++ b/demosplan/DemosPlanCoreBundle/ResourceTypes/OrgaResourceType.php
@@ -280,14 +280,17 @@ final class OrgaResourceType extends DplanResourceType implements OrgaResourceTy
 
     public function getRegistrationStatuses(Orga $orga): array
     {
-        return $this->getRegistration($orga)
+        // array_values() reindexes sequentially: getRegistration() may return a collection
+        // filtered down from a larger one, whose keys would otherwise stay non-sequential and
+        // make json_encode() emit a JSON object instead of an array.
+        return array_values($this->getRegistration($orga)
             ->map(
                 static fn (OrgaStatusInCustomer $orgaStatusInCustomer) => [
                     OrgaResourceType::REGISTRATION_STATUSES_STATUS    => $orgaStatusInCustomer->getStatus(),
                     OrgaResourceType::REGISTRATION_STATUSES_TYPE      => $orgaStatusInCustomer->getOrgaType()->getName(),
                     OrgaResourceType::REGISTRATION_STATUSES_SUBDOMAIN => $orgaStatusInCustomer->getCustomer()->getSubdomain(),
                 ]
-            )->toArray();
+            )->toArray());
     }
 
     public function getEmailNotificationNewStatement(Orga $orga): bool

--- a/tests/backend/core/JsonApi/InstitutionTagResourceTypeTest.php
+++ b/tests/backend/core/JsonApi/InstitutionTagResourceTypeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\JsonApi;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\InstitutionTagCategoryFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\InstitutionTagFactory;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\InstitutionTagResourceType;
+use InvalidArgumentException;
+use Tests\Base\FunctionalTestCase;
+
+class InstitutionTagResourceTypeTest extends FunctionalTestCase
+{
+    protected ?InstitutionTagResourceType $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = $this->getContainer()->get(InstitutionTagResourceType::class);
+
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $this->logIn($user);
+        $this->enablePermissions(['feature_institution_tag_read']);
+    }
+
+    public function testTagOwnedByCurrentCustomerIsAccessible(): void
+    {
+        // Arrange
+        $currentCustomer = CustomerFactory::createOne(['subdomain' => 'current-customer-'.uniqid()]);
+        $this->makeCustomerCurrent($currentCustomer->_real());
+        $ownTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new(['customer' => $currentCustomer]),
+        ]);
+
+        // Act
+        $result = $this->sut->getEntity($ownTag->getId());
+
+        // Assert
+        self::assertSame($ownTag->getId(), $result->getId());
+    }
+
+    public function testTagOwnedByAnotherCustomerIsNotAccessible(): void
+    {
+        // Arrange
+        $currentCustomer = CustomerFactory::createOne(['subdomain' => 'current-customer-'.uniqid()]);
+        $this->makeCustomerCurrent($currentCustomer->_real());
+        $otherCustomer = CustomerFactory::createOne(['subdomain' => 'other-customer-'.uniqid()]);
+        $foreignTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new(['customer' => $otherCustomer]),
+        ]);
+
+        // Act & Assert
+        $this->expectException(InvalidArgumentException::class);
+        $this->sut->getEntity($foreignTag->getId());
+    }
+
+    private function makeCustomerCurrent(Customer $customer): void
+    {
+        $globalConfig = $this->getContainer()->get(GlobalConfigInterface::class);
+        $globalConfig->setSubdomain($customer->getSubdomain());
+    }
+}

--- a/tests/backend/core/JsonApi/InvitableInstitutionResourceTypeTest.php
+++ b/tests/backend/core/JsonApi/InvitableInstitutionResourceTypeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\JsonApi;
+
+use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\InstitutionTagCategoryFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\InstitutionTagFactory;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
+use demosplan\DemosPlanCoreBundle\Entity\User\InstitutionTag;
+use demosplan\DemosPlanCoreBundle\Entity\User\Orga;
+use demosplan\DemosPlanCoreBundle\ResourceTypes\InvitableInstitutionResourceType;
+use EDT\Wrapping\EntityData;
+use Tests\Base\FunctionalTestCase;
+
+class InvitableInstitutionResourceTypeTest extends FunctionalTestCase
+{
+    protected ?InvitableInstitutionResourceType $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = $this->getContainer()->get(InvitableInstitutionResourceType::class);
+
+        $user = $this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY);
+        $this->logIn($user);
+        $this->enablePermissions([
+            'feature_institution_tag_assign',
+            'feature_institution_tag_read',
+            'feature_institution_tag_update',
+        ]);
+    }
+
+    /**
+     * An institution can be a member of several customers and carries the tags of all of them,
+     * while a request only ever covers the current customer. Sending the tags of the current
+     * customer must not drop the tags an institution holds elsewhere.
+     */
+    public function testUpdateKeepsTagsOfOtherCustomers(): void
+    {
+        // Arrange
+        $institution = $this->getInvitableInstitution();
+        $currentCustomer = $this->getCurrentCustomerOf($institution);
+        $this->makeCustomerCurrent($currentCustomer);
+
+        $ownTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new(['customer' => $currentCustomer]),
+        ])->_real();
+        $foreignTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new([
+                'customer' => CustomerFactory::new(['subdomain' => 'other-customer-'.uniqid()]),
+            ]),
+        ])->_real();
+
+        $institution->addAssignedTag($ownTag);
+        $institution->addAssignedTag($foreignTag);
+        $this->getEntityManager()->flush();
+
+        // Act
+        $this->sut->updateEntity(
+            $institution->getId(),
+            new EntityData('InvitableInstitution', [], [], ['assignedTags' => []])
+        );
+        $this->getEntityManager()->flush();
+
+        // Assert
+        $assignedTagIds = $institution->getAssignedTags()
+            ->map(static fn (InstitutionTag $tag): string => $tag->getId())
+            ->toArray();
+        self::assertNotContains($ownTag->getId(), $assignedTagIds);
+        self::assertContains($foreignTag->getId(), $assignedTagIds);
+    }
+
+    public function testUpdateRemovesTagsOfCurrentCustomer(): void
+    {
+        // Arrange
+        $institution = $this->getInvitableInstitution();
+        $currentCustomer = $this->getCurrentCustomerOf($institution);
+        $this->makeCustomerCurrent($currentCustomer);
+
+        $keptTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new(['customer' => $currentCustomer]),
+        ])->_real();
+        $removedTag = InstitutionTagFactory::createOne([
+            'category' => InstitutionTagCategoryFactory::new(['customer' => $currentCustomer]),
+        ])->_real();
+
+        $institution->addAssignedTag($keptTag);
+        $institution->addAssignedTag($removedTag);
+        $this->getEntityManager()->flush();
+
+        // Act
+        $this->sut->updateEntity(
+            $institution->getId(),
+            new EntityData('InvitableInstitution', [], [], [
+                'assignedTags' => [['type' => 'InstitutionTag', 'id' => $keptTag->getId()]],
+            ])
+        );
+        $this->getEntityManager()->flush();
+
+        // Assert
+        $assignedTagIds = $institution->getAssignedTags()
+            ->map(static fn (InstitutionTag $tag): string => $tag->getId())
+            ->toArray();
+        self::assertContains($keptTag->getId(), $assignedTagIds);
+        self::assertNotContains($removedTag->getId(), $assignedTagIds);
+    }
+
+    private function getInvitableInstitution(): Orga
+    {
+        return $this->getReference(LoadUserData::TEST_ORGA_PUBLIC_AGENCY);
+    }
+
+    private function getCurrentCustomerOf(Orga $institution): Customer
+    {
+        return $institution->getStatusInCustomers()->first()->getCustomer();
+    }
+
+    private function makeCustomerCurrent(Customer $customer): void
+    {
+        $globalConfig = $this->getContainer()->get(GlobalConfigInterface::class);
+        $globalConfig->setSubdomain($customer->getSubdomain());
+    }
+}


### PR DESCRIPTION
Backport of #6728.
Ado-57428

Institution tags are scoped to a customer only through their category, but
`InstitutionTagResourceType` returned all tags regardless of customer. An organisation that is a
member of several customers therefore exposed its tags from every one of them:

- Reading: the tag came back while its category did not (the category type does filter by
  customer), so the institution list received a tag with `category: null` and the row failed to
  render as soon as a category column was selected.
- Writing: the `assignedTags` payload only ever covers the current customer, but the update diffed
  it against the organisation's complete tag collection, so saving an institution silently deleted
  the tags it holds in other customers.

Fixed on both sides — access conditions scope reads via `category->customer`, and removals are
limited to tags of the current customer. The institution list additionally skips tags whose
category it cannot resolve, since those have no column to be displayed or edited in.

### How to review/test
- An organisation in two customers, tagged in both: the foreign tag must be invisible in the other
  customer, and editing the organisation there must leave that assignment intact.
- `InstitutionTagResourceTypeTest` covers same-customer and cross-customer reads,
  `InvitableInstitutionResourceTypeTest` covers the update keeping foreign tags while still
  removing own ones.

### PR Checklist
- [x] Create/Update tests