### PR TITLE
fix(refs HDDP-27): delete assessment table export jobs with their procedure

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Procedure/ProcedureDeleter.php
@@ -142,6 +142,9 @@ class ProcedureDeleter
         // export fields configuration
         $this->deleteExportFieldsConfiguration($procedureIds, $isDryRun);
 
+        // assessment table export jobs
+        $this->deleteAssessmentTableExportJobs($procedureIds, $isDryRun);
+
         // maillane connection fixme does this table exist in all projects?
         $this->deleteMaillaneConnection($procedureIds, $isDryRun);
 
@@ -442,6 +445,14 @@ class ProcedureDeleter
     private function deleteExportFieldsConfiguration(array $procedureIds, $isDryRun): void
     {
         $this->queriesService->deleteFromTableByIdentifierArray('export_fields_configuration', 'procedure_id', $procedureIds, $isDryRun);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function deleteAssessmentTableExportJobs(array $procedureIds, bool $isDryRun): void
+    {
+        $this->queriesService->deleteFromTableByIdentifierArray('assessment_table_export_job', 'procedure_id', $procedureIds, $isDryRun);
     }
 
     /**

--- a/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
+++ b/tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php
@@ -17,6 +17,7 @@ use demosplan\DemosPlanCoreBundle\Entity\CustomFields\CustomFieldConfiguration;
 use demosplan\DemosPlanCoreBundle\Entity\File;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\Procedure;
 use demosplan\DemosPlanCoreBundle\Entity\Procedure\ProcedurePhase;
+use demosplan\DemosPlanCoreBundle\Entity\Statement\AssessmentTableExportJob;
 use demosplan\DemosPlanCoreBundle\Logic\Procedure\ProcedureDeleter;
 use demosplan\DemosPlanCoreBundle\Services\Queries\SqlQueriesService;
 use League\Flysystem\FilesystemOperator;
@@ -152,6 +153,58 @@ class ProcedureDeleterTest extends FunctionalTestCase
             $this->countEntries(ProcedurePhase::class),
             'Dry run must not delete procedure_phase rows'
         );
+    }
+
+    public function testDeleteProcedureRemovesAssessmentTableExportJobs(): void
+    {
+        // Arrange
+        $procedure = $this->testProcedures[0]->_real();
+        $otherProcedure = $this->testProcedures[1]->_real();
+        $this->persistExportJob($procedure->getId());
+        $otherJob = $this->persistExportJob($otherProcedure->getId());
+
+        // Act
+        $this->sut->deleteProcedures([$procedure->getId()], false);
+
+        // Assert
+        static::assertSame(
+            0,
+            $this->countEntries(AssessmentTableExportJob::class, ['procedureId' => $procedure->getId()]),
+            'Export jobs of the deleted procedure should be removed'
+        );
+        static::assertNotNull(
+            $this->getEntityManager()->find(AssessmentTableExportJob::class, $otherJob->getId()),
+            'Export jobs of other procedures must survive'
+        );
+    }
+
+    public function testDeleteProcedureDryRunKeepsAssessmentTableExportJobs(): void
+    {
+        // Arrange
+        $procedure = $this->testProcedure->_real();
+        $job = $this->persistExportJob($procedure->getId());
+
+        // Act
+        $this->sut->deleteProcedures([$procedure->getId()], true);
+
+        // Assert
+        static::assertNotNull(
+            $this->getEntityManager()->find(AssessmentTableExportJob::class, $job->getId()),
+            'Dry run must not delete assessment_table_export_job rows'
+        );
+    }
+
+    private function persistExportJob(string $procedureId): AssessmentTableExportJob
+    {
+        $job = new AssessmentTableExportJob();
+        $job->setProcedureId($procedureId);
+        $job->setUserId('user-1');
+        $job->setParametersHash(str_pad('h', 64, 'h'));
+
+        $this->getEntityManager()->persist($job);
+        $this->getEntityManager()->flush();
+
+        return $job;
     }
 
     public function testDeleteProcedureRemovesFilesFromStorage(): void


### PR DESCRIPTION
### Ticket
HDDP-27

ProcedureDeleter did not touch `assessment_table_export_job`, so deleting a procedure left its export job rows behind until the maintenance sweep pruned them by age. The rows also pin no download file: the result file's `_files` row already carries the procedure id and is removed by the deleter's existing file sweep.

Adds the matching `deleteFromTableByIdentifierArray` call (covered on every deletion path, which all funnel through `ProcedureDeleter::deleteProcedures()`) plus tests for deletion and dry run.

### How to review/test
`vendor/bin/phpunit tests/backend/core/Procedure/Functional/ProcedureDeleterTest.php`

### PR Checklist
- [x] Create/Update tests