### PR TITLE
refac(DPLAN-18330): prevent the export options from being duplicated in the single statement view

### DIFF
--- a/client/js/components/statement/StatementExportModal.vue
+++ b/client/js/components/statement/StatementExportModal.vue
@@ -56,45 +56,44 @@
           :message="exportTypes[active].hint"
           type="warning"
         />
-      </fieldset>
-
-      <fieldset
-        v-if="!['xlsx_normal', 'csv_normal'].includes(active)"
-        class="border-b border-neutral"
-      >
-        <legend
-          class="text-base py-4"
-          v-text="Translator.trans('export.options')"
-        />
-        <dp-checkbox
-          id="censoredCitizen"
-          v-model="isCitizenDataCensored"
-          class="mb-1"
-          data-cy="exportModal:censoredCitizen"
-          :label="{
-            regular: true,
-            text: Translator.trans('export.censored.citizen'),
-          }"
-        />
-        <dp-checkbox
-          id="censoredInstitution"
-          v-model="isInstitutionDataCensored"
-          class="mb-1"
-          data-cy="exportModal:censoredInstitution"
-          :label="{
-            regular: true,
-            text: Translator.trans('export.censored.institution')
-          }"
-        />
-        <dp-checkbox
-          id="obscured"
-          v-model="isObscure"
-          data-cy="exportModal:obscured"
-          :label="{
-            regular: true,
-            text: Translator.trans('export.docx.obscured')
-          }"
-        />
+        <fieldset
+          v-if="!['xlsx_normal', 'csv_normal'].includes(active)"
+          class="border-b border-neutral"
+        >
+          <legend
+            class="text-base py-4"
+            v-text="Translator.trans('export.options')"
+          />
+          <dp-checkbox
+            id="censoredCitizen"
+            v-model="isCitizenDataCensored"
+            class="mb-1"
+            data-cy="exportModal:censoredCitizen"
+            :label="{
+              regular: true,
+              text: Translator.trans('export.censored.citizen'),
+            }"
+          />
+          <dp-checkbox
+            id="censoredInstitution"
+            v-model="isInstitutionDataCensored"
+            class="mb-1"
+            data-cy="exportModal:censoredInstitution"
+            :label="{
+              regular: true,
+              text: Translator.trans('export.censored.institution')
+            }"
+          />
+          <dp-checkbox
+            id="obscured"
+            v-model="isObscure"
+            data-cy="exportModal:obscured"
+            :label="{
+              regular: true,
+              text: Translator.trans('export.docx.obscured')
+            }"
+          />
+        </fieldset>
       </fieldset>
 
       <fieldset
@@ -102,7 +101,7 @@
         class="border-b border-neutral"
       >
         <legend
-          class="text-base py-4"
+          class="text-base pb-4"
           v-text="Translator.trans('export.options')"
         />
         <dp-checkbox
@@ -195,7 +194,7 @@
 
       <div
         v-if="isSingleStatementExport && hasPermission('feature_statement_via_template_export')"
-        class="border-b border-neutral py-4"
+        class="pt-4"
       >
         <dp-label
           :hint="Translator.trans('docx.export.via_template.upload.hint')"
@@ -282,7 +281,7 @@
         }"
         :maxlength="customHeaderMaxLength"
         :placeholder="Translator.trans('docx.export.header.custom.placeholder')"
-        class="py-4"
+        class="pt-4"
         data-cy="exportModal:customHeaderText"
         type="text"
       />

--- a/client/js/components/statement/StatementExportModal.vue
+++ b/client/js/components/statement/StatementExportModal.vue
@@ -58,7 +58,7 @@
         />
         <fieldset
           v-if="!['xlsx_normal', 'csv_normal'].includes(active)"
-          class="border-b border-neutral"
+          class="pb-0"
         >
           <legend
             class="text-base py-4"


### PR DESCRIPTION
### Ticket
[DPLAN-18330](https://demoseurope.youtrack.cloud/issue/DPLAN-18330) Export Modal: Doppelte Optionen bei einzelner Stellungname

**Description:** This PR fixes a layout issue where two sections with checkboxes were displayed in the single statement view. Refactor the export modal by moving the export options inside the export type section (for not single statement), as it was [before](https://github.com/demos-europe/demosplan-core/pull/6705/changes#diff-88188973df7d5a374ea5a2f8b1942f23c543bdc1b3e4d381edb1f6012a78cd43L50-L78).

### How to review/test
Go to STN-List > export > Modal should work as before
Go to _Erwiderung Verfasen_ Page > export > Modal should work as before (no duplicated setions)

### PR Checklist
<!-- Reminders for handling PRs 

Delete the checkbox if it doesn't apply/isn't necessary. -->

- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes ([conventions](https://dplan-documentation.demos-europe.eu/development/guidelines-conventions/coding-styleguides/twig_html.html#guideline-for-naming-cypress-hooks))
- [ ] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog 
