### PR TITLE
fix: correct stale PHPDoc types that conflicted with native type declarations

### DIFF
--- a/demosplan/DemosPlanCoreBundle/Application/FrontController.php
+++ b/demosplan/DemosPlanCoreBundle/Application/FrontController.php
@@ -168,7 +168,6 @@ final class FrontController
             Debug::enable();
         }
 
-        /** @var DemosPlanKernel|HttpCache $kernel */
         $kernel = new DemosPlanKernel($activeProject, $environment, $debug);
         $kernel = new HttpCache($kernel);
 

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -12,13 +12,8 @@ declare(strict_types=1);
 
 namespace demosplan\DemosPlanCoreBundle\Command\Addon;
 
-use Composer\Package\BasePackage;
-use Composer\Package\CompleteAliasPackage;
-use Composer\Package\CompletePackage;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\PackageInterface;
-use Composer\Package\RootAliasPackage;
-use Composer\Package\RootPackage;
 use DemosEurope\DemosplanAddon\Exception\JsonException;
 use DemosEurope\DemosplanAddon\Utilities\Json;
 use demosplan\DemosPlanCoreBundle\Addon\AddonManifestCollection;
@@ -36,7 +31,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Addon/AddonInstallFromZipCommand.php
@@ -340,8 +340,6 @@ class AddonInstallFromZipCommand extends CoreCommand
     }
 
     /**
-     * @return BasePackage|CompleteAliasPackage|CompletePackage|RootAliasPackage|RootPackage|InputDefinition
-     *
      * @throws JsonException
      */
     public function loadPackageDefinition(): PackageInterface

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
@@ -89,7 +89,6 @@ class PermissionListCommand extends CoreCommand
     {
         $projectPermissions = [];
 
-        /** @var SplFileInfo[] $projects */
         $projects = (new Finder())
             ->directories()
             ->depth(0)

--- a/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
+++ b/demosplan/DemosPlanCoreBundle/Command/Documentation/PermissionListCommand.php
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Document/DemosPlanDocumentController.php
@@ -96,8 +96,6 @@ class DemosPlanDocumentController extends BaseController
      * @param string $procedure
      * @param string $elementId
      *
-     * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_admin_paragraphed_document')]
@@ -686,8 +684,6 @@ class DemosPlanDocumentController extends BaseController
 
     /**
      * Save imported elements and redirect to route: @see elementAdminListAction.
-     *
-     * @return Response
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanMailController.php
@@ -182,8 +182,6 @@ class DemosPlanMailController extends BaseController
     /**
      * @param string $procedureId
      *
-     * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_procedure_send_submitter_email')]

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureController.php
@@ -2601,8 +2601,6 @@ class DemosPlanProcedureController extends BaseController
      * @param string $procedure
      * @param string $boilerplateGroupId
      *
-     * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_admin_boilerplates')]
@@ -2754,6 +2752,7 @@ class DemosPlanProcedureController extends BaseController
     protected function handleDeleteBoilerplateGroup(
         string $boilerplateGroupId,
     ) {
+        /** @var ArrayCollection<int, Boilerplate> $boilerplatesOfGroupToDelete */
         $boilerplatesOfGroupToDelete = new ArrayCollection();
         $boilerplateGroupToDelete = $this->procedureService->getBoilerplateGroup($boilerplateGroupId);
         $title = '';
@@ -2765,7 +2764,6 @@ class DemosPlanProcedureController extends BaseController
         }
 
         $successfully = $this->procedureService->deleteBoilerplateGroup($boilerplateGroupToDelete);
-        /** @var Boilerplate $boilerplate */
         foreach ($boilerplatesOfGroupToDelete as $boilerplate) {
             $successfully = $successfully && $this->procedureService->deleteBoilerplate($boilerplate->getId());
         }
@@ -2805,6 +2803,7 @@ class DemosPlanProcedureController extends BaseController
     protected function handleDeleteBoilerplateGroups(
         array $boilerplateGroupIds,
     ) {
+        /** @var ArrayCollection<int, Boilerplate> $boilerplatesOfGroupsToDelete */
         $boilerplatesOfGroupsToDelete = new ArrayCollection();
         foreach ($boilerplateGroupIds as $boilerplateGroupId) {
             $boilerplateGroup = $this->procedureService->getBoilerplateGroup($boilerplateGroupId);
@@ -2817,7 +2816,6 @@ class DemosPlanProcedureController extends BaseController
             }
         }
         $allDeleted = $this->procedureService->deleteBoilerplateGroupsByIds($boilerplateGroupIds);
-        /** @var Boilerplate $boilerplate */
         foreach ($boilerplatesOfGroupsToDelete as $boilerplate) {
             $allDeleted = $allDeleted && $this->procedureService->deleteBoilerplate($boilerplate->getId());
         }

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/DemosPlanProcedureListController.php
@@ -534,8 +534,6 @@ class DemosPlanProcedureListController extends DemosPlanProcedureController
 
     /**
      * (Umkreis-)Suche nach Verfahren in der öffentlichen Beteiligung.
-     *
-     * @return Response
      */
     #[DplanPermissions('area_public_participation')]
     #[Route(path: '/suggest/procedureLocation/json', name: 'DemosPlan_procedure_public_suggest_procedure_location_json', options: ['expose' => true])]

--- a/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Procedure/ProcedureProposalController.php
@@ -130,8 +130,6 @@ class ProcedureProposalController extends BaseController
     /**
      * Generate new Procedure from ProcedureProposal.
      *
-     * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      *
      * @deprecated a {@link DemosPlanProcedureAPIController::createAction} (does not exist yet) should be used instead with the data needed sent by the frontend in an JSON:API POST request

--- a/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
@@ -35,8 +35,6 @@ class SlugDraftApiController extends APIController
      * However, that changes if the route starts to support an
      * "is-slug-already-taken"-functionality, in this case adjust the permissions
      * accordingly.
-     *
-     * @return APIResponse|JsonResponse
      */
     #[DplanPermissions('feature_short_url')]
     #[Route(name: 'create', methods: ['POST'])]

--- a/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/SlugDraftApiController.php
@@ -19,7 +19,6 @@ use demosplan\DemosPlanCoreBundle\Attribute\DplanPermissions;
 use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Transformers\SlugDraftTransformer;
 use demosplan\DemosPlanCoreBundle\ValueObject\SlugDraftValueObject;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanAssessmentStatementFragmentController.php
@@ -336,8 +336,6 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
 
     /**
      * Edit a single fragment.
-     *
-     * @return RedirectResponse|Response
      */
     #[DplanPermissions('feature_statements_fragment_edit')]
     #[Route(path: '/_ajax/procedure/{procedure}/fragment/{fragmentId}/edit', name: 'DemosPlan_statement_fragment_edit_ajax', options: ['expose' => true])]
@@ -400,8 +398,6 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Delete a single fragment.
      *
      * @param string $fragmentId
-     *
-     * @return RedirectResponse|Response
      */
     #[DplanPermissions(['area_admin_assessmenttable', 'feature_statements_fragment_edit'])]
     #[Route(path: '/_ajax/procedure/{procedureId}/statement/{statementId}/fragment/{fragmentId}/delete', name: 'DemosPlan_statement_fragment_delete_ajax', options: ['expose' => true], methods: ['POST'])]
@@ -584,8 +580,6 @@ class DemosPlanAssessmentStatementFragmentController extends DemosPlanAssessment
      * Set a vote or advice to a fragment statement.
      *
      * @param bool $isReviewer
-     *
-     * @return RedirectResponse|Response
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
@@ -49,9 +49,6 @@ class DemosPlanEntityContentChangeAPIController extends APIController
     }
 
     // @improve T12984
-    /**
-     * @return APIResponse|JsonResponse
-     */
     #[DplanPermissions('feature_statement_fragment_content_changes_view')]
     #[Route(path: '/api/1.0/statements/{procedureId}/statementfragment/{statementFragmentId}/history', name: 'dplan_api_statement_fragment_history', options: ['expose' => true], methods: ['GET'])]
     public function getStatementFragmentHistory(

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanEntityContentChangeAPIController.php
@@ -23,7 +23,6 @@ use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementFragmentService;
 use demosplan\DemosPlanCoreBundle\Transformers\EntityContentChangeComparisonTransformer;
 use demosplan\DemosPlanCoreBundle\Transformers\HistoryDayTransformer;
 use Doctrine\ORM\EntityNotFoundException;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -55,7 +55,6 @@ use EDT\Wrapping\Utilities\SchemaPathProcessor;
 use Exception;
 use League\Fractal\Resource\Collection;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementAPIController.php
@@ -99,8 +99,6 @@ class DemosPlanStatementAPIController extends APIController
     /**
      * Copy Statement into (another) procedure.
      *
-     * @return APIResponse|JsonResponse
-     *
      * @throws MessageBagException
      */
     #[DplanPermissions('feature_statement_copy_to_procedure')]
@@ -204,8 +202,6 @@ class DemosPlanStatementAPIController extends APIController
 
     // @improve T12984
     /**
-     * @return APIResponse|JsonResponse
-     *
      * @throws MessageBagException
      */
     #[DplanPermissions('feature_statement_move_to_procedure')]
@@ -314,8 +310,6 @@ class DemosPlanStatementAPIController extends APIController
     // @improve T12984
     /**
      * @param string $statementId
-     *
-     * @return JsonResponse
      */
     #[DplanPermissions('area_admin_assessmenttable')]
     #[Route(path: '/api/1.0/statements/{procedureId}/{statementId}/edit', name: 'dplan_api_statement_edit', options: ['expose' => true], methods: ['POST'])]
@@ -587,8 +581,6 @@ class DemosPlanStatementAPIController extends APIController
      * <li>User sent placeholder statements (only or together with other statements): Show message "%count% der markierten Stellungnahmen befinden sich nicht im aktuellen Verfahren und wurden Ihnen nicht zugewiesen."
      * <li>User sent claim and edit action together for one or more unclaimed statements
      * </ul>
-     *
-     * @return JsonResponse
      *
      * @throws MessageBagException
      */

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -1637,7 +1637,7 @@ class DemosPlanStatementController extends BaseController
         } else {
             $draftListFilterVO = $draftFilterList[$procedureId][$templateName];
         }
-        /** @var DraftStatementListFilters $draftListFilterVO */
+        /* @var DraftStatementListFilters $draftListFilterVO */
 
         if ($request->query->has('reset')) {
             $draftFilterList[$procedureId][$templateName] = new DraftStatementListFilters();

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/DemosPlanStatementController.php
@@ -795,8 +795,6 @@ class DemosPlanStatementController extends BaseController
      * @param string $procedure
      * @param string $statementId
      *
-     * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('feature_statements_like_may_like')]
@@ -836,8 +834,6 @@ class DemosPlanStatementController extends BaseController
      * Speichere eine Stellungnahme via Ajax-Aufruf.
      *
      * @param string $procedure Procedure Id
-     *
-     * @return Response
      *
      * initially use area_demosplan, specific permissions are checked below
      *
@@ -1038,8 +1034,6 @@ class DemosPlanStatementController extends BaseController
 
     /**
      * Edit Statement.
-     *
-     * @return RedirectResponse|Response
      *
      * @throws Exception
      */
@@ -1571,8 +1565,6 @@ class DemosPlanStatementController extends BaseController
      * @param string $procedureId      Needed for initializing
      * @param string $draftStatementId
      *
-     * @return Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_statements')]
@@ -1639,13 +1631,13 @@ class DemosPlanStatementController extends BaseController
             $draftFilterList[$procedureId][$templateName] = null;
         }
 
-        /** @var DraftStatementListFilters $draftListFilterVO */
         $draftListFilterVO = null;
         if (!$draftFilterList[$procedureId][$templateName] instanceof DraftStatementListFilters) {
             $draftListFilterVO = new DraftStatementListFilters();
         } else {
             $draftListFilterVO = $draftFilterList[$procedureId][$templateName];
         }
+        /** @var DraftStatementListFilters $draftListFilterVO */
 
         if ($request->query->has('reset')) {
             $draftFilterList[$procedureId][$templateName] = new DraftStatementListFilters();

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
@@ -21,7 +21,6 @@ use demosplan\DemosPlanCoreBundle\Exception\BadRequestException;
 use demosplan\DemosPlanCoreBundle\Exception\InvalidDataException;
 use demosplan\DemosPlanCoreBundle\Logic\Statement\StatementHandler;
 use demosplan\DemosPlanCoreBundle\ResourceTypes\StatementFragmentResourceType;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 

--- a/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/Statement/StatementFragmentAPIController.php
@@ -30,9 +30,6 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 class StatementFragmentAPIController extends APIController
 {
-    /**
-     * @return JsonResponse
-     */
     #[DplanPermissions('feature_statements_fragment_edit')]
     #[Route(path: '/api/1.0/statement-fragment/{statementFragmentId}/edit', name: 'dplan_api_statement_fragment_edit', options: ['expose' => true], methods: ['PATCH'])]
     public function update(PermissionsInterface $permissions, Request $request, StatementHandler $statementHandler, string $statementFragmentId): APIResponse

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanDepartmentController.php
@@ -173,8 +173,6 @@ class DemosPlanDepartmentController extends BaseController
      *
      * @param string $orgaId
      *
-     * @return RedirectResponse|Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_manage_departments')]

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanMasterToebController.php
@@ -94,8 +94,6 @@ class DemosPlanMasterToebController extends BaseController
      *
      * @param string $userId
      *
-     * @return Response
-     *
      * @throws \Exception
      */
     #[DplanPermissions('area_report_mastertoeblist')]

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanOrgaController.php
@@ -129,8 +129,6 @@ class DemosPlanOrgaController extends BaseController
     /**
      * Edit Organisation.
      *
-     * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
     #[DplanPermissions('area_manage_orgadata')]

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserAuthenticationController.php
@@ -80,8 +80,6 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Passwort ändern.
      *
-     * @return Response
-     *
      * @throws Exception
      */
     #[DplanPermissions('area_mydata_password')]
@@ -105,8 +103,6 @@ class DemosPlanUserAuthenticationController extends DemosPlanUserController
     /**
      * Request change of email.
      * Send Mail to verify change of E-Mail-Address.
-     *
-     * @return RedirectResponse|Response
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserController.php
@@ -412,8 +412,6 @@ class DemosPlanUserController extends BaseController
     }
 
     /**
-     * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
     #[DplanPermissions('feature_citizen_registration')]
@@ -521,8 +519,6 @@ class DemosPlanUserController extends BaseController
 
     /**
      * Speichere Nutzerdaten.
-     *
-     * @return RedirectResponse|Response
      *
      * @throws MessageBagException
      */

--- a/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
+++ b/demosplan/DemosPlanCoreBundle/Controller/User/DemosPlanUserListController.php
@@ -102,8 +102,6 @@ class DemosPlanUserListController extends DemosPlanUserController
      * Administrate users.
      * In this case administrate means, save or delete users.
      *
-     * @return RedirectResponse|Response
-     *
      * @throws MessageBagException
      */
     #[DplanPermissions('area_manage_users')]

--- a/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/StatementFactory.php
+++ b/demosplan/DemosPlanCoreBundle/DataGenerator/CustomFactory/StatementFactory.php
@@ -98,8 +98,6 @@ class StatementFactory extends FactoryBase
     }
 
     /**
-     * @return mixed
-     *
      * @throws DataProviderException
      */
     protected function makeStatement(): Statement

--- a/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Document/Elements.php
@@ -493,7 +493,7 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
     }
 
     /**
-     * @return Collection<int,Elements>|Elements[]
+     * @return Collection<int,Elements>
      */
     public function getChildren(): Collection
     {
@@ -509,7 +509,7 @@ class Elements extends CoreEntity implements UuidEntityInterface, ElementsInterf
     }
 
     /**
-     * @return Collection<int,Orga>|Orga[]
+     * @return Collection<int,Orga>
      */
     public function getOrganisations(): Collection
     {

--- a/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Map/GisLayer.php
@@ -672,9 +672,6 @@ class GisLayer extends CoreEntity implements GisLayerInterface
 
     // improve T16806
 
-    /**
-     * @return bool
-     */
     public function getCustomer(): ?CustomerInterface
     {
         return $this->customer;

--- a/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/Procedure/Procedure.php
@@ -1631,7 +1631,7 @@ class Procedure extends SluggedEntity implements ProcedureInterface
     {
         $planningOfficeIds = [];
 
-        /** @var Orga[] $planningOffices */
+        /** @var Collection<int, Orga> $planningOffices */
         $planningOffices = $this->getPlanningOffices();
         foreach ($planningOffices as $organisation) {
             $planningOfficeIds[] = $organisation->getId();

--- a/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
+++ b/demosplan/DemosPlanCoreBundle/Entity/User/Orga.php
@@ -1103,7 +1103,7 @@ class Orga extends SluggedEntity implements OrgaInterface, Stringable
     {
         $users = collect([]);
 
-        /** @var Department[] $departments */
+        /** @var IlluminateCollection<int, Department> $departments */
         $departments = $this->getDepartments();
         foreach ($departments as $department) {
             $users = $users->merge($department->getUsers());

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
@@ -1108,9 +1108,9 @@ class EntityContentChangeService
     }
 
     /**
-     * @param string|CoreEntity|int|null $contentChange diff of values
-     * @param Department|User            $changer       (juristic) person who is executing the change. Can be a
-     *                                                  department or a user.
+     * @param string           $contentChange diff of values
+     * @param Department|User $changer       (juristic) person who is executing the change. Can be a
+     *                                       department or a user.
      */
     public function createEntityContentChangeEntity(
         CoreEntity $updatedObject,

--- a/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/EntityContentChangeService.php
@@ -1108,7 +1108,7 @@ class EntityContentChangeService
     }
 
     /**
-     * @param string           $contentChange diff of values
+     * @param string          $contentChange diff of values
      * @param Department|User $changer       (juristic) person who is executing the change. Can be a
      *                                       department or a user.
      */

--- a/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
@@ -173,8 +173,8 @@ abstract class EntityGrouper
     /**
      * Places a single entity inside the given {@link EntityGroupInterface}.
      *
-     * @param EntityGroupInterface<T>    $group               The group the given entity is placed in. The entity may be placed directly in the group or in one of its subgroups (at any depth).
-     * @param T&EntityInterface          $entity              the entity to be placed inside the given {@link EntityGroupInterface}
+     * @param EntityGroupInterface<T> $group               The group the given entity is placed in. The entity may be placed directly in the group or in one of its subgroups (at any depth).
+     * @param T&EntityInterface       $entity              the entity to be placed inside the given {@link EntityGroupInterface}
      * @param string[]                $entityFieldsToUse   Controls the resulting group structure.
      *                                                     Each element in this array represents a layer of the resulting tree.
      *                                                     For example if the array is empty the given entity will be placed

--- a/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Grouping/EntityGrouper.php
@@ -173,8 +173,8 @@ abstract class EntityGrouper
     /**
      * Places a single entity inside the given {@link EntityGroupInterface}.
      *
-     * @param EntityGroupInterface<T> $group               The group the given entity is placed in. The entity may be placed directly in the group or in one of its subgroups (at any depth).
-     * @param T                       $entity              the entity to be placed inside the given {@link EntityGroupInterface}
+     * @param EntityGroupInterface<T>    $group               The group the given entity is placed in. The entity may be placed directly in the group or in one of its subgroups (at any depth).
+     * @param T&EntityInterface          $entity              the entity to be placed inside the given {@link EntityGroupInterface}
      * @param string[]                $entityFieldsToUse   Controls the resulting group structure.
      *                                                     Each element in this array represents a layer of the resulting tree.
      *                                                     For example if the array is empty the given entity will be placed

--- a/demosplan/DemosPlanCoreBundle/Logic/HttpCall.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/HttpCall.php
@@ -55,8 +55,6 @@ class HttpCall
      *
      * @param string|array $data
      *
-     * @return mixed
-     *
      * @throws InvalidArgumentException
      */
     public function request(string $method, ?string $path, $data): array

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/AssessmentTableExporter/AssessmentTableXlsExporter.php
@@ -484,11 +484,11 @@ class AssessmentTableXlsExporter extends AssessmentTableFileExporterAbstract
     /**
      * Adds a definition for a column depending on the given permission.
      *
-     * @param array       $columnsDefinition array of resulting column-definitions
-     * @param string      $key               key to get value from statement array (elasticsearch result) later on
-     * @param string|null $permission        permission to determine if column will be added
-     * @param string|null $columnTitle       translation-key used as title for column in resulting document
-     * @param int         $width             width of column in resulting document
+     * @param array  $columnsDefinition array of resulting column-definitions
+     * @param string $key               key to get value from statement array (elasticsearch result) later on
+     * @param string $permission        permission to determine if column will be added
+     * @param string $columnTitle       translation-key used as title for column in resulting document
+     * @param int    $width             width of column in resulting document
      */
     private function addColumnDefinition(
         array &$columnsDefinition,

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/DraftStatementService.php
@@ -1377,13 +1377,10 @@ class DraftStatementService
      * Ruft die unveränderten freigegebenen Stellungnahmen eines Nutzers ab.
      *
      * @param string      $procedureId
-     * @param array       $filters
      * @param string      $search
      * @param array|null  $sort            deprecated
      * @param User        $user
      * @param string|null $manualSortScope
-     *
-     * @return array DraftStatementVersionList
      *
      * @throws Exception
      */

--- a/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/Statement/StatementSubmissionNotifier.php
@@ -255,8 +255,7 @@ class StatementSubmissionNotifier
     /**
      * Send Notification because Statement needs to be checked by Planner.
      *
-     * @param array|Statement $statement
-     * @param string[]        $ccs
+     * @param string[] $ccs
      *
      * @throws Throwable
      * @throws Twig_Error_Loader

--- a/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/User/UserHandler.php
@@ -1810,7 +1810,7 @@ class UserHandler extends CoreHandler implements UserHandlerInterface
             }
 
             // if one of the related departments have a user, return false
-            /** @var Department[] $departments */
+            /** @var Collection<int, Department> $departments */
             $departments = $organisation->getDepartments();
             foreach ($departments as $department) {
                 if ($requiredRelationsAreSolved && !$department->getUsers()->isEmpty()) {

--- a/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
+++ b/demosplan/DemosPlanCoreBundle/Logic/ZipImportService.php
@@ -65,7 +65,7 @@ class ZipImportService
             Assert::notNull($extractDir);
             $this->finder->files()->in($extractDir);
             if ($this->finder->hasResults()) {
-                /** @var SplFileInfo $file */
+                /** @var \Symfony\Component\Finder\SplFileInfo $file */
                 foreach ($this->finder as $file) {
                     $extension = $file->getExtension();
                     $fileNameParts = explode('_', $file->getFilename());

--- a/demosplan/DemosPlanCoreBundle/Repository/FileContainerRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/FileContainerRepository.php
@@ -34,7 +34,6 @@ class FileContainerRepository extends FluentRepository implements ObjectInterfac
     public function getFiles(string $entityClass, string $id, string $field): array
     {
         try {
-            /** @var FileContainer|null $files */
             $files = $this->findBy(['entityId' => $id, 'entityClass' => $entityClass, 'entityField' => $field]);
             if (null !== $files) {
                 $fileEntities = [];
@@ -87,7 +86,6 @@ class FileContainerRepository extends FluentRepository implements ObjectInterfac
     public function getFileStrings($entityClass, $id, $field): array
     {
         try {
-            /** @var FileContainer|null $files */
             $files = $this->findBy(['entityId' => $id, 'entityClass' => $entityClass, 'entityField' => $field]);
             if (null !== $files) {
                 return collect($files)

--- a/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
+++ b/demosplan/DemosPlanCoreBundle/Repository/MapRepository.php
@@ -712,8 +712,6 @@ class MapRepository extends FluentRepository implements ArrayInterface, ObjectIn
     }
 
     /**
-     * @return CoreEntity
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */


### PR DESCRIPTION
## Summary
- 35 files where a `@return`/`@var`/`@param` PHPDoc tag no longer matched the native type hint already declared on the same method/variable. Native type declarations were already correct and more specific in every case; the PHPDoc was stale (predates a return-type narrowing, e.g. `Response` -> `RedirectResponse`/`JsonResponse`/`APIResponse`) or simply wrong (copy-paste artifacts like `@return bool` on a `getCustomer(): ?CustomerInterface` getter).
- A few `@var` tags were misplaced (annotating a variable before its final assignment, or before a `foreach` loop instead of inside it) rather than wrong in content; moved to the correct statement.
- One generic template mismatch in `EntityGrouper::fillEntityIntoGroupStructure()` (`T` widened to `T&EntityInterface` for that parameter only, no change to the class-wide template bound).
- No behavior changes — doc-only and one generic type annotation.

## Test plan
- [ ] `bin/ewm d:php -l2` no longer reports `return.phpDocType`, `varTag.nativeType`, or `parameter.phpDocType` for these files
- [ ] Static analysis / CI passes