### PR TITLE
fix(DPLAN-17573): delete remaining customer-scoped data on customer d…

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Customer/CustomerDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Customer/CustomerDeleter.php
@@ -66,6 +66,15 @@ class CustomerDeleter
         // delete customer-orga-orgaType relations
         $this->deleteCustoemrOrgaOrgaTypeRelations($customerId, $isDryRun);
 
+        // delete customer-specific procedure phase definitions (global ones with customer_id NULL stay)
+        $this->deleteCustomerProcedurePhaseDefinitions($customerId, $isDryRun);
+
+        $this->deleteCustomerAccessControl($customerId, $isDryRun);
+
+        $this->deleteCustomerUserAccessControl($customerId, $isDryRun);
+
+        $this->deleteCustomerReportEntries($customerId, $isDryRun);
+
         // delete customer
         $this->deleteFromCustomerTable($customerId, $isDryRun);
 
@@ -202,6 +211,58 @@ class CustomerDeleter
     {
         $this->queriesService->deleteFromTableByIdentifierArray(
             'customer',
+            '_c_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerProcedurePhaseDefinitions(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'procedure_phase_definition',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerAccessControl(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'access_control',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerUserAccessControl(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            'user_access_control',
+            'customer_id',
+            [$customerId],
+            $isDryRun
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteCustomerReportEntries(string $customerId, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray(
+            '_report_entries',
             '_c_id',
             [$customerId],
             $isDryRun


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-17573/Mandant-Daten-vom-PTV-loschen

Description: 
dplan:customer:delete left rows behind that are scoped to the deleted customer. This PR extends CustomerDeleter to also remove:

- procedure_phase_definition — customer-specific phase definitions (Verfahrensschritte). Rows with customer_id = NULL are the global fallback definitions and are intentionally kept.
- access_control — customer-scoped permission data.
- user_access_control — user-specific permission grants for this customer (e.g. admin permissions granted per user). Without this, a user whose granting customer no longer exists would still evaluate against these rows if the customer id ever reappeared in the permission check chain.
- _report_entries — report/activity entries referencing the deleted customer.

All four are deleted by customer_id before the customer row itself is removed, so dplan:customer:delete no longer leaves customer-scoped data orphaned. Users, orgas and their cross-customer relations remain untouched, as before — only the link tables scoped to this customer are cleaned up. Runs within the existing dry-run/transaction mechanics of the command.

How to review/test

- Code review of CustomerDeleter::deleteCustomer() — verify the four new delete calls and their column mappings (customer_id / _c_id).
- Functional check (optional): bin/<project> dplan:customer:delete with --dry-run on a dev DB — the new tables should appear in the dry-run output; then a real run on a test customer, followed by SELECT COUNT(*) FROM procedure_phase_definition WHERE customer_id = '<id>' (and the other three tables) returning 0, while procedure_phase_definition rows with customer_id IS NULL still exist.
- PHPStan level 5 passes on the changed file.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

