### PR TITLE
feat(refs DPLAN-18114): Leave side panel open after filter reset and when using pagination

### DIFF
--- a/client/js/components/procedure/SegmentsList/SegmentsList.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsList.vue
@@ -769,6 +769,7 @@ export default {
     ...mapGetters('FilterFlyout', [
       'getFilterQuery',
       'getIsExpandedByCategoryId',
+      'getLastAppliedFilterQuery',
     ]),
 
     ...mapState('Orga', {
@@ -1047,7 +1048,7 @@ export default {
       fetchAssignableUsers: 'list',
     }),
 
-    ...mapActions('FilterFlyout', ['commitFilterQuery', 'discardUnappliedChanges', 'updateFilterQuery']),
+    ...mapActions('FilterFlyout', ['commitFilterQuery', 'updateFilterQuery']),
 
     ...mapActions('Place', {
       fetchPlaces: 'list',
@@ -1074,15 +1075,12 @@ export default {
     },
 
     applyQuery (page) {
-      // Drop unapplied filter selections before reading getFilterQuery, then close the panel
-      this.discardUnappliedChanges()
-      this.closeFilterSlidebar()
       lscache.remove(this.lsKey.allSegments)
       lscache.remove(this.lsKey.toggledSegments)
       this.allItemsCount = null
 
       const filter = {
-        ...this.getFilterQuery,
+        ...this.getLastAppliedFilterQuery,
         sameProcedure: {
           condition: {
             path: 'parentStatement.procedure.id',
@@ -1154,7 +1152,7 @@ export default {
         })
         .catch(() => {
           if (
-            Object.keys(this.getFilterQuery).length > 0 ||
+            Object.keys(this.getLastAppliedFilterQuery).length > 0 ||
             this.searchTerm !== ''
           ) {
             this.resetQuery()
@@ -2077,7 +2075,7 @@ export default {
       })
     }
 
-    // Snapshot the initial filters as applied so the first applyQuery does not discard them
+    // Snapshot the initial filters as applied so the first applyQuery fetches with them
     this.commitFilterQuery()
 
     this.initPagination()

--- a/client/js/components/procedure/SegmentsList/SegmentsListFilter.vue
+++ b/client/js/components/procedure/SegmentsList/SegmentsListFilter.vue
@@ -377,8 +377,8 @@ export default {
       })
 
       /*
-       * Snapshot the applied query before emitting: the emit synchronously triggers applyQuery,
-       * which discards unapplied changes against this snapshot.
+       * Snapshot the current selection as applied before emitting: applyQuery reads this snapshot
+       * (getLastAppliedFilterQuery) for the fetch, so it must be up to date first.
        */
       commitFilterQuery()
       emit('filterApply', mergedFilter)


### PR DESCRIPTION
### Ticket
[DPLAN-18114](https://demoseurope.youtrack.cloud/issue/DPLAN-18114/ADO-56766-Auslagerung-der-Filterung-in-ein-

<!-- Description: Clearly and concisely describe the intention of your PR including the problem you're solving 
and the reasoning behind the solution. -->

This PR adjusts behaviour of handling unapplied changes in filter side panel:
- panel stays open after user clicks `Filterauswahl zurücksetzen`
- panel stays open, and the unapplied chnages stay, when user changes page or items-per-page

### How to review/test
<!-- If there is a recommended way to review and/or test this PR, please describe it here.-->
1. go to segments' list
2. check the panel behaviour on filter reset and when using pagination/items-per-page

### Linked PR
main PR: https://github.com/demos-europe/demosplan-core/pull/6757
<!-- 
### Linked PRs (optional)
List other PRs that are somehow connected to this and explain the connection. Don't
link private repositories in public ones, but the other way around is fine.

- Other PR1 #{PR-number1}
- Other PR2 #{PR-number2}
-->



