### PR TITLE
fix(refs: DPLAN-18312): render statement text once in docx export

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -795,9 +795,6 @@ class DocxExporter
         }
         try {
             $text = self::replaceTags($text);
-            $text = $this->htmlSanitizer->sanitizeCssForPhpWord($text);
-            Html::addHtml($cell, $text, false);
-            $text = $this->replaceTags($text);
             // remove STX (start of text) EOT (end of text) special chars
             $text = str_replace([chr(2), chr(3)], '', $text);
 
@@ -805,6 +802,8 @@ class DocxExporter
             if ($this->writerSelector->isOdtFormat()) {
                 $this->odtHtmlProcessor->processHtmlForCell($cell, $text);
             } else {
+                // non-numeric CSS line-height values crash PHPWord's DOCX HTML parser
+                $text = $this->htmlSanitizer->sanitizeCssForPhpWord($text);
                 Html::addHtml($cell, $text, false);
             }
         } catch (Exception $e) {

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -794,7 +794,7 @@ class DocxExporter
             return '';
         }
         try {
-            $text = self::replaceTags($text);
+            $text = $this->replaceTags($text);
             // remove STX (start of text) EOT (end of text) special chars
             $text = str_replace([chr(2), chr(3)], '', $text);
 


### PR DESCRIPTION
### Ticket
DPLAN-18312

`DocxExporter::addHtml()` called `Html::addHtml($cell, $text, false)` twice for the non-ODT (docx) branch, so every statement text cell in the Abwägungstabelle docx export contained the text twice. This removes the duplicate call and scopes the CSS line-height sanitization (needed only for PHPWord's docx HTML parser) to that same branch, leaving the ODT export path untouched.

### How to review/test
Export an Abwägungstabelle as .docx and confirm each entry's statement text appears once. ODT export should be unaffected.

### PR Checklist
- [ ] Create/Update tests
- [ ] Update documentation
- [ ] Add/Update data-cy attributes
- [ ] Run `yarn lint`
- [ ] Run `yarn test`
- [x] Link all relevant tickets
- [x] Move the tickets on the board accordingly
- [ ] Update changelog