### PR TITLE
fix(refs DPLAN-18366): resolve addon-declared permissions when gating UI hooks

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/AddonRegistry.php
@@ -32,7 +32,10 @@ class AddonRegistry implements ArrayAccess
     }
 
     /**
-     * @param Definition[] $addonInfos
+     * The compiler pass passes {@link Definition}s here, which the container resolves into the
+     * actual instances before this method ever runs.
+     *
+     * @param AddonInfo[] $addonInfos
      */
     public function boot(array $addonInfos = [])
     {

--- a/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
@@ -20,7 +20,7 @@ final readonly class FrontendAssetProvider
 {
     public function __construct(
         private PermissionEvaluatorInterface $permissionEvaluator,
-        private AddonRegistry $registry
+        private AddonRegistry $registry,
     ) {
     }
 

--- a/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
+++ b/demosplan/DemosPlanCoreBundle/Addon/FrontendAssetProvider.php
@@ -10,70 +10,123 @@
 
 namespace demosplan\DemosPlanCoreBundle\Addon;
 
-use DemosEurope\DemosplanAddon\Contracts\PermissionsInterface;
+use DemosEurope\DemosplanAddon\Permission\PermissionEvaluatorInterface;
 use demosplan\DemosPlanCoreBundle\Exception\AddonException;
+use demosplan\DemosPlanCoreBundle\Permissions\RuntimePermissionIdentifier;
 use demosplan\DemosPlanCoreBundle\Utilities\DemosPlanPath;
 use Symfony\Component\Yaml\Yaml;
 
-final class FrontendAssetProvider
+final readonly class FrontendAssetProvider
 {
-    public function __construct(private readonly PermissionsInterface $permissions, private readonly AddonRegistry $registry)
-    {
+    public function __construct(
+        private PermissionEvaluatorInterface $permissionEvaluator,
+        private AddonRegistry $registry
+    ) {
     }
 
     /**
-     * @return array<string, array<string, mixed>>>
+     * @return array<string, array<string, mixed>>
      */
     public function getFrontendClassesForHook(string $hookName): array
     {
-        $assetList = array_map(function (AddonInfo $addonInfo) use ($hookName) {
-            if (!$addonInfo->isEnabled() || !$addonInfo->hasUIHooks()) {
-                return [];
+        $assetList = [];
+
+        foreach ($this->registry->getAddonInfos() as $addonName => $addonInfo) {
+            $assets = $this->getFrontendClassForHook($addonName, $addonInfo, $hookName);
+
+            // avoid exposing addon information unnecessarily
+            if ([] !== $assets) {
+                $assetList[$addonName] = $assets;
             }
+        }
 
-            $uiData = $addonInfo->getUIHooks();
+        return $assetList;
+    }
 
-            if (!array_key_exists($hookName, $uiData['hooks'])) {
-                return [];
+    /**
+     * @return array<string, mixed>
+     */
+    private function getFrontendClassForHook(string $addonName, AddonInfo $addonInfo, string $hookName): array
+    {
+        if (!$addonInfo->isEnabled() || !$addonInfo->hasUIHooks()) {
+            return [];
+        }
+
+        $uiData = $addonInfo->getUIHooks();
+
+        if (!array_key_exists($hookName, $uiData['hooks'])) {
+            return [];
+        }
+
+        $hookData = $uiData['hooks'][$hookName];
+
+        // Return if no access granted for that addon at that entrypoint
+        if (!$this->isHookEnabled($addonName, $hookData['options'])) {
+            return [];
+        }
+
+        $manifestPath = DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/'.$uiData['manifest'];
+        $assetContents = $this->readAssetContents($addonInfo, $manifestPath, $hookData['entry']);
+
+        if ([] === $assetContents) {
+            return [];
+        }
+
+        return $this->createAddonFrontendAssetsEntry($hookData, $assetContents);
+    }
+
+    /**
+     * @return array<string, string> mapping from asset name to asset content, empty if unreadable
+     */
+    private function readAssetContents(AddonInfo $addonInfo, string $manifestPath, string $entryName): array
+    {
+        try {
+            $entries = $this->getAssetPathsFromManifest($manifestPath, $entryName);
+
+            if (!array_key_exists('js', $entries)) {
+                throw new AddonException('Entry has no javascript and is thus pretty much useless');
             }
+        } catch (AddonException) {
+            return [];
+        }
 
-            $hookData = $uiData['hooks'][$hookName];
-            $manifestPath = DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/'.$uiData['manifest'];
+        $assetContents = [];
 
-            // Return if no access granted for that addon at that entrypoint
-            if (array_key_exists('permissions', $hookData['options'])
-                && !$this->permissions->hasPermissions($hookData['options']['permissions'], 'OR')) {
-                return [];
+        foreach ($entries['js'] as $entry) {
+            // Try to get the content of the actual asset
+            $entryFilePath = DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/dist/'.$entry;
+            // uses local file, no need for flysystem
+            $assetContents[$entry] = file_get_contents($entryFilePath);
+        }
+
+        return $assetContents;
+    }
+
+    /**
+     * A hook may be guarded by permissions declared either by the addon itself or by the core.
+     * Addon permissions live in a collection of their own, so they have to be addressed with the
+     * owning addon as identifier - a plain name lookup would only ever reach the core permissions.
+     *
+     * @param array<string, mixed> $hookOptions
+     */
+    private function isHookEnabled(string $addonName, array $hookOptions): bool
+    {
+        if (!array_key_exists('permissions', $hookOptions)) {
+            return true;
+        }
+
+        foreach ($hookOptions['permissions'] as $permissionName) {
+            $addonPermission = RuntimePermissionIdentifier::forAddon($permissionName, $addonName);
+            $identifier = $this->permissionEvaluator->isPermissionKnown($addonPermission)
+                ? $addonPermission
+                : RuntimePermissionIdentifier::forCore($permissionName);
+
+            if ($this->permissionEvaluator->isPermissionEnabled($identifier)) {
+                return true;
             }
+        }
 
-            try {
-                $entries = $this->getAssetPathsFromManifest($manifestPath, $hookData['entry']);
-
-                if (!array_key_exists('js', $entries)) {
-                    throw new AddonException('Entry has no javascript and is thus pretty much useless');
-                }
-
-                $assetContents = [];
-
-                foreach ($entries['js'] as $entry) {
-                    // Try to get the content of the actual asset
-                    $entryFilePath = DemosPlanPath::getRootPath($addonInfo->getInstallPath()).'/dist/'.$entry;
-                    // uses local file, no need for flysystem
-                    $assetContents[$entry] = file_get_contents($entryFilePath);
-                }
-
-                if ([] === $assetContents) {
-                    return [];
-                }
-            } catch (AddonException) {
-                return [];
-            }
-
-            return $this->createAddonFrontendAssetsEntry($hookData, $assetContents);
-        }, $this->registry->getAddonInfos());
-
-        // avoid exposing addon information unnecessarily
-        return array_filter($assetList, fn (array $assetInfo) => [] !== $assetInfo);
+        return false;
     }
 
     /**
@@ -104,13 +157,13 @@ final class FrontendAssetProvider
     {
         // uses local file, no need for flysystem
         if (!file_exists($manifestPath)) {
-            AddonException::invalidManifest($manifestPath);
+            throw AddonException::invalidManifest($manifestPath);
         }
 
         $manifestContent = Yaml::parseFile($manifestPath);
 
         if (!array_key_exists($entryName, $manifestContent['entrypoints'])) {
-            AddonException::manifestEntryNotFound($entryName);
+            throw AddonException::manifestEntryNotFound($entryName);
         }
 
         return $manifestContent['entrypoints'][$entryName]['assets'];

--- a/demosplan/DemosPlanCoreBundle/Permissions/RuntimePermissionIdentifier.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/RuntimePermissionIdentifier.php
@@ -27,7 +27,7 @@ final readonly class RuntimePermissionIdentifier implements PermissionIdentifier
      */
     private function __construct(
         private string $permissionName,
-        private ?string $addonIdentifier
+        private ?string $addonIdentifier,
     ) {
     }
 

--- a/demosplan/DemosPlanCoreBundle/Permissions/RuntimePermissionIdentifier.php
+++ b/demosplan/DemosPlanCoreBundle/Permissions/RuntimePermissionIdentifier.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace demosplan\DemosPlanCoreBundle\Permissions;
+
+use DemosEurope\DemosplanAddon\Permission\PermissionIdentifierInterface;
+
+/**
+ * Identifies a permission whose name is only known at runtime, e.g. because it was read from an
+ * addon manifest. Permissions known at compile time are to be identified by an enum implementing
+ * {@link PermissionIdentifierInterface} instead.
+ */
+final readonly class RuntimePermissionIdentifier implements PermissionIdentifierInterface
+{
+    /**
+     * @param non-empty-string      $permissionName
+     * @param non-empty-string|null $addonIdentifier
+     */
+    private function __construct(
+        private string $permissionName,
+        private ?string $addonIdentifier
+    ) {
+    }
+
+    /**
+     * @param non-empty-string $permissionName
+     */
+    public static function forCore(string $permissionName): self
+    {
+        return new self($permissionName, null);
+    }
+
+    /**
+     * @param non-empty-string $permissionName
+     * @param non-empty-string $addonIdentifier
+     */
+    public static function forAddon(string $permissionName, string $addonIdentifier): self
+    {
+        return new self($permissionName, $addonIdentifier);
+    }
+
+    public function getAddonIdentifier(): ?string
+    {
+        return $this->addonIdentifier;
+    }
+
+    public function getPermissionName(): string
+    {
+        return $this->permissionName;
+    }
+}

--- a/tests/backend/core/Core/Unit/Addon/FrontendAssetProviderTest.php
+++ b/tests/backend/core/Core/Unit/Addon/FrontendAssetProviderTest.php
@@ -181,7 +181,7 @@ class FrontendAssetProviderTest extends TestCase
         array $hookOptions,
         bool $enabled = true,
         string $entry = 'TestEntry',
-        string $installPath = self::INSTALL_PATH
+        string $installPath = self::INSTALL_PATH,
     ): AddonInfo {
         return new AddonInfo(
             self::ADDON_NAME,

--- a/tests/backend/core/Core/Unit/Addon/FrontendAssetProviderTest.php
+++ b/tests/backend/core/Core/Unit/Addon/FrontendAssetProviderTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the package demosplan.
+ *
+ * (c) 2010-present DEMOS plan GmbH, for more information see the license file.
+ *
+ * All rights reserved
+ */
+
+namespace Tests\Core\Core\Unit\Addon;
+
+use DemosEurope\DemosplanAddon\Permission\PermissionEvaluatorInterface;
+use DemosEurope\DemosplanAddon\Permission\PermissionIdentifierInterface;
+use DemosEurope\DemosplanAddon\Permission\PermissionInitializerInterface;
+use demosplan\DemosPlanCoreBundle\Addon\AddonInfo;
+use demosplan\DemosPlanCoreBundle\Addon\AddonRegistry;
+use demosplan\DemosPlanCoreBundle\Addon\FrontendAssetProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The system under test needs neither container nor database, so this is a plain unit test.
+ *
+ * @group UnitTest
+ */
+class FrontendAssetProviderTest extends TestCase
+{
+    private const ADDON_NAME = 'demos-europe/demosplan-addon-fixture';
+    private const HOOK_NAME = 'import.tabs';
+    private const INSTALL_PATH = 'tests/backend/core/Core/res/frontendAssetProvider/addon';
+    private const ADDON_PERMISSION = 'feature_fixture_addon_permission';
+    private const CORE_PERMISSION = 'feature_fixture_core_permission';
+
+    protected ?FrontendAssetProvider $sut = null;
+
+    /**
+     * @var (PermissionEvaluatorInterface&MockObject)|null
+     */
+    private ?PermissionEvaluatorInterface $permissionEvaluator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->permissionEvaluator = $this->createMock(PermissionEvaluatorInterface::class);
+    }
+
+    public function testHookWithoutPermissionsIsDeliveredWithoutAnyPermissionCheck(): void
+    {
+        $this->createSut($this->createAddonInfo([]));
+
+        $this->permissionEvaluator->expects(self::never())->method('isPermissionEnabled');
+
+        $assets = $this->sut->getFrontendClassesForHook(self::HOOK_NAME);
+
+        self::assertSame(['TestEntry'], $this->getDeliveredEntries($assets));
+    }
+
+    /**
+     * A permission declared by the addon itself lives in a collection of its own. It has to be
+     * looked up with the owning addon as identifier, otherwise the core collection is searched
+     * and the hook is silently dropped even though the user is allowed to see it.
+     */
+    public function testAddonPermissionIsResolvedWithTheOwningAddonAsIdentifier(): void
+    {
+        $this->createSut($this->createAddonInfo(['permissions' => [self::ADDON_PERMISSION]]));
+
+        $this->expectPermissionKnownAsAddonPermission(self::ADDON_PERMISSION, true);
+        $this->permissionEvaluator->expects(self::once())
+            ->method('isPermissionEnabled')
+            ->with(self::callback(
+                fn (PermissionIdentifierInterface $identifier) => self::ADDON_NAME === $identifier->getAddonIdentifier()
+                    && self::ADDON_PERMISSION === $identifier->getPermissionName()
+            ))
+            ->willReturn(true);
+
+        $assets = $this->sut->getFrontendClassesForHook(self::HOOK_NAME);
+
+        self::assertSame(['TestEntry'], $this->getDeliveredEntries($assets));
+    }
+
+    public function testDisabledAddonPermissionOmitsTheHook(): void
+    {
+        $this->createSut($this->createAddonInfo(['permissions' => [self::ADDON_PERMISSION]]));
+
+        $this->expectPermissionKnownAsAddonPermission(self::ADDON_PERMISSION, true);
+        $this->permissionEvaluator->method('isPermissionEnabled')->willReturn(false);
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook(self::HOOK_NAME));
+    }
+
+    /**
+     * Hooks may also be guarded by core permissions, which carry no addon identifier.
+     */
+    public function testPermissionUnknownToTheAddonIsResolvedAgainstTheCore(): void
+    {
+        $this->createSut($this->createAddonInfo(['permissions' => [self::CORE_PERMISSION]]));
+
+        $this->expectPermissionKnownAsAddonPermission(self::CORE_PERMISSION, false);
+        $this->permissionEvaluator->expects(self::once())
+            ->method('isPermissionEnabled')
+            ->with(self::callback(
+                fn (PermissionIdentifierInterface $identifier) => null === $identifier->getAddonIdentifier()
+                    && self::CORE_PERMISSION === $identifier->getPermissionName()
+            ))
+            ->willReturn(true);
+
+        $assets = $this->sut->getFrontendClassesForHook(self::HOOK_NAME);
+
+        self::assertSame(['TestEntry'], $this->getDeliveredEntries($assets));
+    }
+
+    public function testAnyOfTheConfiguredPermissionsSufficesToDeliverTheHook(): void
+    {
+        $this->createSut($this->createAddonInfo([
+            'permissions' => [self::CORE_PERMISSION, self::ADDON_PERMISSION],
+        ]));
+
+        $this->permissionEvaluator->method('isPermissionKnown')->willReturnCallback(
+            fn (PermissionIdentifierInterface $identifier) => self::ADDON_PERMISSION === $identifier->getPermissionName()
+        );
+        $this->permissionEvaluator->method('isPermissionEnabled')->willReturnCallback(
+            fn (PermissionIdentifierInterface $identifier) => self::ADDON_PERMISSION === $identifier->getPermissionName()
+        );
+
+        $assets = $this->sut->getFrontendClassesForHook(self::HOOK_NAME);
+
+        self::assertSame(['TestEntry'], $this->getDeliveredEntries($assets));
+    }
+
+    public function testDisabledAddonIsSkipped(): void
+    {
+        $this->createSut($this->createAddonInfo([], enabled: false));
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook(self::HOOK_NAME));
+    }
+
+    public function testUnrequestedHookIsNotDelivered(): void
+    {
+        $this->createSut($this->createAddonInfo([]));
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook('some.other.hook'));
+    }
+
+    public function testEntryWithoutJavascriptIsNotDelivered(): void
+    {
+        $this->createSut($this->createAddonInfo([], entry: 'StylesOnlyEntry'));
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook(self::HOOK_NAME));
+    }
+
+    public function testEntryMissingFromTheManifestIsNotDelivered(): void
+    {
+        $this->createSut($this->createAddonInfo([], entry: 'NotInTheManifest'));
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook(self::HOOK_NAME));
+    }
+
+    public function testMissingManifestIsNotDelivered(): void
+    {
+        $this->createSut($this->createAddonInfo([], installPath: self::INSTALL_PATH.'/does-not-exist'));
+
+        self::assertSame([], $this->sut->getFrontendClassesForHook(self::HOOK_NAME));
+    }
+
+    private function createSut(AddonInfo $addonInfo): void
+    {
+        $registry = new AddonRegistry();
+        $registry->boot([$addonInfo]);
+
+        $this->sut = new FrontendAssetProvider($this->permissionEvaluator, $registry);
+    }
+
+    /**
+     * @param array<string, mixed> $hookOptions
+     */
+    private function createAddonInfo(
+        array $hookOptions,
+        bool $enabled = true,
+        string $entry = 'TestEntry',
+        string $installPath = self::INSTALL_PATH
+    ): AddonInfo {
+        return new AddonInfo(
+            self::ADDON_NAME,
+            [
+                'enabled'      => $enabled,
+                'install_path' => $installPath,
+                'manifest'     => [
+                    'ui' => [
+                        'manifest' => 'dist/assets-manifest.json',
+                        'hooks'    => [
+                            self::HOOK_NAME => [
+                                'entry'   => $entry,
+                                'options' => $hookOptions,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $this->createMock(PermissionInitializerInterface::class)
+        );
+    }
+
+    private function expectPermissionKnownAsAddonPermission(string $permissionName, bool $known): void
+    {
+        $this->permissionEvaluator->expects(self::once())
+            ->method('isPermissionKnown')
+            ->with(self::callback(
+                fn (PermissionIdentifierInterface $identifier) => self::ADDON_NAME === $identifier->getAddonIdentifier()
+                    && $permissionName === $identifier->getPermissionName()
+            ))
+            ->willReturn($known);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $assets
+     *
+     * @return list<string>
+     */
+    private function getDeliveredEntries(array $assets): array
+    {
+        return array_values(array_map(static fn (array $asset) => $asset['entry'], $assets));
+    }
+}

--- a/tests/backend/core/Core/res/frontendAssetProvider/addon/dist/TestEntry.umd.js
+++ b/tests/backend/core/Core/res/frontendAssetProvider/addon/dist/TestEntry.umd.js
@@ -1,0 +1,1 @@
+window.TestEntry = { default: {} }

--- a/tests/backend/core/Core/res/frontendAssetProvider/addon/dist/assets-manifest.json
+++ b/tests/backend/core/Core/res/frontendAssetProvider/addon/dist/assets-manifest.json
@@ -1,0 +1,18 @@
+{
+  "entrypoints": {
+    "TestEntry": {
+      "assets": {
+        "js": [
+          "TestEntry.umd.js"
+        ]
+      }
+    },
+    "StylesOnlyEntry": {
+      "assets": {
+        "css": [
+          "StylesOnlyEntry.css"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Ticket
DPLAN-18366

Addon UI hooks can be guarded by `options.permissions` in the addon manifest.
`FrontendAssetProvider` resolved those names with a plain core lookup, but
permissions declared by an addon live in a separate collection keyed by addon
and are invisible to the core permission array. Any hook guarded by an
addon-declared permission was therefore dropped for every user, regardless of
their actual access — the PDF import tab and its dashboard chart never
rendered. Hooks guarded by core permissions, and hooks with no `permissions`
option at all, were unaffected, which is why only some addon hooks went
missing.

The name is now resolved against the owning addon when that addon declares it,
falling back to core otherwise. Frontend exposure was already addon-aware, so
`hasPermission()` in JS returned `true` while the backend filter said no.

Two fixes found along the way:

- `getAssetPathsFromManifest()` built its exceptions but never threw them, so a
  malformed manifest fell through to a `TypeError` instead of being caught and
  degrading to "hook not delivered".
- `AddonRegistry::boot()` was annotated `Definition[]`, but the container
  resolves those before the call; the runtime type is `AddonInfo[]`.

### How to review/test
Open a procedure's import page as a user who owns the procedure, with the
PDF import addon installed. The PDF-Import tab should appear and accept
uploads. All three gating branches are covered by
`tests/backend/core/Core/Unit/Addon/FrontendAssetProviderTest.php`
(10 tests): addon-declared permission, core permission fallback, and hooks
with no permission option.

### PR Checklist
- [x] Create/Update tests
- [ ] Link all relevant tickets
- [ ] Move the tickets on the board accordingly
