### PR TITLE
fix(refs DS-619): discard changes on negative report select

### DIFF
--- a/client/js/components/statement/publicStatementModal/StatementModal.vue
+++ b/client/js/components/statement/publicStatementModal/StatementModal.vue
@@ -115,7 +115,7 @@
               id="negative_report_true"
               data-cy="statementModal:indicationerror"
               :checked="formData.r_isNegativeReport === '1'"
-              @change="() => { setStatementData({ r_isNegativeReport: '1'}) }"
+              @change="() => { setStatementData({ r_isNegativeReport: '1'}); clearLocationValidationState() }"
               :label="{
                 hint: Translator.trans('link.title.indicationerror'),
                 text: Translator.trans('indicationerror')
@@ -1211,6 +1211,20 @@ export default {
         r_paragraph_title: ''
       }
       this.setStatementData(elementFields)
+    },
+
+    /*
+     * The vanilla dpValidate lib marks the whole location fieldset invalid on blur once it's
+     * empty, without rechecking whether it's still required - clear that leftover state once
+     * Fehlanzeige makes the location optional again.
+     */
+    clearLocationValidationState () {
+      const fieldset = document.getElementById('locationFieldset')
+      if (!fieldset) {
+        return
+      }
+      const errorClass = this.prefixClass('is-invalid')
+      fieldset.querySelectorAll(`.${errorClass}`).forEach(el => el.classList.remove(errorClass))
     },
 
     removeNotificationsFromStore () {

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupCountyReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupCountyReference.vue
@@ -37,6 +37,7 @@
         name="r_location"
         :checked="statement.location_is_set === 'county'"
         @change="() => { setStatementData({ r_location: 'county', location_is_set: 'county' }) }"
+        @click.native="toggleLocationSelection($event, { r_county: '' })"
         value="county" />
       <select
         v-if="statement.location_is_set === 'county'"
@@ -70,6 +71,7 @@
         name="r_location"
         :checked="statement.location_is_set === 'notLocated'"
         @change="() => { setStatementData({r_location: 'notLocated', location_is_set: 'notLocated'}) }"
+        @click.native="toggleLocationSelection($event)"
         value="notLocated" />
     </div>
   </fieldset>

--- a/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
+++ b/client/js/components/statement/publicStatementModal/formGroups/FormGroupMapReference.vue
@@ -39,6 +39,7 @@
         :checked="isLocationSelected"
         :disabled="disabled"
         @change="() => { const location = (statement.r_location_priority_area_key !== '' ? 'priority_area' :'point'); setStatementData({r_location: 'point', location_is_set: location})}"
+        @click.native="toggleLocationSelection($event, { r_location_geometry: '', r_location_point: '', r_location_priority_area_key: '', r_location_priority_area_type: '' })"
         :label="{
           text: Translator.trans('statement.map.reference.add_on_map')
         }"
@@ -81,6 +82,7 @@
         :checked="statement.r_location === 'county'"
         :disabled="disabled"
         @change="() => { setStatementData({ r_location: 'county', location_is_set: 'county'}) }"
+        @click.native="toggleLocationSelection($event, { r_county: '' })"
         value="county" />
       <select
         v-if="statement.r_location === 'county'"
@@ -116,7 +118,9 @@
         class="u-mb-0_25"
         data-cy="formGroupMap:notLocated"
         :checked="statement.r_location === 'notLocated'"
+        :disabled="disabled"
         @change="() => { setStatementData({r_location: 'notLocated', location_is_set: 'notLocated'}) }"
+        @click.native="toggleLocationSelection($event)"
         value="notLocated" />
     </div>
   </fieldset>

--- a/client/js/components/statement/publicStatementModal/mixins/formGroupMixin.js
+++ b/client/js/components/statement/publicStatementModal/mixins/formGroupMixin.js
@@ -45,6 +45,18 @@ export default {
 
     setStatementData (data) {
       this.updateStatement({ r_ident: this.draftStatementId, ...data })
+    },
+
+    /**
+     * Native radio inputs cannot be unchecked by clicking them again. This handler is bound via
+     * @click (which fires before the browser applies the checked state) so that clicking an
+     * already-checked location radio deselects it instead of being a no-op.
+     */
+    toggleLocationSelection (event, additionalReset = {}) {
+      if (event.target.checked) {
+        event.target.checked = false
+        this.setStatementData({ r_location: '', location_is_set: '', ...additionalReset })
+      }
     }
   }
 }


### PR DESCRIPTION
Ticket: [DS-619](https://demoseurope.youtrack.cloud/tickets/DS-619/WG-28.09.-Einladung-zur-Beteiligung-232.-Anderung-des-Flachennutzungsplanes-Nordlich-Stroer-Allee-in-Koln-Surth)

- Previously, the 'Fehlanzeige' radio button was disabled as soon as any change was made to the fields in the form, even if "kein Ortsbezug" was selected
- the 'Fehlanzeige' radio button is now always enabled. If the user previously made any changes to the form fields, a warning explains that the entries are not saved
- submitting the form asks for confirmation; cancel switches back to "Stellung nehmen", confirm sends a payload without text, references, location and files. The store keeps the content so it reappears when switching back to "Stellung nehmen"
- "kein Ortsbezug" radio buttons are disabled while the 'Fehlanzeige' radio button is selected
- when 'Stellung nehmen' is selected, the user clicks into the editor, then selects 'Fehlanzeige', and then switches back to 'Stellung nehmen', the editor now no longer shows a red error border (this was previously the case because the editor is validated on blur; this validation state is now reset when selecting 'Fehlanzeige')

### How to review/test
1. Log in as an institution user on a procedure with the Fehlanzeige category, open the statement form
2. Enter text and pick a map point or county, then select Fehlanzeige: the fields are disabled and the warning appears
3. Save: a confirm dialog appears. Cancel switches back to "Stellung nehmen" with the content intact. Confirm saves a Fehlanzeige without content
4. Open a new statement modal; click into the empty editor, select Fehlanzeige, then "Stellung nehmen" again: there should be no red border on the editor
5. Reopen the draft from the drafts list: no warning, empty fields, Fehlanzeige selected
6. Select Fehlanzeige on an untouched form: no warning, no dialog, saving goes straight through


- [X] Link all relevant tickets
- [X] Move the tickets on the board accordingly