### PR TITLE
feat(DPLAN-18363): expose pictogram alt text and copyright on public procedure list

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -182,6 +182,8 @@ fos_elastica:
                 publicParticipationContact: {type: text, index: true}
                 publicParticipationPublicationEnabled: { type: boolean }
                 pictogram: {type: keyword, index: false}
+                pictogramAltText: {type: keyword, index: false}
+                pictogramCopyright: {type: keyword, index: false}
                 municipalCode: {type: keyword, index: true}
                 ars: {type: keyword, index: true}
                 planningArea: {type: text, index: true}

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -1535,6 +1535,16 @@ class Procedure extends SluggedEntity implements ProcedureInterface
         return $this->settings->getPictogram();
     }
 
+    public function getPictogramAltText(): string
+    {
+        return $this->settings->getPictogramAltText();
+    }
+
+    public function getPictogramCopyright(): string
+    {
+        return $this->settings->getPictogramCopyright();
+    }
+
     /**
      * @return Collection<int, NotificationReceiver>
      */

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index_list.html.twig
@@ -44,7 +44,7 @@
                             class="{{ 'w-full h-auto'|prefixClass }}"
                             src="{{ publicProcedure.pictogram|default ? path('core_logo', {'hash': publicProcedure.pictogram|getFile('hash')}) : asset('img/procedure-placeholder.gif') }}"
                             loading="lazy"
-                            alt="{{ publicProcedure.pictogramAltText|default ? publicProcedure.pictogramAltText : 'Abbildung für ' ~ procedureDisplayName }}">
+                            alt="{{ publicProcedure.pictogramAltText|default ? publicProcedure.pictogramAltText : 'Piktogramm für das Verfahren ' ~ procedureDisplayName }}">
                         {% if publicProcedure.pictogramCopyright|default %}
                             <div class="{{ 'text-sm color--grey u-mt-0_125 break-words'|prefixClass }}">
                                 © {{ publicProcedure.pictogramCopyright }}

--- a/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index_list.html.twig
+++ b/templates/bundles/DemosPlanCoreBundle/DemosPlanProcedure/public_index_list.html.twig
@@ -44,7 +44,12 @@
                             class="{{ 'w-full h-auto'|prefixClass }}"
                             src="{{ publicProcedure.pictogram|default ? path('core_logo', {'hash': publicProcedure.pictogram|getFile('hash')}) : asset('img/procedure-placeholder.gif') }}"
                             loading="lazy"
-                            alt="Abbildung für {{ procedureDisplayName }}">
+                            alt="{{ publicProcedure.pictogramAltText|default ? publicProcedure.pictogramAltText : 'Abbildung für ' ~ procedureDisplayName }}">
+                        {% if publicProcedure.pictogramCopyright|default %}
+                            <div class="{{ 'text-sm color--grey u-mt-0_125 break-words'|prefixClass }}">
+                                © {{ publicProcedure.pictogramCopyright }}
+                            </div>
+                        {% endif %}
                     {% endif %}
 
                 </div>


### PR DESCRIPTION
### Ticket
DPLAN-18363

### Description
The pictogram alt text and copyright fields were previously collected in the procedure settings but only ever transmitted to the meinBerlin interface — they were never rendered publicly. Projects without that interface therefore save values nobody sees.

This exposes both fields on the public procedure list:

- Index `pictogramAltText` and `pictogramCopyright` in the procedure Elasticsearch documents (non-indexed keyword fields, like the existing `pictogram` field)
- Use the stored alt text as the `alt` attribute of the list image, falling back to the previous `Abbildung für {procedure name}` when empty
- Render the copyright as a small grey caption below the image when set

Existing procedures show no visual change unless values are set. After deployment the procedure index needs to be repopulated (or procedures resaved) for the new fields to appear in the documents.

### How to review/test
- Reindex procedures (`bin/<project> fos:elastica:populate --index=procedure` or resave a procedure)
- Open the public procedure list and check a procedure with a pictogram: alt attribute + copyright caption
- Check a procedure without copyright/alt values: no caption, fallback alt text

### PR Checklist
- [x] Link all relevant tickets