### PR TITLE
F dplan 18189 fix fragment metadata export

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -947,6 +947,8 @@ services:
         lazy: true
         calls:
             - [ 'setEsStatementFragmentType', [ '@fos_elastica.index.statementFragments' ]]
+        arguments:
+            $esStatementPersister: '@fos_elastica.object_persister.statements'
 
 
     demosplan\DemosPlanCoreBundle\Logic\Statement\TagService:

--- a/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Export/DocxExporter.php
@@ -729,11 +729,12 @@ class DocxExporter
     }
 
     /**
-     * Appends the assigned Potenzialflächen and Schlagworte below the statement text.
+     * Appends the assigned Potenzialflächen and Schlagworte below the given item's text.
      *
-     * Only used by the Verfahrensexport (see $includeStatementMetadataRow in
-     * {@link renderTableItem} and {@link addFragmentRows}); the standalone Abwägungstabelle
-     * export never sets that flag, so this stays out of it.
+     * $item may be a statement or a fragment array — each carries its own
+     * priorityAreaKeys/tagNames. Only used by the Verfahrensexport (see
+     * $includeStatementMetadataRow in {@link renderTableItem} and {@link addFragmentRows});
+     * the standalone Abwägungstabelle export never sets that flag, so this stays out of it.
      */
     private function addStatementMetadataToCell(Cell $cell, array $item, array $styles): void
     {
@@ -971,10 +972,11 @@ class DocxExporter
      * @param int     $recommendationCellWidth
      * @param array   $styles
      * @param bool    $anonymous
-     * @param bool    $includeStatementMetadataRow appends the statement's priority areas/tags
-     *                                             (see {@link addStatementMetadataToCell}) to
-     *                                             the first fragment's text cell, since fragments
-     *                                             have no cell of their own to carry statement-level data
+     * @param bool    $includeStatementMetadataRow appends each fragment's own priority areas/tags
+     *                                             (see {@link addStatementMetadataToCell}) below
+     *                                             its text, since fragments can be assigned
+     *                                             different priority areas/tags than the statement
+     *                                             or each other
      */
     protected function addFragmentRows(
         $item,
@@ -1002,8 +1004,8 @@ class DocxExporter
                 $fragment['text'] = $this->editorService->handleObscureTags($fragment['text'], $anonymous);
                 $this->addHtml($cell2, $fragment['text'], $styles);
             }
-            if (0 === $index && $includeStatementMetadataRow) {
-                $this->addStatementMetadataToCell($cell2, $item, $styles);
+            if ($includeStatementMetadataRow) {
+                $this->addStatementMetadataToCell($cell2, $fragment, $styles);
             }
 
             $cell3 = $assessmentTable->addCell($recommendationCellWidth, $cellStyle);
@@ -1211,6 +1213,9 @@ class DocxExporter
             // as it has the same behaviour
             $item['recommendation'] = $statementFragment->getConsideration();
             $item['text'] = $statementFragment->getText();
+            // the fragment has its own priority areas/tags, distinct from the parent statement's
+            $item['priorityAreaKeys'] = $statementFragment->getPriorityAreaKeys();
+            $item['tagNames'] = $statementFragment->getTagNames();
         }
 
         $item['elementId'] = $tmpElementId;

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementFragmentService.php
@@ -13,6 +13,7 @@ namespace demosplan\DemosPlanCoreBundle\Logic\Statement;
 use DateTime;
 use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\CurrentUserInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\StatementInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
 use DemosEurope\DemosplanAddon\Utilities\Json;
@@ -75,6 +76,7 @@ use Elastica\Query\MatchAll;
 use Elastica\Query\Terms;
 use Elastica\ResultSet;
 use Exception;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use Pagerfanta\Elastica\ElasticaAdapter;
 use Pagerfanta\Exception\NotValidCurrentPageException;
 use Psr\Log\LoggerInterface;
@@ -149,6 +151,7 @@ class StatementFragmentService
         private readonly int $elasticsearchMaxResultWindow,
         #[Autowire(param: 'elasticsearch_search_after_batch_size')]
         private readonly int $searchAfterBatchSize,
+        private readonly ObjectPersisterInterface $esStatementPersister,
     ) {
         $this->assignService = $assignService;
         $this->elementService = $elementService;
@@ -158,6 +161,18 @@ class StatementFragmentService
         $this->procedureService = $procedureService;
         $this->translator = $translator;
         $this->userService = $userService;
+    }
+
+    /**
+     * Statement documents in Elasticsearch embed their fragments as a nested field. Creating,
+     * updating or deleting a StatementFragment does not, by itself, trigger a reindex of the
+     * parent Statement (they are separate entities/indexes), so the Statement's ES document has
+     * to be refreshed explicitly here to keep fragment-dependent features (e.g. the assessment
+     * table / procedure export) in sync without requiring a manual reindex.
+     */
+    private function refreshStatementInElasticsearch(StatementInterface $statement): void
+    {
+        $this->esStatementPersister->replaceOne($statement);
     }
 
     public function setEsStatementFragmentType(Index $esStatementFragmentType)
@@ -261,10 +276,13 @@ class StatementFragmentService
             throw new LockedByAssignmentException(sprintf('Fragment is locked by assignment: %s', $statementFragmentId));
         }
 
+        $statement = $fragmentToDelete->getStatement();
+
         try {
-            $fragmentToDelete->getStatement()->removeFragment($fragmentToDelete);
+            $statement->removeFragment($fragmentToDelete);
             // T12692: version/entityContentChange on createFragment? -> take a look in the history of this method
             $this->statementFragmentRepository->delete($fragmentToDelete);
+            $this->refreshStatementInElasticsearch($statement);
 
             $success = true;
         } catch (Exception $e) {
@@ -853,6 +871,8 @@ class StatementFragmentService
         $version = new StatementFragmentVersion($statementFragment);
         $this->statementFragmentVersionRepository->addObject($version);
 
+        $this->refreshStatementInElasticsearch($statementFragment->getStatement());
+
         return $statementFragment;
     }
 
@@ -898,6 +918,7 @@ class StatementFragmentService
                 }
 
                 $this->createStatementFragmentVersion($version);
+                $this->refreshStatementInElasticsearch($result->getStatement());
             }
         } catch (Exception $e) {
             $this->logger->error('Could not update StatementFragment', [$e]);
@@ -989,6 +1010,7 @@ class StatementFragmentService
                 }
 
                 $this->createStatementFragmentVersion($version);
+                $this->refreshStatementInElasticsearch($result->getStatement());
             }
         } catch (Exception $e) {
             $this->logger->error('Could not update StatementFragment', [$e]);


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-18189

Description: 

The procedure export's assessment table DOCX documents (`Abwaegungstabelle_Liste_mit_Datensaetzen.docx` and its anonymized variant) were missing the priority areas (Potenzialflächen) and tags (Schlagworte) for statements that were split into fragments (Datensätze). This required two fixes:

**1. Export rendering (`DocxExporter`)**

- `addFragmentRows()` now renders the priority areas/tags line for every fragment row, not just the first.
- Each fragment row now shows its **own** priority areas/tags (fetched from the fragment entity), instead of incorrectly inheriting the parent statement's values (`formatFragmentArray()` previously never overrode these fields).

**2. Stale Elasticsearch data (`StatementFragmentService`)**

The assessment table export reads statement data from Elasticsearch, where each Statement document embeds its fragments as a nested field. Creating, updating or deleting a `StatementFragment` never triggered a refresh of the parent Statement's ES document (they are separate entities/indexes), so newly added, edited or removed fragments would not appear in any fragment-dependent export until a manual reindex was run.

`StatementFragmentService` now explicitly refreshes the parent Statement's Elasticsearch document (via the `statements` object persister — the same pattern already used in `ProcedureService`) after every fragment create, update and delete, so exports stay correct without requiring a manual reindex.

### How to review/test

- Add a fragment to a statement, assign it its own priority areas/tags (different from the parent statement's), then run the procedure export — the `_mit_Datensaetzen*` DOCX files should show each fragment's own values, with no manual reindex needed.
- Edit and delete a fragment, then re-export — changes should be reflected immediately.
- Confirm the standalone Abwägungstabelle export (outside the procedure export) is unaffected.
- Confirm regular (non-fragment) statement workflows are unaffected, since `StatementFragmentService` is used by `StatementHandler`, `StatementCopier`, `AssessmentHandler`, etc.


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly

