### PR TITLE
F dplan 18189 procedure export statement metadata

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -64,6 +64,11 @@ when@test:
                     charset: UTF8
                     memory: false
                     user: test
+                    # The messenger_messages exclusion (see base config above) makes
+                    # SchemaTool::dropDatabase() skip the table while createSchema() still
+                    # recreates it via MessengerTransportDoctrineSchemaListener, causing
+                    # "table already exists" on every SQLite schema rebuild in tests.
+                    schema_filter: ~
 
 when@prod:
     doctrine:

--- a/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/AssessmentTable/AssessmentTableServiceOutput.php
@@ -589,6 +589,7 @@ class AssessmentTableServiceOutput
         array $requestPost,
         string $sortType,
         string $viewMode = AssessmentTableViewMode::DEFAULT_VIEW,
+        bool $includeStatementMetadataRow = false,
     ): WriterInterface {
         return $this->docxExporter->generateDocx(
             $outputResult,
@@ -599,7 +600,8 @@ class AssessmentTableServiceOutput
             $viewOrientation,
             $requestPost,
             $sortType,
-            $viewMode
+            $viewMode,
+            $includeStatementMetadataRow
         );
     }
 

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -727,21 +727,25 @@ class DocxExporter
     {
         $priorityAreaKeys = $item['priorityAreaKeys'] ?? [];
         if ([] !== $priorityAreaKeys) {
-            $cell->addText(
-                $this->translator->trans('potential.area').': '.implode(', ', $priorityAreaKeys),
-                $styles['textStyleStatementDetails'],
-                $styles['textStyleStatementDetailsParagraphStyles']
-            );
+            $cell->addTextBreak();
+            $this->addStatementMetadataLine($cell, 'potential.area', $priorityAreaKeys, $styles);
         }
 
         $tagNames = $item['tagNames'] ?? [];
         if ([] !== $tagNames) {
-            $cell->addText(
-                $this->translator->trans('tags').': '.implode(', ', $tagNames),
-                $styles['textStyleStatementDetails'],
-                $styles['textStyleStatementDetailsParagraphStyles']
-            );
+            $cell->addTextBreak();
+            $this->addStatementMetadataLine($cell, 'tags', $tagNames, $styles);
         }
+    }
+
+    /**
+     * Renders "<bold label>: <values>" as a single line, with only the label in bold.
+     */
+    private function addStatementMetadataLine(Cell $cell, string $translationKey, array $values, array $styles): void
+    {
+        $textRun = $cell->addTextRun($styles['textStyleStatementDetailsParagraphStyles']);
+        $textRun->addText($this->translator->trans($translationKey).': ', ['bold' => true]);
+        $textRun->addText(implode(', ', $values));
     }
 
     protected function addSubmitterData(

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -164,6 +164,7 @@ class DocxExporter
         array $requestPost,
         string $sortType,
         string $viewMode = AssessmentTableViewMode::DEFAULT_VIEW,
+        bool $includeStatementMetadataRow = false,
     ): WriterInterface {
         /**
          * I tried to use templates with PHPWord 0.13.0, but it is not possible
@@ -386,7 +387,8 @@ class DocxExporter
                         ViewOrientation::createLandscape(),
                         $phpWord,
                         $exportType,
-                        $requestPost
+                        $requestPost,
+                        $includeStatementMetadataRow
                     );
                     break;
                 default:
@@ -613,6 +615,8 @@ class DocxExporter
             'userPosition'              => $statement['meta']['userPosition'] ?? null,
             'isClusterStatement'        => $statement['isClusterStatement'] ?? null,
             'name'                      => $statement['name'] ?? null,
+            'priorityAreaKeys'          => $statement['priorityAreaKeys'] ?? [],
+            'tagNames'                  => $statement['tagNames'] ?? [],
         ];
     }
 
@@ -655,6 +659,7 @@ class DocxExporter
         $exportType,
         bool $numberStatements = false,
         int $statementNumber = 0,
+        bool $includeStatementMetadataRow = false,
     ): void {
         $styles = $this->getDefaultDocxPageStyles($orientation);
 
@@ -678,6 +683,9 @@ class DocxExporter
                 if (isset($item['text'])) {
                     $item['text'] = $this->editorService->handleObscureTags($item['text'], $anonymous);
                     $this->addHtml($cell2, $item['text'], $styles);
+                }
+                if ($includeStatementMetadataRow) {
+                    $this->addStatementMetadataToCell($cell2, $item, $styles);
                 }
 
                 $cell3 = $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
@@ -705,6 +713,34 @@ class DocxExporter
                 ->addText($movedStatementText, $styles['cellHeadingText'], $styles['textStyleStatementDetailsParagraphStyles']);
 
             $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
+        }
+    }
+
+    /**
+     * Appends the assigned Potenzialflächen and Schlagworte below the statement text.
+     *
+     * Only used by the Verfahrensexport (see $includeStatementMetadataRow in
+     * {@link renderTableItem}); the standalone Abwägungstabelle export never sets that flag,
+     * so this stays out of it.
+     */
+    private function addStatementMetadataToCell(Cell $cell, array $item, array $styles): void
+    {
+        $priorityAreaKeys = $item['priorityAreaKeys'] ?? [];
+        if ([] !== $priorityAreaKeys) {
+            $cell->addText(
+                $this->translator->trans('potential.area').': '.implode(', ', $priorityAreaKeys),
+                $styles['textStyleStatementDetails'],
+                $styles['textStyleStatementDetailsParagraphStyles']
+            );
+        }
+
+        $tagNames = $item['tagNames'] ?? [];
+        if ([] !== $tagNames) {
+            $cell->addText(
+                $this->translator->trans('tags').': '.implode(', ', $tagNames),
+                $styles['textStyleStatementDetails'],
+                $styles['textStyleStatementDetailsParagraphStyles']
+            );
         }
     }
 
@@ -1959,6 +1995,7 @@ class DocxExporter
         PhpWord $phpWord,
         $exportType,
         array $requestPost,
+        bool $includeStatementMetadataRow = false,
     ): WriterInterface {
         $phpWord->setDefaultFontSize(9);
         $styles = $this->getDefaultDocxPageStyles($orientation);
@@ -1998,7 +2035,8 @@ class DocxExporter
                 $orientation,
                 $exportType,
                 $numberStatements,
-                $statementNumber
+                $statementNumber,
+                $includeStatementMetadataRow
             );
             ++$statementNumber;
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -644,15 +644,16 @@ class DocxExporter
      * <p>
      * Fragments can be converted to statement like items using 'formatFragment()' function.
      *
-     * @param Table $assessmentTable
+     * @param Table  $assessmentTable
      * @param array  $item
      * @param bool   $anonymous
      * @param string $exportType
-     * @param array  $renderOptions {
-     *     @var bool $numberStatements
-     *     @var int  $statementNumber
-     *     @var bool $includeStatementMetadataRow
-     * }
+     * @param array  $renderOptions   {
+     *
+     * @var bool $numberStatements
+     * @var int  $statementNumber
+     * @var bool $includeStatementMetadataRow
+     *           }
      *
      * @throws Exception
      */
@@ -2050,8 +2051,8 @@ class DocxExporter
                 $orientation,
                 $exportType,
                 [
-                    'numberStatements' => $numberStatements,
-                    'statementNumber' => $statementNumber,
+                    'numberStatements'            => $numberStatements,
+                    'statementNumber'             => $statementNumber,
                     'includeStatementMetadataRow' => $includeStatementMetadataRow,
                 ]
             );

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -644,10 +644,15 @@ class DocxExporter
      * <p>
      * Fragments can be converted to statement like items using 'formatFragment()' function.
      *
-     * @param Table  $assessmentTable
+     * @param Table $assessmentTable
      * @param array  $item
      * @param bool   $anonymous
      * @param string $exportType
+     * @param array  $renderOptions {
+     *     @var bool $numberStatements
+     *     @var int  $statementNumber
+     *     @var bool $includeStatementMetadataRow
+     * }
      *
      * @throws Exception
      */
@@ -657,43 +662,15 @@ class DocxExporter
         $anonymous,
         ViewOrientation $orientation,
         $exportType,
-        bool $numberStatements = false,
-        int $statementNumber = 0,
-        bool $includeStatementMetadataRow = false,
+        array $renderOptions = [],
     ): void {
+        $numberStatements = $renderOptions['numberStatements'] ?? false;
+        $statementNumber = $renderOptions['statementNumber'] ?? 0;
+        $includeStatementMetadataRow = $renderOptions['includeStatementMetadataRow'] ?? false;
+
         $styles = $this->getDefaultDocxPageStyles($orientation);
 
-        if (null === $item['movedToProcedureName']) {
-            // Stellungnahme oder Datensatz und Erwiderung
-            if ('statementsAndFragments' === $exportType && 0 < (is_countable($item['fragments']) ? count($item['fragments']) : 0)) {
-                $this->addFragmentRows($item, $assessmentTable, $styles['cellWidthTotal'] * 0.44, $styles['cellWidthTotal'] * 0.44, $styles, $anonymous);
-            } else {
-                $assessmentTable->addRow();
-                // add submitterData cell
-                $this->addSubmitterData(
-                    $anonymous,
-                    $assessmentTable,
-                    $item,
-                    $styles,
-                    $numberStatements,
-                    $statementNumber
-                );
-                $cellStyle = $styles['cellTop'];
-                $cell2 = $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
-                if (isset($item['text'])) {
-                    $item['text'] = $this->editorService->handleObscureTags($item['text'], $anonymous);
-                    $this->addHtml($cell2, $item['text'], $styles);
-                }
-                if ($includeStatementMetadataRow) {
-                    $this->addStatementMetadataToCell($cell2, $item, $styles);
-                }
-
-                $cell3 = $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
-                if (isset($item['recommendation'])) {
-                    $this->addHtml($cell3, $item['recommendation'], $styles);
-                }
-            }
-        } else {
+        if (null !== $item['movedToProcedureName']) {
             // Moved Statement
             $assessmentTable->addRow();
             $this->addSubmitterData(
@@ -713,6 +690,40 @@ class DocxExporter
                 ->addText($movedStatementText, $styles['cellHeadingText'], $styles['textStyleStatementDetailsParagraphStyles']);
 
             $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
+
+            return;
+        }
+
+        // Stellungnahme oder Datensatz und Erwiderung
+        if ('statementsAndFragments' === $exportType && 0 < (is_countable($item['fragments']) ? count($item['fragments']) : 0)) {
+            $this->addFragmentRows($item, $assessmentTable, $styles['cellWidthTotal'] * 0.44, $styles['cellWidthTotal'] * 0.44, $styles, $anonymous);
+
+            return;
+        }
+
+        $assessmentTable->addRow();
+        // add submitterData cell
+        $this->addSubmitterData(
+            $anonymous,
+            $assessmentTable,
+            $item,
+            $styles,
+            $numberStatements,
+            $statementNumber
+        );
+        $cellStyle = $styles['cellTop'];
+        $cell2 = $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
+        if (isset($item['text'])) {
+            $item['text'] = $this->editorService->handleObscureTags($item['text'], $anonymous);
+            $this->addHtml($cell2, $item['text'], $styles);
+        }
+        if ($includeStatementMetadataRow) {
+            $this->addStatementMetadataToCell($cell2, $item, $styles);
+        }
+
+        $cell3 = $assessmentTable->addCell($styles['cellWidthTotal'] * 0.44, $cellStyle);
+        if (isset($item['recommendation'])) {
+            $this->addHtml($cell3, $item['recommendation'], $styles);
         }
     }
 
@@ -2038,9 +2049,11 @@ class DocxExporter
                 $anonymous,
                 $orientation,
                 $exportType,
-                $numberStatements,
-                $statementNumber,
-                $includeStatementMetadataRow
+                [
+                    'numberStatements' => $numberStatements,
+                    'statementNumber' => $statementNumber,
+                    'includeStatementMetadataRow' => $includeStatementMetadataRow,
+                ]
             );
             ++$statementNumber;
         }

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -697,7 +697,7 @@ class DocxExporter
 
         // Stellungnahme oder Datensatz und Erwiderung
         if ('statementsAndFragments' === $exportType && 0 < (is_countable($item['fragments']) ? count($item['fragments']) : 0)) {
-            $this->addFragmentRows($item, $assessmentTable, $styles['cellWidthTotal'] * 0.44, $styles['cellWidthTotal'] * 0.44, $styles, $anonymous);
+            $this->addFragmentRows($item, $assessmentTable, $styles['cellWidthTotal'] * 0.44, $styles['cellWidthTotal'] * 0.44, $styles, $anonymous, $includeStatementMetadataRow);
 
             return;
         }
@@ -732,8 +732,8 @@ class DocxExporter
      * Appends the assigned Potenzialflächen and Schlagworte below the statement text.
      *
      * Only used by the Verfahrensexport (see $includeStatementMetadataRow in
-     * {@link renderTableItem}); the standalone Abwägungstabelle export never sets that flag,
-     * so this stays out of it.
+     * {@link renderTableItem} and {@link addFragmentRows}); the standalone Abwägungstabelle
+     * export never sets that flag, so this stays out of it.
      */
     private function addStatementMetadataToCell(Cell $cell, array $item, array $styles): void
     {
@@ -971,6 +971,10 @@ class DocxExporter
      * @param int     $recommendationCellWidth
      * @param array   $styles
      * @param bool    $anonymous
+     * @param bool    $includeStatementMetadataRow appends the statement's priority areas/tags
+     *                                              (see {@link addStatementMetadataToCell}) to
+     *                                              the first fragment's text cell, since fragments
+     *                                              have no cell of their own to carry statement-level data
      */
     protected function addFragmentRows(
         $item,
@@ -978,7 +982,8 @@ class DocxExporter
         $textCellWidth,
         $recommendationCellWidth,
         $styles,
-        $anonymous): void
+        $anonymous,
+        bool $includeStatementMetadataRow = false): void
     {
         foreach ($item['fragments'] as $index => $fragment) {
             $assessmentTable->addRow();
@@ -996,6 +1001,9 @@ class DocxExporter
                 // T6679:
                 $fragment['text'] = $this->editorService->handleObscureTags($fragment['text'], $anonymous);
                 $this->addHtml($cell2, $fragment['text'], $styles);
+            }
+            if (0 === $index && $includeStatementMetadataRow) {
+                $this->addStatementMetadataToCell($cell2, $item, $styles);
             }
 
             $cell3 = $assessmentTable->addCell($recommendationCellWidth, $cellStyle);

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -972,9 +972,9 @@ class DocxExporter
      * @param array   $styles
      * @param bool    $anonymous
      * @param bool    $includeStatementMetadataRow appends the statement's priority areas/tags
-     *                                              (see {@link addStatementMetadataToCell}) to
-     *                                              the first fragment's text cell, since fragments
-     *                                              have no cell of their own to carry statement-level data
+     *                                             (see {@link addStatementMetadataToCell}) to
+     *                                             the first fragment's text cell, since fragments
+     *                                             have no cell of their own to carry statement-level data
      */
     protected function addFragmentRows(
         $item,

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -408,7 +408,8 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                false
+                false,
+                true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {
@@ -458,7 +459,8 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                false
+                false,
+                true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -408,8 +408,7 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                false,
-                true
+                includeStatementMetadataRow:  true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -408,7 +408,7 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                includeStatementMetadataRow:  true
+                includeStatementMetadataRow: true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {
@@ -458,7 +458,7 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                includeStatementMetadataRow:  true
+                includeStatementMetadataRow: true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ExportService.php
@@ -458,8 +458,7 @@ class ExportService
                 $rParams,
                 $type,
                 AssessmentTableViewMode::DEFAULT_VIEW,
-                false,
-                true
+                includeStatementMetadataRow:  true
             );
             $filename = $procedureName.'/'.$this->literals['statements'].'/'.$this->literals['considerationtable'].'/%s.docx';
             switch ($exportType) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/FileNameGenerator.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Segment/Export/FileNameGenerator.php
@@ -15,8 +15,8 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Segment\Export;
 use Cocur\Slugify\Slugify;
 use DemosEurope\DemosplanAddon\Contracts\Entities\UserInterface;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
-use demosplan\DemosPlanCoreBundle\Logic\Procedure\NameGenerator;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
+use demosplan\DemosPlanCoreBundle\Logic\Procedure\NameGenerator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FileNameGenerator

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentHandler.php
@@ -215,6 +215,7 @@ class AssessmentHandler extends CoreHandler
         array $exportChoice,
         string $viewMode,
         bool $original = false,
+        bool $includeStatementMetadataRow = false,
     ): DocxExportResult {
         $outputResult = $this->prepareOutputResult($procedureId, $original, $requestPost);
         try {
@@ -259,7 +260,8 @@ class AssessmentHandler extends CoreHandler
                 $viewOrientation,
                 $requestPost,
                 $exportChoice['sortType'],
-                $viewMode
+                $viewMode,
+                $includeStatementMetadataRow
             );
         } catch (Exception $e) {
             $this->getLogger()->warning($e);


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-18189

Description: 

Requirement: in the procedure export ("Verfahrensexport"), the statement list DOCX documents should additionally show each statement's assigned Potenzialflächen and Schlagworte, directly below the statement text. This must not affect the standalone Abwägungstabelle export — the client explicitly wants the two kept separate.

What changed

The Verfahrensexport's Abwägungstabelle DOCX documents (Abwaegungstabelle_Liste.docx, _mit_Datensaetzen.docx, _Anonym.docx, _mit_Datensaetzen_Anonym.docx) and the standalone Abwägungstabelle export share the same rendering pipeline (AssessmentHandler/AssessmentTableDocxExporter → AssessmentTableServiceOutput::generateDocx → DocxExporter). Since they converge on one code path, a new opt-in flag ($includeStatementMetadataRow, default false) was threaded through the chain, set to true only at the two ExportService call sites (addAssessmentTableToZip, addAssessmentTableAnonymousToZip) that build the Verfahrensexport documents.

When the flag is set, DocxExporter::renderTableItem() appends a bold "Potenzialflächen: …" line and a bold "Schlagworte: …" line under the statement text in the "Stellungnahme" cell (each line only rendered if the statement actually has values). The underlying data (priorityAreaKeys, tagNames) was already available in the statement array used by this pipeline — it just wasn't copied into DocxExporter::formatStatementArray()'s output before.

The standalone Abwägungstabelle export (AssessmentTableDocxExporter) calls the same methods with its original argument list, so the flag defaults to false there and its output is unchanged.



**Additional fix: SQLite functional test schema rebuild**

Unrelated to the export feature, but found while running functional tests on this branch: any test using ORMSqliteDatabaseTool (Liip TestFixturesBundle) failed with SQLSTATE[HY000]: General error: 1 table messenger_messages already exists.

Cause: config/packages/doctrine.yaml excludes messenger_messages from schema_filter on the dplan connection to prevent spurious migration diffs against the real database (that table is owned by Symfony Messenger's Doctrine transport, not an ORM entity). That filter only affects introspection of the live database, not schema generation. The SQLite test-schema rebuild does both:
 - SchemaTool::dropDatabase() introspects the real DB (filter applies) → messenger_messages is invisible → never dropped.
 - SchemaTool::createSchema() builds from ORM metadata + Doctrine event listeners, and MessengerTransportDoctrineSchemaListener re-adds messenger_messages unconditionally (filter doesn't apply here) → CREATE TABLE fails because the table is still there.

Fix: null schema_filter for the test-env dplan connection only (config/packages/doctrine.yaml, when@test block). Dev/prod keep the filter, so real migration-diff behavior is unchanged.


 **Additional cleanup: SonarCloud findings on renderTableItem()**

Two SonarCloud issues were flagged on DocxExporter::renderTableItem() after the metadata-row change above:
 - php:S3776 — Cognitive Complexity 17 > 15. The method had a nested if (moved statement) {...} else { if (fragments) {...} else { if/if/if... } } structure. Flattened it into three sequential guard clauses inside the same method, each ending in an early return; (moved-statement check → fragment-rows check → regular statement row). No new methods were extracted and no new type hints were introduced — every branch now sits at nesting level 0 instead of being stacked inside the others, which is what drives the cognitive-complexity score down (roughly 17 → 6–7).

 - php:S107 — 8 parameters > 7. The three rendering-option flags ($numberStatements, $statementNumber, $includeStatementMetadataRow) are now bundled into a single array $renderOptions = [], destructured back into the same local variable names as the first lines of the method body. The rest of the method is unchanged. One of the two call sites needed no change (it already relied on defaults for these args); the other now passes the options array instead of 3 positional args.


Both changes are structural only — no behavior change, verified by re-running the procedure export manually after each step.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

