### PR TITLE
fix: send 2fa auth code mail through the mail queue

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Mailer/TwoFactorMailer.php
+++ b/demosplan/DemosPlanCoreBundle/Mailer/TwoFactorMailer.php
@@ -12,12 +12,11 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Mailer;
 
+use demosplan\DemosPlanCoreBundle\Entity\MailSend;
+use demosplan\DemosPlanCoreBundle\Logic\MailService;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
-use Symfony\Component\Mime\Email;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -25,7 +24,7 @@ class TwoFactorMailer implements AuthCodeMailerInterface
 {
     public function __construct(
         private readonly Environment $twig,
-        private readonly MailerInterface $mailer,
+        private readonly MailService $mailService,
         private readonly TranslatorInterface $translator,
         private readonly ParameterBagInterface $parameterBag,
     ) {
@@ -33,18 +32,26 @@ class TwoFactorMailer implements AuthCodeMailerInterface
 
     public function sendAuthCode(TwoFactorInterface $user): void
     {
-        $authCode = $user->getEmailAuthCode();
-        $emailContent = $this->twig->render(
-            '@DemosPlanCore/DemosPlanCore/email/2fa_email_auth.html.twig',
-            ['authCode' => $authCode]
+        $vars = [
+            'mailsubject' => $this->translator->trans(
+                '2fa.email.subject',
+                ['projectName' => $this->parameterBag->get('project_name')]
+            ),
+            'mailbody'    => $this->twig->render(
+                '@DemosPlanCore/DemosPlanCore/email/2fa_email_auth.html.twig',
+                ['authCode' => $user->getEmailAuthCode()]
+            ),
+        ];
+
+        $this->mailService->sendMail(
+            'dm_subscription',
+            'de_DE',
+            $user->getEmailAuthRecipient(),
+            '',
+            '',
+            '',
+            MailSend::MAIL_SCOPE_EXTERN,
+            $vars
         );
-        $message = new Email();
-        $message
-            ->to($user->getEmailAuthRecipient())
-            ->from(new Address($this->parameterBag->get('email_system'), ''))
-            ->subject($this->translator->trans('2fa.email.subject', ['projectName' => $this->parameterBag->get('project_name')]))
-            ->text($emailContent)
-        ;
-        $this->mailer->send($message);
     }
 }

--- a/tests/backend/core/Mailer/TwoFactorMailerTest.php
+++ b/tests/backend/core/Mailer/TwoFactorMailerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Mailer;
+
+use demosplan\DemosPlanCoreBundle\Entity\MailSend;
+use demosplan\DemosPlanCoreBundle\Logic\MailService;
+use demosplan\DemosPlanCoreBundle\Mailer\TwoFactorMailer;
+use PHPUnit\Framework\TestCase;
+use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+class TwoFactorMailerTest extends TestCase
+{
+    private ?Environment $twig = null;
+    private ?MailService $mailService = null;
+    private ?TranslatorInterface $translator = null;
+    private ?ParameterBagInterface $parameterBag = null;
+    private ?TwoFactorMailer $sut = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twig = $this->createMock(Environment::class);
+        $this->mailService = $this->createMock(MailService::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
+
+        $this->sut = new TwoFactorMailer(
+            $this->twig,
+            $this->mailService,
+            $this->translator,
+            $this->parameterBag
+        );
+    }
+
+    public function testSendAuthCodeQueuesMailWithRenderedAuthCode(): void
+    {
+        $user = $this->createMock(TwoFactorInterface::class);
+        $user->method('getEmailAuthCode')->willReturn('123456');
+        $user->method('getEmailAuthRecipient')->willReturn('user@example.com');
+
+        $this->parameterBag->method('get')
+            ->with('project_name')
+            ->willReturn('Test Project');
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('2fa.email.subject', ['projectName' => 'Test Project'])
+            ->willReturn('Your login code for Test Project');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                '@DemosPlanCore/DemosPlanCore/email/2fa_email_auth.html.twig',
+                ['authCode' => '123456']
+            )
+            ->willReturn('Your code is 123456');
+
+        $this->mailService->expects($this->once())
+            ->method('sendMail')
+            ->with(
+                'dm_subscription',
+                'de_DE',
+                'user@example.com',
+                '',
+                '',
+                '',
+                MailSend::MAIL_SCOPE_EXTERN,
+                [
+                    'mailsubject' => 'Your login code for Test Project',
+                    'mailbody'    => 'Your code is 123456',
+                ]
+            )
+            ->willReturn(new MailSend());
+
+        $this->sut->sendAuthCode($user);
+    }
+}


### PR DESCRIPTION
### Ticket
–

`TwoFactorMailer` handed the 2FA auth code straight to Symfony's `MailerInterface`, bypassing the mail queue every other mail in the application goes through. Those mails skipped the subject prefix, bounce handling and the queue's sender/reply-to rules, and left no `MailSend` record.

It now renders the existing twig body into the generic `dm_subscription` template and queues it via `MailService::sendMail()` (scope `extern`, sender left empty so the system address is used). Delivery latency is one scheduler tick — `SendEmailsMessage` runs every 5 seconds.

### How to review/test
Trigger an email-based 2FA login and check the mail appears in the mail queue (`_mail_send`) and is delivered with the configured subject prefix.

### PR Checklist
- [x] Create/Update tests
- [ ] Link all relevant tickets
