### PR TITLE
fix(DPLAN-17573): delete remaining customer-scoped data on customer d…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Customer/CustomerDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Customer/CustomerDeleter.php
@@ -66,6 +66,15 @@ class CustomerDeleter
         // delete customer-orga-orgaType relations
         $this->deleteCustoemrOrgaOrgaTypeRelations($customerId, $isDryRun);
 
+        // delete customer-specific procedure phase definitions (global ones with customer_id NULL stay)
+        $this->deleteCustomerProcedurePhaseDefinitions($customerId, $isDryRun);
+
+        $this->deleteCustomerAccessControl($customerId, $isDryRun);
+
+        $this->deleteCustomerUserAccessControl($customerId, $isDryRun);
+
+        $this->deleteCustomerReportEntries($customerId, $isDryRun);
+
         // delete customer
         $this->deleteFromCustomerTable($customerId, $isDryRun);
 
@@ -189,6 +198,58 @@ class CustomerDeleter
     {
         $this->queriesService->deleteFromTableByIdentifierArray(
             'relation_customer_orga_orga_type',
+            '_c_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerProcedurePhaseDefinitions(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'procedure_phase_definition',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerAccessControl(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'access_control',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerUserAccessControl(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'user_access_control',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerReportEntries(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            '_report_entries',
             '_c_id',
             [$customerId],
             $isDryRun

--- a/tests/backend/core/Customer/CustomerDeleterTest.php
+++ b/tests/backend/core/Customer/CustomerDeleterTest.php
@@ -10,9 +10,22 @@
 
 namespace Tests\Core\Customer;
 
+use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Permission\UserAccessControlFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedurePhaseDefinitionFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
+use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
+use demosplan\DemosPlanCoreBundle\Entity\Permission\UserAccessControl;
+use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhaseDefinition;
+use demosplan\DemosPlanCoreBundle\Entity\Report\ReportEntry;
 use demosplan\DemosPlanCoreBundle\Entity\User\Customer;
 use demosplan\DemosPlanCoreBundle\Logic\Customer\CustomerDeleter;
+use demosplan\DemosPlanCoreBundle\Logic\Permission\AccessControlService;
+use demosplan\DemosPlanCoreBundle\Logic\Report\ReportService;
+use demosplan\DemosPlanCoreBundle\Logic\User\RoleHandler;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use Tests\Base\FunctionalTestCase;
 use Zenstruck\Foundry\Persistence\Proxy;
@@ -22,17 +35,23 @@ class CustomerDeleterTest extends FunctionalTestCase
     /** @var array<int, Customer|Proxy>|null */
     private ?array $testCustomers;
     private null|Customer|Proxy $testCustomerToDelete;
+    private ?Customer $customerToDelete;
+    private ?Customer $otherCustomer;
     /** @var CustomerDeleter */
     protected $sut;
     private ?SqlQueriesService $queriesService = null;
+    private ?RoleHandler $roleHandler = null;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->sut = $this->getContainer()->get(CustomerDeleter::class);
         $this->queriesService = $this->getContainer()->get(SqlQueriesService::class);
+        $this->roleHandler = $this->getContainer()->get(RoleHandler::class);
         $this->testCustomers = CustomerFactory::createMany(5);
         $this->testCustomerToDelete = reset($this->testCustomers);
+        $this->customerToDelete = $this->testCustomerToDelete->_real();
+        $this->otherCustomer = $this->testCustomers[1]->_real();
     }
 
     public function testDeleteCustomer(): void
@@ -40,6 +59,91 @@ class CustomerDeleterTest extends FunctionalTestCase
         $this->assertTestCustomersExistsInDataBase();
         $this->sut->deleteCustomer($this->testCustomerToDelete->getId(), false);
         $this->assertCustomerIsNotInDatabase($this->testCustomerToDelete->getId());
+    }
+
+    public function testDeleteCustomerRemovesCustomerScopedData(): void
+    {
+        // Arrange
+        $customerPhaseDefinition = ProcedurePhaseDefinitionFactory::createOne(['customer' => $this->customerToDelete])->_real();
+        $otherCustomersPhaseDefinition = ProcedurePhaseDefinitionFactory::createOne(['customer' => $this->otherCustomer])->_real();
+        // global definitions (customer_id NULL) must survive the deletion
+        $globalPhaseDefinition = ProcedurePhaseDefinitionFactory::createOne()->_real();
+
+        $accessControlPermission = $this->createAccessControlEntry($this->customerToDelete);
+        $otherCustomersAccessControlPermission = $this->createAccessControlEntry($this->otherCustomer);
+
+        $userAccessControl = $this->createUserAccessControlEntry($this->customerToDelete);
+        $otherCustomersUserAccessControl = $this->createUserAccessControlEntry($this->otherCustomer);
+
+        $reportEntry = $this->createReportEntry($this->customerToDelete);
+        $otherCustomersReportEntry = $this->createReportEntry($this->otherCustomer);
+
+        // Act
+        $this->sut->deleteCustomer($this->testCustomerToDelete->getId(), false);
+
+        // Assert: data scoped to the deleted customer is gone
+        self::assertCount(0, $this->getEntries(ProcedurePhaseDefinition::class, ['id' => $customerPhaseDefinition->getId()]));
+        self::assertCount(0, $this->getEntriesWhereInIds(AccessControl::class, [$accessControlPermission->getId()]));
+        self::assertCount(0, $this->getEntriesWhereInIds(UserAccessControl::class, [$userAccessControl->getId()]));
+        self::assertCount(0, $this->getEntries(ReportEntry::class, ['identifier' => $reportEntry->getIdentifier()]));
+
+        // Assert: global and other customers' data is kept
+        self::assertCount(1, $this->getEntries(ProcedurePhaseDefinition::class, ['id' => $globalPhaseDefinition->getId()]));
+        self::assertCount(1, $this->getEntries(ProcedurePhaseDefinition::class, ['id' => $otherCustomersPhaseDefinition->getId()]));
+        self::assertCount(1, $this->getEntriesWhereInIds(AccessControl::class, [$otherCustomersAccessControlPermission->getId()]));
+        self::assertCount(1, $this->getEntriesWhereInIds(UserAccessControl::class, [$otherCustomersUserAccessControl->getId()]));
+        self::assertCount(1, $this->getEntries(ReportEntry::class, ['identifier' => $otherCustomersReportEntry->getIdentifier()]));
+    }
+
+    private function createAccessControlEntry(Customer $customer): AccessControl
+    {
+        $accessControlService = $this->getContainer()->get(AccessControlService::class);
+        $role = $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0];
+
+        $accessControl = $accessControlService->createPermission(
+            'my_permission',
+            OrgaFactory::createOne()->_real(),
+            $customer,
+            $role
+        );
+        self::assertInstanceOf(AccessControl::class, $accessControl);
+
+        return $accessControl;
+    }
+
+    /**
+     * All attributes are set explicitly because the UserAccessControlFactory
+     * defaults use attribute-closures that this Foundry version does not
+     * evaluate, and its UserFactory default creates users without an orga.
+     */
+    private function createUserAccessControlEntry(Customer $customer): UserAccessControl
+    {
+        $user = UserFactory::createOne(['orga' => $orga = OrgaFactory::createOne()])->_real();
+
+        return UserAccessControlFactory::createOne([
+            'user'         => $user,
+            'organisation' => $orga->_real(),
+            'customer'     => $customer,
+            'role'         => $this->roleHandler->getUserRolesByCodes([RoleInterface::PRIVATE_PLANNING_AGENCY])[0],
+        ])->_real();
+    }
+
+    private function createReportEntry(Customer $customer): ReportEntry
+    {
+        $reportEntry = new ReportEntry();
+        $reportEntry->setCategory('test');
+        $reportEntry->setGroup('test');
+        $reportEntry->setUser($this->getUserReference(LoadUserData::TEST_USER_PLANNER_AND_PUBLIC_INTEREST_BODY));
+        $reportEntry->setIdentifier(bin2hex(random_bytes(16)));
+        $reportEntry->setMessage('test');
+        $reportEntry->setIncoming('test');
+        $reportEntry->setIdentifierType('procedure');
+        $reportEntry->setCustomer($customer);
+
+        $reportService = $this->getContainer()->get(ReportService::class);
+        $reportService->persistAndFlushReportEntry($reportEntry);
+
+        return $reportEntry;
     }
 
     private function assertTestCustomersExistsInDataBase(): void

--- a/tests/backend/core/Customer/CustomerDeleterTest.php
+++ b/tests/backend/core/Customer/CustomerDeleterTest.php
@@ -11,11 +11,11 @@
 namespace Tests\Core\Customer;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\RoleInterface;
+use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
+use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Permission\UserAccessControlFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Procedure\ProcedurePhaseDefinitionFactory;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\CustomerFactory;
-use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\Orga\OrgaFactory;
-use demosplan\DemosPlanCoreBundle\DataFixtures\ORM\TestData\LoadUserData;
 use demosplan\DemosPlanCoreBundle\DataGenerator\Factory\User\UserFactory;
 use demosplan\DemosPlanCoreBundle\Entity\Permission\AccessControl;
 use demosplan\DemosPlanCoreBundle\Entity\Permission\UserAccessControl;
@@ -34,7 +34,7 @@ class CustomerDeleterTest extends FunctionalTestCase
 {
     /** @var array<int, Customer|Proxy>|null */
     private ?array $testCustomers;
-    private null|Customer|Proxy $testCustomerToDelete;
+    private Customer|Proxy|null $testCustomerToDelete;
     private ?Customer $customerToDelete;
     private ?Customer $otherCustomer;
     /** @var CustomerDeleter */


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17573/Mandant-Daten-vom-PTV-loschen

Description: 
dplan:customer:delete left rows behind that are scoped to the deleted customer. This PR extends CustomerDeleter to also remove:

- procedure_phase_definition — customer-specific phase definitions (Verfahrensschritte). Rows with customer_id = NULL are the global fallback definitions and are intentionally kept.
- access_control — customer-scoped permission data.
- user_access_control — user-specific permission grants for this customer (e.g. admin permissions granted per user). Without this, a user whose granting customer no longer exists would still evaluate against these rows if the customer id ever reappeared in the permission check chain.
- _report_entries — report/activity entries referencing the deleted customer.

All four are deleted by customer_id before the customer row itself is removed, so dplan:customer:delete no longer leaves customer-scoped data orphaned. Users, orgas and their cross-customer relations remain untouched, as before — only the link tables scoped to this customer are cleaned up. Runs within the existing dry-run/transaction mechanics of the command.

How to review/test

- Code review of CustomerDeleter::deleteCustomer() — verify the four new delete calls and their column mappings (customer_id / _c_id).
- Functional check (optional): bin/<project> dplan:customer:delete with --dry-run on a dev DB — the new tables should appear in the dry-run output; then a real run on a test customer, followed by SELECT COUNT(*) FROM procedure_phase_definition WHERE customer_id = '<id>' (and the other three tables) returning 0, while procedure_phase_definition rows with customer_id IS NULL still exist.
- PHPStan level 5 passes on the changed file.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

