### PR TITLE
fix: Allow scalar or array hook options

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/ManifestConfiguration.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/ManifestConfiguration.php
@@ -43,7 +43,7 @@ class ManifestConfiguration implements ConfigurationInterface
                 ->arrayNode('options')
                     ->variablePrototype()
                     ->validate()
-                        ->ifTrue(static fn($value): bool => !is_scalar($value) && !is_array($value) && null !== $value)
+                        ->ifTrue(static fn ($value): bool => !is_scalar($value) && !is_array($value) && null !== $value)
                         ->thenInvalid('Hook option values must be scalar or array.')
                         ->end()
                 ->end()

--- a/demosplan/DemosPlanCoreBundle/Addon/ManifestConfiguration.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/ManifestConfiguration.php
@@ -41,7 +41,11 @@ class ManifestConfiguration implements ConfigurationInterface
             ->children()
                 ->scalarNode('entry')->end()
                 ->arrayNode('options')
-                    ->scalarPrototype()->end()
+                    ->variablePrototype()
+                    ->validate()
+                        ->ifTrue(static fn($value): bool => !is_scalar($value) && !is_array($value) && null !== $value)
+                        ->thenInvalid('Hook option values must be scalar or array.')
+                        ->end()
                 ->end()
             ->end()
         ->end();


### PR DESCRIPTION
### Ticket
(No Ticket)


<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

The manifest configuration parser failed on non-scalar options, however, other code like the permissions checking in `FrontendAssetProvider` already expects demosPlan core to be able to handle scalar and array options. This adds a variable node that is evaluated based on it's contents and allows both value types.

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->

<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->

Install an addon with defined hook permissions locally (--develop). It should not fail.

<!--
### Tasks (optional)
A list of all related tasks that need to be done before this can be merged.

- [x] Task1
- [ ] Task2
-->
