### PR TITLE
fix: scope global gis layers to their customer

### DIFF
--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/09/Version20260904103000.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/09/Version20260904103000.php
@@ -28,7 +28,7 @@ final class Version20260904103000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add customer_id to _gis to scope global GIS layers to a single customer';
+        return 'chore: (refs: DPLAN-18357) Add customer_id to _gis to scope global GIS layers to a single customer';
     }
 
     /**

--- a/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/09/Version20260904103000.php
+++ b/demosplan/DemosPlanCoreBundle/DoctrineMigrations/2026/09/Version20260904103000.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds {@see \demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer::$customer}, which binds a global
+ * GIS layer to the customer it was created in and thereby limits which procedures it is copied into.
+ *
+ * Existing rows keep customer_id NULL: layers created before customer scoping stay visible to every
+ * customer so they can still be administered and removed.
+ */
+final class Version20260904103000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add customer_id to _gis to scope global GIS layers to a single customer';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _gis ADD customer_id CHAR(36) DEFAULT NULL');
+        $this->addSql('ALTER TABLE _gis ADD CONSTRAINT FK_8281ED259395C3F3 FOREIGN KEY (customer_id) REFERENCES customer (_c_id)');
+        $this->addSql('CREATE INDEX IDX_8281ED259395C3F3 ON _gis (customer_id)');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIfNotMysql();
+
+        $this->addSql('ALTER TABLE _gis DROP FOREIGN KEY FK_8281ED259395C3F3');
+        $this->addSql('DROP INDEX IDX_8281ED259395C3F3 ON _gis');
+        $this->addSql('ALTER TABLE _gis DROP customer_id');
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function abortIfNotMysql(): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+    }
+}

--- a/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
@@ -12,11 +12,13 @@ namespace demosplan\DemosPlanCoreBundle\Entity\Map;
 
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ContextualHelpInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\GisLayerCategoryInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\GisLayerInterface;
 use demosplan\DemosPlanCoreBundle\Doctrine\Generator\UuidV4Generator;
 use demosplan\DemosPlanCoreBundle\Entity\CoreEntity;
 use demosplan\DemosPlanCoreBundle\Entity\Help\ContextualHelp;
+use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Repository\MapRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -183,6 +185,17 @@ class GisLayer extends CoreEntity implements GisLayerInterface
      * @var array
      */
     protected $globalGis;
+
+    /**
+     * Customer a global layer belongs to. Only set on global layers (those without a
+     * procedure); it limits which procedures the layer is copied into. Null on layers
+     * that predate customer scoping, which stay visible to every customer.
+     *
+     * @var Customer|null
+     */
+    #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: '_c_id', nullable: true)]
+    #[ORM\ManyToOne(targetEntity: Customer::class)]
+    protected $customer;
 
     /**
      * The service version for the layer.
@@ -662,6 +675,18 @@ class GisLayer extends CoreEntity implements GisLayerInterface
     /**
      * @return bool
      */
+    public function getCustomer(): ?CustomerInterface
+    {
+        return $this->customer;
+    }
+
+    public function setCustomer(?CustomerInterface $customer): self
+    {
+        $this->customer = $customer;
+
+        return $this;
+    }
+
     public function isGlobalLayer()
     {
         return $this->globalLayer;

--- a/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Map/MapService.php
@@ -11,6 +11,7 @@
 namespace demosplan\DemosPlanCoreBundle\Logic\Map;
 
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayerCategory;
@@ -18,6 +19,7 @@ use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\DraftStatement;
 use demosplan\DemosPlanCoreBundle\Entity\Statement\Statement;
 use demosplan\DemosPlanCoreBundle\Exception\AttachedChildException;
+use demosplan\DemosPlanCoreBundle\Exception\CustomerNotFoundException;
 use demosplan\DemosPlanCoreBundle\Exception\StatementOrDraftStatementNotFoundException;
 use demosplan\DemosPlanCoreBundle\Logic\DateHelper;
 use demosplan\DemosPlanCoreBundle\Logic\EntityHelper;
@@ -27,6 +29,7 @@ use demosplan\DemosPlanCoreBundle\Logic\Procedure\MasterTemplateService;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\DraftStatementService;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use demosplan\DemosPlanCoreBundle\Repository\GisLayerCategoryRepository;
 use demosplan\DemosPlanCoreBundle\Repository\MapRepository;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanTools;
@@ -85,6 +88,7 @@ class MapService
         MapScreenshotter $mapScreenshotter,
         private readonly MasterTemplateService $masterTemplateService,
         private readonly StatementService $statementService,
+        private readonly CustomerService $customerService,
         private readonly LoggerInterface $logger,
     ) {
         $this->fileService = $fileService;
@@ -192,17 +196,7 @@ class MapService
         // $search und $sort werden bisher bei den GislayerListen nicht verwendet, deshalb werden sie nicht weiter beachtet
 
         $listOfGlobalGisLayers = $this->mapRepository
-            ->findBy(
-                [
-                    'procedureId' => '',
-                    'deleted'     => false,
-                    'enabled'     => true,
-                ],
-                [
-                    'type' => 'desc',
-                    'name' => 'asc',
-                ]
-            );
+            ->findGlobalLayersForCustomer($this->getCurrentCustomer());
 
         return array_map($this->convertToLegacy(...), $listOfGlobalGisLayers);
     }
@@ -266,6 +260,12 @@ class MapService
     public function addGis($data)
     {
         try {
+            // A layer without a procedure is global and is copied into every procedure of
+            // its customer, so it has to be bound to the customer it is created in.
+            if (!isset($data['pId']) || '' === $data['pId']) {
+                $data['customer'] = $this->getCurrentCustomer();
+            }
+
             $singleGis = $this->mapRepository->add($data);
             // convert to Legacy Array
             $singleGis = $this->convertToLegacy($singleGis);
@@ -274,6 +274,16 @@ class MapService
         } catch (Exception $e) {
             $this->logger->warning('Fehler beim Anlegen eines GisLayers: ', [$e]);
             throw $e;
+        }
+    }
+
+    private function getCurrentCustomer(): ?CustomerInterface
+    {
+        try {
+            return $this->customerService->getCurrentCustomer();
+        } catch (CustomerNotFoundException) {
+            // e.g. CLI context, where no subdomain resolves to a customer
+            return null;
         }
     }
 

--- a/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
@@ -10,6 +10,7 @@
 
 namespace demosplan\DemosPlanCoreBundle\Repository;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\CustomerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\GisLayerInterface;
 use DemosEurope\DemosplanAddon\Contracts\Repositories\MapRepositoryInterface;
 use DemosEurope\DemosplanAddon\Logic\ApiRequest\FluentRepository;
@@ -104,10 +105,14 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
             }
 
             if ($this->isGlobal($newGisLayer)) {
-                $allProcedures = $this->getEntityManager()->getRepository(Procedure::class)->findAll();
+                // Only procedures of the layer's own customer receive a copy. Using findAll()
+                // here would push one customer's layer into every other customer's procedures,
+                // their blueprints and the platform master template.
+                $targetProcedures = $this->getEntityManager()->getRepository(Procedure::class)
+                    ->findBy(['customer' => $newGisLayer->getCustomer()]);
                 $gisLayerCategoryRepository = $this->getEntityManager()->getRepository(GisLayerCategory::class);
 
-                foreach ($allProcedures as $singleProcedure) {
+                foreach ($targetProcedures as $singleProcedure) {
                     $copyOfGisLayer = clone $newGisLayer;
                     $copyOfGisLayer->setIdent(null);
                     $copyOfGisLayer->setCreateDate(null);
@@ -115,6 +120,8 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
                     $copyOfGisLayer->setDeleteDate(null);
                     $copyOfGisLayer->setGId($newGisLayer->getIdent());
                     $copyOfGisLayer->setProcedureId($singleProcedure->getId());
+                    // The copy is scoped by its procedure; only the global original carries a customer.
+                    $copyOfGisLayer->setCustomer(null);
                     $rootCategory = $gisLayerCategoryRepository->getRootLayerCategory($singleProcedure->getId());
                     if ($rootCategory instanceof GisLayerCategory) {
                         $copyOfGisLayer->setCategory($rootCategory);
@@ -129,6 +136,35 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
             $this->logger->warning('GisLayer could not be added. ', [$e]);
             throw $e;
         }
+    }
+
+    /**
+     * Global layers (those without a procedure) that the given customer may administer:
+     * its own ones plus those without a customer, which predate customer scoping and
+     * therefore still apply platform-wide.
+     *
+     * @return GisLayer[]
+     */
+    public function findGlobalLayersForCustomer(?CustomerInterface $customer): array
+    {
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder()
+            ->select('g')
+            ->from(GisLayer::class, 'g');
+
+        return $queryBuilder
+            ->where('g.procedureId = :noProcedure')
+            ->andWhere('g.deleted = false')
+            ->andWhere('g.enabled = true')
+            ->andWhere($queryBuilder->expr()->orX(
+                'g.customer = :customer',
+                'g.customer IS NULL'
+            ))
+            ->setParameter('noProcedure', '')
+            ->setParameter('customer', $customer)
+            ->orderBy('g.type', 'DESC')
+            ->addOrderBy('g.name', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 
     /**
@@ -648,6 +684,9 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
         }
         if (array_key_exists('gId', $data)) {
             $gisLayer->setGlobalLayerId($data['gId']);
+        }
+        if (array_key_exists('customer', $data)) {
+            $gisLayer->setCustomer($data['customer']);
         }
         if (array_key_exists('xplan', $data)) {
             $gisLayer->setXplan($data['xplan']);

--- a/tests/backend/core/Map/Functional/MapServiceTest.php
+++ b/tests/backend/core/Map/Functional/MapServiceTest.php
@@ -15,6 +15,7 @@ use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedureSetti
 use demosplan\DemosPlanCoreBundle\Entity\Map\GisLayer;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Logic\Map\MapService;
+use demosplan\DemosPlanCoreBundle\Logic\User\CustomerService;
 use Tests\Base\FunctionalTestCase;
 
 class MapServiceTest extends FunctionalTestCase
@@ -164,11 +165,42 @@ class MapServiceTest extends FunctionalTestCase
         $this->sut->addGis($data);
         $numberOfEntriesAfter = $this->countEntries(GisLayer::class);
 
-        // es werden Anzahl aller Einträge von vorher + den neuen global Eintrag + Anzahl der Verfahren erwartet.
-        $numberOfProcedures = $this->countEntries(Procedure::class);
+        // es werden Anzahl aller Einträge von vorher + den neuen global Eintrag
+        // + Anzahl der Verfahren des aktuellen Mandanten erwartet.
         static::assertEquals(
-            $numberOfEntriesBefore + $numberOfProcedures + 1,
+            $numberOfEntriesBefore + $this->countProceduresOfCurrentCustomer() + 1,
             $numberOfEntriesAfter
+        );
+    }
+
+    public function testAddGlobalGisSkipsProceduresOfOtherCustomers(): void
+    {
+        $otherCustomerProcedure = $this->getEntries(
+            Procedure::class,
+            ['customer' => null]
+        )[0] ?? null;
+        static::assertInstanceOf(Procedure::class, $otherCustomerProcedure);
+
+        $layersBefore = $this->countEntries(
+            GisLayer::class,
+            ['procedureId' => $otherCustomerProcedure->getId()]
+        );
+
+        $this->sut->addGis([
+            'type'     => 'base',
+            'name'     => 'globale testkarte',
+            'url'      => 'http://www.globaletestkarte.de',
+            'Layer'    => '0',
+            'pId'      => '',
+            'globalId' => null,
+        ]);
+
+        static::assertSame(
+            $layersBefore,
+            $this->countEntries(
+                GisLayer::class,
+                ['procedureId' => $otherCustomerProcedure->getId()]
+            )
         );
     }
 
@@ -217,15 +249,22 @@ class MapServiceTest extends FunctionalTestCase
         ];
         $globalLayer = $this->sut->addGis($data);
 
-        $numberOfProcedures = $this->countEntries(Procedure::class);
+        $numberOfCopies = $this->countProceduresOfCurrentCustomer();
         $numberOfEntriesBefore = $this->countEntries(GisLayer::class);
         $this->sut->deleteGis($globalLayer['ident']);
         $numberOfEntriesAfter = $this->countEntries(GisLayer::class);
 
         static::assertEquals(
-            $numberOfEntriesBefore - $numberOfProcedures - 1,
+            $numberOfEntriesBefore - $numberOfCopies - 1,
             $numberOfEntriesAfter
         );
+    }
+
+    private function countProceduresOfCurrentCustomer(): int
+    {
+        $customer = $this->getContainer()->get(CustomerService::class)->getCurrentCustomer();
+
+        return $this->countEntries(Procedure::class, ['customer' => $customer]);
     }
 
     public function testDeleteGis()


### PR DESCRIPTION
### Ticket
DPLAN-18357
ado-55709

Creating a global gis layer copied it into **every** procedure in the database. The fan-out in `MapRepository::add()` used `Procedure::findAll()` without any customer filter, so a layer created by one customer's admin appeared in every other customer's procedures, in their organisation blueprints and in the platform master template — and, via the master template, in every procedure created afterwards. The edit path propagated changes into those copies as well.

This binds a global layer to the customer it is created in and limits both the fan-out and the global admin list to that customer:

- new `GisLayer::$customer` (`_gis.customer_id`, nullable), set in `MapService::addGis()` for layers without a procedure
- `MapRepository::add()` copies into procedures of that customer only; the copies themselves carry no customer, they are scoped by their procedure
- `MapRepository::findGlobalLayersForCustomer()` backs `MapService::getGisGlobalList()`

Layers with `customer_id IS NULL` predate the scoping and stay visible to every customer, so existing ones can still be administered and removed.

Not covered here: global gis layer create/update/delete still produce no report entry, so the acting user cannot be traced. Noted in the ticket as a follow-up.

### How to review/test
1. Run `vendor/bin/phpunit tests/backend/core/Map/` — includes the new regression test `MapServiceTest::testAddGlobalGisSkipsProceduresOfOtherCustomers`.
2. Create a global layer under "Globale GIS-Layer" and check that it appears in the procedures of the current customer only, and no longer in the master template.
3. `doctrine:migrations:diff` produces no further `_gis` statements after applying `Version20260904103000`.

### PR Checklist

- [x] Create/Update tests
- [x] Link all relevant tickets
