### PR TITLE
fix: drop invalid include from TagTopic list request

### DIFF
--- a/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
+++ b/client/js/components/procedure/SegmentsBulkEdit/SegmentsBulkEdit.vue
@@ -869,7 +869,7 @@ export default {
 
   mounted () {
     const promises = [
-      this.listTagTopics({ include: 'tag' }),
+      this.listTagTopics(),
       this.listTags({ include: 'topic' }),
       this.fetchPlaces(),
     ]


### PR DESCRIPTION
### Ticket
none — fixes Sentry issue PROD-EWM-X2 (19.5k warning events)

### Description
The segments bulk edit page requested `include=tag` when listing tag topics, but the `TagTopic` resource type only exposes the relationship `tags`. The API dropped the invalid include with a warning on every page load.

The include has never been functional (the name never matched), so nothing ever consumed the included data — the page groups tags client-side from the `Tag` store (`tag.relationships.topic`). Making the include valid would initialize one lazy tags collection per topic (N+1), so it is removed instead of corrected.

Fixes PROD-EWM-X2