### PR TITLE
f_DPLAN-18151: add systemwide information banner

### DIFF
--- a/client/js/InitVue.js
+++ b/client/js/InitVue.js
@@ -32,6 +32,7 @@ import loadSentry from './loadSentry'
 import NotificationStoreAdapter from '@DpJs/store/core/NotificationStoreAdapter'
 import NotifyContainer from '@DpJs/components/shared/NotifyContainer'
 import RegisterFlyout from '@DpJs/components/user/RegisterFlyout'
+import ServerBanner from '@DpJs/components/shared/ServerBanner'
 import SessionTimer from '@DpJs/components/shared/SessionTimer'
 import UnsavedChangesDialog from '@DpJs/components/shared/UnsavedChangesDialog'
 
@@ -97,6 +98,7 @@ function initialize (components = {}, storeModules = {}, apiStoreModules = [], p
     app.component('DpObscure', DpObscure)
     app.component('UnsavedChangesDialog', UnsavedChangesDialog)
     app.component('NotifyContainer', NotifyContainer)
+    app.component('ServerBanner', ServerBanner)
     app.component('DpAccordion', DpAccordion)
     app.component('DpFlyout', DpFlyout)
     app.component('HamburgerMenuButton', HamburgerMenuButton)

--- a/client/js/components/shared/ServerBanner.vue
+++ b/client/js/components/shared/ServerBanner.vue
@@ -1,0 +1,48 @@
+<license>
+  (c) 2010-present DEMOS plan GmbH.
+
+  This file is part of the package demosplan,
+  for more information see the license file.
+
+  All rights reserved
+</license>
+
+<template>
+  <div
+    v-if="isVisible"
+    :class="prefixClass('bg-message-warning text-message-warning border border-message-warning relative px-2 pt-2')"
+  >
+    <!-- message is server-controlled markdown (SERVER_BANNER.md via ServerBannerLoader), never user input -->
+    <div
+      v-html="message"
+    />
+    <dp-button
+      :class="prefixClass('absolute top-2 right-2')"
+      :text="Translator.trans('close')"
+      hide-text
+      icon="x"
+      variant="subtle"
+      @click="dismiss"
+    />
+  </div>
+</template>
+
+<script setup>
+import { DpButton, prefixClass } from '@demos-europe/demosplan-ui'
+import { ref } from 'vue'
+
+defineProps({
+  message: {
+    type: String,
+    required: true,
+  },
+})
+
+const storageKey = 'serverBannerDismissed'
+const isVisible = ref(sessionStorage.getItem(storageKey) === null)
+
+const dismiss = () => {
+  isVisible.value = false
+  sessionStorage.setItem(storageKey, '1')
+}
+</script>

--- a/client/js/components/shared/ServerBanner.vue
+++ b/client/js/components/shared/ServerBanner.vue
@@ -12,9 +12,9 @@
     v-if="isVisible"
     :class="prefixClass('bg-message-warning text-message-warning border border-message-warning relative px-2 pt-2')"
   >
-    <!-- message is server-controlled markdown (SERVER_BANNER.md via ServerBannerLoader), never user input -->
+    <!-- message originates from SERVER_BANNER.md; sanitize before rendering HTML -->
     <div
-      v-html="message"
+      v-html="sanitizedMessage"
     />
     <dp-button
       :class="prefixClass('absolute top-2 right-2')"
@@ -28,10 +28,11 @@
 </template>
 
 <script setup>
+import { computed, ref } from 'vue'
 import { DpButton, prefixClass } from '@demos-europe/demosplan-ui'
-import { ref } from 'vue'
+import DomPurify from 'dompurify'
 
-defineProps({
+const props = defineProps({
   message: {
     type: String,
     required: true,
@@ -40,6 +41,7 @@ defineProps({
 
 const storageKey = 'serverBannerDismissed'
 const isVisible = ref(sessionStorage.getItem(storageKey) === null)
+const sanitizedMessage = computed(() => DomPurify.sanitize(props.message))
 
 const dismiss = () => {
   isVisible.value = false

--- a/client/js/components/shared/ServerBanner.vue
+++ b/client/js/components/shared/ServerBanner.vue
@@ -12,7 +12,6 @@
     v-if="isVisible"
     :class="prefixClass('bg-message-warning text-message-warning border border-message-warning relative px-2 pt-2')"
   >
-    <!-- message originates from SERVER_BANNER.md; sanitize before rendering HTML -->
     <div
       v-html="sanitizedMessage"
     />

--- a/client/js/components/shared/ServerBanner.vue
+++ b/client/js/components/shared/ServerBanner.vue
@@ -11,6 +11,7 @@
   <div
     v-if="isVisible"
     :class="prefixClass('bg-message-warning text-message-warning border border-message-warning relative px-2 pt-2')"
+    role="alert"
   >
     <div
       v-html="sanitizedMessage"
@@ -20,7 +21,7 @@
       :text="Translator.trans('close')"
       hide-text
       icon="x"
-      variant="subtle"
+      variant="transparent"
       @click="dismiss"
     />
   </div>
@@ -39,11 +40,11 @@ const props = defineProps({
 })
 
 const storageKey = 'serverBannerDismissed'
-const isVisible = ref(sessionStorage.getItem(storageKey) === null)
+const isVisible = ref(sessionStorage.getItem(storageKey) !== props.message)
 const sanitizedMessage = computed(() => DomPurify.sanitize(props.message))
 
 const dismiss = () => {
   isVisible.value = false
-  sessionStorage.setItem(storageKey, '1')
+  sessionStorage.setItem(storageKey, props.message)
 }
 </script>

--- a/client/js/components/shared/ServerBanner.vue
+++ b/client/js/components/shared/ServerBanner.vue
@@ -14,7 +14,7 @@
     role="alert"
   >
     <div
-      v-html="sanitizedMessage"
+      v-cleanhtml="props.message"
     />
     <dp-button
       :class="prefixClass('absolute top-2 right-2')"
@@ -28,9 +28,10 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
-import { DpButton, prefixClass } from '@demos-europe/demosplan-ui'
-import DomPurify from 'dompurify'
+import { CleanHtml, DpButton, prefixClass } from '@demos-europe/demosplan-ui'
+import { ref } from 'vue'
+
+const vCleanhtml = CleanHtml
 
 const props = defineProps({
   message: {
@@ -41,7 +42,6 @@ const props = defineProps({
 
 const storageKey = 'serverBannerDismissed'
 const isVisible = ref(sessionStorage.getItem(storageKey) !== props.message)
-const sanitizedMessage = computed(() => DomPurify.sanitize(props.message))
 
 const dismiss = () => {
   isVisible.value = false

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base.html.twig
@@ -53,6 +53,9 @@
 
         {# Mount vue instance to this wrapper #}
         <div id="app" class="o-page__wrapper">
+            {% if serverBanner is defined and serverBanner is not empty %}
+                <server-banner :message="JSON.parse('{{ serverBanner|json_encode|e('js', 'utf-8') }}')"></server-banner>
+            {% endif %}
 
             {% block a11y_jump_navigation %}
                 {# @improve T17928 investigate focus vs. visibility  #}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanCore/base_oeb.html.twig
@@ -43,6 +43,9 @@
 
         {# Mount vue instance to this wrapper #}
         <div id="app" class="{{ 'o-page__wrapper'|prefixClass }}">
+            {% if serverBanner is defined and serverBanner is not empty %}
+                <server-banner :message="JSON.parse('{{ serverBanner|json_encode|e('js', 'utf-8') }}')"></server-banner>
+            {% endif %}
 
             {% block a11y_jump_navigation %}
                 {# @improve T17928 investigate focus vs. visibility #}

--- a/tests/frontend/unit/ServerBanner.spec.js
+++ b/tests/frontend/unit/ServerBanner.spec.js
@@ -1,0 +1,40 @@
+import { enableAutoUnmount } from '@vue/test-utils'
+import ServerBanner from '@DpJs/components/shared/ServerBanner'
+import shallowMountWithGlobalMocks from '@DpJs/VueConfigLocal'
+
+describe('ServerBanner', () => {
+  const message = '<p>Downtime des Systems heute zwischen 12:00 und 12:15 Uhr</p>'
+  const storageKey = 'serverBannerDismissed'
+
+  let wrapper
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    wrapper = shallowMountWithGlobalMocks(ServerBanner, {
+      props: { message },
+    })
+  })
+
+  enableAutoUnmount(afterEach)
+
+  it('renders the given message', () => {
+    expect(wrapper.html()).toContain(message)
+  })
+
+  it('hides the banner and marks it as dismissed in sessionStorage when the close button is clicked', async () => {
+    await wrapper.findComponent({ name: 'DpButton' }).vm.$emit('click')
+
+    expect(wrapper.find('div').exists()).toBe(false)
+    expect(sessionStorage.getItem(storageKey)).toBe('1')
+  })
+
+  it('does not render if the banner was already dismissed earlier in this session', () => {
+    sessionStorage.setItem(storageKey, '1')
+
+    const dismissedWrapper = shallowMountWithGlobalMocks(ServerBanner, {
+      props: { message },
+    })
+
+    expect(dismissedWrapper.find('div').exists()).toBe(false)
+  })
+})

--- a/tests/frontend/unit/ServerBanner.spec.js
+++ b/tests/frontend/unit/ServerBanner.spec.js
@@ -25,16 +25,26 @@ describe('ServerBanner', () => {
     await wrapper.findComponent({ name: 'DpButton' }).vm.$emit('click')
 
     expect(wrapper.find('div').exists()).toBe(false)
-    expect(sessionStorage.getItem(storageKey)).toBe('1')
+    expect(sessionStorage.getItem(storageKey)).toBe(message)
   })
 
   it('does not render if the banner was already dismissed earlier in this session', () => {
-    sessionStorage.setItem(storageKey, '1')
+    sessionStorage.setItem(storageKey, message)
 
     const dismissedWrapper = shallowMountWithGlobalMocks(ServerBanner, {
       props: { message },
     })
 
     expect(dismissedWrapper.find('div').exists()).toBe(false)
+  })
+
+  it('renders again if the message changed since it was last dismissed', () => {
+    sessionStorage.setItem(storageKey, 'some earlier message')
+
+    const changedWrapper = shallowMountWithGlobalMocks(ServerBanner, {
+      props: { message },
+    })
+
+    expect(changedWrapper.find('div').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
### Ticket
DPLAN-18151

Frontend part on top of #6710. Renders the `serverBanner` Twig variable as a dismissible warning banner on every page, including login.

- New `ServerBanner` Vue component (registered globally like `NotifyContainer`/`UnsavedChangesDialog`), mounted inside `#app` in `base.html.twig` and `base_oeb.html.twig`.
- Dismissal is session-scoped (`sessionStorage`), so the banner reappears on the next login/session, not permanently hidden like `localStorage`-based dismissals.

### How to review/test
1. Create a `SERVER_BANNER.md` file at the repository root (same level as `composer.json`), e.g.:
   ```
   **Downtime des Systems heute zwischen 12:00 und 12:15 Uhr**
   ```
2. Reload any page and the login page — banner should appear at the top, inside the yellow warning style.
3. Click the close (X) button — banner disappears; reload in the same tab — stays hidden.
4. Open a new session (e.g. new incognito window) — banner reappears.
5. Remove `SERVER_BANNER.md` — banner no longer renders.

### PR Checklist
- [x] Create/Update tests
- [ ] Update documentation
- [x] Run `yarn lint`
- [x] Run `yarn test`
- [x] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
- [ ] Update changelog